### PR TITLE
Skip application workflows for documentation-only changes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,8 +3,20 @@ name: CMake
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/cmake.yml'
+      - 'CMakeLists.txt'
+      - 'Info.plist.in'
+      - 'EGTRAIN/QEGTRAIN/**'
+      - 'tools/**'
   pull_request:
     branches: [main]
+    paths:
+      - '.github/workflows/cmake.yml'
+      - 'CMakeLists.txt'
+      - 'Info.plist.in'
+      - 'EGTRAIN/QEGTRAIN/**'
+      - 'tools/**'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
       - ci/release-pipeline
     tags:
       - 'v*'
+    paths:
+      - '.github/workflows/release.yml'
+      - 'CMakeLists.txt'
+      - 'Info.plist.in'
+      - 'EGTRAIN/QEGTRAIN/**'
   workflow_dispatch:
 
 jobs:

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def main() -> None:
     workflow = (ROOT / ".github/workflows/cmake.yml").read_text(encoding="utf-8")
+    release_workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     blocks = workflow.split("\n      - ")
     required = {
         "Test": "ctest --test-dir build",
@@ -63,8 +64,25 @@ def main() -> None:
         for path in ("ctest-sanitizer.log", "qegtrain-gui-autostart-smoke.log")
     ):
         missing.append("sanitizer job failure logs")
+    application_paths = "\n".join(
+        (
+            "    paths:",
+            "      - '.github/workflows/cmake.yml'",
+            "      - 'CMakeLists.txt'",
+            "      - 'Info.plist.in'",
+            "      - 'EGTRAIN/QEGTRAIN/**'",
+            "      - 'tools/**'",
+        )
+    )
+    if workflow.count(application_paths) != 2:
+        missing.append("application path filters for pushes and pull requests")
+    release_paths = application_paths.replace("cmake.yml", "release.yml").replace(
+        "\n      - 'tools/**'", ""
+    )
+    if release_paths not in release_workflow:
+        missing.append("release application path filter")
     if missing:
-        raise SystemExit("CMake workflow is missing: " + ", ".join(missing))
+        raise SystemExit("CI workflows are missing: " + ", ".join(missing))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Documentation-only changes currently start the full CMake and packaging
workflows because neither workflow limits its file paths.

This change restricts the CMake workflow to application, build, workflow, and
test files. It applies the same boundary to release builds without affecting
version-tag releases or manual runs. The existing CI workflow check now
verifies both filters.

Checks:

- `python3 tools/e2e/test_ci_workflow.py`
- `python3 -m py_compile tools/e2e/test_ci_workflow.py`
- `git diff --check`
