### PR TITLE
Fix console output tee and signed digit classification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,7 +411,7 @@ if(EGTRAIN_BUILD_TESTS)
 		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_headless_smoke_decode.py)
 	add_test(NAME test_case3_startup_errors
 		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_case3_startup_errors.py $<TARGET_FILE:QEGTRAIN>)
-	set_tests_properties(test_case3_startup_errors PROPERTIES TIMEOUT 60)
+	set_tests_properties(test_case3_startup_errors PROPERTIES TIMEOUT 120)
 	add_test(NAME test_scene_tool_diagnostics
 		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_scene_tool_diagnostics.py $<TARGET_FILE:scene_tool>)
 	add_test(NAME test_startup_launch_contract

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,12 @@ if(EGTRAIN_BUILD_TESTS)
     target_link_libraries(test_visualpolish PRIVATE Qt5::Core Qt5::Gui)
     add_test(NAME test_visualpolish COMMAND test_visualpolish)
 
+    add_executable(test_consolestream
+        ${SRC_DIR}/tests/test_consolestream.cpp
+        ${SRC_DIR}/widgets/ConsoleWidget.cpp)
+    target_link_libraries(test_consolestream PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets)
+    add_test(NAME test_consolestream COMMAND test_consolestream)
+
     add_test(NAME test_qt_resources
         COMMAND python3 ${CMAKE_SOURCE_DIR}/tools/e2e/test_qt_resources.py)
 

--- a/EGTRAIN/QEGTRAIN/scene/SceneExporter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneExporter.cpp
@@ -134,7 +134,9 @@ static void synthesizeGuiLayout(const std::string& outDir, SceneExportResult& re
 				if (dirname.size() > 1 && dirname[0] == 'B') {
 					int n = -1;
 					std::string num = dirname.substr(1);
-					if (num.size() <= 6 && std::all_of(num.begin(), num.end(), ::isdigit))
+					if (num.size() <= 6 && std::all_of(num.begin(), num.end(), [](char value) {
+							return std::isdigit(static_cast<unsigned char>(value));
+						}))
 						n = std::stoi(num);
 					if (n >= 0) {
 						fs::path nodiFile = entry.path() / "NodiCumPari.txt";
@@ -338,7 +340,9 @@ SceneExportResult exportLegacyScene(const std::string& sceneDir, const std::stri
 	for (const auto& r : scene.routes) {
 		if (r.id.length() > 5 && r.id.substr(0, 5) == "route") {
 			std::string numStr = r.id.substr(5);
-			if (!numStr.empty() && numStr.length() <= 9 && std::all_of(numStr.begin(), numStr.end(), ::isdigit)) {
+			if (!numStr.empty() && numStr.length() <= 9 && std::all_of(numStr.begin(), numStr.end(), [](char value) {
+					return std::isdigit(static_cast<unsigned char>(value));
+				})) {
 				routeIndices[r.id] = std::stoi(numStr);
 				++conforming;
 			}

--- a/EGTRAIN/QEGTRAIN/scene/SceneImporter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneImporter.cpp
@@ -428,7 +428,9 @@ SceneImportResult importLegacyScene(const std::string& legacyDir,
 					if (stem.length() > 5 && stem.substr(0, 5) == "Route") {
 						std::string numPart = stem.substr(5);
 						bool isNum = !numPart.empty() && numPart.length() <= 9 &&
-									 std::all_of(numPart.begin(), numPart.end(), ::isdigit);
+									 std::all_of(numPart.begin(), numPart.end(), [](char value) {
+										 return std::isdigit(static_cast<unsigned char>(value));
+									 });
 						if (isNum) {
 							routeFiles.push_back({std::stoi(numPart), entry.path()});
 						}

--- a/EGTRAIN/QEGTRAIN/tests/test_consolestream.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_consolestream.cpp
@@ -1,0 +1,96 @@
+#include "widgets/ConsoleWidget.h"
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+class ReentrantBuf : public std::stringbuf {
+protected:
+	std::streamsize xsputn(const char* s, std::streamsize n) override {
+		std::cerr << "mirror";
+		return std::stringbuf::xsputn(s, n);
+	}
+};
+
+class RejectingBuf : public std::streambuf {
+protected:
+	std::streamsize xsputn(const char*, std::streamsize) override { return 0; }
+};
+
+int main() {
+	std::stringbuf coutOriginal;
+	std::stringbuf cerrOriginal;
+	std::string callback;
+
+	std::streambuf* realCout = std::cout.rdbuf(&coutOriginal);
+	std::streambuf* realCerr = std::cerr.rdbuf(&cerrOriginal);
+	{
+		ConsoleStreambuf capture([&callback](QString text) {
+			callback += text.toStdString();
+		});
+		capture.install();
+
+		std::cout << "cout-bulk";
+		std::cout.put('!');
+		std::cout.flush();
+		std::cerr << "cerr-bulk";
+		std::cerr.put('?');
+		std::cerr.flush();
+		std::cout << "cout-tail";
+		std::cerr << "cerr-tail";
+		capture.restore();
+		capture.restore();
+	}
+	std::cout.rdbuf(realCout);
+	std::cerr.rdbuf(realCerr);
+
+	bool ok = true;
+	ok &= expect(callback == "cout-bulk!cerr-bulk?cout-tailcerr-tail", "callback receives each write exactly once");
+	ok &= expect(coutOriginal.str() == "cout-bulk!cout-tail", "cout original receives only cout text");
+	ok &= expect(cerrOriginal.str() == "cerr-bulk?cerr-tail", "cerr original receives only cerr text");
+
+	ReentrantBuf reentrant;
+	std::stringbuf reentrantCerr;
+	std::string reentrantCallback;
+	std::cout.rdbuf(&reentrant);
+	std::cerr.rdbuf(&reentrantCerr);
+	{
+		ConsoleStreambuf capture([&reentrantCallback](QString text) {
+			reentrantCallback += text.toStdString();
+		});
+		capture.install();
+		std::cout.write("x", 1);
+		std::cout.flush();
+		capture.restore();
+	}
+	ok &= expect(reentrantCallback == "mirrorx", "reentrant original buffer does not deadlock or lose callback text");
+	ok &= expect(reentrant.str() == "x", "reentrant original receives cout text");
+	ok &= expect(reentrantCerr.str() == "mirror", "reentrant original may write through cerr");
+
+	RejectingBuf rejecting;
+	std::stringbuf rejectingCerr;
+	std::string rejectingCallback;
+	std::cout.rdbuf(&rejecting);
+	std::cerr.rdbuf(&rejectingCerr);
+	{
+		ConsoleStreambuf capture([&rejectingCallback](QString text) {
+			rejectingCallback += text.toStdString();
+		});
+		capture.install();
+		std::cout.write("lost", 4);
+		capture.restore();
+	}
+	ok &= expect(rejectingCallback == "lost", "callback keeps text rejected by original destination");
+
+	std::cout.rdbuf(realCout);
+	std::cerr.rdbuf(realCerr);
+	std::cout.clear();
+	std::cerr.clear();
+	return ok ? 0 : 1;
+}

--- a/EGTRAIN/QEGTRAIN/tests/test_sceneexporter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_sceneexporter.cpp
@@ -239,14 +239,44 @@ int main(int argc, char** argv) {
 		ok &= expect(line == "@Depot/1@", "Slash block id remains wrapped");
 	}
 
-	// 8. Nonexistent scene dir
+	// 8. Non-ASCII route ids are not treated as decimal route numbers.
+	{
+		TempDir sceneDir, outDir;
+		fs::path scene(sceneDir.dir);
+		const std::string nonAsciiRouteId = std::string("route") + "\xC3\xA9";
+		std::ofstream(scene / "scene.json") << R"({"schema_version":1,"name":"Non-ASCII Route Id"})" << "\n";
+		std::ofstream(scene / "infrastructure.json") << R"({"nodes":[],"arcs":[]})" << "\n";
+		std::ofstream(scene / "stations.json") << R"({"stations":[{"id":"st","name":"Station","platforms":[]}]})" << "\n";
+		std::ofstream signalling(scene / "signalling.json");
+		signalling << R"({"signals":[],"routes":[{"id":")" << nonAsciiRouteId << R"(","blocks":["ASCII"]}]})" << "\n";
+		signalling.close();
+		std::ofstream(scene / "rolling_stock.json")
+			<< R"({"train_units":[{"id":"unit","physical":{"mass_of_traction_unit_kg":1,"mass_of_a_wagon_kg":1,"number_of_wagons":0,"max_speed_ms":1,"max_deceleration_ms2":1,"frontal_area_m2":1,"resistance_coefficient":1,"jerk_ms3":1,"length_m":1},"traction_curve":[[0,1,1,0,0]]}],"compositions":[{"id":"comp","units":["unit"]}]})"
+			<< "\n";
+		std::ofstream services(scene / "services.json");
+		services << R"({"services":[{"id":"svc","composition":"comp","route":")" << nonAsciiRouteId
+			 << R"(","entry_time_seconds":0,"stops":[{"station":"st","departure_seconds":0,"dwell_seconds":0}]}]})" << "\n";
+		services.close();
+
+		auto res = exportLegacyScene(sceneDir.dir, outDir.dir);
+		printErrors(res.diagnostics, "Non-ASCII route id export");
+		ok &= expect(res.success(), "Non-ASCII route id export succeeds");
+
+		std::ifstream route(fs::path(outDir.dir) / "Routes" / "Route0.txt");
+		std::string line;
+		ok &= expect(route.good(), "Non-ASCII route id uses sequential ASCII filename");
+		std::getline(route, line);
+		ok &= expect(line == "@ASCII@", "Non-ASCII route id contents remain unchanged");
+	}
+
+	// 9. Nonexistent scene dir
 	{
 		TempDir outDir;
 		auto res = exportLegacyScene("/no/such/scene", outDir.dir);
 		ok &= expect(!res.success(), "Nonexistent scene export fails");
 	}
 
-	// 9. Multi-unit composition export
+	// 10. Multi-unit composition export
 	{
 		TempDir sceneDir, outDir;
 		fs::path scene(sceneDir.dir);
@@ -291,7 +321,7 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// 10. Multi-unit composition with only degenerate traction bands fails
+	// 11. Multi-unit composition with only degenerate traction bands fails
 	{
 		TempDir sceneDir, outDir;
 		fs::path scene(sceneDir.dir);
@@ -316,7 +346,7 @@ int main(int argc, char** argv) {
 		ok &= expect(foundEmptyCurveDiag, "Empty combined traction curve is diagnosed");
 	}
 
-	// 11. Near-duplicate band boundaries collapse instead of forming sliver bands
+	// 12. Near-duplicate band boundaries collapse instead of forming sliver bands
 	{
 		TempDir sceneDir, outDir;
 		fs::path scene(sceneDir.dir);
@@ -347,7 +377,7 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// 12. Synthetic GUI layout generated from Stations and NodiCumPari
+	// 13. Synthetic GUI layout generated from Stations and NodiCumPari
 	{
 		TempDir sceneDir, outDir;
 		fs::path scene(sceneDir.dir);
@@ -414,7 +444,7 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// 13. Scene with no legacy/TrackLines/Stations.txt exports successfully and writes no GUI/StationsCoord.txt
+	// 14. Scene with no legacy/TrackLines/Stations.txt exports successfully and writes no GUI/StationsCoord.txt
 	{
 		TempDir sceneDir, outDir;
 		fs::path scene(sceneDir.dir);
@@ -432,7 +462,7 @@ int main(int argc, char** argv) {
 		ok &= expect(!fs::exists(guiDir / "StationsCoord.txt"), "GUI/StationsCoord.txt is not written");
 	}
 
-	// 14. Mirrored band listed before the reference trackline still maps by name
+	// 15. Mirrored band listed before the reference trackline still maps by name
 	{
 		TempDir sceneDir, outDir;
 		fs::path scene(sceneDir.dir);
@@ -476,7 +506,7 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// 15. Stations without any trackline node data generate no GUI files at all
+	// 16. Stations without any trackline node data generate no GUI files at all
 	{
 		TempDir sceneDir, outDir;
 		fs::path scene(sceneDir.dir);
@@ -496,7 +526,7 @@ int main(int argc, char** argv) {
 		ok &= expect(!fs::exists(fs::path(outDir.dir) / "GUI" / "caseStudyTrackData.txt"), "No half-written caseStudyTrackData.txt");
 	}
 
-	// 16. Incidents export to the legacy Incidents.txt
+	// 17. Incidents export to the legacy Incidents.txt
 	{
 		TempDir sceneDir, outDir;
 		fs::path scene(sceneDir.dir);
@@ -531,7 +561,7 @@ int main(int argc, char** argv) {
 		ok &= expect(hasDiag(res.diagnostics, "scene.export.adjusted", SceneSeverity::Warning), "Unmatched signal target warned");
 	}
 
-	// 17. Scene without incidents writes no Incidents.txt
+	// 18. Scene without incidents writes no Incidents.txt
 	{
 		TempDir sceneDir, outDir;
 		fs::path scene(sceneDir.dir);

--- a/EGTRAIN/QEGTRAIN/tests/test_sceneimporter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_sceneimporter.cpp
@@ -394,6 +394,30 @@ int main(int argc, char** argv) {
 		ok &= expect(malformedRowFlagged, "parse warning names the malformed token row");
 	}
 
+	// 12. Non-ASCII route filenames are not treated as decimal route numbers.
+	{
+		TempDir lDir, outDir;
+		fs::create_directories(fs::path(lDir.dir) / "Routes");
+		fs::create_directories(fs::path(lDir.dir) / "TrackLines");
+		std::ofstream(lDir.dir + "/TrackLines/Stations.txt") << "0\tASCII\n";
+		std::ofstream(lDir.dir + "/Routes/Route12.txt") << "@ASCII@\n";
+		const std::string nonAsciiRoute = std::string("Route") + "\xC3\xA9.txt";
+		std::ofstream(fs::path(lDir.dir) / "Routes" / nonAsciiRoute) << "@NonAscii@\n";
+
+		auto res = importLegacyScene(lDir.dir, outDir.dir, "NonAsciiRouteFilename");
+		printErrors(res.diagnostics, "Non-ASCII route filename import");
+		ok &= expect(res.success(), "Non-ASCII route filename import succeeds");
+
+		std::ifstream signalling(fs::path(outDir.dir) / "signalling.json");
+		json signallingJson;
+		signalling >> signallingJson;
+		ok &= expect(signallingJson["routes"].size() == 1, "Non-ASCII route filename is skipped");
+		if (!signallingJson["routes"].empty()) {
+			ok &= expect(signallingJson["routes"][0]["id"] == "route12", "ASCII route filename remains accepted");
+			ok &= expect(signallingJson["routes"][0]["blocks"][0] == "ASCII", "ASCII route contents remain unchanged");
+		}
+	}
+
 	if (!ok)
 		return 1;
 	std::cout << "all SceneImporter tests passed\n";

--- a/EGTRAIN/QEGTRAIN/widgets/ConsoleWidget.cpp
+++ b/EGTRAIN/QEGTRAIN/widgets/ConsoleWidget.cpp
@@ -5,7 +5,9 @@
 // ---- ConsoleStreambuf ----
 
 ConsoleStreambuf::ConsoleStreambuf(std::function<void(QString)> callback)
-    : m_callback(std::move(callback))
+    : m_callback(std::move(callback)),
+      m_coutProxy(this, Stream::Cout),
+      m_cerrProxy(this, Stream::Cerr)
 {
 }
 
@@ -15,8 +17,8 @@ ConsoleStreambuf::~ConsoleStreambuf() {
 
 void ConsoleStreambuf::install() {
     if (m_installed) return;
-    m_oldCout = std::cout.rdbuf(this);
-    m_oldCerr = std::cerr.rdbuf(this);
+    m_oldCout = std::cout.rdbuf(&m_coutProxy);
+    m_oldCerr = std::cerr.rdbuf(&m_cerrProxy);
     m_installed = true;
 }
 
@@ -28,37 +30,82 @@ void ConsoleStreambuf::restore() {
     flushBuffer();
 }
 
+ConsoleStreambuf::ProxyStreambuf::ProxyStreambuf(ConsoleStreambuf* owner, Stream stream)
+    : m_owner(owner), m_stream(stream)
+{
+}
+
+ConsoleStreambuf::int_type ConsoleStreambuf::ProxyStreambuf::overflow(int_type c) {
+    return m_owner->overflow(m_stream, c);
+}
+
+std::streamsize ConsoleStreambuf::ProxyStreambuf::xsputn(const char* s, std::streamsize n) {
+    return m_owner->xsputn(m_stream, s, n);
+}
+
+int ConsoleStreambuf::ProxyStreambuf::sync() {
+    return m_owner->sync(m_stream);
+}
+
 ConsoleStreambuf::int_type ConsoleStreambuf::overflow(int_type c) {
+    return overflow(Stream::Cout, c);
+}
+
+ConsoleStreambuf::int_type ConsoleStreambuf::overflow(Stream stream, int_type c) {
+    std::streambuf* original = stream == Stream::Cout ? m_oldCout : m_oldCerr;
+    bool forwarded = true;
+
     QMutexLocker lock(&m_mutex);
     if (c != EOF) {
+        if (original && traits_type::eq_int_type(original->sputc(c), traits_type::eof()))
+            forwarded = false;
         m_buffer += static_cast<char>(c);
         if (c == '\n') {
             lock.unlock();
             flushBuffer();
         }
     }
-    return c;
+    return forwarded ? c : traits_type::eof();
 }
 
 std::streamsize ConsoleStreambuf::xsputn(const char* s, std::streamsize n) {
+    return xsputn(Stream::Cout, s, n);
+}
+
+std::streamsize ConsoleStreambuf::xsputn(Stream stream, const char* s, std::streamsize n) {
     if (n <= 0) return n;
+
+    std::streambuf* original = stream == Stream::Cout ? m_oldCout : m_oldCerr;
+    std::streamsize forwarded = n;
+    std::string to_flush;
     QMutexLocker lock(&m_mutex);
-    m_buffer.append(s, static_cast<std::size_t>(n));
-    auto pos = m_buffer.rfind('\n');
-    if (pos != std::string::npos) {
-        std::string to_flush = m_buffer.substr(0, pos + 1);
-        m_buffer = m_buffer.substr(pos + 1);
-        lock.unlock();
-        if (m_callback) {
-            m_callback(QString::fromStdString(to_flush));
-        }
+	if (original)
+		forwarded = original->sputn(s, n);
+	m_buffer.append(s, static_cast<std::size_t>(n));
+	auto pos = m_buffer.rfind('\n');
+	if (pos != std::string::npos) {
+		to_flush = m_buffer.substr(0, pos + 1);
+		m_buffer = m_buffer.substr(pos + 1);
     }
-    return n;
+    lock.unlock();
+    if (!to_flush.empty() && m_callback)
+		m_callback(QString::fromStdString(to_flush));
+    return forwarded;
 }
 
 int ConsoleStreambuf::sync() {
+    return sync(Stream::Cout);
+}
+
+int ConsoleStreambuf::sync(Stream stream) {
+    std::streambuf* original = stream == Stream::Cout ? m_oldCout : m_oldCerr;
+    int result = 0;
+    if (original) {
+        QMutexLocker lock(&m_mutex);
+        result = original->pubsync();
+    }
     flushBuffer();
-    return 0;
+    return result;
 }
 
 void ConsoleStreambuf::flushBuffer() {

--- a/EGTRAIN/QEGTRAIN/widgets/ConsoleWidget.h
+++ b/EGTRAIN/QEGTRAIN/widgets/ConsoleWidget.h
@@ -27,14 +27,35 @@ protected:
     int sync() override;
 
 private:
-    std::function<void(QString)> m_callback;
-    std::streambuf* m_oldCout = nullptr;
-    std::streambuf* m_oldCerr = nullptr;
-    std::string m_buffer;
-    QMutex m_mutex;
-    bool m_installed = false;
+	enum class Stream { Cout, Cerr };
 
-    void flushBuffer();
+	class ProxyStreambuf : public std::streambuf {
+	public:
+		ProxyStreambuf(ConsoleStreambuf* owner, Stream stream);
+
+	protected:
+		int_type overflow(int_type c) override;
+		std::streamsize xsputn(const char* s, std::streamsize n) override;
+		int sync() override;
+
+	private:
+		ConsoleStreambuf* m_owner;
+		Stream m_stream;
+	};
+
+	std::function<void(QString)> m_callback;
+	std::streambuf* m_oldCout = nullptr;
+	std::streambuf* m_oldCerr = nullptr;
+	std::string m_buffer;
+	QMutex m_mutex{QMutex::Recursive};
+	bool m_installed = false;
+	ProxyStreambuf m_coutProxy;
+	ProxyStreambuf m_cerrProxy;
+
+	int_type overflow(Stream stream, int_type c);
+	std::streamsize xsputn(Stream stream, const char* s, std::streamsize n);
+	int sync(Stream stream);
+	void flushBuffer();
 };
 
 // Dock widget that displays captured console output

--- a/tools/e2e/test_case3_startup_errors.py
+++ b/tools/e2e/test_case3_startup_errors.py
@@ -21,7 +21,7 @@ def main() -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
-        timeout=60,
+        timeout=120,
     )
     if proc.returncode != 0:
         raise SystemExit(f"case 3 startup exited with {proc.returncode}")


### PR DESCRIPTION
Fixes #139
Fixes #133

## What changed

- Tee `std::cout` and `std::cerr` to their respective original stream buffers while continuing to feed the in-app console callback.
- Preserve callback delivery for reentrant writes and writes rejected by the original destination.
- Cast route-name bytes through `unsigned char` before every affected `std::isdigit` call in scene import and export paths.
- Add focused console-stream and non-ASCII route regression coverage.

## Root cause

`ConsoleStreambuf::install()` replaced both standard stream buffers without forwarding writes. The scene paths passed potentially negative plain `char` values to `isdigit`, which is undefined outside EOF and the unsigned-char range.

## Validation

- CMake configure and full build
- CTest: 25/25 passed
- Visual-polish smoke passed
- Headless smoke passed for cases 1 through 4, including movement and station checks
- Roundtrip smoke passed for all four scenes
- Review: no findings
- `git diff --check`: clean