### PR TITLE
Bound connected block dependencies

### DIFF
--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -1241,7 +1241,7 @@ void setDependenciesBetweenBlocks() {
 				break;
 		}
 		// test for Copenhagen
-		if (section.ID == "@5-B6@" && section.N_ConnectedBS < maxConnectedBlocks)
+		if (section.ID == "@5-B6@")
 			addConnection("@1-B30@-4.592000/@5-B7@-4.620000");
 
 		//

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -1,5 +1,6 @@
 #include "simulation/Signalling.h"
 #include "scene/SceneModel.h"
+#include <iterator>
 extern Logger owl;
 
 
@@ -1221,20 +1222,27 @@ void setList(string input, list<Section>& BSConnected) {
 // This Function is used to set the dependencies between two block section connected by means of switches
 void setDependenciesBetweenBlocks() {
 	for (int i = 0; i < Blocks; i++) {
+		auto& section = signalling_block_sections[i];
+		const auto maxConnectedBlocks = std::size(section.IDConnectedBS);
+		auto addConnection = [&](const string& id) {
+			if (section.N_ConnectedBS >= maxConnectedBlocks) {
+				cerr << "ERROR: Block section " << section.ID << " has more than "
+					 << maxConnectedBlocks << " connected block sections\n";
+				return false;
+			}
+			section.IDConnectedBS[section.N_ConnectedBS++] = id;
+			return true;
+		};
 		list<Section> BSConn_i;
-		setList(signalling_block_sections[i].ID, BSConn_i);
+		setList(section.ID, BSConn_i);
 		list<Section>::iterator it;
 		for (it = BSConn_i.begin(); it != BSConn_i.end(); it++) {
-			if (it->ID != signalling_block_sections[i].ID) {
-				signalling_block_sections[i].N_ConnectedBS++;
-				signalling_block_sections[i].IDConnectedBS[signalling_block_sections[i].N_ConnectedBS - 1] = it->ID;
-			}
-			// test for Copenhagen
-			if (signalling_block_sections[i].ID == "@5-B6@") {
-				signalling_block_sections[i].N_ConnectedBS++;
-				signalling_block_sections[i].IDConnectedBS[signalling_block_sections[i].N_ConnectedBS - 1] = "@1-B30@-4.592000/@5-B7@-4.620000";
-			}
+			if (it->ID != section.ID && !addConnection(it->ID))
+				break;
 		}
+		// test for Copenhagen
+		if (section.ID == "@5-B6@" && section.N_ConnectedBS < maxConnectedBlocks)
+			addConnection("@1-B30@-4.592000/@5-B7@-4.620000");
 
 		//
 		// Now transferring the right Block Connections to the nodes with numConnections >0

--- a/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
@@ -1,6 +1,7 @@
 #include "scene/SceneModel.h"
 #include "simulation/Signalling.h"
 #include <iostream>
+#include <sstream>
 
 Logger owl;
 
@@ -78,6 +79,18 @@ int main() {
 			copenhagenDependencies++;
 	}
 	ok &= expect(copenhagenDependencies == 1, "Copenhagen dependency has the expected ID");
+
+	resetRouteState();
+	signalling_block_sections[0] = makeSection("@5-B6@", 0.0, 1.0);
+	for (int i = 1; i <= 10; i++)
+		signalling_block_sections[i] = makeSection("@5-B6@-branch" + std::to_string(i), i, i + 1);
+	Blocks = 11;
+	std::ostringstream errors;
+	auto* oldErrorBuffer = std::cerr.rdbuf(errors.rdbuf());
+	setDependenciesBetweenBlocks();
+	std::cerr.rdbuf(oldErrorBuffer);
+	ok &= expect(errors.str().find("has more than") != std::string::npos,
+		"Copenhagen dependency overflow is reported");
 
 	resetRouteState();
 	seedThreeSections();

--- a/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
@@ -66,6 +66,20 @@ int main() {
 	}
 
 	resetRouteState();
+	signalling_block_sections[0] = makeSection("@5-B6@", 0.0, 1.0);
+	signalling_block_sections[1] = makeSection("@5-B6@-branch", 1.0, 2.0);
+	Blocks = 2;
+	setDependenciesBetweenBlocks();
+	ok &= expect(signalling_block_sections[0].N_ConnectedBS == 2,
+		"Copenhagen dependency is added once");
+	int copenhagenDependencies = 0;
+	for (int i = 0; i < signalling_block_sections[0].N_ConnectedBS; i++) {
+		if (signalling_block_sections[0].IDConnectedBS[i] == "@1-B30@-4.592000/@5-B7@-4.620000")
+			copenhagenDependencies++;
+	}
+	ok &= expect(copenhagenDependencies == 1, "Copenhagen dependency has the expected ID");
+
+	resetRouteState();
 	seedThreeSections();
 
 	SceneModel reversedScene;

--- a/tools/e2e/test_signalling_bounds.py
+++ b/tools/e2e/test_signalling_bounds.py
@@ -9,6 +9,11 @@ def main() -> None:
     text = SOURCE.read_text(encoding="utf-8")
     if "i <= N_BLSPrev_Conn" in text:
         raise SystemExit("connected-block cleanup reads one entry past the initialized range")
+    dependencies = text[
+        text.index("void setDependenciesBetweenBlocks()") : text.index("bool areBlocksConnected")
+    ]
+    if "N_ConnectedBS >= maxConnectedBlocks" not in dependencies:
+        raise SystemExit("connected-block insertion does not enforce the IDConnectedBS capacity")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #140

## Changes

- Bound connected block writes using the size of `IDConnectedBS` and report excess dependencies.
- Add the Copenhagen dependency once after the general match loop.
- Add regressions for the capacity check and the Copenhagen dependency ID.

## Checks

- CMake build
- CTest: 24 of 24 passed
- GUI autostart smoke: passed
