### PR TITLE
Launch cleanly, reload scenes, and show imported scene data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,13 +386,13 @@ if(EGTRAIN_BUILD_TESTS)
 	endif()
 	add_test(NAME test_scenebuilder COMMAND test_scenebuilder)
 
-add_test(NAME test_headless_smoke_decode
-    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_headless_smoke_decode.py)
-add_test(NAME test_startup_launch_contract
-    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/startup_launch_contract.py $<TARGET_FILE:QEGTRAIN>)
-set_tests_properties(test_startup_launch_contract PROPERTIES TIMEOUT 15)
-add_test(NAME test_windows_subsystem_config
-    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_windows_subsystem_config.py)
+	add_test(NAME test_headless_smoke_decode
+		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_headless_smoke_decode.py)
+	add_test(NAME test_startup_launch_contract
+		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/startup_launch_contract.py $<TARGET_FILE:QEGTRAIN>)
+	set_tests_properties(test_startup_launch_contract PROPERTIES TIMEOUT 15)
+	add_test(NAME test_windows_subsystem_config
+		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_windows_subsystem_config.py)
 endif()
 
 # Install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,10 @@ else()
 endif()
 
 if(WIN32)
+    set_target_properties(QEGTRAIN PROPERTIES WIN32_EXECUTABLE TRUE)
+    if(TARGET Qt5::WinMain)
+        target_link_libraries(QEGTRAIN PRIVATE Qt5::WinMain)
+    endif()
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:10000000000")
 endif()
 
@@ -382,8 +386,13 @@ if(EGTRAIN_BUILD_TESTS)
 	endif()
 	add_test(NAME test_scenebuilder COMMAND test_scenebuilder)
 
-	add_test(NAME test_headless_smoke_decode
-		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_headless_smoke_decode.py)
+add_test(NAME test_headless_smoke_decode
+    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_headless_smoke_decode.py)
+add_test(NAME test_startup_launch_contract
+    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/startup_launch_contract.py $<TARGET_FILE:QEGTRAIN>)
+set_tests_properties(test_startup_launch_contract PROPERTIES TIMEOUT 15)
+add_test(NAME test_windows_subsystem_config
+    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_windows_subsystem_config.py)
 endif()
 
 # Install

--- a/EGTRAIN/QEGTRAIN/QEGTRAIN.vcxproj
+++ b/EGTRAIN/QEGTRAIN/QEGTRAIN.vcxproj
@@ -71,7 +71,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
@@ -114,7 +114,7 @@
       <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -724,6 +724,7 @@ void MainWindow::openSceneDialog() {
 
 bool MainWindow::openSceneDirectory(const QString& dir) {
 	QString scenePath = QDir(dir).absolutePath();
+	const bool reloadingSameScene = m_sceneLoaded && QDir(m_sceneDir).absolutePath() == scenePath;
 	auto result = loadScene(scenePath.toStdString());
 	int errorCount = errorDiagnosticCount(result.diagnostics);
 	if (errorCount > 0) {
@@ -735,6 +736,11 @@ bool MainWindow::openSceneDirectory(const QString& dir) {
 		return false;
 	}
 
+	teardownGUI();
+	simulation.resetState();
+	delete m_runStagingDir;
+	m_runStagingDir = nullptr;
+
 	m_sceneDir = scenePath;
 	m_sceneModel = result.scene;
 	m_sceneLoaded = true;
@@ -742,7 +748,8 @@ bool MainWindow::openSceneDirectory(const QString& dir) {
 	updateSceneWindowTitle();
 	updateSceneActions();
 	addRecentScene(scenePath);
-	statusBar()->showMessage(QString("Scene loaded: %1 (%2 services, %3 routes)")
+	statusBar()->showMessage(QString("%1: %2 (%3 services, %4 routes)")
+								 .arg(reloadingSameScene ? "Scene reloaded" : "Scene loaded")
 								 .arg(QString::fromStdString(m_sceneModel.name))
 								 .arg(static_cast<int>(m_sceneModel.services.size()))
 								 .arg(static_cast<int>(m_sceneModel.routes.size())));
@@ -2711,6 +2718,30 @@ void MainWindow::runEditorSmokeE2E() {
 		if (!opened || !m_sceneLoaded) {
 			ok = false;
 			failures << "scene did not open";
+		} else {
+			bool reopened = openSceneDirectory(scenePath);
+			if (!reopened || !m_sceneLoaded || QDir(m_sceneDir).absolutePath() != QDir(scenePath).absolutePath()) {
+				ok = false;
+				failures << "scene did not reopen";
+			}
+			if (!allTrains.isEmpty() || !allArcs.isEmpty()) {
+				ok = false;
+				failures << "legacy scene state not cleared";
+			}
+			QString alternateScenePath = qEnvironmentVariable("QEGTRAIN_E2E_SCENE_ALT");
+			if (!alternateScenePath.isEmpty()
+					&& QDir(alternateScenePath).absolutePath() != QDir(scenePath).absolutePath()) {
+				bool switched = openSceneDirectory(alternateScenePath);
+				if (!switched || !m_sceneLoaded
+						|| QDir(m_sceneDir).absolutePath() != QDir(alternateScenePath).absolutePath()) {
+					ok = false;
+					failures << "alternate scene did not open";
+				}
+				if (!allTrains.isEmpty() || !allArcs.isEmpty()) {
+					ok = false;
+					failures << "legacy scene state not cleared on alternate";
+				}
+			}
 		}
 	}
 

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -2763,10 +2763,22 @@ void MainWindow::runEditorSmokeE2E() {
 			ok = false;
 			failures << "scene did not open";
 		} else {
+			// simulate a clicked-item highlight; the scene owns the effect, so a
+			// reopen must also reset the cached pointer or the next click reuses
+			// a deleted effect
+			if (scene && !effect) {
+				QGraphicsItem* highlightCarrier = scene->addRect(QRectF(0, 0, 1, 1));
+				effect = new HighlightEffect(Qt::blue, 1);
+				highlightCarrier->setGraphicsEffect(effect);
+			}
 			bool reopened = openSceneDirectory(scenePath);
 			if (!reopened || !m_sceneLoaded || QDir(m_sceneDir).absolutePath() != QDir(scenePath).absolutePath()) {
 				ok = false;
 				failures << "scene did not reopen";
+			}
+			if (effect != nullptr) {
+				ok = false;
+				failures << "highlight effect not reset on reopen";
 			}
 			if (!allTrains.isEmpty() || !allArcs.isEmpty()) {
 				ok = false;
@@ -3377,6 +3389,8 @@ void MainWindow::teardownGUI() {
 	trainPaxItem = nullptr;
 	paxIconInfoItem = nullptr;
 	paxIconItem = nullptr;
+	effect = nullptr; // owned and deleted by the cleared item
+
 	regionStations.clear();
 	virtualInterRegionConnections.clear();
 	m_followTrainIndex = -1;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -44,6 +44,16 @@ namespace {
 const char* kRecentScenesKey = "recentScenes";
 const int kMaxRecentScenes = 8;
 
+void addLoadedDataTreeItem(QTreeWidget* tree, QTreeWidgetItem* parent, const SceneLoadedData& item) {
+	auto* row = parent ? new QTreeWidgetItem(parent) : new QTreeWidgetItem(tree);
+	row->setText(0, QString::fromStdString(item.category));
+	row->setText(1, QString::fromStdString(item.sourceFile));
+	row->setText(2, QString::number(item.parsedCount));
+	row->setText(3, QString::fromStdString(item.status));
+	for (const auto& child : item.children)
+		addLoadedDataTreeItem(tree, row, child);
+}
+
 bool e2eDialogsSuppressed() {
 	return qEnvironmentVariableIsSet("QEGTRAIN_E2E_VISUAL_POLISH") || qEnvironmentVariableIsSet("QEGTRAIN_E2E_SCENE_RUN") || qEnvironmentVariableIsSet("QEGTRAIN_E2E_EDITOR_SMOKE");
 }
@@ -373,6 +383,19 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	tabifyDockWidget(m_logPane, m_validationDock);
 	if (ui->menuView)
 		ui->menuView->addAction(m_validationDock->toggleViewAction());
+
+	m_loadedDataDock = new QDockWidget("Loaded Data", this);
+	m_loadedDataTree = new QTreeWidget(m_loadedDataDock);
+	m_loadedDataTree->setColumnCount(4);
+	m_loadedDataTree->setHeaderLabels(QStringList() << "Category" << "Source" << "Count" << "Status");
+	m_loadedDataTree->setEditTriggers(QAbstractItemView::NoEditTriggers);
+	m_loadedDataTree->setSelectionBehavior(QAbstractItemView::SelectRows);
+	m_loadedDataTree->header()->setStretchLastSection(true);
+	m_loadedDataDock->setWidget(m_loadedDataTree);
+	addDockWidget(Qt::BottomDockWidgetArea, m_loadedDataDock);
+	tabifyDockWidget(m_validationDock, m_loadedDataDock);
+	if (ui->menuView)
+		ui->menuView->addAction(m_loadedDataDock->toggleViewAction());
 
 	// composition editor: dockable panel to view and edit train compositions.
 	// this is the first editable scene panel, so it sets the pattern later
@@ -779,6 +802,7 @@ bool MainWindow::saveSceneToCurrentDir() {
 		return false;
 	}
 
+	refreshSavedSceneMetadata(m_sceneModel);
 	m_sceneDirty = false;
 	updateSceneWindowTitle();
 	updateSceneActions();
@@ -832,6 +856,7 @@ bool MainWindow::saveSceneAsToDirectory() {
 	}
 
 	m_sceneDir = targetPath;
+	refreshSavedSceneMetadata(m_sceneModel);
 	m_sceneDirty = false;
 	updateSceneWindowTitle();
 	updateSceneActions();
@@ -925,6 +950,7 @@ void MainWindow::refreshValidationPanel() {
 			m_validationTable->setRowCount(0);
 		if (m_validationStatusLabel)
 			m_validationStatusLabel->clear();
+		refreshLoadedDataTree();
 		return;
 	}
 
@@ -956,6 +982,24 @@ void MainWindow::refreshValidationPanel() {
 		message += QString(", %1 info").arg(counts.infos);
 	if (m_validationStatusLabel)
 		m_validationStatusLabel->setText(message);
+	refreshLoadedDataTree();
+}
+
+void MainWindow::refreshLoadedDataTree() {
+	if (!m_loadedDataTree)
+		return;
+
+	m_loadedDataTree->clear();
+	if (!m_sceneLoaded)
+		return;
+
+	refreshLoadedDataSummary(m_sceneModel);
+	refreshLoadedDataDiagnostics(m_sceneModel, m_sceneDiagnostics);
+	for (const auto& item : m_sceneModel.loadedData) {
+		addLoadedDataTreeItem(m_loadedDataTree, nullptr, item);
+	}
+	m_loadedDataTree->resizeColumnToContents(0);
+	m_loadedDataTree->resizeColumnToContents(1);
 }
 
 void MainWindow::refreshCompositionPanel() {
@@ -2756,6 +2800,13 @@ void MainWindow::runEditorSmokeE2E() {
 
 	// step b: validation assertions
 	if (m_sceneLoaded) {
+		if (!m_loadedDataTree || m_loadedDataTree->topLevelItemCount() <= 0) {
+			ok = false;
+			failures << "loaded data tree empty";
+		} else if (m_loadedDataTree->topLevelItem(0)->childCount() <= 0) {
+			ok = false;
+			failures << "loaded data tree lacks drilldown rows";
+		}
 		if (hasErrors(m_sceneDiagnostics)) {
 			ok = false;
 			failures << "validation errors on open";

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -2741,6 +2741,15 @@ void MainWindow::runEditorSmokeE2E() {
 					ok = false;
 					failures << "legacy scene state not cleared on alternate";
 				}
+				bool restored = openSceneDirectory(scenePath);
+				if (!restored || !m_sceneLoaded) {
+					ok = false;
+					failures << "scene did not reopen after alternate";
+				}
+			}
+			if (QDir(m_sceneDir).absolutePath() != QDir(scenePath).absolutePath()) {
+				ok = false;
+				failures << "primary scene not restored";
 			}
 		}
 	}

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -48,6 +48,7 @@
 #include <QDockWidget>
 #include <Qt>
 #include <QLineEdit>
+#include <QTreeWidget>
 #include <sstream>
 #include <QGraphicsPixmapItem>
 #include <QGraphicsItemGroup>
@@ -378,6 +379,8 @@ private:
 	QDockWidget* m_validationDock = nullptr;
 	QTableWidget* m_validationTable = nullptr;
 	QLabel* m_validationStatusLabel = nullptr;
+	QDockWidget* m_loadedDataDock = nullptr;
+	QTreeWidget* m_loadedDataTree = nullptr;
 	std::vector<SceneDiagnostic> m_sceneDiagnostics;
 
 	// composition editor dock (first editable scene panel)
@@ -448,6 +451,7 @@ private:
 	bool copyScenePassthroughFiles(const QString& targetDir);
 	void updateSceneWindowTitle();
 	void refreshValidationPanel();
+	void refreshLoadedDataTree();
 
 	// composition editor
 	void refreshCompositionPanel();

--- a/EGTRAIN/QEGTRAIN/app/main.cpp
+++ b/EGTRAIN/QEGTRAIN/app/main.cpp
@@ -30,23 +30,18 @@ char* getCmdOption(char** begin, char** end, const std::string& option) {
 	return 0;
 }
 
-void parseCmdOptions(int argc, char* argv[]) {
-	// When launched as a macOS .app bundle, stdin is not a terminal.
-	// Skip interactive prompts and use sensible defaults so the GUI can open.
-	bool interactive = isatty(STDIN_FILENO);
+bool interactivePromptModeEnabled(int argc, char* argv[]) {
+	return cmdOptionEntered(argv, argv + argc, "--interactive") ||
+		cmdOptionEntered(argv, argv + argc, "-interactive");
+}
 
-	if (argc < 2 && !interactive) {
-		initial_variables.set_case(1);  // Netherlands
-		initial_variables.GUI = 1;
-		initial_variables.PAX_GUI = 0;
-		initial_variables.TSM = 0;
-		initial_variables.RChoice = 0;
-		return;
-	}
+void parseCmdOptions(int argc, char* argv[]) {
+	// Keep the legacy questionnaire opt-in so normal launches open the GUI.
+	const bool promptForMissingOptions = interactivePromptModeEnabled(argc, argv);
 
 	// no options entered
 	if (argc < 2) {
-		std::cout << "No arguments inserted. \n";
+		std::cout << "No arguments. Using defaults (GUI mode, case study 1).\n";
 	}
 
 	// select case study
@@ -56,11 +51,13 @@ void parseCmdOptions(int argc, char* argv[]) {
 			initial_variables.set_case(std::atoi(argument));
 			initial_variables.nArgProvided = true;
 		}
-	} else {
+	} else if (promptForMissingOptions) {
 		int case_study;
 		std::cout << "Please enter ID number of Case study(1: Netherlands, 2: Paimpol, 3: Copenhagen, 4: Brescia, 5: Assignment):";
 		std::cin >> case_study;
 		initial_variables.set_case(case_study);
+	} else {
+		initial_variables.set_case(1); // Netherlands
 	}
 
 	// simulation horizon
@@ -70,7 +67,7 @@ void parseCmdOptions(int argc, char* argv[]) {
 			initial_variables.times = std::atoi(argument);
 		}
 
-	} else {
+	} else if (promptForMissingOptions) {
 		char answer;
 		do {
 			std::cout << "The duration of the simulation of the " << initial_variables.name << " is " << initial_variables.times << " seconds.\n";
@@ -131,9 +128,11 @@ void parseCmdOptions(int argc, char* argv[]) {
 		if (argument) {
 			initial_variables.GUI = std::atoi(argument);
 		}
-	} else {
+	} else if (promptForMissingOptions) {
 		std::cout << "It seems you have not selected if you need a GUI. Please insert your choice [1: GUI , 0: no GUI] :";
 		std::cin >> initial_variables.GUI;
+	} else {
+		initial_variables.GUI = 1;
 	}
 
 	// utilization of passenger GUI
@@ -143,9 +142,11 @@ void parseCmdOptions(int argc, char* argv[]) {
 			if (argument) {
 				initial_variables.PAX_GUI = std::atoi(argument);
 			}
-		} else {
+		} else if (promptForMissingOptions) {
 			std::cout << "You have not selected if you want to use the Passenger GUI. Please insert your choice [1: Pax GUI on, 0: Pax GUI off]: ";
 			std::cin >> initial_variables.PAX_GUI;
+		} else {
+			initial_variables.PAX_GUI = 0;
 		}
 	}
 
@@ -155,9 +156,11 @@ void parseCmdOptions(int argc, char* argv[]) {
 		if (argument) {
 			initial_variables.TSM = std::atoi(argument);
 		}
-	} else {
+	} else if (promptForMissingOptions) {
 		std::cout << "Do you want EGTRAIN to share the traffic state at port 5555 (1:share , 0 :do not share)?  :";
 		std::cin >> initial_variables.TSM;
+	} else {
+		initial_variables.TSM = 0;
 	}
 	// RTTP (receive on port 5556 if enabled)
 	if (cmdOptionEntered(argv, argv + argc, "-RC")) {
@@ -165,9 +168,11 @@ void parseCmdOptions(int argc, char* argv[]) {
 		if (argument) {
 			initial_variables.RChoice = std::atoi(argument);
 		}
-	} else {
+	} else if (promptForMissingOptions) {
 		std::cout << "Do you want EGTRAIN to share passengers' state with the Route Choice at port 5556 (1:share , 0 :do not share)?  :";
 		std::cin >> initial_variables.RChoice;
+	} else {
+		initial_variables.RChoice = 0;
 	}
 }
 
@@ -230,7 +235,7 @@ int main(int argc, char* argv[]) {
 		QString inputPath = QString::fromStdString(InputMainFolder);
 #ifdef __APPLE__
 		QString bundledPath = QDir(QCoreApplication::applicationDirPath() + "/../Resources")
-		                          .filePath(inputPath);
+								  .filePath(inputPath);
 		if (QDir(bundledPath).exists())
 			InputMainFolder = bundledPath.toStdString();
 #else
@@ -240,6 +245,7 @@ int main(int argc, char* argv[]) {
 				InputMainFolder = candidate.toStdString();
 		}
 #endif
+		initial_variables.InputMainFolder = InputMainFolder;
 	};
 
 	char test;

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
@@ -1,4 +1,5 @@
 #include "scene/SceneModel.h"
+#include <algorithm>
 #include <fstream>
 #include <filesystem>
 #include <nlohmann/json.hpp>
@@ -16,6 +17,154 @@ static bool readFile(const std::string& path, std::string& content) {
 
 static std::string joinPath(const std::string& parent, const std::string& key) {
 	return parent.empty() ? key : parent + "." + key;
+}
+
+static SceneLoadedData makeLoadedData(const std::string& category, const std::string& sourceFile, int parsedCount, const std::string& status) {
+	SceneLoadedData data;
+	data.category = category;
+	data.sourceFile = sourceFile;
+	data.parsedCount = parsedCount;
+	data.status = status;
+	return data;
+}
+
+static std::string loadedDataDiagnosticStatus(const SceneDiagnosticCounts& counts) {
+	std::vector<std::string> parts;
+	if (counts.errors > 0)
+		parts.push_back(std::to_string(counts.errors) + (counts.errors == 1 ? " error" : " errors"));
+	if (counts.warnings > 0)
+		parts.push_back(std::to_string(counts.warnings) + (counts.warnings == 1 ? " warning" : " warnings"));
+	if (counts.infos > 0)
+		parts.push_back(std::to_string(counts.infos) + (counts.infos == 1 ? " info" : " infos"));
+	if (parts.empty())
+		return "ok";
+	std::string status = parts[0];
+	for (std::size_t i = 1; i < parts.size(); ++i)
+		status += ", " + parts[i];
+	return status;
+}
+
+static std::size_t loadedDataIndexForDiagnostic(const SceneModel& scene, const SceneDiagnostic& diagnostic) {
+	if (!diagnostic.file.empty()) {
+		for (std::size_t i = 0; i < scene.loadedData.size(); ++i) {
+			if (scene.loadedData[i].sourceFile == diagnostic.file)
+				return i;
+		}
+	}
+	for (std::size_t i = 0; i < scene.loadedData.size(); ++i) {
+		if (scene.loadedData[i].category == "scene")
+			return i;
+	}
+	return 0;
+}
+
+void refreshLoadedDataSummary(SceneModel& scene) {
+	scene.loadedData.clear();
+
+	auto add = [&](const std::string& category, const std::string& sourceFile, int parsedCount, const std::string& status) {
+		SceneLoadedData data = makeLoadedData(category, sourceFile, parsedCount, status);
+		if (!sourceFile.empty()) {
+			data.children.push_back(makeLoadedData("raw_file", sourceFile, status == "loaded" ? 1 : 0, status));
+			data.children.push_back(makeLoadedData("parsed_objects", sourceFile, parsedCount, status));
+			data.children.push_back(makeLoadedData("derived_simulation", "", 0, status == "loaded" ? "not_built" : status));
+		}
+		scene.loadedData.push_back(data);
+	};
+	auto statusForFile = [&](const std::string& sourceFile) {
+		return scene.sourceFiles.count(sourceFile) > 0 ? "loaded" : "missing";
+	};
+
+	add("scene", "scene.json", scene.schemaVersion > 0 ? 1 : 0, statusForFile("scene.json"));
+	add("infrastructure", "infrastructure.json", 0, statusForFile("infrastructure.json"));
+	add("stations", "stations.json", static_cast<int>(scene.stations.size()), statusForFile("stations.json"));
+	add("timetable", "services.json", static_cast<int>(scene.services.size()), statusForFile("services.json"));
+	add("rolling_stock", "rolling_stock.json",
+			static_cast<int>(scene.trainUnits.size() + scene.compositions.size()),
+			statusForFile("rolling_stock.json"));
+	{
+		SceneLoadedData& rollingStock = scene.loadedData.back();
+		const std::string status = rollingStock.status;
+		rollingStock.children.push_back(makeLoadedData("train_units", "rolling_stock.json",
+				static_cast<int>(scene.trainUnits.size()), status));
+		rollingStock.children.push_back(makeLoadedData("compositions", "rolling_stock.json",
+				static_cast<int>(scene.compositions.size()), status));
+
+		SceneLoadedData sourceFiles = makeLoadedData("source_files", "",
+				0, "missing");
+		for (const auto& unit : scene.trainUnits) {
+			if (!unit.sourceDataFile.empty()) {
+				sourceFiles.children.push_back(makeLoadedData("data_file", unit.sourceDataFile, 1, "loaded"));
+				++sourceFiles.parsedCount;
+			}
+			if (!unit.sourceTractionFile.empty()) {
+				sourceFiles.children.push_back(makeLoadedData("traction_file", unit.sourceTractionFile, 1, "loaded"));
+				++sourceFiles.parsedCount;
+			}
+		}
+		if (sourceFiles.parsedCount > 0)
+			sourceFiles.status = "loaded";
+		rollingStock.children.push_back(sourceFiles);
+	}
+	add("signalling", "signalling.json",
+			static_cast<int>(scene.signals.size() + scene.routes.size()),
+			statusForFile("signalling.json"));
+	{
+		SceneLoadedData& signalling = scene.loadedData.back();
+		const std::string status = signalling.status;
+		signalling.children.push_back(makeLoadedData("signals", "signalling.json",
+				static_cast<int>(scene.signals.size()), status));
+		signalling.children.push_back(makeLoadedData("routes", "signalling.json",
+				static_cast<int>(scene.routes.size()), status));
+	}
+	add("incidents", "incidents.json", static_cast<int>(scene.incidents.size()), statusForFile("incidents.json"));
+	add("passenger_data", "", 0, "unimplemented");
+}
+
+void refreshLoadedDataDiagnostics(SceneModel& scene, const std::vector<SceneDiagnostic>& diagnostics) {
+	if (scene.loadedData.empty())
+		refreshLoadedDataSummary(scene);
+	if (scene.loadedData.empty())
+		return;
+
+	std::vector<SceneDiagnosticCounts> counts(scene.loadedData.size());
+	for (auto& item : scene.loadedData) {
+		item.children.erase(std::remove_if(item.children.begin(), item.children.end(), [](const SceneLoadedData& child) {
+			return child.category == "validation";
+		}), item.children.end());
+	}
+	for (const auto& diagnostic : diagnostics) {
+		SceneDiagnosticCounts& count = counts[loadedDataIndexForDiagnostic(scene, diagnostic)];
+		switch (diagnostic.severity) {
+		case SceneSeverity::Error:
+			++count.errors;
+			break;
+		case SceneSeverity::Warning:
+			++count.warnings;
+			break;
+		case SceneSeverity::Info:
+			++count.infos;
+			break;
+		}
+	}
+	for (std::size_t i = 0; i < scene.loadedData.size(); ++i) {
+		const SceneDiagnosticCounts& count = counts[i];
+		int total = count.errors + count.warnings + count.infos;
+		scene.loadedData[i].children.push_back(makeLoadedData("validation", scene.loadedData[i].sourceFile, total, loadedDataDiagnosticStatus(count)));
+	}
+}
+
+void refreshSavedSceneMetadata(SceneModel& scene) {
+	scene.sourceFiles.insert("scene.json");
+	scene.sourceFiles.insert("infrastructure.json");
+	scene.sourceFiles.insert("stations.json");
+	scene.sourceFiles.insert("signalling.json");
+	scene.sourceFiles.insert("rolling_stock.json");
+	scene.sourceFiles.insert("services.json");
+	if (!scene.incidents.empty())
+		scene.sourceFiles.insert("incidents.json");
+	else
+		scene.sourceFiles.erase("incidents.json");
+	refreshLoadedDataSummary(scene);
 }
 
 SceneLoadResult loadScene(const std::string& sceneDir) {
@@ -52,6 +201,7 @@ SceneLoadResult loadScene(const std::string& sceneDir) {
 			addError("scene.section.missing", filename, "Root element must be an object");
 			return false;
 		}
+		result.scene.sourceFiles.insert(filename);
 		return true;
 	};
 
@@ -358,5 +508,6 @@ SceneLoadResult loadScene(const std::string& sceneDir) {
 		}
 	}
 
+	refreshLoadedDataSummary(result.scene);
 	return result;
 }

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.h
@@ -2,6 +2,7 @@
 #define SCENEMODEL_H
 
 #include "scene/SceneDiagnostic.h"
+#include <set>
 #include <string>
 #include <vector>
 
@@ -79,12 +80,22 @@ struct SceneIncident {
 	double endSeconds = 0.0;
 };
 
+struct SceneLoadedData {
+	std::string category;
+	std::string sourceFile;
+	int parsedCount = 0;
+	std::string status;
+	std::vector<SceneLoadedData> children;
+};
+
 struct SceneModel {
 	int schemaVersion = 0;
 	std::string name;
 	std::string description;
 	std::string baseTime;
 
+	std::vector<SceneLoadedData> loadedData;
+	std::set<std::string> sourceFiles;
 	std::vector<SceneStation> stations;
 	std::vector<SceneSignal> signals;
 	std::vector<SceneRoute> routes;
@@ -100,5 +111,8 @@ struct SceneLoadResult {
 };
 
 SceneLoadResult loadScene(const std::string& sceneDir);
+void refreshLoadedDataSummary(SceneModel& scene);
+void refreshLoadedDataDiagnostics(SceneModel& scene, const std::vector<SceneDiagnostic>& diagnostics);
+void refreshSavedSceneMetadata(SceneModel& scene);
 
 #endif // SCENEMODEL_H

--- a/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
@@ -135,6 +135,29 @@ static json writeServices(const SceneModel& scene) {
 	return services;
 }
 
+static json writeLoadedDataItem(const SceneLoadedData& item) {
+	json data = {
+			{"category", item.category},
+			{"source_file", item.sourceFile},
+			{"parsed_count", item.parsedCount},
+			{"status", item.status},
+	};
+	if (!item.children.empty()) {
+		json children = json::array();
+		for (const auto& child : item.children)
+			children.push_back(writeLoadedDataItem(child));
+		data["children"] = children;
+	}
+	return data;
+}
+
+static json writeLoadedData(const SceneModel& scene) {
+	json loadedData = json::array();
+	for (const auto& item : scene.loadedData)
+		loadedData.push_back(writeLoadedDataItem(item));
+	return loadedData;
+}
+
 SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) {
 	SceneSaveResult result;
 	fs::path scenePath(sceneDir);
@@ -145,15 +168,19 @@ SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) 
 		return result;
 	}
 
+	SceneModel sceneForWrite = scene;
+	refreshSavedSceneMetadata(sceneForWrite);
+
 	json sceneJson = {
-		{"schema_version", scene.schemaVersion},
-		{"name", scene.name},
+		{"schema_version", sceneForWrite.schemaVersion},
+		{"name", sceneForWrite.name},
 	};
-	if (!scene.description.empty())
-		sceneJson["description"] = scene.description;
-	if (!scene.baseTime.empty())
-		sceneJson["base_time"] = scene.baseTime;
+	if (!sceneForWrite.description.empty())
+		sceneJson["description"] = sceneForWrite.description;
+	if (!sceneForWrite.baseTime.empty())
+		sceneJson["base_time"] = sceneForWrite.baseTime;
 	sceneJson["units"] = {{"distance", "m"}, {"time", "s"}, {"speed", "m/s"}};
+	sceneJson["loaded_data"] = writeLoadedData(sceneForWrite);
 
 	json stations = json::array();
 	for (const auto& station : scene.stations) {

--- a/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
@@ -135,28 +135,7 @@ static json writeServices(const SceneModel& scene) {
 	return services;
 }
 
-static json writeLoadedDataItem(const SceneLoadedData& item) {
-	json data = {
-			{"category", item.category},
-			{"source_file", item.sourceFile},
-			{"parsed_count", item.parsedCount},
-			{"status", item.status},
-	};
-	if (!item.children.empty()) {
-		json children = json::array();
-		for (const auto& child : item.children)
-			children.push_back(writeLoadedDataItem(child));
-		data["children"] = children;
-	}
-	return data;
-}
 
-static json writeLoadedData(const SceneModel& scene) {
-	json loadedData = json::array();
-	for (const auto& item : scene.loadedData)
-		loadedData.push_back(writeLoadedDataItem(item));
-	return loadedData;
-}
 
 SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) {
 	SceneSaveResult result;
@@ -168,19 +147,15 @@ SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) 
 		return result;
 	}
 
-	SceneModel sceneForWrite = scene;
-	refreshSavedSceneMetadata(sceneForWrite);
-
 	json sceneJson = {
-		{"schema_version", sceneForWrite.schemaVersion},
-		{"name", sceneForWrite.name},
+		{"schema_version", scene.schemaVersion},
+		{"name", scene.name},
 	};
-	if (!sceneForWrite.description.empty())
-		sceneJson["description"] = sceneForWrite.description;
-	if (!sceneForWrite.baseTime.empty())
-		sceneJson["base_time"] = sceneForWrite.baseTime;
+	if (!scene.description.empty())
+		sceneJson["description"] = scene.description;
+	if (!scene.baseTime.empty())
+		sceneJson["base_time"] = scene.baseTime;
 	sceneJson["units"] = {{"distance", "m"}, {"time", "s"}, {"speed", "m/s"}};
-	sceneJson["loaded_data"] = writeLoadedData(sceneForWrite);
 
 	json stations = json::array();
 	for (const auto& station : scene.stations) {

--- a/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
@@ -50,16 +50,6 @@ static const SceneLoadedData* findLoadedDataChildSource(const SceneLoadedData* p
 	return nullptr;
 }
 
-static bool jsonChildrenContain(const nlohmann::json& item, const std::string& category) {
-	if (!item.contains("children") || !item["children"].is_array())
-		return false;
-	for (const auto& child : item["children"]) {
-		if (child.value("category", "") == category)
-			return true;
-	}
-	return false;
-}
-
 struct TempDir {
 	std::string dir;
 
@@ -167,19 +157,7 @@ int main(int argc, char** argv) {
 		std::ifstream sceneFile(fs::path(outDir.dir) / "scene.json");
 		nlohmann::json sceneJson;
 		sceneFile >> sceneJson;
-		ok &= expect(sceneJson["loaded_data"].is_array(), "loaded data metadata written");
-		if (sceneJson["loaded_data"].is_array()) {
-			bool foundStationsChildren = false;
-			for (const auto& item : sceneJson["loaded_data"]) {
-				if (item.value("category", "") == "stations") {
-					foundStationsChildren = jsonChildrenContain(item, "raw_file")
-							&& jsonChildrenContain(item, "parsed_objects")
-							&& jsonChildrenContain(item, "derived_simulation");
-					break;
-				}
-			}
-			ok &= expect(foundStationsChildren, "loaded data children written");
-		}
+		ok &= expect(!sceneJson.contains("loaded_data"), "loaded data metadata is not written to scene.json");
 	}
 
 	auto reloadRes = loadScene(outDir.dir);

--- a/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
@@ -22,6 +22,44 @@ static void printErrors(const std::vector<SceneDiagnostic>& diags, const char* l
 	}
 }
 
+static const SceneLoadedData* findLoadedData(const SceneModel& scene, const std::string& category) {
+	for (const auto& item : scene.loadedData) {
+		if (item.category == category)
+			return &item;
+	}
+	return nullptr;
+}
+
+static const SceneLoadedData* findLoadedDataChild(const SceneLoadedData* parent, const std::string& category) {
+	if (!parent)
+		return nullptr;
+	for (const auto& item : parent->children) {
+		if (item.category == category)
+			return &item;
+	}
+	return nullptr;
+}
+
+static const SceneLoadedData* findLoadedDataChildSource(const SceneLoadedData* parent, const std::string& sourceFile) {
+	if (!parent)
+		return nullptr;
+	for (const auto& item : parent->children) {
+		if (item.sourceFile == sourceFile)
+			return &item;
+	}
+	return nullptr;
+}
+
+static bool jsonChildrenContain(const nlohmann::json& item, const std::string& category) {
+	if (!item.contains("children") || !item["children"].is_array())
+		return false;
+	for (const auto& child : item["children"]) {
+		if (child.value("category", "") == category)
+			return true;
+	}
+	return false;
+}
+
 struct TempDir {
 	std::string dir;
 
@@ -55,6 +93,48 @@ int main(int argc, char** argv) {
 	ok &= expect(scene.schemaVersion == 1, "schema version loaded");
 	ok &= expect(scene.name == "Assignment Gvc-Gdg-Ut", "scene name loaded");
 	ok &= expect(scene.description == "Den Haag Centraal - Gouda - Utrecht Centraal corridor", "description loaded");
+	ok &= expect(!scene.loadedData.empty(), "loaded data summary present");
+	const SceneLoadedData* sceneData = findLoadedData(scene, "scene");
+	ok &= expect(sceneData && sceneData->sourceFile == "scene.json" && sceneData->parsedCount == 1 && sceneData->status == "loaded", "scene loaded data summary");
+	const SceneLoadedData* stationData = findLoadedData(scene, "stations");
+	ok &= expect(stationData && stationData->sourceFile == "stations.json" && stationData->parsedCount == 3 && stationData->status == "loaded", "stations loaded data summary");
+	const SceneLoadedData* stationRawData = findLoadedDataChild(stationData, "raw_file");
+	ok &= expect(stationRawData && stationRawData->sourceFile == "stations.json" && stationRawData->parsedCount == 1 && stationRawData->status == "loaded", "stations raw file drilldown");
+	const SceneLoadedData* stationParsedData = findLoadedDataChild(stationData, "parsed_objects");
+	ok &= expect(stationParsedData && stationParsedData->sourceFile == "stations.json" && stationParsedData->parsedCount == 3 && stationParsedData->status == "loaded", "stations parsed object drilldown");
+	const SceneLoadedData* timetableData = findLoadedData(scene, "timetable");
+	ok &= expect(timetableData && timetableData->sourceFile == "services.json" && timetableData->parsedCount == 8 && timetableData->status == "loaded", "timetable loaded data summary");
+	const SceneLoadedData* timetableRawData = findLoadedDataChild(timetableData, "raw_file");
+	ok &= expect(timetableRawData && timetableRawData->sourceFile == "services.json" && timetableRawData->parsedCount == 1 && timetableRawData->status == "loaded", "timetable raw file drilldown");
+	const SceneLoadedData* timetableParsedData = findLoadedDataChild(timetableData, "parsed_objects");
+	ok &= expect(timetableParsedData && timetableParsedData->sourceFile == "services.json" && timetableParsedData->parsedCount == 8 && timetableParsedData->status == "loaded", "timetable parsed object drilldown");
+	const SceneLoadedData* passengerData = findLoadedData(scene, "passenger_data");
+	ok &= expect(passengerData && passengerData->status == "unimplemented", "passenger data visible as unimplemented");
+	const SceneLoadedData* signallingData = findLoadedData(scene, "signalling");
+	ok &= expect(signallingData && signallingData->sourceFile == "signalling.json" && signallingData->parsedCount == 2 && signallingData->status == "loaded", "signalling loaded data summary");
+	const SceneLoadedData* signalsData = findLoadedDataChild(signallingData, "signals");
+	ok &= expect(signalsData && signalsData->sourceFile == "signalling.json" && signalsData->parsedCount == 0 && signalsData->status == "loaded", "signalling signals drilldown");
+	const SceneLoadedData* routesData = findLoadedDataChild(signallingData, "routes");
+	ok &= expect(routesData && routesData->sourceFile == "signalling.json" && routesData->parsedCount == 2 && routesData->status == "loaded", "signalling routes drilldown");
+	{
+		SceneModel sceneWithDiagnostics = scene;
+		std::vector<SceneDiagnostic> diagnostics;
+		SceneDiagnostic serviceError;
+		serviceError.severity = SceneSeverity::Error;
+		serviceError.file = "services.json";
+		diagnostics.push_back(serviceError);
+		SceneDiagnostic stationWarning;
+		stationWarning.severity = SceneSeverity::Warning;
+		stationWarning.file = "stations.json";
+		diagnostics.push_back(stationWarning);
+		refreshLoadedDataDiagnostics(sceneWithDiagnostics, diagnostics);
+		const SceneLoadedData* stationValidation = findLoadedDataChild(findLoadedData(sceneWithDiagnostics, "stations"), "validation");
+		ok &= expect(stationValidation && stationValidation->parsedCount == 1 && stationValidation->status == "1 warning", "stations validation warning summary");
+		const SceneLoadedData* timetableValidation = findLoadedDataChild(findLoadedData(sceneWithDiagnostics, "timetable"), "validation");
+		ok &= expect(timetableValidation && timetableValidation->parsedCount == 1 && timetableValidation->status == "1 error", "timetable validation error summary");
+		const SceneLoadedData* rollingValidation = findLoadedDataChild(findLoadedData(sceneWithDiagnostics, "rolling_stock"), "validation");
+		ok &= expect(rollingValidation && rollingValidation->parsedCount == 0 && rollingValidation->status == "ok", "clean category validation summary");
+	}
 	ok &= expect(scene.baseTime == "07:00:00", "base_time loaded");
 	ok &= expect(scene.stations.size() == 3, "station count loaded");
 	ok &= expect(scene.routes.size() == 2, "route count loaded");
@@ -62,11 +142,45 @@ int main(int argc, char** argv) {
 	ok &= expect(scene.trainUnits.size() == 1, "train unit count loaded");
 	ok &= expect(scene.compositions.size() == 1, "composition count loaded");
 
+	{
+		SceneModel sourceScene = scene;
+		sourceScene.trainUnits[0].sourceDataFile = "/TrainData/LITRA_SA.txt";
+		sourceScene.trainUnits[0].sourceTractionFile = "/TrainData/T_LITRA_SA.txt";
+		refreshLoadedDataSummary(sourceScene);
+		const SceneLoadedData* rollingStockData = findLoadedData(sourceScene, "rolling_stock");
+		const SceneLoadedData* trainUnitsData = findLoadedDataChild(rollingStockData, "train_units");
+		ok &= expect(trainUnitsData && trainUnitsData->parsedCount == 1 && trainUnitsData->status == "loaded", "rolling stock train unit drilldown");
+		const SceneLoadedData* compositionsData = findLoadedDataChild(rollingStockData, "compositions");
+		ok &= expect(compositionsData && compositionsData->parsedCount == 1 && compositionsData->status == "loaded", "rolling stock composition drilldown");
+		const SceneLoadedData* sourceFilesData = findLoadedDataChild(rollingStockData, "source_files");
+		ok &= expect(sourceFilesData && sourceFilesData->parsedCount == 2 && sourceFilesData->status == "loaded", "rolling stock source file drilldown");
+		ok &= expect(findLoadedDataChildSource(sourceFilesData, "/TrainData/LITRA_SA.txt") != nullptr, "rolling stock LITRA source file visible");
+		ok &= expect(findLoadedDataChildSource(sourceFilesData, "/TrainData/T_LITRA_SA.txt") != nullptr, "rolling stock T_LITRA source file visible");
+	}
+
 	TempDir outDir;
 	auto saveRes = saveScene(scene, outDir.dir);
 	printErrors(saveRes.diagnostics, "save");
 	ok &= expect(saveRes.success(), "first save succeeds");
 	ok &= expect(!fs::exists(fs::path(outDir.dir) / "legacy"), "saveScene does not create legacy folder");
+	{
+		std::ifstream sceneFile(fs::path(outDir.dir) / "scene.json");
+		nlohmann::json sceneJson;
+		sceneFile >> sceneJson;
+		ok &= expect(sceneJson["loaded_data"].is_array(), "loaded data metadata written");
+		if (sceneJson["loaded_data"].is_array()) {
+			bool foundStationsChildren = false;
+			for (const auto& item : sceneJson["loaded_data"]) {
+				if (item.value("category", "") == "stations") {
+					foundStationsChildren = jsonChildrenContain(item, "raw_file")
+							&& jsonChildrenContain(item, "parsed_objects")
+							&& jsonChildrenContain(item, "derived_simulation");
+					break;
+				}
+			}
+			ok &= expect(foundStationsChildren, "loaded data children written");
+		}
+	}
 
 	auto reloadRes = loadScene(outDir.dir);
 	printErrors(reloadRes.diagnostics, "reload");
@@ -82,6 +196,13 @@ int main(int argc, char** argv) {
 	ok &= expect(reloaded.services.size() == scene.services.size(), "service count round-trips");
 	ok &= expect(reloaded.trainUnits.size() == scene.trainUnits.size(), "train unit count round-trips");
 	ok &= expect(reloaded.compositions.size() == scene.compositions.size(), "composition count round-trips");
+	ok &= expect(reloaded.loadedData.size() == scene.loadedData.size(), "loaded data summary count round-trips");
+	const SceneLoadedData* reloadedSceneData = findLoadedData(reloaded, "scene");
+	ok &= expect(reloadedSceneData && reloadedSceneData->sourceFile == "scene.json" && reloadedSceneData->parsedCount == 1 && reloadedSceneData->status == "loaded", "loaded data scene round-trips");
+	const SceneLoadedData* reloadedStationData = findLoadedData(reloaded, "stations");
+	ok &= expect(reloadedStationData && reloadedStationData->sourceFile == "stations.json" && reloadedStationData->parsedCount == 3 && reloadedStationData->status == "loaded", "loaded data stations round-trips");
+	const SceneLoadedData* reloadedStationRawData = findLoadedDataChild(reloadedStationData, "raw_file");
+	ok &= expect(reloadedStationRawData && reloadedStationRawData->sourceFile == "stations.json" && reloadedStationRawData->parsedCount == 1 && reloadedStationRawData->status == "loaded", "loaded data station raw file round-trips");
 
 	if (!reloaded.stations.empty()) {
 		ok &= expect(reloaded.stations[0].id == "Gvc", "first station id round-trips");
@@ -148,6 +269,31 @@ int main(int argc, char** argv) {
 			ok &= expect(!obj.contains("physical"), "physical block absent");
 			ok &= expect(!obj.contains("traction_curve"), "traction_curve absent");
 		}
+
+		auto bareReloadRes = loadScene(bareOut.dir);
+		ok &= expect(!hasErrors(bareReloadRes.diagnostics), "bare scene reloads");
+		const SceneLoadedData* bareStationData = findLoadedData(bareReloadRes.scene, "stations");
+		ok &= expect(bareStationData && bareStationData->sourceFile == "stations.json" && bareStationData->parsedCount == 0 && bareStationData->status == "loaded", "empty stations file reported loaded");
+		const SceneLoadedData* bareTimetableData = findLoadedData(bareReloadRes.scene, "timetable");
+		ok &= expect(bareTimetableData && bareTimetableData->sourceFile == "services.json" && bareTimetableData->parsedCount == 0 && bareTimetableData->status == "loaded", "empty services file reported loaded");
+	}
+
+	{
+		SceneModel incidentScene = scene;
+		incidentScene.sourceFiles.erase("incidents.json");
+		SceneIncident incident;
+		incident.id = "signal_down";
+		incident.type = "signal_failure";
+		incident.target = "sigA";
+		incidentScene.incidents.push_back(incident);
+		refreshSavedSceneMetadata(incidentScene);
+		const SceneLoadedData* incidentData = findLoadedData(incidentScene, "incidents");
+		ok &= expect(incidentData && incidentData->sourceFile == "incidents.json" && incidentData->parsedCount == 1 && incidentData->status == "loaded", "saved incident metadata reports loaded");
+
+		incidentScene.incidents.clear();
+		refreshSavedSceneMetadata(incidentScene);
+		incidentData = findLoadedData(incidentScene, "incidents");
+		ok &= expect(incidentData && incidentData->sourceFile == "incidents.json" && incidentData->parsedCount == 0 && incidentData->status == "missing", "saved empty incident metadata reports missing");
 	}
 
 	if (!ok)

--- a/README.md
+++ b/README.md
@@ -58,8 +58,12 @@ Run from `EGTRAIN/QEGTRAIN` so the legacy relative input paths resolve.
 
 ```bash
 cd EGTRAIN/QEGTRAIN
-../../build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN -n 3
+../../build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN
 ```
+
+No-argument launch opens the GUI with case study 1. Use flags for a specific
+case or automated run, for example `-n 3 -h 8000 -g 1 -pax 0 -TSM 0 -RC 0`.
+Add `--interactive` only when you want the legacy terminal questionnaire.
 
 Case selector:
 

--- a/docs/architecture/scene-editor-flow.md
+++ b/docs/architecture/scene-editor-flow.md
@@ -73,7 +73,7 @@ Tables are read-only first. Editing happens through explicit row, cell, add, dup
 | Services and timetable | Services, composition choice, route choice, stopping patterns, station stops, platform choices, arrival times, departure times, dwell times, entry time, repeated-service headway, per-service performance values | Station definitions, route block definitions, signal definitions |
 | Incidents | Signal failure incidents and train breakdown incidents: id, type, target, start time, end time | Target lists derived from signals and services |
 
-Two edit fields depend on scene-layer work that is tracked separately from the editor issues: per-service performance values need a new field in `services.json` and `SceneModel`, and incidents take simulation effect only once `SceneExporter` exports `incidents.json` to the legacy input. Until then the incidents pane edits and saves scene data without changing run behavior.
+Per-service performance values still need new fields in `services.json` and `SceneModel`. Incident edits are already part of the run handoff: when incidents are present, `SceneExporter` writes `incidents.json` to legacy `Incidents.txt`, which the simulator loads for signal failures and train breakdowns.
 
 ## Explicit out-of-scope list
 

--- a/docs/architecture/scene-schema.md
+++ b/docs/architecture/scene-schema.md
@@ -21,7 +21,7 @@ The schema is versioned using an integer `schema_version` inside `scene.json`. T
 
 ## Loaded Data Metadata
 
-`scene.json.loaded_data` is derived provenance metadata written by the app. The loader recomputes it from the canonical files, so it is not the source of truth. Each row has `category`, `source_file`, `parsed_count`, `status`, and optional recursive `children`.
+`loaded_data` is derived provenance metadata maintained by the app at runtime as UI state. The loader recomputes it from the canonical files, so it is not the source of truth and it is not written to `scene.json`. Each row has `category`, `source_file`, `parsed_count`, `status`, and optional recursive `children`.
 
 Current categories are `scene`, `infrastructure`, `stations`, `timetable`, `rolling_stock`, `signalling`, `incidents`, and `passenger_data`. File-backed categories include drill-down rows for `raw_file`, `parsed_objects`, and `derived_simulation`; the GUI adds validation status rows from current diagnostics. `rolling_stock` also exposes `train_units`, `compositions`, and `source_files`; `source_files` lists linked `data_file` / `traction_file` entries such as `LITRA` and `T_LITRA` files when present. `signalling` exposes `signals` and `routes`.
 

--- a/docs/architecture/scene-schema.md
+++ b/docs/architecture/scene-schema.md
@@ -19,6 +19,12 @@ The schema is versioned using an integer `schema_version` inside `scene.json`. T
 | incidents.json | no | `incidents: [{id, type: "signal_failure"\|"train_breakdown", target, start_seconds, end_seconds}]` |
 | views.json | no | free-form display defaults; parse-checked only |
 
+## Loaded Data Metadata
+
+`scene.json.loaded_data` is derived provenance metadata written by the app. The loader recomputes it from the canonical files, so it is not the source of truth. Each row has `category`, `source_file`, `parsed_count`, `status`, and optional recursive `children`.
+
+Current categories are `scene`, `infrastructure`, `stations`, `timetable`, `rolling_stock`, `signalling`, `incidents`, and `passenger_data`. File-backed categories include drill-down rows for `raw_file`, `parsed_objects`, and `derived_simulation`; the GUI adds validation status rows from current diagnostics. `rolling_stock` also exposes `train_units`, `compositions`, and `source_files`; `source_files` lists linked `data_file` / `traction_file` entries such as `LITRA` and `T_LITRA` files when present. `signalling` exposes `signals` and `routes`.
+
 ## Examples
 
 **scene.json**
@@ -199,11 +205,12 @@ The mapping back is:
 - `services.json` -> `Trains/`, `TimeTable/`, and `trainNames.txt`
 - `rolling_stock.json` -> `TrainData/`
 - `signalling.json` (routes) -> `Routes/`
+- `incidents.json` -> `Incidents.txt` when incidents are present
 - `<sceneDir>/legacy/` is recursively walked and copied to the export directory. During this passthrough, top-level directories named `tracklines` or `timetable` (case-insensitive) are renamed to `TrackLines` and `TimeTable` to match the simulator's hard-coded case-sensitive paths.
 
 What is not exported and why:
 - `stations.json` and `infrastructure.json`: The simulator reads infrastructure from the Tracklines passthrough, so they are not written directly.
-- `incidents.json` and `views.json`: Not exported in V1.
+- `views.json`: UI-only preferences, not simulation input.
 
 **Known lossiness during round-trip**:
 - `legacy_source` records provenance when a scene is imported and does not round-trip.

--- a/docs/github-issues/099-epic-single-file-scene-bundle.md
+++ b/docs/github-issues/099-epic-single-file-scene-bundle.md
@@ -1,0 +1,63 @@
+# #99 Epic: Portable Single-File Scene Bundle (.egscene) As V2 Scene Input
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/99
+- State: open
+- Labels: `type: epic`, `area: scene model`, `area: bundle`, `enhancement`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+## Goal
+
+Introduce a **v2 scene input format**: a single, portable file a student can download and open, instead of a folder of loose JSON files they have to keep together on disk.
+
+Today a scene is a **directory** (`EGTRAIN/QEGTRAIN/Scenes/<Name>/`) containing `scene.json` plus `stations.json`, `signalling.json`, `services.json`, `rolling_stock.json`, `infrastructure.json`, and optionally `incidents.json` / `views.json`. To hand a scenario to a student we have to hand them a whole folder; if one file goes missing or the folder is unzipped into the wrong place, the scene fails to load. `MainWindow::openSceneDialog()` even asks for a directory (`QFileDialog::getExistingDirectory`, `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:722`), which is an unusual and error-prone thing to ask a student to do.
+
+The scene-model design already anticipates this. `docs/architecture/scene-model.md` says: *"The schema can be split later if a single-file scene is easier for exchange."* This epic does exactly that.
+
+## Why
+
+- **One artifact.** A student downloads one `.egscene` file, double-clicks or picks it in the app, and the scenario loads. No folder to keep intact, no "select the right subdirectory" step.
+- **Integrity.** A single archive can't lose one of its seven JSON files in transit. The reader validates the whole bundle up front.
+- **Distribution.** Case studies and assignments become downloadable attachments on GitHub releases and in the course materials, rather than a directory tree to clone.
+- **No format churn for authors.** The bundle is just the existing scene directory zipped, so the editor, validator, importer, and exporter keep working on the same JSON. We are adding a container, not a new data model.
+
+## Design
+
+- **Container: ZIP.** Extension **`.egscene`**, MIME `application/vnd.egscene+zip`. Same well-understood pattern as `.docx` / `.epub` / Scratch `.sb3`: a zip with a known internal layout.
+- **Internal layout:** the current scene directory at the archive root — `scene.json` (manifest) plus the other JSON files. The derived `legacy/` passthrough is **not** included; bundles carry only canonical data.
+- **Manifest:** `scene.json` gains a `format: "egscene"` marker and a `bundle_version` alongside the existing `schema_version` (currently `1`) so a reader can sniff and version-check the container independently of the data schema.
+- **Code shape:** a new `scene/SceneBundle.{h,cpp}` exposing `loadSceneBundle(path)` and `saveSceneBundle(scene, path)`. The first cut can extract to a temp directory and reuse the existing `loadScene(sceneDir)` / `saveScene(scene, sceneDir)` unchanged, so the container is isolated from the model code.
+- **Zip dependency:** vendor a small MIT single-file zip lib (e.g. miniz) under `io/third_party/`, mirroring the existing pugixml pattern. Alternative considered: Qt's private `QZipReader`/`QZipWriter` (no new dep but private API, not guaranteed stable across Qt versions).
+
+## Decisions
+
+- **Extension: `.egscene`** (decided).
+- **Container: ZIP** (decided). Keeps the existing multi-file layout and compresses the large `signalling.json` (96–170 KB) well; a single merged-JSON container was considered and rejected because it loses per-section editing on disk.
+
+## Open questions
+
+- **Zip library** — vendored miniz (single-file, MIT; proposed) vs Qt private `QZipReader`/`QZipWriter` (no new dependency but private API, not API-stable across Qt versions).
+
+## Children
+
+- #100 Define the `.egscene` bundle format and manifest (v2 scene container spec)
+- #101 Read a scene from an `.egscene` bundle (bundle loader)
+- #102 Write a scene to an `.egscene` bundle (bundle writer and `scene_tool` pack/unpack)
+- #103 Open and save single-file scene bundles from the GUI
+- #104 Accept an `.egscene` bundle path from the CLI and headless tools
+- #105 Harden bundle loading against malformed and hostile archives
+- #106 Package the case studies as downloadable `.egscene` bundles on releases
+- #107 Document how students download and open a scene bundle
+
+## Boundary / relationships
+
+- This epic is about **packaging** scene input for exchange. It sits on top of the canonical scene model and is independent of whether the engine runs a scene natively (#83) or via the legacy export path — a bundle loads to a `SceneModel` either way. Where the two meet (running a bundle straight from CLI/GUI) is called out and tracked against #88.
+- Directory scenes keep working. The bundle is an additional open/save path, not a replacement, so existing `Scenes/<Name>/` folders and tests are untouched.
+
+## Acceptance criteria
+
+- A scene directory can be saved to a single `.egscene` file and re-opened into an identical `SceneModel` (round-trip).
+- The GUI can open and save `.egscene` bundles via a normal file picker, and the CLI accepts a bundle path anywhere a scene directory is accepted.
+- The four case studies ship as downloadable `.egscene` bundles.
+- Student-facing documentation explains "download a scene file, open it in EGTRAIN" with no mention of folders.
+- Malformed or hostile archives are rejected with a clear diagnostic, not a crash.

--- a/docs/github-issues/100-define-egscene-bundle-format.md
+++ b/docs/github-issues/100-define-egscene-bundle-format.md
@@ -1,0 +1,60 @@
+# #100 Define The .egscene Bundle Format And Manifest (V2 Scene Container Spec)
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/100
+- State: open
+- Labels: `type: feature`, `area: scene model`, `area: bundle`, `documentation`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+Part of the single-file scene bundle epic (#99).
+
+## Summary
+
+Define and document the **`.egscene` bundle format**: the container, the internal layout, and the manifest fields that let a reader recognise and version-check a single-file scene. This is the spec every other child in the epic builds against, so it lands first.
+
+## Format
+
+- **Container:** ZIP (deflate). No encryption, no password.
+- **Extension:** `.egscene`. **MIME:** `application/vnd.egscene+zip`.
+- **Internal layout:** the current scene directory, at the archive root:
+
+  ```
+  scene.json            manifest: name, schema_version, format, bundle_version
+  stations.json
+  signalling.json
+  services.json
+  rolling_stock.json
+  infrastructure.json
+  incidents.json        optional
+  views.json            optional
+  ```
+
+- The derived `legacy/` passthrough directory is **excluded** from bundles. A bundle carries only canonical scene data; the legacy export is regenerated on demand.
+- Unknown extra files at the root are ignored by the reader (forward compatibility) but a writer only emits the files above.
+
+## Manifest additions (`scene.json`)
+
+Today `scene.json` holds `{ name, schema_version, legacy_source }` with `schema_version: 1`. Add:
+
+- `format: "egscene"` — a fixed marker so a reader can sniff a valid bundle before trusting it.
+- `bundle_version: 1` — versions the **container** independently of `schema_version`, which continues to version the **data**.
+
+A reader accepts a bundle when `scene.json` exists at the root, `format == "egscene"`, and `bundle_version`/`schema_version` are within the supported range.
+
+## Scope
+
+- Write `docs/architecture/scene-bundle.md` specifying the container, layout, manifest, MIME, magic (ZIP `PK\x03\x04`), and the exclusion of `legacy/`.
+- Add a `## Bundle format (v2)` section to `docs/architecture/scene-model.md`, replacing the "The schema can be split later..." sentence with a link to the new spec.
+- Extend the scene-schema doc / JSON schema for `scene.json` with the `format` and `bundle_version` fields, marked optional for directory scenes and required inside a bundle.
+- Bump the writer to emit the new manifest fields (behaviour change is documented, no reader breakage — the fields are additive).
+
+## Acceptance criteria
+
+- `docs/architecture/scene-bundle.md` exists and fully specifies the container, layout, and manifest.
+- The manifest fields (`format`, `bundle_version`) are documented in the schema doc.
+- The spec explicitly states which files are included and that `legacy/` is excluded.
+- No code that reads directory scenes is broken by the additive manifest fields.
+
+## Notes
+
+Depends on nothing. Reader (bundle loader) and writer children implement against this spec. The extension (`.egscene`) and container (ZIP) are settled in the epic's Decisions; the merged-JSON alternative was considered and rejected there.

--- a/docs/github-issues/101-read-scene-from-egscene-bundle.md
+++ b/docs/github-issues/101-read-scene-from-egscene-bundle.md
@@ -1,0 +1,49 @@
+# #101 Read A Scene From An .egscene Bundle (Bundle Loader)
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/101
+- State: open
+- Labels: `type: feature`, `area: scene model`, `area: bundle`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+Part of the single-file scene bundle epic (#99).
+
+## Summary
+
+Read a scene from a single `.egscene` file into a `SceneModel`, so the rest of the app can consume a bundle exactly as it consumes a scene directory today.
+
+## Design
+
+- Add `scene/SceneBundle.{h,cpp}` with:
+
+  ```cpp
+  SceneLoadResult loadSceneBundle(const std::string& bundlePath);
+  ```
+
+  returning the same `SceneLoadResult` (`scene/SceneModel.h`) as the existing `loadScene(sceneDir)`, so every current caller can accept a bundle by branching on the path.
+
+- **First cut — extract then reuse.** Open the ZIP, extract the recognised JSON entries to a temp directory (`QTemporaryDir`), then call the existing `loadScene(tempDir)` unchanged and delete the temp dir. This keeps the container fully isolated from the model loader.
+- **Follow-up (optional, note only):** feed JSON blobs to the loader in-memory to avoid touching disk. Out of scope here.
+
+## Zip dependency
+
+- Vendor **miniz** (single-file, MIT) under `EGTRAIN/QEGTRAIN/io/third_party/miniz/`, mirroring the existing `io/third_party/pugixml` pattern, and wire it into CMake.
+- Alternative considered: Qt private `QZipReader`. Rejected for the first cut because it depends on private Qt Gui headers that are not API-stable across Qt versions.
+
+## Scope
+
+- Implement `loadSceneBundle` (open zip → validate manifest per the spec → extract → `loadScene` → cleanup).
+- Reject a file whose `scene.json` is missing or whose `format` / `bundle_version` is unrecognised, with a `SceneDiagnostic` that names the file and the reason (reuse the existing diagnostic pattern from `SceneValidator`).
+- Ignore a `legacy/` entry if present.
+- Unit tests in `EGTRAIN/QEGTRAIN/tests/test_scenebundle.cpp`: load a good bundle; verify the resulting `SceneModel` equals the one from the equivalent directory; reject missing-manifest, wrong-`format`, and truncated-zip inputs.
+- Add a fixture bundle under `EGTRAIN/QEGTRAIN/tests/fixtures/scenes/` (zip the existing `minimal/` scene).
+
+## Acceptance criteria
+
+- `loadSceneBundle("<scene>.egscene")` returns a `SceneModel` identical to `loadScene("<scene>/")` for the same scene.
+- A malformed or non-bundle file returns diagnostics, never crashes.
+- New ctest target passes on macOS with Qt 5; no regression in the existing scene tests.
+
+## Notes
+
+Depends on the format spec child. Hostile-archive hardening (zip bombs, path traversal, size caps) is deliberately split into its own child so this issue stays focused on the happy path plus basic validity.

--- a/docs/github-issues/102-write-scene-to-egscene-bundle.md
+++ b/docs/github-issues/102-write-scene-to-egscene-bundle.md
@@ -1,0 +1,46 @@
+# #102 Write A Scene To An .egscene Bundle (Bundle Writer And scene_tool Pack/Unpack)
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/102
+- State: open
+- Labels: `type: feature`, `area: scene model`, `area: bundle`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+Part of the single-file scene bundle epic (#99).
+
+## Summary
+
+Write a `SceneModel` (or an existing scene directory) to a single `.egscene` file, so authors can produce the one-file artifact students download.
+
+## Design
+
+- Extend `scene/SceneBundle.{h,cpp}` with:
+
+  ```cpp
+  SceneSaveResult saveSceneBundle(const SceneModel& scene, const std::string& bundlePath);
+  ```
+
+  returning the same `SceneSaveResult` as `saveScene` (`scene/SceneWriter.h`).
+
+- **First cut — write then zip.** Call the existing `saveScene(scene, tempDir)`, then add each emitted JSON file to a ZIP at `bundlePath` with miniz, then delete the temp dir. Reuses all serialization logic in `SceneWriter`.
+- Emit the manifest fields defined in the spec (`format: "egscene"`, `bundle_version`) into `scene.json`.
+- **Exclude** the `legacy/` passthrough — bundles carry canonical data only.
+- Deterministic output: sort entries by name and use fixed timestamps so re-saving an unchanged scene yields a byte-stable archive (helps diffs and release reproducibility).
+
+## Scope
+
+- Implement `saveSceneBundle`.
+- Add a `scene_tool` sub-command (see `scene/SceneTool.cpp`) to pack a directory into a bundle and unpack a bundle back to a directory, e.g. `scene_tool bundle <sceneDir> <out.egscene>` / `scene_tool unbundle <in.egscene> <sceneDir>` — useful for scripting and CI.
+- Round-trip test in `test_scenebundle.cpp`: `saveSceneBundle` then `loadSceneBundle` yields an equal `SceneModel`; and directory → bundle → directory is content-equal for the canonical files.
+- Confirm no `legacy/` entry appears in a produced bundle.
+
+## Acceptance criteria
+
+- `saveSceneBundle` produces a valid `.egscene` that `loadSceneBundle` reads back to an equal `SceneModel`.
+- Re-saving an unchanged scene produces a byte-identical archive.
+- `legacy/` is never written into a bundle.
+- New tests pass; existing `test_scenewriter` unaffected.
+
+## Notes
+
+Depends on the format spec and shares `SceneBundle.{h,cpp}` with the reader child; can land in the same PR series. Pairs with the GUI child, which calls `saveSceneBundle` from "Save Scene As".

--- a/docs/github-issues/103-open-save-bundles-from-gui.md
+++ b/docs/github-issues/103-open-save-bundles-from-gui.md
@@ -1,0 +1,40 @@
+# #103 Open And Save Single-File Scene Bundles From The GUI
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/103
+- State: open
+- Labels: `type: feature`, `area: ui`, `area: bundle`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+Part of the single-file scene bundle epic (#99).
+
+## Summary
+
+Let a student open and save a scene as a single `.egscene` file from the GUI, using an ordinary file picker instead of the current "pick a directory" flow.
+
+## Current state
+
+- `MainWindow::openSceneDialog()` calls `QFileDialog::getExistingDirectory(this, "Open Scene", ...)` (`EGTRAIN/QEGTRAIN/app/MainWindow.cpp:722`) and then `openSceneDirectory(dir)` → `loadScene(...)`.
+- "Save Scene As" also uses `getExistingDirectory` (`app/MainWindow.cpp:799`).
+- Asking a student to select a folder is unusual and easy to get wrong (they select the parent, or a subfolder).
+
+## Scope
+
+- **Open:** replace the open flow with `QFileDialog::getOpenFileName` filtered to `EGTRAIN scene (*.egscene)`, routing through the new `loadSceneBundle(path)`. Keep opening a directory available as a secondary path (a "Open Scene Folder…" action, or auto-detect: if the chosen path is a directory use `loadScene`, else `loadSceneBundle`) so existing `Scenes/<Name>/` folders still work.
+- **Save:** change "Save Scene As" to `getSaveFileName` with the `.egscene` filter and call `saveSceneBundle`, appending `.egscene` if the user omits it. Keep a "Save as Folder…" option for authors who want the exploded layout.
+- **Drag and drop:** accept a dropped `.egscene` onto the main window (`dragEnterEvent` / `dropEvent`) and open it.
+- **Recent files:** add opened bundles to a "Recent Scenes" menu (`QSettings`), so returning students reopen with one click.
+- Update the window title / status to show the loaded bundle name; keep `m_sceneLoaded` / `m_runSceneAction` gating (`app/MainWindow.cpp:910`) working.
+
+## Acceptance criteria
+
+- File → Open shows a file picker for `*.egscene` and loads the selected bundle.
+- File → Save Scene As writes a single `.egscene` file.
+- Dropping a `.egscene` file onto the window opens it.
+- Recent Scenes lists and reopens previously opened bundles.
+- Opening an existing scene **directory** still works (back-compat path preserved).
+- Visual smoke coverage: open a bundle, confirm the network view renders (ties into the existing scene-render smokes referenced by #77).
+
+## Notes
+
+Depends on the reader and writer children. OS-level file association (double-click a `.egscene` in Finder/Explorer to launch EGTRAIN) is handled separately in the packaging child so this issue stays inside the app.

--- a/docs/github-issues/104-accept-egscene-bundle-cli.md
+++ b/docs/github-issues/104-accept-egscene-bundle-cli.md
@@ -1,0 +1,30 @@
+# #104 Accept An .egscene Bundle Path From The CLI And Headless Tools
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/104
+- State: open
+- Labels: `type: feature`, `area: bundle`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+Part of the single-file scene bundle epic (#99).
+
+## Summary
+
+Accept an `.egscene` bundle path anywhere the CLI and headless tools accept a scene directory, so scripts, CI, and the native-run path can consume the single-file format.
+
+## Scope
+
+- Wherever a tool takes a scene directory and calls `loadScene(dir)` — the CLI/headless entry point, `scene/SceneValidator.cpp`, `scene/SceneExporter.cpp`, `scene/SceneTool.cpp` — accept a path that may be a directory **or** a `.egscene` file, dispatching to `loadScene` or `loadSceneBundle` based on the path (a file with the `.egscene` extension / ZIP magic → bundle; a directory → directory).
+- Centralise the dispatch in one helper (e.g. `loadSceneAny(path)` in `scene/SceneBundle.h`) so every caller shares one rule.
+- `scene_tool validate <path>` and `scene_tool export <path>` work on both a directory and a bundle.
+- Extend the native scene-run entry point (the CLI scene argument in #88) to accept a bundle path, so a student scenario can be run headless as `... --scene copenhagen.egscene`.
+
+## Acceptance criteria
+
+- Every command that previously took a scene directory also takes an `.egscene` bundle and behaves identically.
+- Validation and export produce the same results from a bundle as from the equivalent directory.
+- Headless smoke covers running a scene from a bundle path.
+
+## Notes
+
+Depends on the reader child. Overlaps with #88 (run a scene natively from CLI/GUI) — coordinate so the scene-path argument added there accepts both forms rather than adding two arguments.

--- a/docs/github-issues/105-harden-bundle-loading.md
+++ b/docs/github-issues/105-harden-bundle-loading.md
@@ -1,0 +1,38 @@
+# #105 Harden Bundle Loading Against Malformed And Hostile Archives
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/105
+- State: open
+- Labels: `type: feature`, `area: bundle`, `testing`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+Part of the single-file scene bundle epic (#99).
+
+## Summary
+
+Harden `.egscene` loading against malformed and hostile archives. A bundle is an untrusted file a student downloads from the internet, so the reader must fail safely on anything abnormal rather than crash, hang, or write outside its temp directory.
+
+## Threats to defend against
+
+- **Zip-slip / path traversal:** an entry named `../../etc/...` or an absolute path escaping the extraction directory. Reject any entry whose normalised path leaves the temp root.
+- **Zip bomb:** a tiny archive that expands to gigabytes. Cap total uncompressed size (e.g. 256 MB), per-entry size, entry count, and compression ratio; abort when a cap is exceeded.
+- **Unexpected members:** only extract the recognised canonical filenames (`scene.json` and the known JSON files); ignore everything else, and never execute or follow symlinks.
+- **Malformed data:** truncated ZIP, corrupt central directory, non-UTF-8 or non-JSON contents → a clear diagnostic naming the offending entry.
+- **Resource cleanup:** always delete the temp extraction directory, including on the error path.
+
+## Scope
+
+- Add the caps and traversal checks to `loadSceneBundle` (and the shared extraction routine).
+- Emit `SceneDiagnostic`s that name the entry and the limit/rule violated (reuse the `SceneValidator` diagnostic style).
+- Malicious-fixture tests in `test_scenebundle.cpp`: zip-slip entry, oversize/ratio bomb (synthetic, not a real 4 GB file), truncated archive, absolute-path entry, symlink entry, non-JSON member. Each must return diagnostics and leave no files outside the temp dir.
+
+## Acceptance criteria
+
+- No archive can cause a write outside the extraction temp directory.
+- Configured size/count/ratio caps abort loading with a diagnostic.
+- Every malicious fixture is rejected cleanly; ASan build stays clean.
+- Temp directories are removed on both success and failure.
+
+## Notes
+
+Depends on the reader child. Kept separate so the reader can land on the happy path first and the security work is reviewable on its own — appropriate weight for a file format students obtain from the internet.

--- a/docs/github-issues/106-package-case-studies-bundles.md
+++ b/docs/github-issues/106-package-case-studies-bundles.md
@@ -1,0 +1,30 @@
+# #106 Package The Case Studies As Downloadable .egscene Bundles On Releases
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/106
+- State: open
+- Labels: `type: feature`, `area: bundle`, `area: ci`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+Part of the single-file scene bundle epic (#99).
+
+## Summary
+
+Package the four case studies (and the assignment scenario) as downloadable `.egscene` bundles and attach them to GitHub releases, so a student's whole starting point is one link → one file → open.
+
+## Scope
+
+- Add a build/CI step that packs each committed scene under `EGTRAIN/QEGTRAIN/Scenes/` — `Copenhagen`, `Netherlands` (NL), `Milano_Brescia`, `Paimpol`, and `Assignment_Gvc_Gdg_Ut` — into `<Name>.egscene` using `scene_tool bundle` (from the writer child).
+- Attach the generated `.egscene` files to tagged GitHub releases, alongside the platform binaries (extends #73, "attach release artifacts to tagged releases").
+- Verify each shipped bundle in CI: pack it, then `scene_tool validate <Name>.egscene` and load it headless, so a broken bundle can't be released.
+- Keep the source scene **directories** in the repo as the editable source of truth; bundles are generated artifacts, not committed blobs.
+
+## Acceptance criteria
+
+- Each tagged release carries an `.egscene` for every case study and the assignment scenario.
+- CI validates every bundle it produces before upload; a validation failure fails the release job.
+- Source scene directories remain the version-controlled source; bundles are build outputs.
+
+## Notes
+
+Depends on the writer child (produces the bundles) and the CLI child (validates them headless). Coordinates with the release-artifact issues (#69–#73). The student-facing "how to download and open" guide is a separate docs child.

--- a/docs/github-issues/107-document-opening-scene-bundle.md
+++ b/docs/github-issues/107-document-opening-scene-bundle.md
@@ -1,0 +1,35 @@
+# #107 Document How Students Download And Open A Scene Bundle
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/107
+- State: open
+- Labels: `type: docs`, `documentation`, `area: bundle`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+Part of the single-file scene bundle epic (#99).
+
+## Summary
+
+Write the student-facing guide for the single-file scene workflow: download a `.egscene` file, open it in EGTRAIN, run it. No mention of folders, subdirectories, or loose JSON files.
+
+## Scope
+
+- Add `docs/product/opening-a-scene.md` (or a section in the existing user/getting-started docs) covering:
+  - where to download case-study / assignment bundles (release page link from the distribution child),
+  - File → Open (or drag-and-drop) a `.egscene` file,
+  - what to do if a bundle fails to load (the reader's diagnostics, re-download),
+  - optional: double-click to open once file association lands.
+- Include one annotated screenshot of the open flow and the loaded network view.
+- Add a short "Authoring a bundle" note for instructors: edit the scene, Save As `.egscene`, or `scene_tool bundle <dir> <out.egscene>`.
+- Cross-link the format spec (`docs/architecture/scene-bundle.md`) for readers who want the internals.
+- Update the top-level README's quick-start to point at the bundle flow.
+
+## Acceptance criteria
+
+- A new student can follow the guide end to end: download a bundle, open it, run the simulation.
+- The guide references only single-file steps for the student path; folder handling is confined to the instructor/authoring note.
+- Screenshots match the shipped GUI.
+
+## Notes
+
+Depends on the GUI child (for the real open flow and screenshots) and the distribution child (for the download location). Keep the prose plain and task-oriented.

--- a/docs/github-issues/108-consolidate-image-assets-resources.md
+++ b/docs/github-issues/108-consolidate-image-assets-resources.md
@@ -1,0 +1,50 @@
+# #108 Consolidate Scattered Image Assets Into A Resources Folder And Load Them From Qt Resources
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/108
+- State: open
+- Labels: `type: tech debt`, `area: ui`, `portability`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+## Summary
+
+Consolidate the scattered GUI image files into a single `resources/` folder and load them through Qt's resource system (`:/` paths) instead of by working-directory-relative filename. Today the assets sit loose next to the source and only load if the app happens to run from the right directory.
+
+## Current state
+
+- Three image assets live at the top of the source tree:
+  - `EGTRAIN/QEGTRAIN/train_station.png`
+  - `EGTRAIN/QEGTRAIN/pax_icon.png`
+  - `EGTRAIN/QEGTRAIN/window_icon.jpg`
+- They are loaded by **relative path from the current working directory**:
+  - `station_pixmap = QPixmap("train_station.png");` — `app/MainWindow.cpp:217`
+  - `pax_pixmap = QPixmap("pax_icon.png");` — `app/MainWindow.cpp:220`
+  - `QIcon window_icon = QIcon(QPixmap("window_icon.jpg"));` — `app/MainWindow.cpp:306`
+- To make that work, `CMakeLists.txt:246-257` has a bespoke step that **copies** each PNG/JPG next to the binary (and into the `.app` bundle). If the app is launched from any other directory, the icons silently fail to load (blank station/passenger glyphs) — a latent portability bug.
+- A resource bundle already exists but is **empty**: `app/resources.qrc` declares `<qresource prefix="MainWindow">` with no files, and it is already compiled in (`CMakeLists.txt:189`). The machinery is there; it just isn't used.
+
+## Scope
+
+- Create `EGTRAIN/QEGTRAIN/resources/` with a clear layout, e.g.:
+
+  ```
+  resources/
+    icons/      station.png, passenger.png, ... (in-scene entity glyphs)
+    app/        window/app icon source(s)
+  ```
+
+- Move the three existing assets there and register them in `resources.qrc` under a sensible prefix.
+- Replace the CWD-relative loads in `app/MainWindow.cpp` with resource paths, e.g. `QPixmap(":/icons/station.png")`.
+- Delete the bespoke image-copy commands in `CMakeLists.txt:246-257`; `qrc` embeds the assets in the binary, so nothing needs copying and the CWD dependency disappears. (Keep the Input-data copy step; that is separate.)
+- Grep the tree for any other loose asset load and route it through the resource system too.
+
+## Acceptance criteria
+
+- No GUI image is loaded by a bare relative filename; all go through `:/` resource paths.
+- Launching the built app from an arbitrary working directory shows the station and passenger icons and the window icon correctly.
+- `resources.qrc` lists every bundled asset; the ad-hoc copy step for images is gone from CMake.
+- Build and all ctest targets still pass on macOS with Qt 5.
+
+## Notes
+
+`type: tech debt` because it changes no user-facing behaviour when the app is launched normally, but it removes a fragile pattern and fixes the wrong-CWD failure. This is the natural home for the new artwork in the icon-revamp issues, so it should land first.

--- a/docs/github-issues/109-revamp-in-scene-entity-icons.md
+++ b/docs/github-issues/109-revamp-in-scene-entity-icons.md
@@ -1,0 +1,38 @@
+# #109 Revamp The In-Scene Entity Icons (Stations, Passengers, Trains, Signals)
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/109
+- State: open
+- Labels: `type: feature`, `area: ui`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+## Summary
+
+Design and ship a cohesive icon set for the in-scene entities — stations, passengers, trains, and signals — so the network view reads as one deliberate visual system instead of a couple of stock PNGs plus ad-hoc painted shapes.
+
+## Current state
+
+- **Stations** use `train_station.png` (a single raster, 6.3 KB), drawn via a `QPixmap` (`app/MainWindow.cpp:217`, rendered through `graphics/items/IconItem`).
+- **Passengers** use `pax_icon.png` (15.2 KB), drawn through `graphics/items/PassengerItem` (`app/MainWindow.h:299` `pax_pixmap` / `pax_pixmap_scaled`).
+- **Trains** are custom-painted polygons/bodies (`graphics/items/TrainItemGroup`, `TrainBodyItem`), not icons.
+- **Signals** are custom-painted (`graphics/items/SignalItem`).
+- The result is visually inconsistent: two different raster styles for stations/passengers and hand-drawn geometry for trains/signals, with no shared line weight, palette, or grid.
+
+## Scope
+
+- Define a small **icon design spec**: shared grid size, stroke weight, corner radius, and a restrained palette that works on the network background (light and dark), consistent with the UI refresh (#79) and the rendering redesign (#80).
+- Produce vector-first source art (SVG) for: **station** (and station variants if types differ), **passenger**, **train** (per category where categories exist), and **signal aspects**. Rasterize to the resolutions the scene needs, or render SVG directly where practical.
+- Ensure icons stay legible at the zoom levels the playback view uses and degrade gracefully when small (tie into the readability goals in #80).
+- Wire the new artwork through the `resources/` folder and `:/` resource paths introduced in the resources-consolidation issue (#108); retire `train_station.png` / `pax_icon.png`.
+- Update `IconItem` / `PassengerItem` and the train/signal painters to consume the new assets/spec.
+
+## Acceptance criteria
+
+- Stations, passengers, trains, and signals share one visual language (grid, weight, palette).
+- Icons are legible at default zoom and at the dense-station zoom used in the visual smokes.
+- New artwork is delivered as versioned source (SVG) plus the rendered assets, loaded from Qt resources — no loose PNGs.
+- A before/after screenshot of the default case is attached to the issue.
+
+## Notes
+
+Depends on the resources-folder consolidation (#108, where the art lives) and coordinates with #79 (UI shell refresh) and #80 (train/track rendering) so entity icons, tracks, and chrome share one look. Application/desktop icon is handled separately.

--- a/docs/github-issues/110-replace-application-window-icon.md
+++ b/docs/github-issues/110-replace-application-window-icon.md
@@ -1,0 +1,39 @@
+# #110 Replace The Application And Window Icon With A Proper Multi-Resolution App Icon
+
+- GitHub: https://github.com/Ancientkingg/EGTRAIN/issues/110
+- State: open
+- Labels: `type: feature`, `area: ui`, `portability`
+- Created: 2026-07-06
+- Mirrored: 2026-07-06
+
+## Summary
+
+Replace the application / window icon with a proper, purpose-designed, multi-resolution app icon, and register it per platform so EGTRAIN has a recognisable identity in the title bar, taskbar/dock, Alt-Tab, and the installed app listing.
+
+## Current state
+
+- The window icon is a **JPEG**: `QIcon(QPixmap("window_icon.jpg"))` at `app/MainWindow.cpp:306-307`, loaded (like the other assets) by CWD-relative path from `EGTRAIN/QEGTRAIN/window_icon.jpg`.
+- JPEG is the wrong format for an icon: no transparency, block artefacts at small sizes, single resolution.
+- No platform icon is set for the packaged apps, so the macOS `.app`, the Windows `.exe`, and the Linux desktop entry fall back to a generic icon (relevant to the release-packaging work in #70–#72).
+
+## Scope
+
+- Design a distinctive EGTRAIN mark (railway/dispatch themed), consistent with the entity-icon set (#109) and the UI refresh (#79). Deliver **vector source** (SVG) plus rendered raster sizes (16–1024 px).
+- Export the platform icon formats:
+  - macOS: `.icns` and set it as the bundle icon (`MACOSX_BUNDLE_ICON_FILE` / `Info.plist`).
+  - Windows: `.ico` and reference it from the app resource script so the `.exe` carries it.
+  - Linux: PNG(s) plus a `.desktop` entry `Icon=`.
+- Set the in-app window icon from the Qt resource system (`setWindowIcon(QIcon(":/app/icon.png"))`), replacing the JPEG relative-path load in `app/MainWindow.cpp:306`.
+- Store all icon sources/exports under the new `resources/app/` folder.
+- (If the `.egscene` file association from #103's packaging work lands) provide a companion document-type icon so scene files have their own glyph in the OS file browser.
+
+## Acceptance criteria
+
+- The window/taskbar/dock icon is a crisp, transparent, multi-resolution icon on macOS, Windows, and Linux — no JPEG.
+- The packaged macOS `.app`, Windows `.exe`, and Linux desktop entry all show the new icon.
+- Icon sources (SVG) and platform exports (`.icns`, `.ico`, PNG set) live under `resources/app/` and are loaded via Qt resources in-app.
+- `window_icon.jpg` is removed.
+
+## Notes
+
+`type: feature` + `portability` because half the work is the per-platform icon toolchain in packaging (coordinate with #70–#72). Depends on the resources-folder consolidation (#108) for where the assets live; shares design direction with the entity-icon set (#109) and #79.

--- a/docs/github-issues/README.md
+++ b/docs/github-issues/README.md
@@ -1,6 +1,6 @@
 # GitHub Issue Mirror
 
-Last updated: 2026-07-05
+Last updated: 2026-07-06
 
 This directory mirrors GitHub issues that track UI design and release automation work for EGTRAIN. It exists because no local issue mirror was present in the repository.
 
@@ -23,6 +23,28 @@ Mockup files:
 
 - `docs/ui/egtrain-ui-refresh-mock.svg`
 - `docs/ui/egtrain-ui-refresh-mock.png`
+
+## Scene Bundle (v2 Scene Input)
+
+A portable single-file `.egscene` (ZIP) scene container so a student downloads and opens one file instead of a folder of loose JSON. The format spec is in `docs/architecture/scene-bundle.md` (added by #100).
+
+- [#99 Epic: Portable single-file scene bundle (.egscene) as v2 scene input](099-epic-single-file-scene-bundle.md)
+- [#100 Define the .egscene bundle format and manifest](100-define-egscene-bundle-format.md)
+- [#101 Read a scene from an .egscene bundle (bundle loader)](101-read-scene-from-egscene-bundle.md)
+- [#102 Write a scene to an .egscene bundle (bundle writer and scene_tool pack/unpack)](102-write-scene-to-egscene-bundle.md)
+- [#103 Open and save single-file scene bundles from the GUI](103-open-save-bundles-from-gui.md)
+- [#104 Accept an .egscene bundle path from the CLI and headless tools](104-accept-egscene-bundle-cli.md)
+- [#105 Harden bundle loading against malformed and hostile archives](105-harden-bundle-loading.md)
+- [#106 Package the case studies as downloadable .egscene bundles on releases](106-package-case-studies-bundles.md)
+- [#107 Document how students download and open a scene bundle](107-document-opening-scene-bundle.md)
+
+## Icons And Visual Assets
+
+- [#108 Consolidate scattered image assets into a resources folder and load them from Qt resources](108-consolidate-image-assets-resources.md)
+- [#109 Revamp the in-scene entity icons (stations, passengers, trains, signals)](109-revamp-in-scene-entity-icons.md)
+- [#110 Replace the application and window icon with a proper multi-resolution app icon](110-replace-application-window-icon.md)
+
+#108 is the prerequisite that gives the icon work (#109, #110) a home under `EGTRAIN/QEGTRAIN/resources/` and fixes the current CWD-relative asset loading.
 
 ## Cross-Platform Build And Release Work
 

--- a/tools/e2e/editor_smoke.sh
+++ b/tools/e2e/editor_smoke.sh
@@ -4,11 +4,16 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 APP="$ROOT/build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN"
 SCENE="${1:-$ROOT/EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut}"
+ALT_SCENE="${QEGTRAIN_E2E_SCENE_ALT:-$ROOT/EGTRAIN/QEGTRAIN/Scenes/Copenhagen}"
 OUT="${TMPDIR:-/tmp}/qegtrain-editor-smoke-e2e"
 LOG="${TMPDIR:-/tmp}/qegtrain-editor-smoke-e2e.log"
 
 if [[ ! -x "$APP" ]]; then
 	echo "QEGTRAIN app not found or not executable: $APP" >&2
+	exit 1
+fi
+if [[ ! -d "$ALT_SCENE" ]]; then
+	echo "Alternate scene not found: $ALT_SCENE" >&2
 	exit 1
 fi
 
@@ -19,6 +24,7 @@ mkdir -p "$OUT"
 set +e
 QEGTRAIN_E2E_EDITOR_SMOKE=1 \
 QEGTRAIN_E2E_SCENE="$SCENE" \
+QEGTRAIN_E2E_SCENE_ALT="$ALT_SCENE" \
 QEGTRAIN_E2E_OUT="$OUT" \
 "$APP" -n 3 -h 100 -g 1 -pax 0 -TSM 0 -RC 0 >"$LOG" 2>&1
 APP_EXIT=$?

--- a/tools/e2e/startup_launch_contract.py
+++ b/tools/e2e/startup_launch_contract.py
@@ -70,6 +70,7 @@ def assert_launch_reaches_defaults(app: Path, args: list[str], label: str) -> No
             proc.wait(timeout=2)
         except subprocess.TimeoutExpired:
             os.killpg(proc.pid, signal.SIGKILL)
+        os.close(master)
 
 
 def main() -> None:

--- a/tools/e2e/startup_launch_contract.py
+++ b/tools/e2e/startup_launch_contract.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import os
+import select
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RUN_DIR = ROOT / "EGTRAIN/QEGTRAIN"
+PROMPT_MARKERS = (
+    "No arguments inserted",
+    "Please enter",
+    "Please insert",
+    "Do you want to change it",
+)
+READY_MARKERS = (
+    "Graphical user interface (GUI):",
+    "Passenger GUI:",
+)
+
+
+def assert_launch_reaches_defaults(app: Path, args: list[str], label: str) -> None:
+    master, slave = pty.openpty()
+    output = b""
+    env = os.environ.copy()
+    env.setdefault("QT_QPA_PLATFORM", "offscreen")
+    proc = subprocess.Popen(
+        [str(app), *args],
+        cwd=RUN_DIR,
+        env=env,
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        preexec_fn=os.setsid,
+    )
+    os.close(slave)
+
+    try:
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([master], [], [], 0.1)
+            if master not in readable:
+                continue
+            try:
+                chunk = os.read(master, 4096)
+            except OSError:
+                break
+            if not chunk:
+                break
+            output += chunk
+            text = output.decode("utf-8", errors="replace").replace("\r", "")
+            for marker in PROMPT_MARKERS:
+                if marker in text:
+                    raise SystemExit(
+                        f"{label} prompted for console input via {marker!r}\n{text[:1200]}"
+                    )
+            if any(marker in text for marker in READY_MARKERS):
+                return
+
+        text = output.decode("utf-8", errors="replace").replace("\r", "")
+        raise SystemExit(f"{label} did not reach GUI defaults before timeout\n{text[:1200]}")
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            os.killpg(proc.pid, signal.SIGKILL)
+
+
+def main() -> None:
+    if os.name == "nt":
+        print("startup launch PTY test skipped on Windows")
+        return
+
+    global pty
+    import pty
+
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: startup_launch_contract.py PATH_TO_QEGTRAIN")
+
+    app = Path(sys.argv[1]).resolve()
+    if not app.exists():
+        raise SystemExit(f"QEGTRAIN executable not found: {app}")
+
+    assert_launch_reaches_defaults(app, [], "no-argument launch")
+    assert_launch_reaches_defaults(app, ["-n", "1", "-g", "1"], "partial-argument launch")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/e2e/test_windows_subsystem_config.py
+++ b/tools/e2e/test_windows_subsystem_config.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> None:
+    cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+    vcxproj = (ROOT / "EGTRAIN/QEGTRAIN/QEGTRAIN.vcxproj").read_text(encoding="utf-8")
+
+    if "WIN32_EXECUTABLE TRUE" not in cmake and "add_executable(QEGTRAIN WIN32" not in cmake:
+        raise SystemExit("CMake QEGTRAIN target is not configured as a Windows GUI executable")
+
+    if "<SubSystem>Console</SubSystem>" in vcxproj:
+        raise SystemExit("Visual Studio project still links QEGTRAIN with the console subsystem")
+
+    if vcxproj.count("<SubSystem>Windows</SubSystem>") < 2:
+        raise SystemExit("Visual Studio Debug and Release configurations must use Windows subsystem")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Recovers three finished local increments as focused commits.

## Launch without console prompts (#98)
The desktop app now starts without spawning a console window or command-line prompts. Startup behavior is pinned by `test_startup_launch_contract` and `test_windows_subsystem_config`.

## Scene reload from the File menu (#124)
Reopening the current case or another case from the File menu now tears down the running simulation, clears stale scene state, and loads the selected scene. Reopening the same directory reports "Scene reloaded". A cached clicked-item highlight is reset during teardown so selecting an item after a reload cannot touch a deleted effect. Covered by reopen, switch, and restore assertions in the editor smoke.

## Transparent import data tree (#125)
A dockable "Loaded Data" panel lists what the scene import parsed: category, source file, parsed count, and status, with drill-down rows for raw files, parsed objects, and validation results. The tree is runtime state derived from the loaded scene; it is not written to `scene.json`, and `test_scenewriter` asserts the file stays free of it. Save and save-as refresh the panel.

## Verification
From-scratch configure and build at the branch head: 14/14 CTest checks pass, editor smoke passes. With the in-progress #112 test added locally, 15/15 pass.

Closes #98. Closes #124. Closes #125.