### PR TITLE
Fix macOS presentation package validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,14 @@ jobs:
           test -f "$PKG/Scenes/Lebanon/legacy/Tracklines/B7/BlockCumPari.txt"
           test -f "$PKG/lebanon-case-study.md"
           # scene_tool links only header-only JSON, so it runs without Qt.
-          "$PKG/scene_tool" validate "$PKG/Scenes/Lebanon" 2>&1 | grep -q scene.trains.none
+          set +e
+          validation_output="$("$PKG/scene_tool" validate "$PKG/Scenes/Lebanon" 2>&1)"
+          validation_status=$?
+          set -e
+          printf '%s\n' "$validation_output"
+          [ "$validation_status" -eq 1 ]
+          grep -q scene.services.none <<<"$validation_output"
+          grep -q scene.trains.none <<<"$validation_output"
           echo "OK: presentation package holds the app, scene_tool, Lebanon scene, and guide"
 
       - name: Package zip

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -81,6 +81,23 @@ def main() -> None:
     )
     if release_paths not in release_workflow:
         missing.append("release application path filter")
+    macos_package_verification = release_workflow.split(
+        "      - name: Verify the presentation package\n", 1
+    )[1].split("\n      - ", 1)[0]
+    required_macos_validation = (
+        "set +e",
+        'validation_output="$("$PKG/scene_tool" validate "$PKG/Scenes/Lebanon" 2>&1)"',
+        "validation_status=$?",
+        "set -e",
+        '[ "$validation_status" -eq 1 ]',
+        'grep -q scene.services.none <<<"$validation_output"',
+        'grep -q scene.trains.none <<<"$validation_output"',
+    )
+    if (
+        any(check not in macos_package_verification for check in required_macos_validation)
+        or '"$PKG/scene_tool" validate "$PKG/Scenes/Lebanon" 2>&1 | grep' in macos_package_verification
+    ):
+        missing.append("macOS scene validation status handling")
     if missing:
         raise SystemExit("CI workflows are missing: " + ", ".join(missing))
 


### PR DESCRIPTION
## Summary
- capture the Lebanon scene validator output and exit status separately
- accept the expected validation failure while requiring both missing-service and missing-train diagnostics
- add a CI workflow regression check that prevents reintroducing a `pipefail`-sensitive validator pipeline

## Root cause
The Lebanon presentation scene intentionally has no services or rolling stock yet, so `scene_tool validate` emits the expected diagnostics and exits with status 1. The macOS verification step piped that command directly into `grep` while `pipefail` was enabled, causing the step to fail even when `scene.trains.none` was present.

## Verification
- `python3 tools/e2e/test_ci_workflow.py`
- `ctest --test-dir build --output-on-failure -R '^(test_ci_workflow|test_package_contents_smoke)$'`
- exact macOS package verification logic exercised against the built `scene_tool` and packaged Lebanon scene