### PR TITLE
Fix smoke runners and add sanitizer CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: macos-latest
 
-    # Smokes write logs to the platform temp dir; point it at runner.temp so
-    # the failure diagnostics upload finds them (macOS runners keep TMPDIR at
-    # /var/folders/... otherwise).
-    env:
-      TMPDIR: ${{ runner.temp }}
-
     steps:
       - uses: actions/checkout@v4
+
+      # Smokes write logs to the platform temp dir; point it at runner.temp
+      # so the failure diagnostics upload finds them (macOS runners keep
+      # TMPDIR at /var/folders otherwise).
+      - name: Route temp files to runner.temp
+        run: echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
 
       - name: Install Qt
         run: brew install qt@5 libomp zeromq cppzmq nlohmann-json
@@ -76,11 +76,11 @@ jobs:
   sanitizer:
     runs-on: macos-latest
 
-    env:
-      TMPDIR: ${{ runner.temp }}
-
     steps:
       - uses: actions/checkout@v4
+
+      - name: Route temp files to runner.temp
+        run: echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
 
       - name: Install Qt
         run: brew install qt@5 libomp zeromq cppzmq nlohmann-json

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,6 +10,12 @@ jobs:
   build:
     runs-on: macos-latest
 
+    # Smokes write logs to the platform temp dir; point it at runner.temp so
+    # the failure diagnostics upload finds them (macOS runners keep TMPDIR at
+    # /var/folders/... otherwise).
+    env:
+      TMPDIR: ${{ runner.temp }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -69,6 +75,9 @@ jobs:
 
   sanitizer:
     runs-on: macos-latest
+
+    env:
+      TMPDIR: ${{ runner.temp }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,4 +23,79 @@ jobs:
         run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure --output-log "$RUNNER_TEMP/ctest.log"
+
+      - name: Run headless Copenhagen and Brescia smokes
+        run: python3 tools/e2e/headless_smoke.py 3 4
+
+      - name: Run editor smoke
+        run: tools/e2e/editor_smoke.sh
+
+      - name: Run scene roundtrip smoke
+        run: python3 tools/e2e/roundtrip_smoke.py
+
+      - name: Run assignment smoke
+        run: python3 tools/e2e/assignment_smoke.py
+
+      - name: Run incident smoke
+        run: python3 tools/e2e/incident_smoke.py
+
+      - name: Run scene render smoke
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: tools/e2e/scene_render_smoke.sh
+
+      - name: Run visual smoke
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: tools/e2e/visual_polish_smoke.sh
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-diagnostics
+          path: |
+            tools/e2e/headless_case_*.log
+            ${{ runner.temp }}/ctest.log
+            ${{ runner.temp }}/qegtrain-editor-smoke-e2e.log
+            ${{ runner.temp }}/qegtrain-incident-*.log
+            ${{ runner.temp }}/qegtrain-scene-render-e2e.log
+            ${{ runner.temp }}/qegtrain-scene-render-e2e.png
+            ${{ runner.temp }}/qegtrain-visual-polish-e2e.log
+            ${{ runner.temp }}/qegtrain-visual-polish-e2e.png
+            ${{ runner.temp }}/qegtrain-gui-autostart-smoke.log
+          if-no-files-found: ignore
+
+  sanitizer:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Qt
+        run: brew install qt@5 libomp zeromq cppzmq nlohmann-json
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Debug
+          -DEGTRAIN_BUILD_TESTS=ON
+          -DEGTRAIN_ENABLE_SANITIZERS=ON
+          -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure --output-log "$RUNNER_TEMP/ctest-sanitizer.log"
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-diagnostics
+          path: |
+            ${{ runner.temp }}/ctest-sanitizer.log
+            ${{ runner.temp }}/qegtrain-gui-autostart-smoke.log
+          if-no-files-found: ignore

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -88,6 +88,9 @@ jobs:
         run: cmake --build build
 
       - name: Test
+        env:
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+          ASAN_OPTIONS: abort_on_error=1:halt_on_error=1
         run: ctest --test-dir build --output-on-failure --output-log "$RUNNER_TEMP/ctest-sanitizer.log"
 
       - name: Upload failure diagnostics

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,13 @@ if(EGTRAIN_BUILD_TESTS)
 	add_test(NAME test_startup_launch_contract
 		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/startup_launch_contract.py $<TARGET_FILE:QEGTRAIN>)
 	set_tests_properties(test_startup_launch_contract PROPERTIES TIMEOUT 15)
+	add_test(NAME test_gui_autostart_smoke
+		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/gui_autostart_smoke.py $<TARGET_FILE:QEGTRAIN>)
+	set_tests_properties(test_gui_autostart_smoke PROPERTIES TIMEOUT 240)
+	add_test(NAME test_ci_workflow
+		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_ci_workflow.py)
+	add_test(NAME test_signalling_bounds
+		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_signalling_bounds.py)
 	add_test(NAME test_windows_subsystem_config
 		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_windows_subsystem_config.py)
 

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -4025,6 +4025,8 @@ void MainWindow::paintConnection(QPointF start, QPointF end, int pen_width, Conn
 
 // draws trackside signals (X is the beginning of the block section - except for the last signal of each trackline)
 void MainWindow::paintSignal(double X, int size, int pen_width, int track, int track_separation, int sectionIndex) {
+	if (!hasTrackGeometry(track))
+		return;
 	int graphID = blockSets[track].graphID;
 
 	// positions
@@ -4773,6 +4775,13 @@ void MainWindow::fitView() {
 	networkView->fitInView(initialSceneRect, Qt::KeepAspectRatio);
 }
 
+bool MainWindow::hasTrackGeometry(int track) const {
+	if (track < 0 || track >= numTrackLines)
+		return false;
+	const int region = blockSets[track].region;
+	return region >= 0 && region < static_cast<int>(regionStations.size()) && regionStations[region].size() >= 2;
+}
+
 // check if all tracks are assigned to a graphical level
 int MainWindow::allTracksAssigned() {
 
@@ -4787,7 +4796,12 @@ int MainWindow::allTracksAssigned() {
 
 // finds the indexes of the two closest stations given a point
 void MainWindow::neighbourStations(double X, int tracklineID, int* stationIdx) {
-	std::vector<int> trackStIdx = regionStations[blockSets[tracklineID].region];
+	stationIdx[0] = 0;
+	stationIdx[1] = 0;
+	if (!hasTrackGeometry(tracklineID))
+		return;
+	const int region = blockSets[tracklineID].region;
+	std::vector<int> trackStIdx = regionStations[region];
 
 	// find neighbour stations
 	// check if value is inside/outside X range of stations
@@ -4811,6 +4825,11 @@ void MainWindow::neighbourStations(double X, int tracklineID, int* stationIdx) {
 
 // get shifted screen coordinates of a point (given 1D X coordinate)
 void MainWindow::egtrainPoint2Screen(double X, int track, double separation, double& graphX, double& graphY) {
+	if (!hasTrackGeometry(track)) {
+		graphX = 0;
+		graphY = 0;
+		return;
+	}
 	double graphID = (double)blockSets[track].graphID;
 
 	// find index of closest stations
@@ -4832,6 +4851,8 @@ void MainWindow::egtrainPoint2Screen(double X, int track, double separation, dou
 
 // get shifted screen coordinates of a Node
 void MainWindow::egtrainPoint2Screen(Node* Node, int track, double separation) {
+	if (!hasTrackGeometry(track))
+		return;
 	int stationIdx[2];
 	neighbourStations(Node->X, track, stationIdx);
 	int graphID = blockSets[track].graphID;
@@ -4851,6 +4872,8 @@ void MainWindow::egtrainPoint2Screen(Node* Node, int track, double separation) {
 
 // get shifted screen coordinates of a Node
 void MainWindow::egtrainPoint2Screen(Connections* connections, int track1, int track2, double separation) {
+	if (!hasTrackGeometry(track1) || !hasTrackGeometry(track2))
+		return;
 	int graphID1 = blockSets[track1].graphID;
 	int graphID2 = blockSets[track2].graphID;
 
@@ -4885,6 +4908,14 @@ void MainWindow::egtrainPoint2Screen(Connections* connections, int track1, int t
 
 // slot to update GUI at each timestep (no longer blocks; simulation runs on worker thread)
 void MainWindow::waitForUpdates(int timestep) {
+	static bool autostartProgressReported = false;
+	if (!autostartProgressReported && qEnvironmentVariableIsSet("QEGTRAIN_AUTOSTART")) {
+		// fprintf so the marker reaches the real stdout; std::cout is captured
+		// by the console pane once the window exists
+		std::fprintf(stdout, "E2E_GUI_AUTOSTART_RUNNING timestep=%d\n", timestep);
+		std::fflush(stdout);
+		autostartProgressReported = true;
+	}
 	QString clock = QString::fromStdString(formatSimTime(timestep, m_startOffsetSeconds));
 	QString endClock = QString::fromStdString(formatSimTime(static_cast<long long>(initial_variables.times), m_startOffsetSeconds));
 	statusBar()->showMessage(QString("Simulation running  %1 / %2").arg(clock, endClock));
@@ -5317,6 +5348,9 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, int t, int 
 
 				// get station index to extract shifts
 				int stationIdx[2];
+				if (!hasTrackGeometry(currBS.trackLineId)) {
+					continue;
+				}
 				neighbourStations(posX[j], currBS.trackLineId, stationIdx);
 				prevIndex = stationIdx[0];
 				index = stationIdx[1];
@@ -5353,6 +5387,8 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, int t, int 
 							BS2 = signalling_block_sections[b];
 						}
 					}
+					if (!hasTrackGeometry(BS1.trackLineId) || !hasTrackGeometry(BS2.trackLineId))
+						continue;
 
 					// get beginning and end of connection to interpolate
 					egtrainPoint2Screen(connectionX1, BS1.trackLineId, track_separation, ptConnection1.rx(), ptConnection1.ry());

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -198,6 +198,7 @@ public:
 
 	// geographical functions
 	void neighbourStations(double X, int tracklineID, int* stationIdx);
+	bool hasTrackGeometry(int track) const;
 
 	// setup info dock widget
 	void setupInfoDockWidget();

--- a/EGTRAIN/QEGTRAIN/io/InputValidation.cpp
+++ b/EGTRAIN/QEGTRAIN/io/InputValidation.cpp
@@ -8,12 +8,13 @@ static bool fileReadable(const std::string& path) {
 }
 
 InputCheckResult validateCaseStudyInput(const std::string& inputMainFolder) {
-    // required files relative to the case study input folder (confirmed in EGTRAIN.cpp lines 79-80)
+    // files the startup path reads from the case study input folder.
+    // Routes/List_of_Blocks_IDs.txt is not required: printAllBlocksId writes it
+    // as a route-authoring aid and nothing reads it back.
     const std::vector<std::string> required = {
         "/TrackLines/Connections.txt",
         "/TrackLines/Stations.txt",
         "/trainNames.txt",
-        "/Routes/List_of_Blocks_IDs.txt",
     };
     for (const auto& rel : required) {
         std::string full = inputMainFolder + rel;

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -872,7 +872,7 @@ public:
 		string PreviousTrain = "None"; // the previous Train according to the list
 		int IndexOL = BS[0].arcs_in_signalling_block_section[0].startNode.indexOrderList;
 
-		if ((OL[IndexOL].numTeList > 0) && (IndexOL >= 0)) {
+		if ((IndexOL >= 0) && (IndexOL < N_OrderLists) && (IndexOL < 20) && (OL[IndexOL].numTeList > 0)) {
 			cout << "this is the indexOL TRUE \n"
 				 << IndexOL;
 			for (int j = 1; j < OL[IndexOL].numTeList; j++) { // Determining which is the previous train in the list

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -3196,7 +3196,7 @@ void occupyBlockAndConnected(const Section& BLS, const Section& BLSPrev, double 
 			}
 
 			// Load BSConnected to free to the BlocksConnected list
-			for (int i = 0; i <= N_BLSPrev_Conn; i++) {
+			for (int i = 0; i < N_BLSPrev_Conn; i++) {
 				for (list<string>::iterator it = BlocksConnected.begin(); it != BlocksConnected.end(); it++) {
 					if (*it == IDToFree[i]) {
 						IsInBlocksConnected[i] = true;

--- a/EGTRAIN/QEGTRAIN/tests/test_inputvalidation.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_inputvalidation.cpp
@@ -20,7 +20,6 @@ int main() {
 	const auto root = std::filesystem::temp_directory_path() / "egtrain-input-validation";
 	std::filesystem::remove_all(root);
 	std::filesystem::create_directories(root / "TrackLines");
-	std::filesystem::create_directories(root / "Routes");
 	std::ofstream(root / "TrackLines/Connections.txt");
 	std::ofstream(root / "TrackLines/Stations.txt");
 
@@ -29,11 +28,13 @@ int main() {
 
 	std::ofstream(root / "trainNames.txt");
 	r = validateCaseStudyInput(root.string());
-	ok &= expect(!r.ok && r.message.find("List_of_Blocks_IDs.txt") != std::string::npos, "missing route list names its path");
-
-	std::ofstream(root / "Routes/List_of_Blocks_IDs.txt");
-	r = validateCaseStudyInput(root.string());
 	ok &= expect(r.ok, "complete startup file set is valid");
+
+	// exported scenes carry no List_of_Blocks_IDs.txt; the validator must not demand one
+	std::filesystem::create_directories(root / "Routes");
+	std::ofstream(root / "Routes/Route0.txt");
+	r = validateCaseStudyInput(root.string());
+	ok &= expect(r.ok, "scene export layout without route list is valid");
 	std::filesystem::remove_all(root);
 
 	if (!ok)

--- a/tools/e2e/gui_autostart_smoke.py
+++ b/tools/e2e/gui_autostart_smoke.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUN_DIR = ROOT / "EGTRAIN" / "QEGTRAIN"
+DEFAULT_SECONDS = 75
+# startup takes under 10s on a local Release build; sanitized Debug on a
+# shared CI runner needs a much larger budget before the first sim tick
+DEFAULT_MARKER_SECONDS = 120
+
+BAD_PATTERNS = (
+    "AddressSanitizer",
+    "UndefinedBehaviorSanitizer",
+    "runtime error",
+    "std::length_error",
+    "global-buffer-overflow",
+    "heap-buffer-overflow",
+    "stack-buffer-overflow",
+    "Error 1[loadTrainType]",
+    "Error 2 [Load_TrainType]",
+    "ERROR 3[loadTrainType]",
+)
+PROGRESS_MARKER = "E2E_GUI_AUTOSTART_RUNNING"
+
+
+def fail(message: str, log_path: Path, exit_code: int = 1) -> None:
+    print(message, file=sys.stderr)
+    print(f"log: {log_path}", file=sys.stderr)
+    if log_path.exists():
+        print("--- log tail ---", file=sys.stderr)
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for line in lines[-80:]:
+            print(line, file=sys.stderr)
+    raise SystemExit(exit_code)
+
+
+def terminate_process_group(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: gui_autostart_smoke.py /path/to/QEGTRAIN [seconds]")
+
+    app = Path(sys.argv[1]).resolve()
+    if not app.exists():
+        raise SystemExit(f"QEGTRAIN app not found: {app}")
+
+    seconds = int(sys.argv[2]) if len(sys.argv) > 2 else int(os.environ.get("QEGTRAIN_GUI_SMOKE_SECONDS", DEFAULT_SECONDS))
+    marker_seconds = int(os.environ.get("QEGTRAIN_GUI_SMOKE_MARKER_SECONDS", DEFAULT_MARKER_SECONDS))
+    log_path = Path(tempfile.gettempdir()) / "qegtrain-gui-autostart-smoke.log"
+
+    env = os.environ.copy()
+    env["QEGTRAIN_AUTOSTART"] = "1"
+    env.setdefault("QT_QPA_PLATFORM", "offscreen")
+    env.setdefault("ASAN_OPTIONS", "abort_on_error=1:detect_stack_use_after_return=1")
+
+    args = [
+        str(app),
+        "-n",
+        "3",
+        "-h",
+        "8000",
+        "-g",
+        "1",
+        "-pax",
+        "0",
+        "-TSM",
+        "0",
+        "-RC",
+        "0",
+    ]
+
+    with log_path.open("wb") as output:
+        proc = subprocess.Popen(
+            args,
+            cwd=RUN_DIR,
+            env=env,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+
+        # wait for the first simulation tick, then hold a liveness window so
+        # crashes during early simulation still fail the run
+        marker_deadline = time.monotonic() + marker_seconds
+        hold_until = None
+        while True:
+            rc = proc.poll()
+            if rc is not None:
+                fail(f"QEGTRAIN exited during the smoke: rc={rc}", log_path)
+            if hold_until is None:
+                if log_path.exists() and PROGRESS_MARKER in log_path.read_text(encoding="utf-8", errors="replace"):
+                    hold_until = time.monotonic() + seconds
+                elif time.monotonic() >= marker_deadline:
+                    terminate_process_group(proc)
+                    fail(f"QEGTRAIN did not report GUI simulation progress within {marker_seconds}s", log_path)
+            elif time.monotonic() >= hold_until:
+                break
+            time.sleep(0.5)
+
+        rc = proc.poll()
+        if rc is not None:
+            fail(f"QEGTRAIN exited during the {seconds}s liveness window: rc={rc}", log_path)
+        terminate_process_group(proc)
+
+    text = log_path.read_text(encoding="utf-8", errors="replace")
+    for pattern in BAD_PATTERNS:
+        if pattern in text:
+            fail(f"QEGTRAIN log contains failure marker: {pattern}", log_path)
+    if PROGRESS_MARKER not in text:
+        fail("QEGTRAIN did not report GUI simulation progress", log_path)
+
+    print(f"gui autostart smoke passed after {seconds}s of simulation: {log_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/e2e/headless_smoke.py
+++ b/tools/e2e/headless_smoke.py
@@ -7,7 +7,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 APP = ROOT / "build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN"
 RUN_DIR = ROOT / "EGTRAIN/QEGTRAIN"
-PROMPTS = "n\n0\n0\n0\n0\n"
 
 CASES = {
     1: "Output/Output_EGTRAIN_Netherlands/TrainTrajectories",
@@ -38,19 +37,35 @@ def run_command(args, cwd=None, input=None, timeout=None):
     )
 
 
+def case_command(case_id: int) -> list[str]:
+    return [str(APP), "-n", str(case_id), "-g", "0", "-TSM", "0", "-RC", "0"]
+
+
+def route_errors(output: str) -> list[str]:
+    return [line for line in output.splitlines() if line.startswith(("ERROR4 in Route", "ERROR5 in Route"))]
+
+
 def run_case(case_id: int, cwd: Path = RUN_DIR, out_base: Path = RUN_DIR) -> None:
-    proc = run_command(
-        [str(APP), "-n", str(case_id)],
-        cwd=cwd,
-        input=PROMPTS,
-        # The largest case (Copenhagen, 185 trains x 8000 steps) runs for about
-        # five minutes, so keep this well above the real worst case.
-        timeout=600,
-    )
     log = ROOT / f"tools/e2e/headless_case_{case_id}.log"
+    try:
+        proc = run_command(
+            case_command(case_id),
+            cwd=cwd,
+            # The largest case (Copenhagen, 185 trains x 8000 steps) runs for about
+            # five minutes, so keep this well above the real worst case.
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired as err:
+        partial = err.stdout or b""
+        if isinstance(partial, bytes):
+            partial = partial.decode("utf-8", errors="replace")
+        log.write_text(partial, encoding="utf-8", errors="replace")
+        raise SystemExit(f"case {case_id} timed out after 600s; see {log}")
     log.write_text(proc.stdout, encoding="utf-8", errors="replace")
     if proc.returncode != 0:
         raise SystemExit(f"case {case_id} failed with {proc.returncode}; see {log}")
+    if case_id == 3 and (errors := route_errors(proc.stdout)):
+        raise SystemExit(f"case 3 reported {len(errors)} broken route transitions; see {log}")
     print(f"PASS case {case_id} exited cleanly")
 
 

--- a/tools/e2e/incident_smoke.py
+++ b/tools/e2e/incident_smoke.py
@@ -12,6 +12,8 @@ the service's normal travel. Then it runs both and asserts that
 This exercises the whole path: scene incidents.json -> SceneExporter Incidents.txt
 -> Load_Incidents -> Incident_Holds_Train.
 """
+from __future__ import annotations
+
 import json
 import math
 import os
@@ -21,6 +23,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from headless_smoke import case_command
+
 ROOT = Path(__file__).resolve().parents[2]
 SCENE_TOOL = ROOT / "build/scene_tool"
 APP = ROOT / "build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN"
@@ -28,7 +32,6 @@ SCENE_DIR = ROOT / "EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut"
 CASE_ID = 5
 STAGED_NAME = "Input_EGTRAIN_Assignment"
 TRAJ_REL = "Output/Output_EGTRAIN_Assignment/TrainTrajectories/TrainServicePathDiagram.txt"
-PROMPTS = "n\n0\n0\n0\n0\n"
 
 # svc_e1-1 travels during timesteps [239, 2091] in the base scene, so this
 # window is comfortably inside its normal run.
@@ -41,16 +44,21 @@ _TOL = 1.0  # metres; positions within this are treated as unchanged
 
 def export_and_run(scene_dir: Path, tmp: Path, tag: str) -> list[float | None]:
     exported = tmp / f"exported_{tag}"
-    subprocess.run([str(SCENE_TOOL), "export", str(scene_dir), str(exported)], check=True,
-                   stdout=subprocess.DEVNULL)
+    log = Path(tempfile.gettempdir()) / f"qegtrain-incident-{tag}.log"
+    with log.open("wb") as output:
+        export = subprocess.run([str(SCENE_TOOL), "export", str(scene_dir), str(exported)],
+                                stdout=output, stderr=subprocess.STDOUT)
+    if export.returncode != 0:
+        sys.exit(f"[{tag}] scene export failed with {export.returncode}; see {log}")
     staging = tmp / f"staging_{tag}"
     (staging / "Output").mkdir(parents=True)
     (staging / "Input").mkdir()
     os.symlink(exported, staging / "Input" / STAGED_NAME, target_is_directory=True)
-    proc = subprocess.run([str(APP), "-n", str(CASE_ID)], cwd=staging, input=PROMPTS, text=True,
-                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=300)
+    with log.open("ab") as output:
+        proc = subprocess.run(case_command(CASE_ID), cwd=staging, stdout=output,
+                              stderr=subprocess.STDOUT, timeout=300)
     if proc.returncode != 0:
-        sys.exit(f"[{tag}] case {CASE_ID} exited with {proc.returncode}")
+        sys.exit(f"[{tag}] case {CASE_ID} exited with {proc.returncode}; see {log}")
     traj = staging / TRAJ_REL
     if not traj.exists():
         sys.exit(f"[{tag}] no trajectory file written")

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> None:
+    workflow = (ROOT / ".github/workflows/cmake.yml").read_text(encoding="utf-8")
+    blocks = workflow.split("\n      - ")
+    required = {
+        "Test": "ctest --test-dir build",
+        "Run headless Copenhagen and Brescia smokes": "tools/e2e/headless_smoke.py 3 4",
+        "Run editor smoke": "tools/e2e/editor_smoke.sh",
+        "Run scene roundtrip smoke": "tools/e2e/roundtrip_smoke.py",
+        "Run assignment smoke": "tools/e2e/assignment_smoke.py",
+        "Run incident smoke": "tools/e2e/incident_smoke.py",
+        "Run scene render smoke": "tools/e2e/scene_render_smoke.sh",
+        "Run visual smoke": "tools/e2e/visual_polish_smoke.sh",
+        "Configure": "EGTRAIN_ENABLE_SANITIZERS=ON",
+    }
+    missing = [
+        name
+        for name, command in required.items()
+        if not any(block.startswith(f"name: {name}\n") and command in block for block in blocks)
+    ]
+    test_steps = [block for block in blocks if block.startswith("name: Test\n")]
+    if len(test_steps) != 2 or any(
+        "ctest --test-dir build" not in block or "--output-log" not in block
+        for block in test_steps
+    ):
+        missing.append("ctest output logs")
+    uploads = [block for block in blocks if block.startswith("name: Upload failure diagnostics\n")]
+    if len(uploads) != 2 or any(
+        "if: failure()" not in block
+        or "actions/upload-artifact@v4" not in block
+        or "runner.temp" not in block
+        for block in uploads
+    ):
+        missing.append("failure artifact steps")
+    if not uploads or any(
+        path not in uploads[0]
+        for path in ("qegtrain-incident-*.log", "/ctest.log", "qegtrain-gui-autostart-smoke.log")
+    ):
+        missing.append("build job failure logs")
+    if len(uploads) < 2 or any(
+        path not in uploads[1]
+        for path in ("ctest-sanitizer.log", "qegtrain-gui-autostart-smoke.log")
+    ):
+        missing.append("sanitizer job failure logs")
+    if missing:
+        raise SystemExit("CMake workflow is missing: " + ", ".join(missing))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -30,6 +30,19 @@ def main() -> None:
         for block in test_steps
     ):
         missing.append("ctest output logs")
+    sanitizer_test = next(
+        block
+        for block in workflow.split("\n  sanitizer:\n", 1)[1].split("\n      - ")
+        if block.startswith("name: Test\n")
+    )
+    if any(
+        option not in sanitizer_test
+        for option in (
+            "UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1",
+            "ASAN_OPTIONS: abort_on_error=1:halt_on_error=1",
+        )
+    ):
+        missing.append("sanitizer failure options")
     uploads = [block for block in blocks if block.startswith("name: Upload failure diagnostics\n")]
     if len(uploads) != 2 or any(
         "if: failure()" not in block

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -43,6 +43,8 @@ def main() -> None:
         )
     ):
         missing.append("sanitizer failure options")
+    if workflow.count("TMPDIR: ${{ runner.temp }}") != 2:
+        missing.append("job TMPDIR overrides for smoke logs")
     uploads = [block for block in blocks if block.startswith("name: Upload failure diagnostics\n")]
     if len(uploads) != 2 or any(
         "if: failure()" not in block

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -43,8 +43,8 @@ def main() -> None:
         )
     ):
         missing.append("sanitizer failure options")
-    if workflow.count("TMPDIR: ${{ runner.temp }}") != 2:
-        missing.append("job TMPDIR overrides for smoke logs")
+    if workflow.count('echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"') != 2:
+        missing.append("TMPDIR routing steps for smoke logs")
     uploads = [block for block in blocks if block.startswith("name: Upload failure diagnostics\n")]
     if len(uploads) != 2 or any(
         "if: failure()" not in block

--- a/tools/e2e/test_headless_smoke_decode.py
+++ b/tools/e2e/test_headless_smoke_decode.py
@@ -4,10 +4,19 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from headless_smoke import run_command
+from headless_smoke import case_command, route_errors, run_command
 
 
 def main() -> None:
+    command = case_command(3)
+    expected = ["-n", "3", "-g", "0", "-TSM", "0", "-RC", "0"]
+    if command[1:] != expected:
+        raise SystemExit(f"headless case command does not disable the GUI and integrations: {command}")
+
+    errors = route_errors("ok\nERROR4 in Route r1\nERROR5 in Route r1\n")
+    if errors != ["ERROR4 in Route r1", "ERROR5 in Route r1"]:
+        raise SystemExit(f"route error detection failed: {errors}")
+
     proc = run_command(
         [
             sys.executable,

--- a/tools/e2e/test_signalling_bounds.py
+++ b/tools/e2e/test_signalling_bounds.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[2] / "EGTRAIN/QEGTRAIN/simulation/Signalling.cpp"
+
+
+def main() -> None:
+    text = SOURCE.read_text(encoding="utf-8")
+    if "i <= N_BLSPrev_Conn" in text:
+        raise SystemExit("connected-block cleanup reads one entry past the initialized range")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Changes

- Run ASan and UBSan in a Debug CI job and upload CTest and GUI smoke logs on failure.
- Make UBSan halt and ASan abort so sanitizer findings fail CTest.
- Give every headless runner the same explicit non-GUI command.
- Keep the incident smoke importable on Python 3.9.
- Fix the connected-block cleanup bound and two sanitizer-found index guards.
- Drop Routes/List_of_Blocks_IDs.txt from required startup inputs; the app writes that file as a route authoring aid and never reads it, and staged scene exports carry Route files without it.
- Route TMPDIR to runner.temp in CI so the failure diagnostics upload finds the smoke logs.
- Add contract checks for the workflow, runner arguments, and signalling bound.

## Root causes

The smoke runners relied on startup defaults that now open the GUI. The incident runner evaluated Python 3.10 union syntax on Python 3.9. The connected-block cleanup read one element past its initialized range. CI built sanitizer support but never enabled or enforced it. The assignment smoke failed on its first CI run because startup validation demanded a file the exporter never produces.

## Checks

- cmake --build build -j4
- ctest after merging main: 21 of 21 passed
- Assignment smoke from a scene_tool export: all four checks pass
- GUI autostart smoke: passed a 75-second liveness window
- CI: build and sanitizer jobs green on the merge result

Closes #134.
Closes #135.
Closes #136.
Closes #138.