### PR TITLE
Document the student scene workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,13 @@ Case selector:
 - `-n 3`: Copenhagen
 - `-n 4`: Brescia
 
-Copenhagen and Brescia are the current regression cases. The Netherlands data needs repair before it can serve as the assignment scenario.
+Copenhagen and Brescia are the main regression cases. The Netherlands case imports, validates, exports, and runs with eight Sprinter services. Amsterdam to Hilversum services still need route checks and timetable work before the case can be used for the assignment.
 
 ## Planning
 
+- [Application and V1 scene guide](docs/guides/scenes-and-application.md)
+- [V1 scene property reference](docs/guides/v1-scene-properties.md)
+- [Netherlands scene assignment](docs/guides/netherlands-assignment.md)
 - [Assignment workflow](docs/product/assignment-workflow.md)
 - [Scene model design](docs/architecture/scene-model.md)
 - [Roadmap](docs/planning/roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,9 @@
 
 Start here:
 
+- [Using EGTRAIN and authoring V1 scenes](guides/scenes-and-application.md)
+- [V1 scene property reference](guides/v1-scene-properties.md)
+- [Netherlands scene assignment](guides/netherlands-assignment.md)
 - [Assignment workflow](product/assignment-workflow.md)
 - [Scene model design](architecture/scene-model.md)
 - [Roadmap](planning/roadmap.md)

--- a/docs/architecture/scene-model.md
+++ b/docs/architecture/scene-model.md
@@ -65,4 +65,4 @@ The editor should save the canonical scene. The simulation can keep reading expo
 3. Validate converted scenes.
 4. Export scenes back to current input files.
 5. Add the MVP editor on top of the scene model.
-6. Build the Den Haag Centraal to Utrecht assignment case through the scene model.
+6. Build the Amsterdam to Hilversum assignment case through the scene model.

--- a/docs/guides/netherlands-assignment.md
+++ b/docs/guides/netherlands-assignment.md
@@ -1,0 +1,198 @@
+# Netherlands scene assignment
+
+## Objective
+
+Prepare an Amsterdam to Hilversum teaching scene with Sprinter and Intercity services. Start from the full Netherlands case. Do not reduce the network until the selected trains run correctly.
+
+The repository keeps two products:
+
+- `Scenes/Netherlands` is the full V1 reference case.
+- A separate Amsterdam to Hilversum scene will contain the smaller assignment network.
+
+Read [Using EGTRAIN and authoring V1 scenes](scenes-and-application.md) before changing data.
+
+## Supplied files
+
+The professor supplied `Trains.zip` and `trainNames.txt`.
+
+The active manifest contains:
+
+```text
+Spr1.txt
+Spr2.txt
+Spr3.txt
+Spr4.txt
+Spr5.txt
+Spr6.txt
+Spr7.txt
+Spr8.txt
+```
+
+These eight services cover Utrecht, Hilversum, Baarn, and Den Dolder. They do not add Amsterdam services.
+
+The repository already contains the archive contents. The eight active train files use `T_SLT06.txt` instead of the attachment's `T455_04.txt`. Keep the repository value. It matches the SLT train data used by the V1 scene.
+
+The legacy case also contains Amsterdam and Hilversum timetable files, `VIRM06.txt`, `T_VIRM06.txt`, `SLT06.txt`, and `T_SLT06.txt`. The candidate routes named by the professor are:
+
+```text
+29 30 31 32 33 34 35 36
+39 40 41 42
+53 54
+```
+
+The route numbers are leads, not final assignments. Test each route before using it.
+
+## Working rules
+
+- Keep the full Netherlands legacy case intact.
+- Keep `Scenes/Netherlands` as the full V1 reference.
+- Work on copies until a train completes its route.
+- Test one service at a time.
+- Change one input at a time when diagnosing a failure.
+- Record the route, direction, stopping pattern, rolling stock, and result.
+- Remove unrelated infrastructure only after the timetable works.
+
+## Work sequence
+
+### 1. Reproduce the current baseline
+
+Run the legacy Netherlands case with `Spr1.txt` through `Spr8.txt`. Record which services load, move, and reach their final station.
+
+Import the legacy case and validate the result:
+
+```bash
+./build/scene_tool import \
+  EGTRAIN/QEGTRAIN/Input/Input_EGTRAIN_Netherlands \
+  /tmp/netherlands-v1 \
+  Netherlands
+./build/scene_tool validate /tmp/netherlands-v1
+```
+
+Compare the imported JSON files with `EGTRAIN/QEGTRAIN/Scenes/Netherlands`. Explain every difference before changing the committed scene.
+
+### 2. Map the candidate routes
+
+Inspect routes 29 through 36, 39 through 42, 53, and 54. Run a single test train on each plausible route.
+
+Fill in this table as evidence:
+
+| Route | Origin | Destination | Direction | Stations passed | SPR or IC | Test result | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 29 |  |  |  |  |  |  |  |
+| 30 |  |  |  |  |  |  |  |
+| 31 |  |  |  |  |  |  |  |
+| 32 |  |  |  |  |  |  |  |
+| 33 |  |  |  |  |  |  |  |
+| 34 |  |  |  |  |  |  |  |
+| 35 |  |  |  |  |  |  |  |
+| 36 |  |  |  |  |  |  |  |
+| 39 |  |  |  |  |  |  |  |
+| 40 |  |  |  |  |  |  |  |
+| 41 |  |  |  |  |  |  |  |
+| 42 |  |  |  |  |  |  |  |
+| 53 |  |  |  |  |  |  |  |
+| 54 |  |  |  |  |  |  |  |
+
+### 3. Build one working service
+
+Choose one direction. Create one service with:
+
+- a verified route
+- the correct SLT or VIRM composition
+- the matching stopping pattern
+- an entry time inside the simulation window
+- planned arrival and departure times
+- dwell times at scheduled stops
+
+Run it alone. Check movement, station order, final position, and output diagrams.
+
+### 4. Add both train types and directions
+
+After the first service works, add:
+
+- one Sprinter in each direction
+- one Intercity in each direction
+
+Use the service worksheet for every train:
+
+| Service | Type | Route | Direction | Timetable | Composition | Loads | Moves | Completes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |  |  |  |
+
+### 5. Tune the timetable
+
+Set times from observed running times rather than guesses. For each service:
+
+1. Run the train without timetable pressure.
+2. Record the minimum running time between stops.
+3. Add the agreed running time supplement.
+4. Add dwell time.
+5. Round the timetable as required by the assignment.
+6. Run the complete timetable and check conflicts.
+
+Keep the raw measurements with the timetable notes.
+
+### 6. Create the smaller assignment scene
+
+Copy the verified full V1 scene. Remove data in this order:
+
+1. Unused services
+2. Unused compositions and train units
+3. Unused routes
+4. Infrastructure outside the selected route dependency set
+
+Validate and run after each step. Stop at the first failure and restore the last removed dependency.
+
+Record memory use and startup time before and after the reduction.
+
+## Responsibility split
+
+Student 1 owns route and infrastructure analysis. This includes the candidate route table, direction checks, station sequence, and the later network reduction.
+
+Student 2 owns rolling stock and timetable analysis. This includes the SLT and VIRM data, service definitions, stopping patterns, and planned times.
+
+Both students integrate the first service, review each other's mappings, and run the final checks.
+
+## Milestones
+
+### Baseline
+
+- The eight supplied Sprinter services import into V1.
+- `scene_tool validate` exits successfully.
+- The current legacy case reaches the end of the simulation.
+- Known import adjustments are recorded.
+
+### Route map
+
+- Every candidate route has a direction and station sequence, or a recorded reason for rejection.
+- At least one Amsterdam to Hilversum route works in each direction.
+
+### Train set
+
+- One Sprinter and one Intercity work in each direction.
+- Each service uses the correct route, rolling stock, and stopping pattern.
+- Planned times are based on measured runs.
+
+### Assignment scene
+
+- The full Netherlands V1 scene remains available as a reference.
+- The smaller scene validates, exports, and runs.
+- The scene contains no unresolved references.
+- A smoke check proves train movement and station arrival output.
+- The GitHub guide matches the delivered workflow.
+
+## Meeting agenda
+
+Use this 60 minute agenda for the first meeting:
+
+| Time | Topic |
+| --- | --- |
+| 0 to 10 minutes | Goal, source files, and the difference between the full case and assignment scene |
+| 10 to 20 minutes | Open the Netherlands V1 scene and trace one service through the JSON files |
+| 20 to 30 minutes | Import, validate, export, and run workflow |
+| 30 to 40 minutes | Candidate route IDs and the route worksheet |
+| 40 to 50 minutes | Student responsibilities and the first single-train test |
+| 50 to 60 minutes | Evidence, first milestone, and next review date |
+
+End the meeting with one assigned route test per student and a shared date for integrating the first working service.
+

--- a/docs/guides/netherlands-assignment.md
+++ b/docs/guides/netherlands-assignment.md
@@ -195,4 +195,3 @@ Use this 60 minute agenda for the first meeting:
 | 50 to 60 minutes | Evidence, first milestone, and next review date |
 
 End the meeting with one assigned route test per student and a shared date for integrating the first working service.
-

--- a/docs/guides/scenes-and-application.md
+++ b/docs/guides/scenes-and-application.md
@@ -1,0 +1,210 @@
+# Using EGTRAIN and authoring V1 scenes
+
+This guide covers the current V1 scene workflow. Use it to open and edit a scene, convert a legacy case, or prepare a new case for the simulator.
+
+## Build the application
+
+Run these commands from the repository root:
+
+```bash
+cmake -S . -B build -DEGTRAIN_BUILD_TESTS=ON
+cmake --build build
+```
+
+On macOS with Homebrew Qt 5:
+
+```bash
+cmake -S . -B build -DEGTRAIN_BUILD_TESTS=ON \
+  -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt@5
+cmake --build build
+```
+
+Run the application from `EGTRAIN/QEGTRAIN`. Several legacy paths are relative to that directory.
+
+```bash
+cd EGTRAIN/QEGTRAIN
+../../build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN
+```
+
+The executable is `build/QEGTRAIN` on platforms where CMake does not create a macOS application bundle.
+
+## Open and run a scene
+
+1. Start EGTRAIN.
+2. Choose `File > Open Scene...`.
+3. Select the directory that contains `scene.json`.
+4. Read the `Scene Validation` panel before editing.
+5. Use `Save Scene As...` to make a working copy. Create the empty target directory before selecting it.
+6. Edit compositions, services, timetable values, or incidents in the scene dock.
+7. Choose `Run Scene`.
+
+EGTRAIN validates the scene before each run. Errors block the run. Warnings remain visible but do not block it.
+
+`Save Scene` writes the canonical JSON files. `Save Scene As...` also copies `legacy/` and `views.json`. A run uses the current model, including unsaved edits, and exports it to a temporary legacy input directory.
+
+After setup, use the existing diagram windows to inspect speed, time, distance, delay, train path, and blocking time data.
+
+Use `Load Legacy Case...` only for the old case selector. A legacy case opened this way is not an editable V1 scene.
+
+## V1 scene directory
+
+A V1 scene is a directory. Six JSON files are required.
+
+| File | Required | Contents |
+| --- | --- | --- |
+| `scene.json` | yes | Name, schema version, base time, units, and optional source information |
+| `infrastructure.json` | yes | Canonical nodes and arcs |
+| `stations.json` | yes | Stations and platforms |
+| `signalling.json` | yes | Signals, routes, and route block tokens |
+| `rolling_stock.json` | yes | Train units, physical data, traction curves, and compositions |
+| `services.json` | yes | Services, routes, stops, times, and repetition |
+| `incidents.json` | no | Signal failures and train breakdowns |
+| `views.json` | no | Display defaults |
+| `legacy/` | needed by imported cases | Infrastructure and other data still read by the legacy simulator |
+
+The current schema version is `1`. Supported units are metres, seconds, and metres per second.
+
+The main references are:
+
+```text
+services.json
+  composition -> rolling_stock.json
+  route       -> signalling.json
+  stop        -> stations.json
+  platform    -> platform on that station
+
+incidents.json
+  target      -> signal or service
+```
+
+IDs must be unique within their collection. Keep station IDs free of whitespace because the legacy timetable format splits fields on whitespace.
+
+Times in `services.json` are seconds relative to `base_time`. The first stop may omit its arrival. The last stop may omit its departure. A repeated service uses `repeat.headway_seconds`.
+
+`loaded_data` is runtime metadata. EGTRAIN rebuilds it when the scene opens and does not write it to `scene.json`.
+
+Use the [V1 scene property reference](v1-scene-properties.md) while editing JSON. The [scene schema reference](../architecture/scene-schema.md) lists the diagnostic codes and import and export behavior.
+
+## Canonical files and legacy files
+
+The canonical JSON files are the source of truth for an opened V1 scene. Do not edit an exported legacy directory and expect those changes to return to the scene.
+
+The simulator still reads part of the old input structure. Imported scenes keep that data under `legacy/`. During a run, EGTRAIN writes canonical services, rolling stock, routes, and incidents to a temporary input directory, then copies the passthrough data.
+
+Do not delete files from `legacy/` until the scene exports and runs without them. Track infrastructure under `legacy/Tracklines/` is required by the current simulator.
+
+## Convert a legacy case
+
+Use `scene_tool` when a case already exists in the legacy format. Import into a temporary directory first.
+
+```bash
+./build/scene_tool import \
+  EGTRAIN/QEGTRAIN/Input/Input_EGTRAIN_Netherlands \
+  /tmp/netherlands-v1 \
+  Netherlands
+
+./build/scene_tool validate /tmp/netherlands-v1
+```
+
+The importer maps:
+
+| Legacy source | V1 destination |
+| --- | --- |
+| `trainNames.txt` and `Trains/*.txt` | `services.json` |
+| `TrainData/*.txt` | `rolling_stock.json` |
+| `Routes/Route<N>.txt` | `signalling.json` |
+| `Tracklines/Stations.txt` | `stations.json` |
+| Remaining simulator data | `legacy/` |
+
+Inspect every import warning. `scene.import.adjusted` means the importer changed a value. The message names the affected file and service.
+
+Export the result to another temporary directory:
+
+```bash
+./build/scene_tool export /tmp/netherlands-v1 /tmp/netherlands-export
+```
+
+Open `/tmp/netherlands-v1` in EGTRAIN and run it. Do not replace a committed scene until validation, export, and the simulation have passed.
+
+## Start a scene without a legacy case
+
+Use the minimal test fixture as the starting structure:
+
+```bash
+cp -R \
+  EGTRAIN/QEGTRAIN/tests/fixtures/scenes/minimal \
+  /tmp/my-scene
+./build/scene_tool validate /tmp/my-scene
+```
+
+The fixture shows the required JSON shape. It does not contain enough track infrastructure for a real simulation.
+
+For a runnable scene:
+
+1. Set the name, schema version, base time, and units in `scene.json`.
+2. Add stations and platforms.
+3. Add train units and compositions.
+4. Add routes with real block tokens.
+5. Add services that reference those objects.
+6. Add the required legacy track data.
+7. Validate, export, and run one service.
+8. Add the rest of the timetable after the first service completes its route.
+
+Full infrastructure editing is not available in the V1 GUI. Build or import routes and track data outside the application, then use the GUI for compositions, services, timetable values, and incidents.
+
+## Validation
+
+Run validation after every small group of edits:
+
+```bash
+./build/scene_tool validate path/to/scene
+```
+
+Structural errors include missing files, invalid JSON, missing sections, and an unsupported schema version. EGTRAIN stops before semantic checks when structural loading fails.
+
+Semantic errors include unresolved references, duplicate IDs, empty compositions or routes, invalid times, invalid dwell values, and bad incident targets. The [schema reference](../architecture/scene-schema.md#diagnostics) lists every code.
+
+Useful checks for scene work are:
+
+```bash
+ctest --test-dir build -L scene-v1 --output-on-failure
+ctest --test-dir build -L legacy-compat --output-on-failure
+tools/e2e/headless_smoke.py
+tools/e2e/roundtrip_smoke.py
+```
+
+Run the full set after changing committed scene data. For one scene, start with `scene_tool validate`, export it, and run it through the GUI.
+
+## Netherlands case
+
+The full legacy case is in `EGTRAIN/QEGTRAIN/Input/Input_EGTRAIN_Netherlands`. Its V1 counterpart is `EGTRAIN/QEGTRAIN/Scenes/Netherlands`.
+
+The active manifest lists `Spr1.txt` through `Spr8.txt`. These services cover Utrecht (`Ut`), Hilversum (`Hvs`), Baarn (`Brn`), and Den Dolder (`Dld`). The committed train definitions use `SLT06.txt` with the matching `T_SLT06.txt` traction curve.
+
+A fresh import contains:
+
+- 41 stations
+- 74 routes
+- 5,429 route entries
+- 8 services
+- 1 train unit
+- 1 composition
+
+The import reports 30 timetable adjustments for intermediate departures stored as `-1`. These warnings are known. Validation and export still succeed.
+
+The Amsterdam to Hilversum assignment is a separate piece of work. The legacy case contains candidate timetables for Sprinter and Intercity services, plus VIRM train data. Candidate route IDs are 29 through 36, 39 through 42, 53, and 54. Each route must be run and checked before it is assigned to a service.
+
+Keep the full Netherlands scene as the reference case. Build the smaller assignment scene only after the selected Amsterdam to Hilversum services work in the full network.
+
+See [Netherlands assignment brief](netherlands-assignment.md) for the work plan and checklists.
+
+## Before committing a scene
+
+- Validate the scene.
+- Export it to a clean temporary directory.
+- Run at least one train through every new route.
+- Check station order and direction.
+- Check planned arrival, departure, dwell, and entry times.
+- Run the scene and legacy compatibility tests.
+- Keep generated output, temporary exports, `.DS_Store`, and logs out of Git.
+- Record source data and unresolved assumptions in the relevant guide.

--- a/docs/guides/scenes-and-application.md
+++ b/docs/guides/scenes-and-application.md
@@ -89,9 +89,9 @@ Use the [V1 scene property reference](v1-scene-properties.md) while editing JSON
 
 The canonical JSON files are the source of truth for an opened V1 scene. Do not edit an exported legacy directory and expect those changes to return to the scene.
 
-The simulator still reads part of the old input structure. Imported scenes keep that data under `legacy/`. During a run, EGTRAIN writes canonical services, rolling stock, routes, and incidents to a temporary input directory, then copies the passthrough data.
+The simulator still reads part of the old input structure. Imported scenes keep that data under `legacy/`. During a run, EGTRAIN writes canonical services, rolling stock, routes, and incidents to a temporary input directory, then copies passthrough files that do not replace generated files.
 
-Do not delete files from `legacy/` until the scene exports and runs without them. Track infrastructure under `legacy/Tracklines/` is required by the current simulator.
+Do not delete files from `legacy/` until the scene exports and runs without them. Track infrastructure under `legacy/Tracklines/` or `legacy/TrackLines/` is required by the current simulator.
 
 ## Convert a legacy case
 

--- a/docs/guides/v1-scene-properties.md
+++ b/docs/guides/v1-scene-properties.md
@@ -1,0 +1,165 @@
+# V1 scene property reference
+
+Use this reference while editing a V1 scene by hand. The application guide explains the full workflow: [Using EGTRAIN and authoring V1 scenes](scenes-and-application.md).
+
+Each scene is a directory. JSON object and property names are case sensitive. A property marked "required" must exist and have the stated type. An optional property uses the default listed below when it is absent.
+
+## `scene.json`
+
+| Property | Type | Required | Meaning | Accepted value and checks |
+| --- | --- | --- | --- | --- |
+| `schema_version` | integer | yes | Version of the canonical scene data | Must be `1`. Other values stop loading. |
+| `name` | string | yes | Scene name shown in the application | Must not be empty. |
+| `description` | string | no | Short note about the case | Defaults to an empty string. |
+| `base_time` | string | no | Clock time used as the zero point for service times | Must match `HH:MM:SS`, for example `08:00:00`. Defaults to an empty value. The validator checks the shape, not the hour, minute, or second ranges. |
+| `units` | object | no | Unit declarations for scene values | Defaults to metres, seconds, and metres per second. |
+| `units.distance` | string | no | Distance unit | If present, it must be `m`. |
+| `units.time` | string | no | Time unit | If present, it must be `s`. |
+| `units.speed` | string | no | Speed unit | If present, it must be `m/s`. |
+| `legacy_source` | string | no | Path recorded by the legacy importer | Kept as provenance only. The V1 loader ignores it and `Save Scene` does not write it back. |
+
+All times in the other files are measured in seconds relative to `base_time`. Negative service times are allowed because a timetable can start before the base time.
+
+## `infrastructure.json`
+
+| Property | Type | Required | Meaning | Accepted value and checks |
+| --- | --- | --- | --- | --- |
+| `nodes` | array | yes | Reserved canonical infrastructure nodes | The loader checks that this is an array but does not read its entries in V1. Use `[]`. |
+| `arcs` | array | yes | Reserved canonical infrastructure links | The loader checks that this is an array but does not read its entries in V1. Use `[]`. |
+
+The current simulator reads track geometry, blocks, switches, gradients, and speed limits from `legacy/TrackLines/`. Editing `nodes` or `arcs` has no effect on a run.
+
+## `stations.json`
+
+The root property is `stations`, a required array.
+
+| Property | Type | Required | Meaning | Accepted value and checks |
+| --- | --- | --- | --- | --- |
+| `stations[].id` | string | yes | Identifier used by service stops | Must not be empty and must be unique among stations. Keep it free of whitespace so the scene can export to the legacy timetable format. |
+| `stations[].name` | string | yes | Name shown to the user | Must not be empty. It does not act as a reference. |
+| `stations[].platforms` | array | no | Platforms that a stop may name | Defaults to an empty array. A value of another type is currently treated as an empty array. |
+| `stations[].platforms[].id` | string | yes, when the platform exists | Platform identifier within the station | Must not be empty. A service platform must match one of the IDs on its station. The validator does not check duplicate platform IDs. |
+
+## `signalling.json`
+
+The root properties `signals` and `routes` are required arrays.
+
+| Property | Type | Required | Meaning | Accepted value and checks |
+| --- | --- | --- | --- | --- |
+| `signals[].id` | string | yes | Signal identifier | Must not be empty and must be unique among signals. A `signal_failure` incident uses this ID as its target. |
+| `routes[].id` | string | yes | Route identifier used by services | Must not be empty and must be unique among routes. Imported legacy routes use IDs such as `route29`. |
+| `routes[].blocks` | array of strings | yes | Ordered block tokens followed by the route | Must contain at least one string. Non-string entries are ignored. The validator checks for an empty result, but it does not resolve block IDs against the legacy track files. |
+
+Route direction and suitability are properties of the ordered block list, not the route number. Run a train over a route before assigning it to a Sprinter or Intercity service.
+
+## `rolling_stock.json`
+
+The root properties `train_units` and `compositions` are required arrays. At least one unit and one composition must exist.
+
+### Train units
+
+| Property | Type | Required | Meaning | Accepted value and checks |
+| --- | --- | --- | --- | --- |
+| `train_units[].id` | string | yes | Train unit identifier | Must not be empty and must be unique among train units. |
+| `train_units[].physical` | object | no for loading | Physical values needed to export and run the unit | If present, all nine properties below are required numbers. Export fails when a service uses a unit without physical data. |
+| `physical.mass_of_traction_unit_kg` | number | with `physical` | Mass of the powered unit in kilograms | The loader does not impose a range. |
+| `physical.mass_of_a_wagon_kg` | number | with `physical` | Mass of one wagon in kilograms | The loader does not impose a range. |
+| `physical.number_of_wagons` | number | with `physical` | Number of wagons attached to the powered unit | Stored as a number for legacy compatibility. The loader does not require an integer or impose a range. |
+| `physical.max_speed_ms` | number | with `physical` | Maximum train speed in metres per second | The loader does not impose a range. Convert km/h by dividing by `3.6`. |
+| `physical.max_deceleration_ms2` | number | with `physical` | Maximum service deceleration in metres per second squared | The loader does not impose a range. |
+| `physical.frontal_area_m2` | number | with `physical` | Frontal area used by the resistance model, in square metres | The loader does not impose a range. |
+| `physical.resistance_coefficient` | number | with `physical` | Coefficient used by the train resistance calculation | The loader does not impose a range. Copy it from verified train data. |
+| `physical.jerk_ms3` | number | with `physical` | Maximum change in acceleration per second | Measured in metres per second cubed. The loader does not impose a range. |
+| `physical.length_m` | number | with `physical` | Total unit length in metres | The loader does not impose a range. |
+| `train_units[].traction_curve` | array | no for loading | Piecewise traction-force curve | Each row must contain exactly five numbers. Export fails when a used unit has no rows. |
+| `traction_curve[][0]` | number | in each row | Lower speed bound, in metres per second | The loader does not check ordering or overlap. |
+| `traction_curve[][1]` | number | in each row | Upper speed bound, in metres per second | The simulator applies a row when speed is within its interval. |
+| `traction_curve[][2]` | number | in each row | Constant coefficient `C0` | Traction force is `C0 + C1 * v + C2 * v^2` within the row's speed interval. |
+| `traction_curve[][3]` | number | in each row | Linear coefficient `C1` | Used in the traction-force formula above. |
+| `traction_curve[][4]` | number | in each row | Quadratic coefficient `C2` | Used in the traction-force formula above. |
+| `train_units[].source` | object | no | Original legacy train-data paths | If present, both properties below must be non-empty strings. The exporter uses their base filenames. |
+| `source.data_file` | string | with `source` | Source file for the nine physical values | Usually a path such as `/TrainData/SLT06.txt`. |
+| `source.traction_file` | string | with `source` | Source file for the traction curve | Usually a path such as `/TrainData/T_SLT06.txt`. |
+
+### Compositions
+
+| Property | Type | Required | Meaning | Accepted value and checks |
+| --- | --- | --- | --- | --- |
+| `compositions[].id` | string | yes | Identifier used by services | Must not be empty and must be unique among compositions. |
+| `compositions[].units` | array of strings | yes | Ordered train units in the consist | Must contain at least one known train-unit ID. Non-string entries are ignored. Repeating an ID represents coupled copies of that unit. |
+
+When a composition contains several units, the exporter combines their masses, limits, lengths, resistance values, and traction curves into one legacy train definition.
+
+## `services.json`
+
+The root property is `services`, a required array. At least one service must exist.
+
+### Service properties
+
+| Property | Type | Required | Meaning | Accepted value and checks |
+| --- | --- | --- | --- | --- |
+| `services[].id` | string | yes | Service identifier | Must not be empty and must be unique among services. A `train_breakdown` incident uses this ID as its target. |
+| `services[].composition` | string | yes | Train consist used by the service | Must match a composition ID in `rolling_stock.json`. |
+| `services[].route` | string | yes | Infrastructure route used by the service | Must match a route ID in `signalling.json`. |
+| `services[].through` | boolean | no | Marks a service that crosses the scene without scheduled stops | Defaults to `false`. A through service with stops produces a warning. |
+| `services[].entry_time_seconds` | number | no | Time when the train enters the simulation | Defaults to the first stop's departure during legacy export, or `0` if that departure is absent. |
+| `services[].repeat` | object | no | Repetition settings | When absent, the service is exported as a one-shot service. |
+| `services[].repeat.headway_seconds` | number | with `repeat` | Time between repeated trains | Must be greater than `0`. |
+| `services[].stops` | array | yes | Ordered timetable stops | May be empty. An empty non-through service produces a warning. |
+
+### Stop properties
+
+| Property | Type | Required | Meaning | Accepted value and checks |
+| --- | --- | --- | --- | --- |
+| `stops[].station` | string | yes | Station where the train stops | Must match a station ID in `stations.json`. |
+| `stops[].platform` | string | no | Platform used at the station | If present and non-empty, it must match a platform ID on that station. |
+| `stops[].arrival_seconds` | number | no | Planned arrival relative to `base_time` | May be omitted on any stop. It is normally absent at the first stop. Negative values are allowed. |
+| `stops[].departure_seconds` | number | yes, except at the last stop | Planned departure relative to `base_time` | Must be at or after the arrival at the same stop. A lower value than the previous stop's departure produces a warning. Negative values are allowed. |
+| `stops[].dwell_seconds` | number | yes | Planned stationary time at the stop | Must be `0` or greater. A value larger than departure minus arrival produces a warning. |
+
+Keep stops in travel order. Verify that each station belongs to the chosen route because the validator cannot infer station order from legacy block tokens.
+
+## `incidents.json`
+
+This file is optional. When present, its root property `incidents` is a required array.
+
+| Property | Type | Required | Meaning | Accepted value and checks |
+| --- | --- | --- | --- | --- |
+| `incidents[].id` | string | yes | Incident identifier | Must not be empty and must be unique among incidents. |
+| `incidents[].type` | string | yes | Kind of disruption | Must be `signal_failure` or `train_breakdown`. |
+| `incidents[].target` | string | yes | Object affected by the incident | Must match a signal ID for `signal_failure` or a service ID for `train_breakdown`. |
+| `incidents[].start_seconds` | number | yes | Start time relative to `base_time` | Must be `0` or greater. |
+| `incidents[].end_seconds` | number | yes | End time relative to `base_time` | Must be greater than `start_seconds` and `0` or greater. |
+
+`Save Scene` removes `incidents.json` when the scene has no incidents.
+
+## `views.json`
+
+This optional file stores display settings. The V1 loader only checks that it contains valid JSON with an object at the root. It does not interpret or validate any property. `Save Scene As...` copies the file, while `Save Scene` leaves it unchanged.
+
+Do not depend on a `views.json` property for simulation behavior.
+
+## `legacy/`
+
+`legacy/` is a directory, not a JSON property. It contains data that the V1 model does not yet represent. Imported scenes need it for a simulation run.
+
+Common contents include:
+
+| Path | Purpose |
+| --- | --- |
+| `TrackLines/` | Track geometry, block layout, stations, switches, gradients, and speed limits used by the simulator |
+| `TMS/` and `TDS/` | Legacy signalling and train-detection data |
+| `GUI/` | Legacy display coordinates and related settings |
+| Other files | Case-specific input copied through without conversion |
+
+The exporter copies `legacy/` first, then writes routes, trains, timetables, and incidents from the canonical JSON. Do not edit generated files in an export and expect the changes to return to the V1 scene.
+
+## Validation command
+
+Run the validator after editing any file:
+
+```bash
+./build/scene_tool validate path/to/scene
+```
+
+An error blocks the scene from running. A warning points to a timetable or modelling issue that needs inspection but does not block the run. The full list of diagnostic codes is in the [scene schema reference](../architecture/scene-schema.md#diagnostics).

--- a/docs/guides/v1-scene-properties.md
+++ b/docs/guides/v1-scene-properties.md
@@ -27,7 +27,7 @@ All times in the other files are measured in seconds relative to `base_time`. Ne
 | `nodes` | array | yes | Reserved canonical infrastructure nodes | The loader checks that this is an array but does not read its entries in V1. Use `[]`. |
 | `arcs` | array | yes | Reserved canonical infrastructure links | The loader checks that this is an array but does not read its entries in V1. Use `[]`. |
 
-The current simulator reads track geometry, blocks, switches, gradients, and speed limits from `legacy/TrackLines/`. Editing `nodes` or `arcs` has no effect on a run.
+The current simulator reads track geometry, blocks, switches, gradients, and speed limits from the exported `TrackLines/` directory. The exporter accepts `legacy/Tracklines/` or `legacy/TrackLines/` and normalizes the name. Editing `nodes` or `arcs` has no effect on a run.
 
 ## `stations.json`
 
@@ -147,12 +147,12 @@ Common contents include:
 
 | Path | Purpose |
 | --- | --- |
-| `TrackLines/` | Track geometry, block layout, stations, switches, gradients, and speed limits used by the simulator |
+| `Tracklines/` or `TrackLines/` | Track geometry, block layout, stations, switches, gradients, and speed limits used by the simulator |
 | `TMS/` and `TDS/` | Legacy signalling and train-detection data |
 | `GUI/` | Legacy display coordinates and related settings |
 | Other files | Case-specific input copied through without conversion |
 
-The exporter copies `legacy/` first, then writes routes, trains, timetables, and incidents from the canonical JSON. Do not edit generated files in an export and expect the changes to return to the V1 scene.
+The exporter writes routes, trains, timetables, and incidents from the canonical JSON first. It then copies files from `legacy/` only when the generated output does not already contain the destination. Do not edit generated files in an export and expect the changes to return to the V1 scene.
 
 ## Validation command
 

--- a/docs/planning/github-issues.md
+++ b/docs/planning/github-issues.md
@@ -70,7 +70,7 @@
 
 21. Audit Netherlands input data
 22. Decide final assignment corridor
-23. Build `Gvc-Gdg-Ut` scene
+23. Build the Amsterdam to Hilversum scene
 24. Add assignment timetable data
 25. Add assignment smoke test
 

--- a/docs/planning/netherlands-audit.md
+++ b/docs/planning/netherlands-audit.md
@@ -50,6 +50,8 @@ After repair:
   - 1 composition
 - Import still emits 30 `scene.import.adjusted` warnings for `-1` departures at intermediate timetable stops. These are expected and documented adjustments.
 
+The professor's `Trains.zip` contains the same train directory now stored in the case. Its active root files are `Spr1.txt` through `Spr8.txt`. The supplied `trainNames.txt` lists those eight files. The committed versions use `T_SLT06.txt` in place of the attachment's `T455_04.txt`, which keeps the active SLT services tied to the SLT traction curve.
+
 Locked by `test_sceneimporter`, which now imports and validates the Netherlands source and checks that complex route tokens are preserved without parse warnings. `test_sceneexporter` checks that exported Netherlands switch-transition route tokens are not double-wrapped.
 
 ## Runtime Check
@@ -63,6 +65,9 @@ Remaining runtime limitations:
 
 End-to-end Netherlands movement remains outside this slice.
 
-## Wontfix For V1
+## Current limits
 - Unused Waterloo and other bucketed train sets under `Trains/` were left untouched.
-- The repaired legacy Netherlands station set contains `Ut`, `Asd`, `Hvs`, `Brn`, `Dld`, and `Alm`, but not `Gvc` or `Gdg`. The assignment corridor should be built as a dedicated scene rather than treated as already present in this legacy folder.
+- The active services cover Utrecht, Hilversum, Baarn, and Den Dolder. They do not cover Amsterdam.
+- The case contains Amsterdam to Hilversum timetables and SLT and VIRM train data, but the services and planned times still need work.
+- Candidate route IDs are 29 through 36, 39 through 42, 53, and 54. Their direction and train type are not yet verified.
+- Keep the full Netherlands case as the reference. Derive the smaller assignment scene after the selected services run in both directions.

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -61,7 +61,7 @@ Goal: build the first EGTRAIN version of the OpenTrack assignment.
 Missing work:
 
 - Audit and repair Netherlands input data.
-- Choose the final corridor, likely Den Haag Centraal to Gouda to Utrecht Centraal.
+- Verify the Amsterdam to Hilversum route candidates.
 - Build a curated assignment scene.
 - Add train material variants.
 - Add base timetable and disruption scenarios.

--- a/docs/product/assignment-corridor.md
+++ b/docs/product/assignment-corridor.md
@@ -1,20 +1,25 @@
 # Assignment Corridor
 
 ## Decision
-Use Den Haag Centraal (`Gvc`) - Gouda (`Gdg`) - Utrecht Centraal (`Ut`) as the V1 assignment corridor.
+Use Amsterdam (`Asd`) to Hilversum (`Hvs`) as the V1 assignment corridor.
 
 ## Reason
-This is the corridor named by the assignment workflow. The Netherlands audit found that the repaired legacy Netherlands data imports and validates, but its station set does not contain `Gvc` or `Gdg`. It covers a different network centered on Utrecht, Amsterdam, Hilversum, Breukelen, Duivendrecht, and Almere.
+The Netherlands input contains Amsterdam and Hilversum infrastructure, Sprinter and Intercity timetables, and SLT and VIRM train data. This gives the assignment two train types and different stopping patterns.
 
-The consequence is that #32 should build a dedicated Gvc-Gdg-Ut scene. It should not assume that the current `Input_EGTRAIN_Netherlands` folder already contains the assignment infrastructure.
+The active train set currently contains eight Sprinter services around Utrecht, Hilversum, Baarn, and Den Dolder. Amsterdam services still need to be created and tested.
 
-## Rejected Alternatives
-- `Ut` - `Hvs` - `Brn`: present in the repaired legacy data, but not the assignment corridor.
-- `Asd` - `Ut`: present in timetables, but broader than the assignment target and missing Gouda.
-- Full repaired Netherlands case: useful as an import regression source, but too large and still not a running assignment scene.
+Candidate route IDs are 29 through 36, 39 through 42, 53, and 54. These IDs came from the original case author. Each route must be checked for direction, station sequence, and train type.
 
-## Consequences For #32
-- Build the assignment scene around `Gvc`, `Gdg`, and `Ut`.
-- Keep the first version narrow enough for one train and a small repeated timetable.
-- Add only the infrastructure, routes, services, rolling stock, and timetable data needed for the assignment workflow.
-- Use the repaired Netherlands import as regression coverage, not as the source of the final assignment scene.
+## Other options
+
+- Utrecht to Hilversum, Baarn, and Den Dolder already runs with Sprinter services. It remains the baseline but lacks Intercity traffic.
+- The full Netherlands case remains the import and compatibility reference. It is too large for the final teaching scene.
+
+## Assignment scene
+
+- Keep the full Netherlands legacy and V1 cases intact.
+- Verify one Amsterdam to Hilversum service before building a timetable.
+- Add one Sprinter and one Intercity in each direction.
+- Set planned times from measured runs.
+- Derive a smaller scene after the train set works.
+- Remove only infrastructure that is outside the verified route dependency set.

--- a/docs/product/assignment-workflow.md
+++ b/docs/product/assignment-workflow.md
@@ -1,6 +1,6 @@
 # Assignment Workflow
 
-EGTRAIN should replace the current OpenTrack workflow used in the railway traffic management assignment. The target V1 scenario is Den Haag Centraal (`Gvc`) to Gouda (`Gdg`) to Utrecht Centraal (`Ut`).
+EGTRAIN should replace the current OpenTrack workflow used in the railway traffic management assignment. The target V1 scenario is Amsterdam (`Asd`) to Hilversum (`Hvs`), with Sprinter and Intercity services.
 
 ## Users
 


### PR DESCRIPTION
## What changed

- Added a student guide for building, opening, editing, validating, exporting, and running V1 scenes.
- Added a field reference for every V1 JSON property and the legacy passthrough directory.
- Added the Netherlands assignment brief, route worksheet, milestones, responsibility split, and meeting agenda.
- Updated repository navigation and assignment planning for Amsterdam to Hilversum.
- Corrected the documented export order and supported Tracklines directory casing.

## Why

Students need one GitHub source for application use, scene authoring, and the Netherlands assignment. The existing schema page described the file shapes but did not explain each property or the complete work sequence.

## Checks

- All relative Markdown links in the repository resolve.
- The diff passes `git diff --check`.
- All changed Markdown files parse as UTF-8.
- The four reference V1 scenes validate. Copenhagen retains its existing dwell-window warnings.