### PR TITLE
Include climits for Linux release builds

### DIFF
--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 #include <chrono>
 #include <cstdio>
+#include <climits>
 #include <algorithm>
 
 // GUI - Virtual Coupling notifications


### PR DESCRIPTION
## Summary

Adds the direct `<climits>` include required for `INT_MAX` in `RollingStock.cpp`. GCC 13 currently rejects the file during the Linux release build.

This is a compile-only portability fix. Simulation behavior is unchanged.

## Checks

- Configured with GCC 15.2 and Qt 5
- Built the `QEGTRAIN` target with GCC 15.2
- `git diff --check`

Closes #185
