### PR TITLE
Add assignment timetable data

### DIFF
--- a/EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut/services.json
+++ b/EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut/services.json
@@ -1,194 +1,104 @@
 {
     "services": [
         {
-            "id": "svc_e1",
+            "id": "IC1723",
             "route": "route0",
             "composition": "sprinter_single",
-            "entry_time_seconds": 240,
+            "entry_time_seconds": 420,
+            "repeat": {
+                "headway_seconds": 1800
+            },
             "stops": [
                 {
                     "station": "Gvc",
                     "dwell_seconds": 0,
-                    "departure_seconds": 300
+                    "departure_seconds": 480
                 },
                 {
                     "station": "Gdg",
                     "dwell_seconds": 60,
-                    "arrival_seconds": 1260,
-                    "departure_seconds": 1320
+                    "arrival_seconds": 1440,
+                    "departure_seconds": 1500
                 },
                 {
                     "station": "Ut",
                     "dwell_seconds": 0,
-                    "arrival_seconds": 2520
+                    "arrival_seconds": 2580
                 }
             ]
         },
         {
-            "id": "svc_e2",
+            "id": "S19825",
             "route": "route0",
             "composition": "sprinter_single",
-            "entry_time_seconds": 2040,
+            "entry_time_seconds": 600,
+            "repeat": {
+                "headway_seconds": 1800
+            },
             "stops": [
                 {
                     "station": "Gvc",
                     "dwell_seconds": 0,
-                    "departure_seconds": 2100
+                    "departure_seconds": 660
                 },
                 {
                     "station": "Gdg",
-                    "dwell_seconds": 60,
-                    "arrival_seconds": 3060,
-                    "departure_seconds": 3120
-                },
-                {
-                    "station": "Ut",
-                    "dwell_seconds": 0,
-                    "arrival_seconds": 4320
+                    "dwell_seconds": 20,
+                    "arrival_seconds": 2280
                 }
             ]
         },
         {
-            "id": "svc_e3",
+            "id": "IC2025",
             "route": "route0",
             "composition": "sprinter_single",
-            "entry_time_seconds": 3840,
+            "entry_time_seconds": 1320,
+            "repeat": {
+                "headway_seconds": 1800
+            },
             "stops": [
                 {
                     "station": "Gvc",
                     "dwell_seconds": 0,
-                    "departure_seconds": 3900
+                    "departure_seconds": 1380
                 },
                 {
                     "station": "Gdg",
                     "dwell_seconds": 60,
-                    "arrival_seconds": 4860,
-                    "departure_seconds": 4920
+                    "arrival_seconds": 2340,
+                    "departure_seconds": 2400
                 },
                 {
                     "station": "Ut",
                     "dwell_seconds": 0,
-                    "arrival_seconds": 6120
+                    "arrival_seconds": 3480
                 }
             ]
         },
         {
-            "id": "svc_e4",
+            "id": "S9827",
             "route": "route0",
             "composition": "sprinter_single",
-            "entry_time_seconds": 5640,
+            "entry_time_seconds": 1500,
+            "repeat": {
+                "headway_seconds": 1800
+            },
             "stops": [
                 {
                     "station": "Gvc",
                     "dwell_seconds": 0,
-                    "departure_seconds": 5700
+                    "departure_seconds": 1560
                 },
                 {
                     "station": "Gdg",
-                    "dwell_seconds": 60,
-                    "arrival_seconds": 6660,
-                    "departure_seconds": 6720
+                    "dwell_seconds": 20,
+                    "arrival_seconds": 3180,
+                    "departure_seconds": 3540
                 },
                 {
                     "station": "Ut",
                     "dwell_seconds": 0,
-                    "arrival_seconds": 7920
-                }
-            ]
-        },
-        {
-            "id": "svc_w1",
-            "route": "route1",
-            "composition": "sprinter_single",
-            "entry_time_seconds": 1140,
-            "stops": [
-                {
-                    "station": "Ut",
-                    "dwell_seconds": 0,
-                    "departure_seconds": 1200
-                },
-                {
-                    "station": "Gdg",
-                    "dwell_seconds": 60,
-                    "arrival_seconds": 2400,
-                    "departure_seconds": 2460
-                },
-                {
-                    "station": "Gvc",
-                    "dwell_seconds": 0,
-                    "arrival_seconds": 3420
-                }
-            ]
-        },
-        {
-            "id": "svc_w2",
-            "route": "route1",
-            "composition": "sprinter_single",
-            "entry_time_seconds": 2940,
-            "stops": [
-                {
-                    "station": "Ut",
-                    "dwell_seconds": 0,
-                    "departure_seconds": 3000
-                },
-                {
-                    "station": "Gdg",
-                    "dwell_seconds": 60,
-                    "arrival_seconds": 4200,
-                    "departure_seconds": 4260
-                },
-                {
-                    "station": "Gvc",
-                    "dwell_seconds": 0,
-                    "arrival_seconds": 5220
-                }
-            ]
-        },
-        {
-            "id": "svc_w3",
-            "route": "route1",
-            "composition": "sprinter_single",
-            "entry_time_seconds": 4740,
-            "stops": [
-                {
-                    "station": "Ut",
-                    "dwell_seconds": 0,
-                    "departure_seconds": 4800
-                },
-                {
-                    "station": "Gdg",
-                    "dwell_seconds": 60,
-                    "arrival_seconds": 6000,
-                    "departure_seconds": 6060
-                },
-                {
-                    "station": "Gvc",
-                    "dwell_seconds": 0,
-                    "arrival_seconds": 7020
-                }
-            ]
-        },
-        {
-            "id": "svc_w4",
-            "route": "route1",
-            "composition": "sprinter_single",
-            "entry_time_seconds": 6540,
-            "stops": [
-                {
-                    "station": "Ut",
-                    "dwell_seconds": 0,
-                    "departure_seconds": 6600
-                },
-                {
-                    "station": "Gdg",
-                    "dwell_seconds": 60,
-                    "arrival_seconds": 7800,
-                    "departure_seconds": 7860
-                },
-                {
-                    "station": "Gvc",
-                    "dwell_seconds": 0,
-                    "arrival_seconds": 8820
+                    "arrival_seconds": 4920
                 }
             ]
         }

--- a/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
@@ -50,6 +50,76 @@ static const SceneLoadedData* findLoadedDataChildSource(const SceneLoadedData* p
 	return nullptr;
 }
 
+struct ExpectedStop {
+	const char* station;
+	double dwell;
+	bool hasArrival;
+	double arrival;
+	bool hasDeparture;
+	double departure;
+};
+
+struct ExpectedService {
+	const char* id;
+	const char* route;
+	double entry;
+	const ExpectedStop* stops;
+	size_t stopCount;
+};
+
+static bool expectAssignmentTimetable(const SceneModel& scene) {
+	static const ExpectedStop ic1723Stops[] = {
+		{"Gvc", 0, false, 0, true, 480},
+		{"Gdg", 60, true, 1440, true, 1500},
+		{"Ut", 0, true, 2580, false, 0},
+	};
+	static const ExpectedStop s19825Stops[] = {
+		{"Gvc", 0, false, 0, true, 660},
+		{"Gdg", 20, true, 2280, false, 0},
+	};
+	static const ExpectedStop ic2025Stops[] = {
+		{"Gvc", 0, false, 0, true, 1380},
+		{"Gdg", 60, true, 2340, true, 2400},
+		{"Ut", 0, true, 3480, false, 0},
+	};
+	static const ExpectedStop s9827Stops[] = {
+		{"Gvc", 0, false, 0, true, 1560},
+		{"Gdg", 20, true, 3180, true, 3540},
+		{"Ut", 0, true, 4920, false, 0},
+	};
+	static const ExpectedService expected[] = {
+		{"IC1723", "route0", 420, ic1723Stops, 3},
+		{"S19825", "route0", 600, s19825Stops, 2},
+		{"IC2025", "route0", 1320, ic2025Stops, 3},
+		{"S9827", "route0", 1500, s9827Stops, 3},
+	};
+
+	bool ok = expect(scene.services.size() == 4, "assignment timetable service count is 4");
+	const size_t count = scene.services.size() < 4 ? scene.services.size() : 4;
+	for (size_t i = 0; i < count; ++i) {
+		const SceneService& service = scene.services[i];
+		const ExpectedService& want = expected[i];
+		ok &= expect(service.id == want.id, "service id and order match assignment timetable");
+		ok &= expect(service.route == want.route, "service route matches assignment timetable");
+		ok &= expect(service.composition == "sprinter_single", "service composition matches assignment timetable");
+		ok &= expect(service.hasEntryTime && service.entryTimeSeconds == want.entry, "service entry time matches assignment timetable");
+		ok &= expect(service.hasRepeat && service.headwaySeconds == 1800, "service repeat headway matches assignment timetable");
+		ok &= expect(service.stops.size() == want.stopCount, "service stop shape matches assignment timetable");
+		const size_t stopCount = service.stops.size() < want.stopCount ? service.stops.size() : want.stopCount;
+		for (size_t j = 0; j < stopCount; ++j) {
+			const SceneStop& stop = service.stops[j];
+			const ExpectedStop& expectedStop = want.stops[j];
+			ok &= expect(stop.stationId == expectedStop.station, "stop station matches assignment timetable");
+			ok &= expect(stop.dwellSeconds == expectedStop.dwell, "stop dwell matches assignment timetable");
+			ok &= expect(stop.hasArrival == expectedStop.hasArrival, "stop arrival shape matches assignment timetable");
+			ok &= expect(!stop.hasArrival || stop.arrivalSeconds == expectedStop.arrival, "stop arrival matches assignment timetable");
+			ok &= expect(stop.hasDeparture == expectedStop.hasDeparture, "stop departure shape matches assignment timetable");
+			ok &= expect(!stop.hasDeparture || stop.departureSeconds == expectedStop.departure, "stop departure matches assignment timetable");
+		}
+	}
+	return ok;
+}
+
 struct TempDir {
 	std::string dir;
 
@@ -93,11 +163,11 @@ int main(int argc, char** argv) {
 	const SceneLoadedData* stationParsedData = findLoadedDataChild(stationData, "parsed_objects");
 	ok &= expect(stationParsedData && stationParsedData->sourceFile == "stations.json" && stationParsedData->parsedCount == 3 && stationParsedData->status == "loaded", "stations parsed object drilldown");
 	const SceneLoadedData* timetableData = findLoadedData(scene, "timetable");
-	ok &= expect(timetableData && timetableData->sourceFile == "services.json" && timetableData->parsedCount == 8 && timetableData->status == "loaded", "timetable loaded data summary");
+	ok &= expect(timetableData && timetableData->sourceFile == "services.json" && timetableData->parsedCount == 4 && timetableData->status == "loaded", "timetable loaded data summary");
 	const SceneLoadedData* timetableRawData = findLoadedDataChild(timetableData, "raw_file");
 	ok &= expect(timetableRawData && timetableRawData->sourceFile == "services.json" && timetableRawData->parsedCount == 1 && timetableRawData->status == "loaded", "timetable raw file drilldown");
 	const SceneLoadedData* timetableParsedData = findLoadedDataChild(timetableData, "parsed_objects");
-	ok &= expect(timetableParsedData && timetableParsedData->sourceFile == "services.json" && timetableParsedData->parsedCount == 8 && timetableParsedData->status == "loaded", "timetable parsed object drilldown");
+	ok &= expect(timetableParsedData && timetableParsedData->sourceFile == "services.json" && timetableParsedData->parsedCount == 4 && timetableParsedData->status == "loaded", "timetable parsed object drilldown");
 	const SceneLoadedData* passengerData = findLoadedData(scene, "passenger_data");
 	ok &= expect(passengerData && passengerData->status == "unimplemented", "passenger data visible as unimplemented");
 	const SceneLoadedData* signallingData = findLoadedData(scene, "signalling");
@@ -128,7 +198,7 @@ int main(int argc, char** argv) {
 	ok &= expect(scene.baseTime == "07:00:00", "base_time loaded");
 	ok &= expect(scene.stations.size() == 3, "station count loaded");
 	ok &= expect(scene.routes.size() == 2, "route count loaded");
-	ok &= expect(scene.services.size() == 8, "service count loaded");
+	ok &= expectAssignmentTimetable(scene);
 	ok &= expect(scene.trainUnits.size() == 1, "train unit count loaded");
 	ok &= expect(scene.compositions.size() == 1, "composition count loaded");
 
@@ -200,20 +270,20 @@ int main(int argc, char** argv) {
 	}
 	if (!reloaded.services.empty()) {
 		const SceneService& service = reloaded.services[0];
-		ok &= expect(service.id == "svc_e1", "first service id round-trips");
+		ok &= expect(service.id == "IC1723", "first service id round-trips");
 		ok &= expect(service.through, "first service through flag round-trips");
 		ok &= expect(service.composition == "sprinter_single", "first service composition round-trips");
 		ok &= expect(service.route == "route0", "first service route round-trips");
-		ok &= expect(service.hasEntryTime && service.entryTimeSeconds == 240, "entry time round-trips");
-		ok &= expect(!service.hasRepeat, "missing repeat flag round-trips");
+		ok &= expect(service.hasEntryTime && service.entryTimeSeconds == 420, "entry time round-trips");
+		ok &= expect(service.hasRepeat && service.headwaySeconds == 1800, "repeat headway round-trips");
 		ok &= expect(service.stops.size() == 3, "first service stop count round-trips");
 		if (service.stops.size() >= 3) {
 			ok &= expect(service.stops[0].stationId == "Gvc", "first stop station round-trips");
 			ok &= expect(!service.stops[0].hasArrival, "first stop missing arrival round-trips");
-			ok &= expect(service.stops[0].hasDeparture && service.stops[0].departureSeconds == 300, "first stop departure round-trips");
-			ok &= expect(service.stops[1].hasArrival && service.stops[1].arrivalSeconds == 1260, "middle stop arrival round-trips");
-			ok &= expect(service.stops[1].hasDeparture && service.stops[1].departureSeconds == 1320, "middle stop departure round-trips");
-			ok &= expect(service.stops[2].hasArrival && service.stops[2].arrivalSeconds == 2520, "last stop arrival round-trips");
+			ok &= expect(service.stops[0].hasDeparture && service.stops[0].departureSeconds == 480, "first stop departure round-trips");
+			ok &= expect(service.stops[1].hasArrival && service.stops[1].arrivalSeconds == 1440, "middle stop arrival round-trips");
+			ok &= expect(service.stops[1].hasDeparture && service.stops[1].departureSeconds == 1500, "middle stop departure round-trips");
+			ok &= expect(service.stops[2].hasArrival && service.stops[2].arrivalSeconds == 2580, "last stop arrival round-trips");
 			ok &= expect(!service.stops[2].hasDeparture, "last stop missing departure round-trips");
 		}
 	}

--- a/tools/assignment/generate_assignment_scene.py
+++ b/tools/assignment/generate_assignment_scene.py
@@ -3,7 +3,7 @@ Assignment scene Gvc-Gdg-Ut
 
 Den Haag Centraal - Gouda - Utrecht Centraal corridor.
 Contains 2 tracklines (B0 eastbound, B1 westbound), 32 blocks each, 2km per block. B1 uses its own ascending westbound chainage.
-8 services: 4 eastbound (Gvc->Gdg->Ut), 4 westbound (Ut->Gdg->Gvc).
+Contains four eastbound services.
 """
 
 import os
@@ -178,33 +178,38 @@ def main():
     })
 
     # services.json
-    services = []
-    
-    for k in range(4):
-        services.append({
-            "id": f"svc_e{k+1}",
+    service_specs = [
+        ("IC1723", 420, [
+            {"station": "Gvc", "dwell_seconds": 0, "departure_seconds": 480},
+            {"station": "Gdg", "dwell_seconds": 60, "arrival_seconds": 1440, "departure_seconds": 1500},
+            {"station": "Ut", "dwell_seconds": 0, "arrival_seconds": 2580},
+        ]),
+        ("S19825", 600, [
+            {"station": "Gvc", "dwell_seconds": 0, "departure_seconds": 660},
+            {"station": "Gdg", "dwell_seconds": 20, "arrival_seconds": 2280},
+        ]),
+        ("IC2025", 1320, [
+            {"station": "Gvc", "dwell_seconds": 0, "departure_seconds": 1380},
+            {"station": "Gdg", "dwell_seconds": 60, "arrival_seconds": 2340, "departure_seconds": 2400},
+            {"station": "Ut", "dwell_seconds": 0, "arrival_seconds": 3480},
+        ]),
+        ("S9827", 1500, [
+            {"station": "Gvc", "dwell_seconds": 0, "departure_seconds": 1560},
+            {"station": "Gdg", "dwell_seconds": 20, "arrival_seconds": 3180, "departure_seconds": 3540},
+            {"station": "Ut", "dwell_seconds": 0, "arrival_seconds": 4920},
+        ]),
+    ]
+    services = [
+        {
+            "id": service_id,
             "route": "route0",
             "composition": "sprinter_single",
-            "entry_time_seconds": 240 + 1800 * k,
-            "stops": [
-                {"station": "Gvc", "dwell_seconds": 0, "departure_seconds": 300 + 1800 * k},
-                {"station": "Gdg", "dwell_seconds": 60, "arrival_seconds": 1260 + 1800 * k, "departure_seconds": 1320 + 1800 * k},
-                {"station": "Ut", "dwell_seconds": 0, "arrival_seconds": 2520 + 1800 * k}
-            ]
-        })
-        
-    for k in range(4):
-        services.append({
-            "id": f"svc_w{k+1}",
-            "route": "route1",
-            "composition": "sprinter_single",
-            "entry_time_seconds": 1140 + 1800 * k,
-            "stops": [
-                {"station": "Ut", "dwell_seconds": 0, "departure_seconds": 1200 + 1800 * k},
-                {"station": "Gdg", "dwell_seconds": 60, "arrival_seconds": 2400 + 1800 * k, "departure_seconds": 2460 + 1800 * k},
-                {"station": "Gvc", "dwell_seconds": 0, "arrival_seconds": 3420 + 1800 * k}
-            ]
-        })
+            "entry_time_seconds": entry_time,
+            "repeat": {"headway_seconds": 1800},
+            "stops": stops,
+        }
+        for service_id, entry_time, stops in service_specs
+    ]
         
     write_json('services.json', {"services": services})
 

--- a/tools/e2e/assignment_smoke.py
+++ b/tools/e2e/assignment_smoke.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import json
 import subprocess
 import tempfile
 import sys
@@ -10,13 +11,50 @@ SCENE_TOOL = ROOT / "build/scene_tool"
 SCENE_DIR = ROOT / "EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut"
 CASE_ID = 5
 STAGED_NAME = "Input_EGTRAIN_Assignment"
+EXPECTED_IDS = ("IC1723", "S19825", "IC2025", "S9827")
+EXPECTED_ROUTES = ("route0", "route0", "route0", "route0")
+EXPECTED_ENTRIES = (420, 600, 1320, 1500)
+EXPECTED_HEADWAY = 1800
+
+
+def check_canonical_timetable() -> None:
+    services_path = SCENE_DIR / "services.json"
+    try:
+        data = json.loads(services_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.exit(f"assignment timetable mismatch: cannot read {services_path}: {exc}")
+
+    services = data.get("services")
+    if not isinstance(services, list):
+        sys.exit("assignment timetable mismatch: services must be an array")
+    if len(services) != len(EXPECTED_IDS):
+        sys.exit(f"assignment timetable mismatch: expected {len(EXPECTED_IDS)} services, got {len(services)}")
+
+    for index, service in enumerate(services):
+        if not isinstance(service, dict):
+            sys.exit(f"assignment timetable mismatch at service {index}: expected an object")
+        if service.get("id") != EXPECTED_IDS[index]:
+            sys.exit(f"assignment timetable mismatch at service {index}: id {service.get('id')!r}, "
+                     f"expected {EXPECTED_IDS[index]!r}")
+        if service.get("route") != EXPECTED_ROUTES[index]:
+            sys.exit(f"assignment timetable mismatch for {EXPECTED_IDS[index]}: route {service.get('route')!r}, "
+                     f"expected {EXPECTED_ROUTES[index]!r}")
+        if service.get("entry_time_seconds") != EXPECTED_ENTRIES[index]:
+            sys.exit(f"assignment timetable mismatch for {EXPECTED_IDS[index]}: entry_time_seconds "
+                     f"{service.get('entry_time_seconds')!r}, expected {EXPECTED_ENTRIES[index]}")
+        repeat = service.get("repeat")
+        if not isinstance(repeat, dict) or repeat.get("headway_seconds") != EXPECTED_HEADWAY:
+            actual = repeat.get("headway_seconds") if isinstance(repeat, dict) else None
+            sys.exit(f"assignment timetable mismatch for {EXPECTED_IDS[index]}: headway_seconds {actual!r}, "
+                     f"expected {EXPECTED_HEADWAY}")
 
 
 def main() -> None:
-    if not SCENE_TOOL.exists():
-        sys.exit(f"scene_tool not found at {SCENE_TOOL}. Build first.")
     if not SCENE_DIR.exists():
         sys.exit(f"assignment scene not found at {SCENE_DIR}")
+    check_canonical_timetable()
+    if not SCENE_TOOL.exists():
+        sys.exit(f"scene_tool not found at {SCENE_TOOL}. Build first.")
 
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)

--- a/tools/e2e/incident_smoke.py
+++ b/tools/e2e/incident_smoke.py
@@ -33,10 +33,9 @@ CASE_ID = 5
 STAGED_NAME = "Input_EGTRAIN_Assignment"
 TRAJ_REL = "Output/Output_EGTRAIN_Assignment/TrainTrajectories/TrainServicePathDiagram.txt"
 
-# svc_e1-1 travels during timesteps [239, 2091] in the base scene, so this
-# window is comfortably inside its normal run.
-TARGET_SERVICE = "svc_e1"
-TARGET_TRAIN = "svc_e1-1"
+# [800, 1400] lies inside the scheduled trip for IC1723-1.
+TARGET_SERVICE = "IC1723"
+TARGET_TRAIN = "IC1723-1"
 WINDOW_START = 800
 WINDOW_END = 1400
 _TOL = 1.0  # metres; positions within this are treated as unchanged


### PR DESCRIPTION
## Summary

The assignment scene now uses the four eastbound services and times listed in the 2025 model answers. Each base service repeats every 1,800 seconds.

The scene generator, C++ regression coverage, assignment smoke test, and incident smoke target now match that timetable.

## Checks

- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `python3 tools/e2e/assignment_smoke.py`
- `python3 tools/e2e/incident_smoke.py`
- `python3 tools/e2e/roundtrip_smoke.py`
- `scene_tool validate EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut`
- `scene_tool export EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut <outDir>`

Closes #33
