### PR TITLE
Use portable negation in MainWindow

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -7931,7 +7931,7 @@ void MainWindow::askForTrainPathDiagram() {
 
 // manage VCoupling notifications
 void MainWindow::checkVCouplingMsg(TrainItemGroup* trainItem, const GuiTrainState& train, int t) {
-	if (not m_snapshot)
+	if (!m_snapshot)
 		return;
 	for (auto it = m_snapshot->virtualCouplingMessages.rbegin(); it != m_snapshot->virtualCouplingMessages.rend(); ++it) {
 		if (it->trainDescription == train.description && t >= it->timestep && t <= it->timestep + 40) {
@@ -7943,7 +7943,7 @@ void MainWindow::checkVCouplingMsg(TrainItemGroup* trainItem, const GuiTrainStat
 
 // paint VCoupling notification
 void MainWindow::paintVCouplingMsg(TrainItemGroup* trainItem, const std::string& message) {
-	if (not trainItem || not trainItem->trainPolygonItemList || trainItem->trainPolygonItemList->isEmpty())
+	if (!trainItem || !trainItem->trainPolygonItemList || trainItem->trainPolygonItemList->isEmpty())
 		return;
 	TrainBodyItem* headPolygon = trainItem->trainPolygonItemList->at(0);
 	if (!headPolygon || headPolygon->polygon().isEmpty())


### PR DESCRIPTION
## Summary

Replace the three alternative `not` operator tokens in the virtual coupling notification guards with `!`. This preserves the guards and compiles with the MSVC 14.51 toolchain used by Release.

## Root cause

Commit `f79e96a` added the only `not` operators in `MainWindow.cpp`. Windows Release parsed them as identifiers and failed with C2065. The rest of the file uses `!`.

## Checks

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (33 of 33 passed)

Closes #187