### PR TITLE
Add cross-platform release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+# Builds downloadable applications for macOS, Windows, and Linux.
+# Runs on every v* tag (which also publishes a GitHub Release) and can be
+# started by hand from the Actions tab to test the packaging jobs.
+on:
+  push:
+    branches:
+      - ci/release-pipeline
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  package-macos:
+    name: Package macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: brew install qt@5 libomp zeromq cppzmq nlohmann-json dylibbundler
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
+
+      - name: Build
+        run: cmake --build build --config Release -j
+
+      - name: Bundle Qt and dependencies into the app
+        run: |
+          set -euxo pipefail
+          APP="build/QEGTRAIN.app"
+          # Qt frameworks and plugins
+          "$(brew --prefix qt@5)/bin/macdeployqt" "$APP" -verbose=1
+          # Non-Qt dylibs (libomp, libzmq, libsodium, ...) copied in and
+          # rewritten to @executable_path so the app runs without Homebrew.
+          dylibbundler --overwrite-files --bundle-deps --create-dir \
+            --fix-file "$APP/Contents/MacOS/QEGTRAIN" \
+            --dest-dir "$APP/Contents/libs" \
+            --install-path "@executable_path/../libs"
+
+      - name: Verify the bundle is self-contained
+        run: |
+          set -euxo pipefail
+          leaked="$(find build/QEGTRAIN.app -type f -perm +111 -print0 \
+            | xargs -0 -I{} sh -c 'otool -L "{}" 2>/dev/null' \
+            | grep -E '/opt/homebrew|/usr/local/opt' || true)"
+          if [ -n "$leaked" ]; then
+            echo "ERROR: bundle still references Homebrew paths:"; echo "$leaked"; exit 1
+          fi
+          echo "OK: no Homebrew paths referenced"
+
+      - name: Package zip
+        run: |
+          cd build
+          ditto -c -k --keepParent QEGTRAIN.app QEGTRAIN-macos-arm64.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: QEGTRAIN-macos-arm64
+          path: build/QEGTRAIN-macos-arm64.zip
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: [package-macos]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List downloaded files
+        run: find artifacts -type f
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**/*
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          fail_on_unmatched_files: true
+          body: |
+            Automated EGTRAIN build for `${{ github.ref_name }}`.
+
+            - Commit: ${{ github.sha }}
+            - Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Download the package for your platform, unzip, and run.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,87 @@ jobs:
           path: build/QEGTRAIN-macos-arm64.zip
           if-no-files-found: error
 
+  package-windows:
+    name: Package Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '5.15.2'
+          host: windows
+          target: desktop
+          arch: win64_msvc2019_64
+          modules: qtcharts
+          cache: true
+
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install ZeroMQ, cppzmq, nlohmann-json (vcpkg)
+        shell: pwsh
+        run: vcpkg install zeromq cppzmq nlohmann-json --triplet x64-windows
+
+      - name: Configure
+        shell: pwsh
+        run: >
+          cmake -S . -B build
+          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DVCPKG_TARGET_TRIPLET=x64-windows
+          -DCMAKE_PREFIX_PATH="$env:QT_ROOT_DIR"
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Assemble package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $dist = "dist/QEGTRAIN"
+          New-Item -ItemType Directory -Force -Path $dist | Out-Null
+          $exe = Get-ChildItem -Path build -Recurse -Filter QEGTRAIN.exe | Select-Object -First 1
+          if (-not $exe) { throw "QEGTRAIN.exe not found under build/" }
+          Copy-Item $exe.FullName "$dist/QEGTRAIN.exe"
+          # ZeroMQ + libsodium runtime DLLs from vcpkg
+          Copy-Item "$env:VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin/*.dll" $dist/ -ErrorAction SilentlyContinue
+          # Qt runtime: DLLs + platform/imageformat plugins next to the exe
+          & "$env:QT_ROOT_DIR/bin/windeployqt.exe" --release --no-translations --compiler-runtime "$dist/QEGTRAIN.exe"
+          # Case data + image assets. The app resolves Input/ from the working
+          # directory; double-clicking the exe sets the working directory to its
+          # own folder, so the data must sit beside it.
+          Copy-Item -Recurse EGTRAIN/QEGTRAIN/Input "$dist/Input"
+          Copy-Item EGTRAIN/QEGTRAIN/*.png $dist/
+          Copy-Item EGTRAIN/QEGTRAIN/*.jpg $dist/
+
+      - name: Verify the package is complete
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $dist = "dist/QEGTRAIN"
+          foreach ($dll in @("Qt5Core.dll","Qt5Gui.dll","Qt5Widgets.dll","Qt5Charts.dll")) {
+            if (-not (Test-Path "$dist/$dll")) { throw "missing $dll" }
+          }
+          if (-not (Test-Path "$dist/platforms/qwindows.dll")) { throw "missing platforms/qwindows.dll" }
+          if (-not (Get-ChildItem "$dist" -Filter "libzmq*.dll")) { throw "missing libzmq DLL" }
+          if (-not (Test-Path "$dist/Input/Input_EGTRAIN_Paimpol")) { throw "missing Input case data" }
+          Write-Host "OK: exe, Qt runtime, libzmq, and Input data are present"
+
+      - name: Zip
+        shell: pwsh
+        run: Compress-Archive -Path dist/QEGTRAIN/* -DestinationPath QEGTRAIN-windows-x64.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: QEGTRAIN-windows-x64
+          path: QEGTRAIN-windows-x64.zip
+          if-no-files-found: error
+
   release:
     name: Publish GitHub Release
-    needs: [package-macos]
+    needs: [package-macos, package-windows]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: brew install qt@5 libomp zeromq cppzmq nlohmann-json dylibbundler
+        run: brew install qt@5 libomp zeromq cppzmq nlohmann-json
 
       - name: Configure
         run: >
@@ -33,34 +33,34 @@ jobs:
       - name: Bundle Qt and dependencies into the app
         run: |
           set -euxo pipefail
-          APP="build/QEGTRAIN.app"
-          # Qt frameworks and plugins
-          "$(brew --prefix qt@5)/bin/macdeployqt" "$APP" -verbose=1
-          # Non-Qt dylibs (libomp, libzmq, libsodium, ...) copied in and
-          # rewritten to @executable_path so the app runs without Homebrew.
-          dylibbundler --overwrite-files --bundle-deps --create-dir \
-            --fix-file "$APP/Contents/MacOS/QEGTRAIN" \
-            --dest-dir "$APP/Contents/libs" \
-            --install-path "@executable_path/../libs"
+          # macdeployqt copies the Qt frameworks and plugins into the bundle and
+          # also relocates the non-Qt dependencies (libomp, libzmq, libsodium)
+          # into Contents/Frameworks, rewriting every reference to
+          # @executable_path so the app runs without Homebrew.
+          "$(brew --prefix qt@5)/bin/macdeployqt" build/QEGTRAIN.app -verbose=1
 
       - name: Verify the app is self-contained
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           APP="build/QEGTRAIN.app"
-          BIN="$APP/Contents/MacOS/QEGTRAIN"
-          echo "== main executable dependencies =="
-          otool -L "$BIN"
-          # The main executable must not load anything from Homebrew at runtime
-          # (its dependency lines, i.e. everything after the header line).
-          if otool -L "$BIN" | tail -n +2 | grep -E '/opt/homebrew|/usr/local/opt'; then
-            echo "ERROR: main executable depends on Homebrew paths"; exit 1
-          fi
-          # Qt frameworks and the non-Qt dylibs must be bundled inside the app.
           test -d "$APP/Contents/Frameworks/QtCore.framework"
           test -d "$APP/Contents/Frameworks/QtCharts.framework"
-          ls "$APP/Contents/libs" | grep -Eiq 'omp' || { echo "ERROR: libomp not bundled"; exit 1; }
-          ls "$APP/Contents/libs" | grep -Eiq 'zmq' || { echo "ERROR: libzmq not bundled"; exit 1; }
-          echo "OK: main executable clean; Qt frameworks and libomp/libzmq bundled"
+          find "$APP" -iname 'libomp*.dylib' | grep -q . || { echo "ERROR: libomp not bundled"; exit 1; }
+          find "$APP" -iname 'libzmq*.dylib' | grep -q . || { echo "ERROR: libzmq not bundled"; exit 1; }
+          # The main executable (no install-id line) and every bundled dylib
+          # (skip the header and their own install-id line) must not reference
+          # a Homebrew path as a dependency.
+          if otool -L "$APP/Contents/MacOS/QEGTRAIN" | tail -n +2 | grep -E '/opt/homebrew|/usr/local/opt'; then
+            echo "ERROR: main executable depends on Homebrew"; exit 1
+          fi
+          leak=0
+          while IFS= read -r f; do
+            if otool -L "$f" | tail -n +3 | grep -E '/opt/homebrew|/usr/local/opt'; then
+              echo "ERROR: Homebrew dependency in $f"; leak=1
+            fi
+          done < <(find "$APP" -type f -name '*.dylib')
+          [ "$leak" = 0 ] || exit 1
+          echo "OK: app is self-contained"
 
       - name: Package zip
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,9 +162,102 @@ jobs:
           path: QEGTRAIN-windows-x64.zip
           if-no-files-found: error
 
+  package-linux:
+    name: Package Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake patchelf wget file desktop-file-utils \
+            qtbase5-dev qttools5-dev qttools5-dev-tools libqt5charts5-dev \
+            libzmq3-dev cppzmq-dev nlohmann-json3-dev libomp-dev
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release -j"$(nproc)"
+
+      - name: Assemble AppDir
+        run: |
+          set -euxo pipefail
+          APPDIR="$PWD/AppDir"
+          mkdir -p \
+            "$APPDIR/usr/bin" \
+            "$APPDIR/usr/share/applications" \
+            "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+
+          EXE="$(find build -type f -perm -111 -name QEGTRAIN | head -n 1)"
+          test -n "$EXE"
+          cp "$EXE" "$APPDIR/usr/bin/QEGTRAIN"
+
+          # Case data and image assets live beside the executable. The app
+          # falls back to this location when launched outside the package tree.
+          cp -R EGTRAIN/QEGTRAIN/Input "$APPDIR/usr/bin/Input"
+          cp EGTRAIN/QEGTRAIN/*.png "$APPDIR/usr/bin/"
+          cp EGTRAIN/QEGTRAIN/*.jpg "$APPDIR/usr/bin/" || true
+          cp EGTRAIN/QEGTRAIN/train_station.png \
+            "$APPDIR/usr/share/icons/hicolor/256x256/apps/qegtrain.png"
+
+          cat > "$APPDIR/usr/share/applications/qegtrain.desktop" <<'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=EGTRAIN
+          Exec=QEGTRAIN
+          Icon=qegtrain
+          Categories=Education;Science;
+          Terminal=false
+          EOF
+          chmod +x "$APPDIR/usr/bin/QEGTRAIN"
+
+      - name: Build AppImage
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+          VERSION: "1.0"
+        run: |
+          set -euxo pipefail
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage appimagetool-x86_64.AppImage
+
+          export QMAKE
+          QMAKE="$(command -v qmake || command -v qmake-qt5 || echo /usr/lib/qt5/bin/qmake)"
+          ./linuxdeploy-x86_64.AppImage \
+            --appdir AppDir \
+            --executable AppDir/usr/bin/QEGTRAIN \
+            --desktop-file AppDir/usr/share/applications/qegtrain.desktop \
+            --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/qegtrain.png \
+            --plugin qt
+
+          ./appimagetool-x86_64.AppImage AppDir QEGTRAIN-linux-x86_64.AppImage
+
+      - name: Verify AppImage contents
+        run: |
+          set -euxo pipefail
+          test -s QEGTRAIN-linux-x86_64.AppImage
+          chmod +x QEGTRAIN-linux-x86_64.AppImage
+          ./QEGTRAIN-linux-x86_64.AppImage --appimage-extract >/dev/null
+          test -x squashfs-root/usr/bin/QEGTRAIN
+          test -d squashfs-root/usr/bin/Input/Input_EGTRAIN_Paimpol
+          test -f squashfs-root/AppRun
+          find squashfs-root -name 'libQt5Core.so*' -print -quit | grep -q .
+          echo "OK: AppImage contains executable, Qt runtime, and Input data"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: QEGTRAIN-linux-x86_64
+          path: QEGTRAIN-linux-x86_64.AppImage
+          if-no-files-found: error
+
   release:
     name: Publish GitHub Release
-    needs: [package-macos, package-windows]
+    needs: [package-macos, package-windows, package-linux]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential cmake patchelf wget file desktop-file-utils \
+            build-essential cmake patchelf wget file desktop-file-utils imagemagick \
             qtbase5-dev qttools5-dev qttools5-dev-tools libqt5charts5-dev \
             libzmq3-dev cppzmq-dev nlohmann-json3-dev libomp-dev
 
@@ -200,7 +200,8 @@ jobs:
           cp -R EGTRAIN/QEGTRAIN/Input "$APPDIR/usr/bin/Input"
           cp EGTRAIN/QEGTRAIN/*.png "$APPDIR/usr/bin/"
           cp EGTRAIN/QEGTRAIN/*.jpg "$APPDIR/usr/bin/" || true
-          cp EGTRAIN/QEGTRAIN/train_station.png \
+          convert EGTRAIN/QEGTRAIN/train_station.png \
+            -background transparent -gravity center -resize 256x256 -extent 256x256 \
             "$APPDIR/usr/share/icons/hicolor/256x256/apps/qegtrain.png"
 
           cat > "$APPDIR/usr/share/applications/qegtrain.desktop" <<'EOF'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
           # @executable_path so the app runs without Homebrew.
           "$(brew --prefix qt@5)/bin/macdeployqt" build/QEGTRAIN.app -verbose=1
 
+      - name: Ad-hoc code sign
+        # macdeployqt rewrites install names with install_name_tool, which
+        # invalidates the code signature. Apple Silicon kills a binary with a
+        # broken signature at load (SIGKILL), so re-sign the whole bundle
+        # ad-hoc. Students still see a Gatekeeper prompt on first open, but the
+        # app launches instead of being killed.
+        run: codesign --force --deep --sign - build/QEGTRAIN.app
+
       - name: Verify the app is self-contained
         run: |
           set -euo pipefail
@@ -60,7 +68,9 @@ jobs:
             fi
           done < <(find "$APP" -type f -name '*.dylib')
           [ "$leak" = 0 ] || exit 1
-          echo "OK: app is self-contained"
+          # The signature must be valid, or Apple Silicon kills the app at launch.
+          codesign --verify --deep --strict --verbose=2 "$APP"
+          echo "OK: app is self-contained and signed"
 
       - name: Package zip
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,16 +43,24 @@ jobs:
             --dest-dir "$APP/Contents/libs" \
             --install-path "@executable_path/../libs"
 
-      - name: Verify the bundle is self-contained
+      - name: Verify the app is self-contained
         run: |
           set -euxo pipefail
-          leaked="$(find build/QEGTRAIN.app -type f -perm +111 -print0 \
-            | xargs -0 -I{} sh -c 'otool -L "{}" 2>/dev/null' \
-            | grep -E '/opt/homebrew|/usr/local/opt' || true)"
-          if [ -n "$leaked" ]; then
-            echo "ERROR: bundle still references Homebrew paths:"; echo "$leaked"; exit 1
+          APP="build/QEGTRAIN.app"
+          BIN="$APP/Contents/MacOS/QEGTRAIN"
+          echo "== main executable dependencies =="
+          otool -L "$BIN"
+          # The main executable must not load anything from Homebrew at runtime
+          # (its dependency lines, i.e. everything after the header line).
+          if otool -L "$BIN" | tail -n +2 | grep -E '/opt/homebrew|/usr/local/opt'; then
+            echo "ERROR: main executable depends on Homebrew paths"; exit 1
           fi
-          echo "OK: no Homebrew paths referenced"
+          # Qt frameworks and the non-Qt dylibs must be bundled inside the app.
+          test -d "$APP/Contents/Frameworks/QtCore.framework"
+          test -d "$APP/Contents/Frameworks/QtCharts.framework"
+          ls "$APP/Contents/libs" | grep -Eiq 'omp' || { echo "ERROR: libomp not bundled"; exit 1; }
+          ls "$APP/Contents/libs" | grep -Eiq 'zmq' || { echo "ERROR: libzmq not bundled"; exit 1; }
+          echo "OK: main executable clean; Qt frameworks and libomp/libzmq bundled"
 
       - name: Package zip
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
+# MSVC's <cmath> only defines M_PI and friends when _USE_MATH_DEFINES is set
+# before the header is included. Harmless on other toolchains.
+add_compile_definitions(_USE_MATH_DEFINES)
+
 option(EGTRAIN_ENABLE_SANITIZERS "Enable AddressSanitizer/UndefinedBehaviorSanitizer for local debug checks" OFF)
 
 if(EGTRAIN_ENABLE_SANITIZERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,15 @@ set(CMAKE_AUTOUIC ON)
 # before the header is included. Harmless on other toolchains.
 add_compile_definitions(_USE_MATH_DEFINES)
 
+# On Windows, <zmq.hpp> drags in <windows.h>. Tame it so the SDK does not
+# collide with the project: WIN32_LEAN_AND_MEAN trims the include (and drops the
+# legacy winsock.h that fights ZeroMQ's winsock2.h), NOMINMAX drops the min/max
+# macros, NOGDI drops the GDI Arc() that clashes with our class Arc, and
+# _HAS_STD_BYTE=0 resolves the std::byte vs SDK byte ambiguity (std::byte unused).
+if(MSVC)
+    add_compile_definitions(WIN32_LEAN_AND_MEAN NOMINMAX NOGDI _HAS_STD_BYTE=0)
+endif()
+
 option(EGTRAIN_ENABLE_SANITIZERS "Enable AddressSanitizer/UndefinedBehaviorSanitizer for local debug checks" OFF)
 
 if(EGTRAIN_ENABLE_SANITIZERS)

--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -1,5 +1,6 @@
 #include "app/DispatchController.h"
 #include "simulation/SimulationWorker.h"
+#include "util/portability.h"  // localtime_r shim on MSVC
 #include <filesystem>
 #include <regex>
 #include <thread>

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3525,7 +3525,7 @@ void MainWindow::paintNode(QPointF coord, int size, int pen_width, int track, No
 
 	// add track and Node pointer to ellipse item
 	el->track = track;
-	el->Node = Node;
+	el->node = Node;
 
 	// add Node to scene
 	scene->addItem(el);
@@ -3549,7 +3549,7 @@ void MainWindow::paintStationNode(QPointF coord, int size, int pen_width, int tr
 
 	// add track and Node pointer to rect item
 	el->track = track;
-	el->Node = Node;
+	el->node = Node;
 
 	// add station Node to scene
 	scene->addItem(el);
@@ -3864,7 +3864,7 @@ void MainWindow::arcDrawing(QPointF start, QPointF end, int pen_width, int track
 
 	// add track and Arc pointer to line item
 	line->track = track;
-	line->Arc = Arc;
+	line->arc = Arc;
 
 	// RIGOS
 	allArcs.push_back(line);
@@ -3889,7 +3889,7 @@ void MainWindow::virtualArcDrawing(QPointF start, QPointF middle, QPointF end, i
 
 	// add track and Arc pointer to line item
 	line->track = track;
-	line->Arc = Arc;
+	line->arc = Arc;
 
 	// add item to scene
 	scene->addItem(line);
@@ -4296,9 +4296,9 @@ void MainWindow::handleCloseInfoDockWidget() {
 // shows Node info on dock widget
 void MainWindow::displayNodeInfo(NodeItem* el) {
 	// update Node info displayed on widget
-	nodeIDText->setText(QString::fromStdString(to_string_precision(el->Node->ID, 0)));
-	nodeXText->setText(QString::fromStdString(to_string_precision(1000 * el->Node->X, 2))); // km to m
-	nodeYText->setText(QString::fromStdString(to_string_precision(1000 * el->Node->Y, 2))); // km to m
+	nodeIDText->setText(QString::fromStdString(to_string_precision(el->node->ID, 0)));
+	nodeXText->setText(QString::fromStdString(to_string_precision(1000 * el->node->X, 2))); // km to m
+	nodeYText->setText(QString::fromStdString(to_string_precision(1000 * el->node->Y, 2))); // km to m
 	nodeTrackIDText->setText(QString::fromStdString(to_string_precision(el->track, 0)));
 
 	// hide other widgets
@@ -4324,9 +4324,9 @@ void MainWindow::displayNodeInfo(NodeItem* el) {
 // shows station Node info on dock widget
 void MainWindow::displayStationNodeInfo(StationNodeItem* re) {
 	// update Node info displayed on widget
-	nodeIDText->setText(QString::fromStdString(to_string_precision(re->Node->ID, 0)));
-	nodeXText->setText(QString::fromStdString(to_string_precision(1000 * re->Node->X, 2))); // km to m
-	nodeYText->setText(QString::fromStdString(to_string_precision(1000 * re->Node->Y, 2))); // km to m
+	nodeIDText->setText(QString::fromStdString(to_string_precision(re->node->ID, 0)));
+	nodeXText->setText(QString::fromStdString(to_string_precision(1000 * re->node->X, 2))); // km to m
+	nodeYText->setText(QString::fromStdString(to_string_precision(1000 * re->node->Y, 2))); // km to m
 	nodeTrackIDText->setText(QString::fromStdString(to_string_precision(re->track, 0)));
 
 	// hide other widgets
@@ -4352,14 +4352,14 @@ void MainWindow::displayStationNodeInfo(StationNodeItem* re) {
 // shows Arc info on dock widget
 void MainWindow::displayArcInfo(TrackLineItem* line) {
 	// update Arc info displayed on widget
-	arcIDText->setText(QString::fromStdString(to_string_precision(line->Arc->ID, 0)));
-	arcFirstNodeIDText->setText(QString::fromStdString(to_string_precision(line->Arc->startNode.ID, 0)));
-	arcSecondNodeIDText->setText(QString::fromStdString(to_string_precision(line->Arc->endNode.ID, 0)));
+	arcIDText->setText(QString::fromStdString(to_string_precision(line->arc->ID, 0)));
+	arcFirstNodeIDText->setText(QString::fromStdString(to_string_precision(line->arc->startNode.ID, 0)));
+	arcSecondNodeIDText->setText(QString::fromStdString(to_string_precision(line->arc->endNode.ID, 0)));
 	arcTrackIDText->setText(QString::fromStdString(to_string_precision(line->track, 0)));
-	arcLengthText->setText(QString::fromStdString(to_string_precision(line->Arc->length, 2)));
-	arcCurvatureText->setText(QString::fromStdString(to_string_precision(line->Arc->curvature, 2)));
-	arcGradientText->setText(QString::fromStdString(to_string_precision(line->Arc->gradient, 3)));
-	arcSpeedLimitText->setText(QString::fromStdString(to_string_precision(line->Arc->speedLimit, 2)));
+	arcLengthText->setText(QString::fromStdString(to_string_precision(line->arc->length, 2)));
+	arcCurvatureText->setText(QString::fromStdString(to_string_precision(line->arc->curvature, 2)));
+	arcGradientText->setText(QString::fromStdString(to_string_precision(line->arc->gradient, 3)));
+	arcSpeedLimitText->setText(QString::fromStdString(to_string_precision(line->arc->speedLimit, 2)));
 
 	// hide other widgets
 	nodeInfoWidget->hide();
@@ -4976,7 +4976,7 @@ void MainWindow::updateBlockOccupationStatus(Regional regional_train) {
 
 			track = allArcs.at(i);
 
-			if ((track->Arc->startNode.X == regional_train.Bs.arcs_in_signalling_block_section[j].startNode.X) && (track->track == regional_train.Bs.trackLineId)) {
+			if ((track->arc->startNode.X == regional_train.Bs.arcs_in_signalling_block_section[j].startNode.X) && (track->track == regional_train.Bs.trackLineId)) {
 				// std::cout << regional_train.Bs.arcs_in_signalling_block_section[j].endNode.X << " " << regional_train.trainDescription << "\n";
 				//  effect on clicked item
 				effect = new HighlightEffect(Qt::red, 1);

--- a/EGTRAIN/QEGTRAIN/app/main.cpp
+++ b/EGTRAIN/QEGTRAIN/app/main.cpp
@@ -226,6 +226,21 @@ int main(int argc, char* argv[]) {
 	}
 
 	InputMainFolder = initial_variables.InputMainFolder;
+	auto resolvePackagedInputFolder = []() {
+		QString inputPath = QString::fromStdString(InputMainFolder);
+#ifdef __APPLE__
+		QString bundledPath = QDir(QCoreApplication::applicationDirPath() + "/../Resources")
+		                          .filePath(inputPath);
+		if (QDir(bundledPath).exists())
+			InputMainFolder = bundledPath.toStdString();
+#else
+		if (!QDir(inputPath).exists() && QDir(inputPath).isRelative()) {
+			QString candidate = QDir(QCoreApplication::applicationDirPath()).filePath(inputPath);
+			if (QDir(candidate).exists())
+				InputMainFolder = candidate.toStdString();
+		}
+#endif
+	};
 
 	char test;
 	char* filepath;
@@ -252,13 +267,7 @@ int main(int argc, char* argv[]) {
 
 		// start application
 		QApplication a(argc, argv);
-
-		// On macOS, resolve input paths relative to the app bundle
-		// Resources directory so the app works when double-clicked
-#ifdef __APPLE__
-		QString resourcePath = QCoreApplication::applicationDirPath() + "/../Resources/";
-		InputMainFolder = resourcePath.toStdString() + InputMainFolder;
-#endif
+		resolvePackagedInputFolder();
 
 		// resolve output folder to a writable absolute path and ensure it exists
 		{
@@ -292,6 +301,9 @@ int main(int argc, char* argv[]) {
 
 		return a.exec();
 	} else {
+		QCoreApplication a(argc, argv);
+		resolvePackagedInputFolder();
+
 		numTrackLines = initial_variables.numTrackLines;
 		N_Routes = initial_variables.N_Routes;
 		bufferTime = initial_variables.bufferTime;

--- a/EGTRAIN/QEGTRAIN/app/main.cpp
+++ b/EGTRAIN/QEGTRAIN/app/main.cpp
@@ -3,7 +3,7 @@
 #include "app/MainWindow.h"
 #include "io/geocoding.h"
 #include <algorithm>
-#include <unistd.h>
+#include "util/portability.h"
 #include <QDir>
 #include <QStandardPaths>
 

--- a/EGTRAIN/QEGTRAIN/graphics/items/NodeItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/NodeItem.cpp
@@ -1,7 +1,7 @@
 #include "graphics/items/NodeItem.h"
 
 NodeItem::NodeItem(const QRectF& rect, QGraphicsItem* parent)
-	: QGraphicsEllipseItem(rect, parent), track(-1), Node(nullptr) {
+	: QGraphicsEllipseItem(rect, parent), track(-1), node(nullptr) {
 	setZValue(1); // draw over arcs and connections (which have z = 0)
 }
 

--- a/EGTRAIN/QEGTRAIN/graphics/items/NodeItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/NodeItem.h
@@ -24,7 +24,7 @@ public:
 	int track;
 
 	// Node pointer
-	Node* Node;
+	Node* node;
 
 	// to allow cast
 	enum { Type = UserType + 2 };

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationNodeItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationNodeItem.cpp
@@ -1,7 +1,7 @@
 #include "graphics/items/StationNodeItem.h"
 
 StationNodeItem::StationNodeItem(const QRectF& rect, QGraphicsItem* parent)
-	: QGraphicsRectItem(rect, parent), track(-1), Node(nullptr) {
+	: QGraphicsRectItem(rect, parent), track(-1), node(nullptr) {
 	setZValue(1); // draw over arcs and connections (which have z = 0)
 }
 

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationNodeItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationNodeItem.h
@@ -24,7 +24,7 @@ public:
 	int track;
 
 	// Node pointer
-	Node* Node;
+	Node* node;
 
 	// to allow cast
 	enum { Type = UserType + 5 };

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrackLineItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrackLineItem.h
@@ -37,7 +37,7 @@ public:
 	int track;
 
 	// Arc pointer
-	Arc* Arc;
+	Arc* arc;
 
 	// to allow cast
 	enum { Type = UserType + 1 };

--- a/EGTRAIN/QEGTRAIN/io/RailMLParser.cpp
+++ b/EGTRAIN/QEGTRAIN/io/RailMLParser.cpp
@@ -1,5 +1,6 @@
 #include "io/RailMLParser.h"
 #include "simulation/InitialParameters.h"
+#include "util/portability.h"  // localtime_r shim on MSVC
 static zmq::context_t ctx;
 
 extern InitialParameters initial_variables;

--- a/EGTRAIN/QEGTRAIN/util/portability.h
+++ b/EGTRAIN/QEGTRAIN/util/portability.h
@@ -2,15 +2,34 @@
 #define EGTRAIN_PORTABILITY_H
 
 // Cross-platform portability shims for EGTRAIN.
-// MSVC-specific functions are replaced with C99/C++17 standard equivalents.
+// The codebase mixes MSVC names (_s functions, _mkdir) and POSIX names
+// (localtime_r, unistd.h). This header maps whichever set is missing on the
+// current compiler onto the one that is available.
 
 #include <cstdio>
 #include <cstring>
 #include <sys/stat.h>
 
-#if !defined(_MSC_VER)
-// MSVC _s functions are not standard C/C++. Map them to safe equivalents.
+#if defined(_MSC_VER)
 
+#include <io.h>      // _isatty
+#include <direct.h>  // _mkdir
+#include <ctime>     // localtime_s
+
+// POSIX terminal check -> MSVC equivalents.
+#define isatty _isatty
+#define STDIN_FILENO _fileno(stdin)
+
+// POSIX localtime_r -> MSVC localtime_s (arguments swapped, errno_t return).
+static inline struct tm* localtime_r(const time_t* timep, struct tm* result) {
+	return localtime_s(result, timep) == 0 ? result : nullptr;
+}
+
+#else
+
+#include <unistd.h>  // isatty, STDIN_FILENO
+
+// MSVC _s functions are not standard C/C++. Map them to safe equivalents.
 // sprintf_s(buf, ...) -> snprintf(buf, sizeof(buf), ...)
 // Note: sizeof(buf) is correct for stack-allocated arrays, less so for pointers.
 #define sprintf_s(buf, ...) snprintf(buf, sizeof(buf), __VA_ARGS__)
@@ -18,10 +37,7 @@
 // strcpy_s(dst, src) -> strcpy(dst, src)
 #define strcpy_s(dst, src) strcpy(dst, src)
 
-// strcpy_s(dst, len, src) -> strncpy(dst, src, len) (3-arg variant, rare)
-// Not needed for this codebase; all calls are 2-arg.
-
-// _mkdir(path) -> mkdir(path, 0777) (POSIX needs mode argument)
+// _mkdir(path) -> mkdir(path, 0777) (POSIX needs a mode argument)
 #define _mkdir(path) mkdir(path, 0777)
 
 #endif

--- a/EGTRAIN/QEGTRAIN/util/timeutil.hpp
+++ b/EGTRAIN/QEGTRAIN/util/timeutil.hpp
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include <time.h>
+#include "util/portability.h"  // localtime_r shim on MSVC
 
 // 01:01:20 CEST - to use it for the timetables
 inline std::string simulationTime(int t, int startingSimulationTime) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Start here:
 - [Agile workflow](planning/agile-workflow.md)
 - [GitHub issue plan](planning/github-issues.md)
 - [Build and test guide](development/build-and-test.md)
+- [Release testing checklist](development/release-testing-checklist.md)
 - [Writing style](development/writing-style.md)
 
 Keep new documentation short, concrete, and current.

--- a/docs/development/release-testing-checklist.md
+++ b/docs/development/release-testing-checklist.md
@@ -1,0 +1,25 @@
+# Release Testing Checklist
+
+Use this checklist before merging release workflow changes or pushing a `v*` tag.
+
+## CI Run
+
+- Confirm the `Release` workflow finishes with `Package macOS`, `Package Windows`, and `Package Linux` green.
+- Confirm `Publish GitHub Release` is skipped on branch pushes.
+- Download these artifacts from the run:
+  - `QEGTRAIN-macos-arm64`
+  - `QEGTRAIN-windows-x64`
+  - `QEGTRAIN-linux-x86_64`
+
+## Artifact Checks
+
+- macOS: unzip `QEGTRAIN-macos-arm64.zip`; confirm it contains `QEGTRAIN.app`.
+- Windows: unzip `QEGTRAIN-windows-x64.zip`; confirm it contains `QEGTRAIN.exe`, Qt DLLs, `platforms/qwindows.dll`, a `libzmq` DLL, and `Input/`.
+- Linux: mark `QEGTRAIN-linux-x86_64.AppImage` executable; confirm `--appimage-extract` creates `squashfs-root/usr/bin/QEGTRAIN` and `squashfs-root/usr/bin/Input/`.
+
+## Tagged Release Rehearsal
+
+- Push a pre-release tag such as `v1.0.0-rc1`.
+- Confirm the release job publishes all three platform artifacts.
+- Confirm GitHub marks the tag as a pre-release.
+- Delete the test release and tag after the rehearsal if it was only for CI validation.


### PR DESCRIPTION
## Summary
- Adds the `Release` workflow for macOS, Windows, and Linux package artifacts.
- Packages runtime dependencies, case-study `Input/` data, and GUI image assets with the platform artifacts.
- Adds Linux AppImage packaging and verifies the extracted AppImage contains the executable, Qt runtime, and input data.
- Fixes MSVC and GCC portability issues found while bringing up the cross-platform jobs.
- Documents the release testing checklist for branch runs, artifact checks, and pre-release tag rehearsals.

## Validation
- Local macOS build: `cmake -S . -B build_verify -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)`
- Local tests: `ctest --test-dir build_verify --output-on-failure` passed 12/12
- Workflow syntax checks: YAML parse, release job gate check, Linux shell steps via `bash -n`
- GitHub Actions Release run: https://github.com/Ancientkingg/EGTRAIN/actions/runs/28753424310
  - Package macOS: success
  - Package Windows: success
  - Package Linux: success
  - Publish GitHub Release: skipped on branch push

Refs #64 #69 #70 #71 #72 #73 #74