### PR TITLE
Rewrite Netherlands assignment guide and document V1 gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,57 @@
 # EGTRAIN
 
-EGTRAIN is a Qt desktop application for railway micro-simulation. It loads a case-study railway network, runs train movements over signalled infrastructure, and shows timetable, delay, speed, and blocking-time outputs.
+EGTRAIN is a desktop application for microscopic railway simulation. It
+combines railway infrastructure, signalling, rolling stock, services,
+timetables, and passenger demand in an interactive Qt interface.
 
-The product goal is a student-friendly replacement for the current OpenTrack assignment workflow. The first target is a V1 workflow where students can load an assignment scene, edit trains and services inside the app, run simulations, inspect diagrams, and export report data without editing legacy text files by hand.
+The application is built for students and railway researchers who want to
+create and study operating scenarios without editing collections of legacy
+text files by hand. A complete workflow stays inside EGTRAIN: open a case
+study, inspect or edit its trains and services, run the simulation, examine
+the diagrams, and export data for reports or further analysis.
 
-## Repository layout
+## What EGTRAIN does
 
-```text
-EGTRAIN/QEGTRAIN/        C++ Qt application source
-EGTRAIN/QEGTRAIN/Input/  Case-study input data used by smoke tests
-EGTRAIN/QEGTRAIN/tests/  C++ regression tests
-tools/e2e/               End-to-end smoke tests
-tools/golden_master/     Output comparison helpers
-docs/                    Product, architecture, planning, build notes
-```
+- Loads railway networks and service data from the included case studies.
+- Displays tracks, stations, signals, routes, and moving trains in a graphical
+  scene.
+- Lets users inspect and edit trains, services, timetables, and scene
+  properties.
+- Simulates train movement over signalled infrastructure, including delays and
+  passenger operations.
+- Produces timetable, train-path, delay, speed, trajectory, and blocking-time
+  results.
+- Exports simulation data for reports and external analysis.
+- Retains compatibility with existing EGTRAIN input data while scene-based
+  editing replaces manual text-file work.
 
-Runtime output is written under `EGTRAIN/QEGTRAIN/Output/` and is ignored by git.
+## Background
+
+EGTRAIN was originally developed by
+[Egidio Quaglietta](https://orcid.org/0000-0002-7936-5832) as a microscopic
+railway simulation model. The model and its early applications are described
+in [Quaglietta's doctoral thesis](https://doi.org/10.6092/unina/fedoa/8599).
+
+This repository continues that work as a desktop application for students and
+researchers. The original EGTRAIN case-study inputs for the SORTEDMOBILITY
+research project are available from
+[4TU.ResearchData](https://doi.org/10.4121/e78d0dc2-3123-4510-a2c5-7ad017a02e33.v1).
+
+## Included case studies
+
+EGTRAIN includes four railway scenarios:
+
+- Netherlands
+- Paimpol, France
+- Copenhagen, Denmark
+- Milan to Brescia, Italy
+
+They can be selected with the `-n` command-line option:
+
+- `-n 1`: Netherlands
+- `-n 2`: Paimpol
+- `-n 3`: Copenhagen
+- `-n 4`: Milan to Brescia
 
 ## Build
 
@@ -42,6 +78,26 @@ cmake -S . -B build -DEGTRAIN_BUILD_TESTS=ON -DCMAKE_PREFIX_PATH=/opt/homebrew/o
 cmake --build build
 ```
 
+## Run
+
+Run EGTRAIN from `EGTRAIN/QEGTRAIN` so legacy relative input paths resolve:
+
+```bash
+cd EGTRAIN/QEGTRAIN
+../../build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN
+```
+
+Launching without arguments opens the graphical application with the
+Netherlands case study. Command-line options can select another case or
+configure an automated run. For example:
+
+```bash
+../../build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN \
+  -n 3 -h 8000 -g 1 -pax 0 -TSM 0 -RC 0
+```
+
+Add `--interactive` to use the legacy terminal questionnaire.
+
 ## Test
 
 ```bash
@@ -50,38 +106,28 @@ tools/e2e/headless_smoke.py
 tools/e2e/visual_polish_smoke.sh
 ```
 
-The headless smoke test runs the Copenhagen and Brescia cases. It checks process exit, train movement, trajectory samples, and served-station output.
+The smoke tests cover all four case studies and check application startup,
+train movement, trajectory samples, served-station output, and the graphical
+interface.
 
-## Run
+## Documentation
 
-Run from `EGTRAIN/QEGTRAIN` so the legacy relative input paths resolve.
+- [Application and scene guide](docs/guides/scenes-and-application.md)
+- [Scene property reference](docs/guides/v1-scene-properties.md)
+- [Netherlands assignment guide](docs/guides/netherlands-assignment.md)
+- [Assignment workflow](docs/product/assignment-workflow.md)
+- [Scene model architecture](docs/architecture/scene-model.md)
+- [Build and test guide](docs/development/build-and-test.md)
 
-```bash
-cd EGTRAIN/QEGTRAIN
-../../build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN
+## Repository layout
+
+```text
+EGTRAIN/QEGTRAIN/        C++ Qt application source
+EGTRAIN/QEGTRAIN/Input/  Included case-study data
+EGTRAIN/QEGTRAIN/tests/  C++ regression tests
+tools/e2e/               End-to-end smoke tests
+tools/golden_master/     Output comparison helpers
+docs/                    User, architecture, and development documentation
 ```
 
-No-argument launch opens the GUI with case study 1. Use flags for a specific
-case or automated run, for example `-n 3 -h 8000 -g 1 -pax 0 -TSM 0 -RC 0`.
-Add `--interactive` only when you want the legacy terminal questionnaire.
-
-Case selector:
-
-- `-n 1`: Netherlands
-- `-n 2`: Paimpol
-- `-n 3`: Copenhagen
-- `-n 4`: Brescia
-
-Copenhagen and Brescia are the main regression cases. The Netherlands case imports, validates, exports, and runs with eight Sprinter services. Amsterdam to Hilversum services still need route checks and timetable work before the case can be used for the assignment.
-
-## Planning
-
-- [Application and V1 scene guide](docs/guides/scenes-and-application.md)
-- [V1 scene property reference](docs/guides/v1-scene-properties.md)
-- [Netherlands scene assignment](docs/guides/netherlands-assignment.md)
-- [Assignment workflow](docs/product/assignment-workflow.md)
-- [Scene model design](docs/architecture/scene-model.md)
-- [Roadmap](docs/planning/roadmap.md)
-- [Agile workflow](docs/planning/agile-workflow.md)
-- [GitHub issue plan](docs/planning/github-issues.md)
-- [Build and test guide](docs/development/build-and-test.md)
+Runtime output is written under `EGTRAIN/QEGTRAIN/Output/` and is ignored by git.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Add `--interactive` to use the legacy terminal questionnaire.
 
 ## Test
 
+Run these commands from the repository root:
+
 ```bash
 ctest --test-dir build --output-on-failure
 tools/e2e/headless_smoke.py

--- a/docs/guides/netherlands-assignment.md
+++ b/docs/guides/netherlands-assignment.md
@@ -1,38 +1,33 @@
-# Netherlands scene assignment
+# Netherlands assignment development brief
 
-## Objective
+## Purpose
 
-Prepare an Amsterdam to Hilversum teaching scene with Sprinter and Intercity services. Start from the full Netherlands case. Do not reduce the network until the selected trains run correctly.
+This is a working brief for the assignment lead and two teaching assistants. The three of us are co-authors of a new EGTRAIN assignment based on the existing OpenTrack assignment. The teaching assistants are not students completing the assignment.
 
-The repository keeps two products:
+Our first task is to agree on the learning goals, build a working Amsterdam to Hilversum reference case, and decide which parts of the OpenTrack assignment transfer well to EGTRAIN. The final student handout and model answers come after the reference case works.
 
-- `Scenes/Netherlands` is the full V1 reference case.
-- A separate Amsterdam to Hilversum scene will contain the smaller assignment network.
+Read [Using EGTRAIN and authoring V1 scenes](scenes-and-application.md) and the [V1 scene property reference](v1-scene-properties.md) before changing scene data.
 
-Read [Using EGTRAIN and authoring V1 scenes](scenes-and-application.md) before changing data.
+## Material we are adapting
 
-## Supplied files
+The OpenTrack model answers use the Den Haag Centraal to Utrecht corridor. They assess a sequence of modelling and analysis tasks:
 
-The professor supplied `Trains.zip` and `trainNames.txt`.
+1. Define train compositions and services.
+2. Measure minimum running times with unhindered trains.
+3. Add running time supplements and produce a conflict-free timetable.
+4. Inspect speed, traction, and blocking time diagrams.
+5. Compare rolling stock assignments.
+6. Calculate headways, identify critical blocks, and assess capacity.
+7. Simulate signal and rolling stock failures.
+8. Insert an extra train with as little delay as possible.
 
-The active manifest contains:
+The model answers state that the method matters more than reproducing their exact numerical results. Our assignment should follow the same rule. We must document the assumptions, rounding method, train performance settings, and service choices used for our own reference answers.
 
-```text
-Spr1.txt
-Spr2.txt
-Spr3.txt
-Spr4.txt
-Spr5.txt
-Spr6.txt
-Spr7.txt
-Spr8.txt
-```
+The Netherlands material supplied by the professor includes `Trains.zip` and `trainNames.txt`. The active manifest contains `Spr1.txt` through `Spr8.txt`. These services cover Utrecht, Hilversum, Baarn, and Den Dolder, but not Amsterdam.
 
-These eight services cover Utrecht, Hilversum, Baarn, and Den Dolder. They do not add Amsterdam services.
+The committed files use `T_SLT06.txt` instead of the attachment's `T455_04.txt`. Keep `T_SLT06.txt`; it matches the SLT data used by the current Netherlands scene. The case also contains Amsterdam and Hilversum timetable files plus SLT and VIRM rolling stock data.
 
-The repository already contains the archive contents. The eight active train files use `T_SLT06.txt` instead of the attachment's `T455_04.txt`. Keep the repository value. It matches the SLT train data used by the V1 scene.
-
-The legacy case also contains Amsterdam and Hilversum timetable files, `VIRM06.txt`, `T_VIRM06.txt`, `SLT06.txt`, and `T_SLT06.txt`. The candidate routes named by the professor are:
+The professor identified these route numbers as candidates:
 
 ```text
 29 30 31 32 33 34 35 36
@@ -40,25 +35,22 @@ The legacy case also contains Amsterdam and Hilversum timetable files, `VIRM06.t
 53 54
 ```
 
-The route numbers are leads, not final assignments. Test each route before using it.
+They are leads, not confirmed assignments. We must establish direction, station order, stopping suitability, and runtime behaviour before using any of them in the assignment.
 
-## Working rules
+## Current EGTRAIN baseline
 
-- Keep the full Netherlands legacy case intact.
-- Keep `Scenes/Netherlands` as the full V1 reference.
-- Work on copies until a train completes its route.
-- Test one service at a time.
-- Change one input at a time when diagnosing a failure.
-- Record the route, direction, stopping pattern, rolling stock, and result.
-- Remove unrelated infrastructure only after the timetable works.
+`EGTRAIN/QEGTRAIN/Scenes/Netherlands` is the full V1 reference scene. Keep it intact. Create the smaller Amsterdam to Hilversum scene only after the selected services work on the full network.
 
-## Work sequence
+The repaired legacy case currently imports and validates with:
 
-### 1. Reproduce the current baseline
+- 41 stations
+- 74 routes with 5,429 route entries
+- 8 Sprinter services
+- 1 train unit and 1 composition
 
-Run the legacy Netherlands case with `Spr1.txt` through `Spr8.txt`. Record which services load, move, and reach their final station.
+The eight services run to the end of the simulation, but they do not yet establish the Amsterdam to Hilversum assignment. Station output, optional passenger data, the GUI timetable template, the candidate route directions, and the Intercity services still need verification.
 
-Import the legacy case and validate the result:
+Reproduce the baseline with:
 
 ```bash
 ./build/scene_tool import \
@@ -68,130 +60,126 @@ Import the legacy case and validate the result:
 ./build/scene_tool validate /tmp/netherlands-v1
 ```
 
-Compare the imported JSON files with `EGTRAIN/QEGTRAIN/Scenes/Netherlands`. Explain every difference before changing the committed scene.
+Compare the result with `EGTRAIN/QEGTRAIN/Scenes/Netherlands`. Record every importer adjustment that affects the proposed assignment.
 
-### 2. Map the candidate routes
+## Decisions for the co-author team
 
-Inspect routes 29 through 36, 39 through 42, 53, and 54. Run a single test train on each plausible route.
+Before writing student questions, agree on:
 
-Fill in this table as evidence:
+- the learning outcomes and assumed prior knowledge
+- the exact corridor boundaries and stations
+- the Sprinter and Intercity service pattern in both directions
+- the train compositions and performance settings
+- the timetable period, dwell times, supplements, and rounding rules
+- which OpenTrack analysis tasks EGTRAIN can support with evidence students can inspect
+- the evidence students must submit for each question
+- the grading criteria and acceptable numerical variation
 
-| Route | Origin | Destination | Direction | Stations passed | SPR or IC | Test result | Notes |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| 29 |  |  |  |  |  |  |  |
-| 30 |  |  |  |  |  |  |  |
-| 31 |  |  |  |  |  |  |  |
-| 32 |  |  |  |  |  |  |  |
-| 33 |  |  |  |  |  |  |  |
-| 34 |  |  |  |  |  |  |  |
-| 35 |  |  |  |  |  |  |  |
-| 36 |  |  |  |  |  |  |  |
-| 39 |  |  |  |  |  |  |  |
-| 40 |  |  |  |  |  |  |  |
-| 41 |  |  |  |  |  |  |  |
-| 42 |  |  |  |  |  |  |  |
-| 53 |  |  |  |  |  |  |  |
-| 54 |  |  |  |  |  |  |  |
+Use this table to decide what transfers from OpenTrack:
 
-### 3. Build one working service
+| OpenTrack task | Keep, adapt, or omit | EGTRAIN evidence | Reference answer owner | Open question |
+| --- | --- | --- | --- | --- |
+| Train compositions and services |  |  |  |  |
+| Minimum running times |  |  |  |  |
+| Running time supplements |  |  |  |  |
+| Conflict-free timetable and overtaking |  |  |  |  |
+| Speed and traction analysis |  |  |  |  |
+| Blocking time analysis |  |  |  |  |
+| Rolling stock comparison |  |  |  |  |
+| Headway and capacity assessment |  |  |  |  |
+| Signal and train failures |  |  |  |  |
+| Extra train insertion |  |  |  |  |
 
-Choose one direction. Create one service with:
+## Development sequence
 
-- a verified route
-- the correct SLT or VIRM composition
-- the matching stopping pattern
-- an entry time inside the simulation window
-- planned arrival and departure times
-- dwell times at scheduled stops
+### 1. Verify the route and service data
 
-Run it alone. Check movement, station order, final position, and output diagrams.
+Test each candidate route with one train at a time. Record the result instead of inferring direction or suitability from the route number.
 
-### 4. Add both train types and directions
+| Route | Origin | Destination | Direction | Stations passed | Suitable for | Result and evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| 29 |  |  |  |  |  |  |
+| 30 |  |  |  |  |  |  |
+| 31 |  |  |  |  |  |  |
+| 32 |  |  |  |  |  |  |
+| 33 |  |  |  |  |  |  |
+| 34 |  |  |  |  |  |  |
+| 35 |  |  |  |  |  |  |
+| 36 |  |  |  |  |  |  |
+| 39 |  |  |  |  |  |  |
+| 40 |  |  |  |  |  |  |
+| 41 |  |  |  |  |  |  |
+| 42 |  |  |  |  |  |  |
+| 53 |  |  |  |  |  |  |
+| 54 |  |  |  |  |  |  |
 
-After the first service works, add:
+### 2. Build the reference service set
 
-- one Sprinter in each direction
-- one Intercity in each direction
+Start with one verified service. Check its route, direction, rolling stock, stopping pattern, entry time, dwell times, station order, and final position. Then add one Sprinter and one Intercity in each direction.
 
-Use the service worksheet for every train:
-
-| Service | Type | Route | Direction | Timetable | Composition | Loads | Moves | Completes |
+| Service | Type | Route | Direction | Composition | Loads | Moves | Completes | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 |  |  |  |  |  |  |  |  |  |
 
-### 5. Tune the timetable
+Run trains separately before measuring minimum running times. Add timetable constraints only after the unhindered runs are repeatable.
 
-Set times from observed running times rather than guesses. For each service:
+### 3. Prototype the assignment questions
 
-1. Run the train without timetable pressure.
-2. Record the minimum running time between stops.
-3. Add the agreed running time supplement.
-4. Add dwell time.
-5. Round the timetable as required by the assignment.
-6. Run the complete timetable and check conflicts.
+For each retained OpenTrack task, write one EGTRAIN question and solve it ourselves. Keep the evidence that produced the answer, including input values, output files, screenshots where they clarify a diagram, and any calculation outside EGTRAIN.
 
-Keep the raw measurements with the timetable notes.
+A question stays in the assignment only when:
 
-### 6. Create the smaller assignment scene
+- the required EGTRAIN function works on the reference scene
+- the result can be checked from saved evidence
+- the wording permits documented modelling choices without making the answer arbitrary
+- the model answer explains the method and the expected range of results
 
-Copy the verified full V1 scene. Remove data in this order:
+### 4. Build the smaller assignment scene
 
-1. Unused services
-2. Unused compositions and train units
-3. Unused routes
-4. Infrastructure outside the selected route dependency set
+Copy the verified full scene. Remove unused services, rolling stock, routes, and infrastructure in that order. Validate and run after each reduction. Keep a dependency when removing it changes the route or simulation result.
 
-Validate and run after each step. Stop at the first failure and restore the last removed dependency.
+The current V1 format still depends on `legacy/` for track geometry and other runtime inputs. Do not distribute a scene without that directory until the native scene-input work listed in the [V1 reference](v1-scene-properties.md#work-that-removes-the-legacy-dependency) is complete.
 
-Record memory use and startup time before and after the reduction.
+### 5. Test the student workflow
 
-## Responsibility split
+Each co-author completes the draft from a clean copy without using the model answers. Record ambiguous wording, missing files, hidden assumptions, runtime, and any step that requires repository knowledge not taught in the handout.
 
-Student 1 owns route and infrastructure analysis. This includes the candidate route table, direction checks, station sequence, and the later network reduction.
+Revise the handout and model answers from those test runs. A second review should reproduce the same method and a defensible range of numerical results.
 
-Student 2 owns rolling stock and timetable analysis. This includes the SLT and VIRM data, service definitions, stopping patterns, and planned times.
+## Work ownership
 
-Both students integrate the first service, review each other's mappings, and run the final checks.
+Choose owners during the first meeting. Ownership is for development and review, not a division into student roles.
 
-## Milestones
+| Workstream | Owner | Reviewer | First deliverable |
+| --- | --- | --- | --- |
+| Learning outcomes and assignment structure |  |  | Question map |
+| Route and infrastructure verification |  |  | Completed route table |
+| Rolling stock and service definitions |  |  | Four-service reference set |
+| Timetable and analysis questions |  |  | Solved question prototype |
+| Scene packaging and clean-run test |  |  | Tested assignment scene |
+| Student handout and model answers |  |  | Reviewable draft |
 
-### Baseline
+## First meeting agenda
 
-- The eight supplied Sprinter services import into V1.
-- `scene_tool validate` exits successfully.
-- The current legacy case reaches the end of the simulation.
-- Known import adjustments are recorded.
+Use the first 60 minutes to leave with decisions and named work, not to perform the assignment.
 
-### Route map
+| Time | Discussion | Output |
+| --- | --- | --- |
+| 0 to 10 minutes | Intended course role and learning outcomes | Agreed audience and outcomes |
+| 10 to 20 minutes | OpenTrack question sequence and professor's comments | Initial keep, adapt, or omit decisions |
+| 20 to 30 minutes | Current Netherlands scene, supplied trains, and route candidates | Confirmed starting material and unknowns |
+| 30 to 40 minutes | Proposed Amsterdam to Hilversum service pattern | Reference service target |
+| 40 to 50 minutes | Workstreams, evidence, and review method | Owners and reviewers |
+| 50 to 60 minutes | First development cycle | Deliverables and next review date |
 
-- Every candidate route has a direction and station sequence, or a recorded reason for rejection.
-- At least one Amsterdam to Hilversum route works in each direction.
+The meeting is complete when the team has an agreed assignment aim, a first route test for each technical workstream, one owner for the question map, and a date to review the first working service.
 
-### Train set
+## Release criteria for the assignment draft
 
-- One Sprinter and one Intercity work in each direction.
-- Each service uses the correct route, rolling stock, and stopping pattern.
-- Planned times are based on measured runs.
-
-### Assignment scene
-
-- The full Netherlands V1 scene remains available as a reference.
-- The smaller scene validates, exports, and runs.
-- The scene contains no unresolved references.
-- A smoke check proves train movement and station arrival output.
-- The GitHub guide matches the delivered workflow.
-
-## Meeting agenda
-
-Use this 60 minute agenda for the first meeting:
-
-| Time | Topic |
-| --- | --- |
-| 0 to 10 minutes | Goal, source files, and the difference between the full case and assignment scene |
-| 10 to 20 minutes | Open the Netherlands V1 scene and trace one service through the JSON files |
-| 20 to 30 minutes | Import, validate, export, and run workflow |
-| 30 to 40 minutes | Candidate route IDs and the route worksheet |
-| 40 to 50 minutes | Student responsibilities and the first single-train test |
-| 50 to 60 minutes | Evidence, first milestone, and next review date |
-
-End the meeting with one assigned route test per student and a shared date for integrating the first working service.
+- One Sprinter and one Intercity run in each direction on verified routes.
+- The planned times come from recorded unhindered runs and stated supplements.
+- Every assignment question has been solved from a clean copy by a co-author.
+- The model answers explain the method, assumptions, and accepted result range.
+- The smaller scene validates, exports, and runs without unresolved references.
+- The full Netherlands scene remains available as the reference case.
+- The handout distinguishes student instructions from notes for instructors and maintainers.

--- a/docs/guides/v1-scene-properties.md
+++ b/docs/guides/v1-scene-properties.md
@@ -4,6 +4,8 @@ Use this reference while editing a V1 scene by hand. The application guide expla
 
 Each scene is a directory. JSON object and property names are case sensitive. A property marked "required" must exist and have the stated type. An optional property uses the default listed below when it is absent.
 
+This reference describes the implementation as it works now. V1 is not yet a self-contained simulation format. Some JSON sections are canonical and used by the loader, validator, and exporter; other sections are placeholders or parse-only files. A runnable imported scene still needs files under `legacy/`.
+
 ## `scene.json`
 
 | Property | Type | Required | Meaning | Accepted value and checks |
@@ -27,7 +29,7 @@ All times in the other files are measured in seconds relative to `base_time`. Ne
 | `nodes` | array | yes | Reserved canonical infrastructure nodes | The loader checks that this is an array but does not read its entries in V1. Use `[]`. |
 | `arcs` | array | yes | Reserved canonical infrastructure links | The loader checks that this is an array but does not read its entries in V1. Use `[]`. |
 
-The current simulator reads track geometry, blocks, switches, gradients, and speed limits from the exported `TrackLines/` directory. The exporter accepts `legacy/Tracklines/` or `legacy/TrackLines/` and normalizes the name. Editing `nodes` or `arcs` has no effect on a run.
+The current simulator reads track geometry, blocks, switches, gradients, and speed limits from the exported `TrackLines/` directory. The exporter accepts `legacy/Tracklines/` or `legacy/TrackLines/` and normalizes the name. Editing `nodes` or `arcs` has no effect on a run. `Save Scene` rewrites both arrays as `[]`, so it does not preserve entries placed in them.
 
 ## `stations.json`
 
@@ -37,6 +39,7 @@ The root property is `stations`, a required array.
 | --- | --- | --- | --- | --- |
 | `stations[].id` | string | yes | Identifier used by service stops | Must not be empty and must be unique among stations. Keep it free of whitespace so the scene can export to the legacy timetable format. |
 | `stations[].name` | string | yes | Name shown to the user | Must not be empty. It does not act as a reference. |
+| `stations[].position_km` | number | no | Track position emitted by the legacy importer | The V1 loader ignores it and `Save Scene` does not write it back. The simulator obtains the station position from `legacy/TrackLines/`. |
 | `stations[].platforms` | array | no | Platforms that a stop may name | Defaults to an empty array. A value of another type is currently treated as an empty array. |
 | `stations[].platforms[].id` | string | yes, when the platform exists | Platform identifier within the station | Must not be empty. A service platform must match one of the IDs on its station. The validator does not check duplicate platform IDs. |
 
@@ -150,9 +153,29 @@ Common contents include:
 | `Tracklines/` or `TrackLines/` | Track geometry, block layout, stations, switches, gradients, and speed limits used by the simulator |
 | `TMS/` and `TDS/` | Legacy signalling and train-detection data |
 | `GUI/` | Legacy display coordinates and related settings |
-| Other files | Case-specific input copied through without conversion |
+| `Rescheduling/`, `Passengers/`, and `RoutesToWrite/` | Optional case-specific runtime data not represented by the V1 model |
+| `Timetable/Scenarios_*` | Scenario directories copied through without conversion |
+| Non-route files under `Routes/` | Route support files copied through without conversion |
 
 The exporter writes routes, trains, timetables, and incidents from the canonical JSON first. It then copies files from `legacy/` only when the generated output does not already contain the destination. Do not edit generated files in an export and expect the changes to return to the V1 scene.
+
+### Work that removes the legacy dependency
+
+Issue status checked on 13 July 2026:
+
+- [#83](https://github.com/Ancientkingg/EGTRAIN/issues/83) is the open epic for making the scene model the simulator's native input.
+- [#84](https://github.com/Ancientkingg/EGTRAIN/issues/84) converted the four case studies, but it is complete and did not remove their `legacy/` passthrough.
+- [#85](https://github.com/Ancientkingg/EGTRAIN/issues/85) covers the main format gap: building track, block, switch, station, connection, route, and signalling structures from canonical scene data.
+- [#86](https://github.com/Ancientkingg/EGTRAIN/issues/86) replaces the legacy rolling stock, service, and timetable loaders.
+- [#87](https://github.com/Ancientkingg/EGTRAIN/issues/87) loads incidents directly from the scene model.
+- [#88](https://github.com/Ancientkingg/EGTRAIN/issues/88) changes the GUI and CLI run path so it no longer stages a legacy export before simulation.
+- [#89](https://github.com/Ancientkingg/EGTRAIN/issues/89) removes the old text loaders and input trees after the native path works.
+
+These issues cover the main simulation path, but the tracking is incomplete. No dedicated issue currently converts `GUI/`, `TMS/`, `TDS/`, `Rescheduling/`, `Passengers/`, or `RoutesToWrite/` into canonical scene properties. [#125](https://github.com/Ancientkingg/EGTRAIN/issues/125) makes missing or unimplemented data visible in the UI, but it does not define or load those properties.
+
+Issue #85 also needs a schema and importer step. Its current text says to build infrastructure from `SceneModel`, but the current model has no node or arc fields, the loader only checks that the two arrays exist, and the importer writes both arrays empty.
+
+The bundle work in [#99](https://github.com/Ancientkingg/EGTRAIN/issues/99), [#100](https://github.com/Ancientkingg/EGTRAIN/issues/100), and [#102](https://github.com/Ancientkingg/EGTRAIN/issues/102) says that `.egscene` files exclude `legacy/`. That is not sufficient for the current run path. A portable bundle either needs the native-input work above and coverage for the remaining passthrough data, or it must carry `legacy/` until that migration is complete.
 
 ## Validation command
 


### PR DESCRIPTION
## What changed

- Rewrite the Netherlands assignment guide as a development brief for the assignment lead and two teaching-assistant co-authors.
- Map the OpenTrack model-answer workflow to the proposed EGTRAIN assignment development process.
- Document the current V1 scene boundary, including ignored and non-persistent properties.
- Link the issues that track native scene input and identify passthrough data that has no dedicated migration issue.
- Record the conflict between the current `legacy/` dependency and bundle issues that propose excluding it.

## Why

The previous Netherlands guide addressed the teaching assistants as students completing the assignment. It also did not distinguish the V1 properties used by the application from placeholders and legacy passthrough data.

## Impact

The guide now supports the co-author meeting and assignment-development workflow. The V1 reference states which migration issues cover the native-input work and which legacy categories remain untracked.

## Checks

- `git diff --cached --check`
- Markdown code-fence and relative-link validation