### PR TITLE
Fix scene import path error handling

### DIFF
--- a/EGTRAIN/QEGTRAIN/scene/SceneImporter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneImporter.cpp
@@ -166,7 +166,8 @@ static bool containsPath(const fs::path& parent, const fs::path& child) {
 	return parentIt == parent.end();
 }
 
-static fs::path uniqueSiblingPath(const fs::path& target, const std::string& tag) {
+static fs::path uniqueSiblingPath(const fs::path& target, const std::string& tag, std::error_code& error) {
+	error.clear();
 	fs::path parent = target.parent_path();
 	if (parent.empty())
 		parent = ".";
@@ -176,8 +177,10 @@ static fs::path uniqueSiblingPath(const fs::path& target, const std::string& tag
 	const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
 	for (unsigned int suffix = 0;; ++suffix) {
 		fs::path candidate = parent / (base + "." + tag + "." + std::to_string(stamp) + "." + std::to_string(suffix));
-		std::error_code ec;
-		if (!fs::exists(candidate, ec) && !ec)
+		const bool exists = fs::exists(candidate, error);
+		if (error)
+			return {};
+		if (!exists)
 			return candidate;
 	}
 }
@@ -644,12 +647,20 @@ SceneImportResult importLegacyScene(const std::string& legacyDir,
 		return result;
 	}
 
-	const fs::path stagingPath = uniqueSiblingPath(scenePath, "importing");
+	std::error_code stagingPathEc;
+	const fs::path stagingPath = uniqueSiblingPath(scenePath, "importing", stagingPathEc);
 	fs::path backupPath;
 	auto removeStaging = [&]() {
+		if (stagingPath.empty())
+			return;
 		std::error_code cleanupEc;
 		fs::remove_all(stagingPath, cleanupEc);
 	};
+	if (stagingPathEc) {
+		addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot inspect scene destination: " + stagingPathEc.message(), scenePath.string());
+		removeStaging();
+		return result;
+	}
 
 	fs::create_directories(stagingPath, ec);
 	if (ec) {
@@ -798,7 +809,13 @@ SceneImportResult importLegacyScene(const std::string& legacyDir,
 		return result;
 	}
 	if (destinationExists) {
-		backupPath = uniqueSiblingPath(scenePath, "backup");
+		std::error_code backupPathEc;
+		backupPath = uniqueSiblingPath(scenePath, "backup", backupPathEc);
+		if (backupPathEc) {
+			addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot inspect scene destination: " + backupPathEc.message(), scenePath.string());
+			removeStaging();
+			return result;
+		}
 		fs::rename(scenePath, backupPath, destinationEc);
 		if (destinationEc) {
 			addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot move existing scene to backup: " + destinationEc.message(), scenePath.string());

--- a/EGTRAIN/QEGTRAIN/tests/test_sceneimporter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_sceneimporter.cpp
@@ -579,7 +579,68 @@ int main(int argc, char** argv) {
 		ok &= expect(siblingsAfter == siblingsBefore, "Failed import cleans staging and backup siblings");
 	}
 
-	// 17. Import errors identify the concrete source path that failed.
+	// 17. Permission errors while selecting a staging sibling return without
+	// publishing or changing an existing destination.
+	{
+		TempDir lDir, outDir;
+		fs::create_directories(fs::path(lDir.dir) / "TrackLines");
+		std::ofstream(lDir.dir + "/TrackLines/Stations.txt") << "0\tPermissionSource\n";
+
+		const fs::path destinationParent = fs::path(outDir.dir) / "restricted";
+		const fs::path scenePath = destinationParent / "scene";
+		fs::create_directories(scenePath);
+		const fs::path markerPath = scenePath / "marker.txt";
+		std::ofstream(markerPath) << "destination stays unchanged\n";
+
+		std::error_code statusEc;
+		const fs::perms originalPermissions = fs::status(destinationParent, statusEc).permissions();
+		if (statusEc) {
+			std::cerr << "skipped: unable to inspect destination parent permissions: " << statusEc.message() << "\n";
+		} else {
+			std::error_code restrictEc;
+			fs::permissions(destinationParent, fs::perms::none, fs::perm_options::replace, restrictEc);
+			if (restrictEc) {
+				std::error_code restoreEc;
+				fs::permissions(destinationParent, originalPermissions, fs::perm_options::replace, restoreEc);
+				ok &= expect(!restoreEc, "Permission test restores destination parent after setup failure");
+				std::cerr << "skipped: unable to remove destination parent access: " << restrictEc.message() << "\n";
+			} else {
+				std::error_code probeEc;
+				fs::exists(destinationParent / "probe", probeEc);
+				if (!probeEc) {
+					std::error_code restoreEc;
+					fs::permissions(destinationParent, originalPermissions, fs::perm_options::replace, restoreEc);
+					ok &= expect(!restoreEc, "Permission test restores destination parent when probe succeeds");
+					std::cerr << "skipped: destination parent permissions did not produce an fs::exists error\n";
+				} else {
+					auto res = importLegacyScene(lDir.dir, scenePath.string(), "PermissionError");
+					std::error_code restoreEc;
+					fs::permissions(destinationParent, originalPermissions, fs::perm_options::replace, restoreEc);
+					ok &= expect(!restoreEc, "Permission test restores destination parent after import");
+					if (!restoreEc) {
+						ok &= expect(!res.wroteScene, "Permission-error import wroteScene false");
+						ok &= expect(!res.success(), "Permission-error import success false");
+						bool foundDestinationDiagnostic = false;
+						for (const auto& d : res.diagnostics) {
+							if (d.severity == SceneSeverity::Error && d.code == "scene.import.missing"
+								&& d.file == scenePath.string()) {
+								foundDestinationDiagnostic = true;
+								break;
+							}
+						}
+						ok &= expect(foundDestinationDiagnostic,
+								"Permission-error import names the scene destination");
+						std::ifstream marker(markerPath);
+						std::string markerContent((std::istreambuf_iterator<char>(marker)), std::istreambuf_iterator<char>());
+						ok &= expect(markerContent == "destination stays unchanged\n",
+								"Permission-error import preserves destination marker");
+					}
+				}
+			}
+		}
+	}
+
+	// 18. Import errors identify the concrete source path that failed.
 	{
 		TempDir lDir, outDir;
 		fs::create_directories(fs::path(lDir.dir) / "TrackLines");
@@ -623,7 +684,7 @@ int main(int argc, char** argv) {
 		ok &= expect(foundRoute, "Missing route diagnostic names referenced route path");
 	}
 
-	// 18. Every committed legacy input, including the Banedanmark alias and
+	// 19. Every committed legacy input, including the Banedanmark alias and
 	// both Paimpol variants, keeps the importer output shape.
 	auto checkCommittedImport = [&](const std::string& legacyDir, const std::string& sceneName,
 								   size_t stationCount, size_t unitCount, size_t serviceCount, size_t routeCount) {


### PR DESCRIPTION
Fixes #170

## What changed

- Stop sibling-path selection when filesystem inspection fails.
- Return a destination-specific diagnostic without changing the existing scene.
- Cover the persistent permission-error path while preserving ordinary collision handling.

## Checks

- `cmake --build build -j4`
- `ctest --test-dir build --output-on-failure`
- `tools/e2e/headless_smoke.py`
- `python3 tools/e2e/roundtrip_smoke.py`

The direct roundtrip invocation is tracked in #174 because the script is not executable.