### PR TITLE
Improve network playback rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ set(EGTRAIN_SOURCES
     ${SRC_DIR}/graphics/items/NodeItem.cpp
     ${SRC_DIR}/graphics/items/BaseNetworkItem.cpp
     ${SRC_DIR}/graphics/items/TrackLineItem.cpp
+    ${SRC_DIR}/graphics/items/TrainBadgeItem.cpp
+    ${SRC_DIR}/graphics/items/NetworkLegendItem.cpp
     ${SRC_DIR}/graphics/items/IconItem.cpp
     ${SRC_DIR}/graphics/items/StationNodeItem.cpp
     ${SRC_DIR}/graphics/NetworkScene.cpp
@@ -151,6 +153,8 @@ set(EGTRAIN_HEADERS
     ${SRC_DIR}/graphics/items/NodeItem.h
     ${SRC_DIR}/graphics/items/BaseNetworkItem.h
     ${SRC_DIR}/graphics/items/TrackLineItem.h
+    ${SRC_DIR}/graphics/items/TrainBadgeItem.h
+    ${SRC_DIR}/graphics/items/NetworkLegendItem.h
     ${SRC_DIR}/graphics/items/IconItem.h
     ${SRC_DIR}/graphics/items/StationNodeItem.h
     ${SRC_DIR}/graphics/NetworkScene.h

--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -50,12 +50,14 @@ GuiSimulationSnapshot buildGuiSimulationSnapshot(int timestep) {
 			}
 		}
 
-		const int arcCount = std::min(train.Bs.total_arcs,
-			static_cast<int>(sizeof(train.Bs.arcs_in_signalling_block_section)
-				/ sizeof(train.Bs.arcs_in_signalling_block_section[0])));
-		for (int arc = 0; arc < arcCount; ++arc) {
-			state.occupiedArcs.push_back({train.Bs.trackLineId,
-				train.Bs.arcs_in_signalling_block_section[arc].startNode.X});
+		if (guiTrainPublishesOccupiedArcs(state)) {
+			const int arcCount = std::min(train.Bs.total_arcs,
+				static_cast<int>(sizeof(train.Bs.arcs_in_signalling_block_section)
+					/ sizeof(train.Bs.arcs_in_signalling_block_section[0])));
+			for (int arc = 0; arc < arcCount; ++arc) {
+				state.occupiedArcs.push_back({train.Bs.trackLineId,
+					train.Bs.arcs_in_signalling_block_section[arc].startNode.X});
+			}
 		}
 		snapshot.trains.push_back(std::move(state));
 	}

--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include <chrono>
 #include <memory>
+#include <map>
 
 namespace {
 void ensureDirectory(const string& path) {
@@ -63,12 +64,18 @@ GuiSimulationSnapshot buildGuiSimulationSnapshot(int timestep) {
 		if (!id.empty())
 			snapshot.signalStates.push_back({id, code, reversed});
 	};
+	std::map<std::string, GuiSectionState> sectionStates;
 	const int routeCount = std::min(N_Routes, static_cast<int>(train_route.size()));
 	for (int routeIndex = 0; routeIndex < routeCount; ++routeIndex) {
 		const Route& route = train_route[routeIndex];
 		for (int sectionIndex = 0; sectionIndex < route.N_Block_Sections; ++sectionIndex) {
 			const Section& section = route.sequence_of_block_sections[sectionIndex];
 			const std::string& id = section.ID;
+			if (!id.empty()) {
+				auto& state = sectionStates[id];
+				state.sectionId = id;
+				state.prepared = state.prepared || section.code != 0.0;
+			}
 			if (id.find('/') == std::string::npos) {
 				appendSignal(id, static_cast<int>(section.code), route.reversed_direction);
 				continue;
@@ -82,6 +89,21 @@ GuiSimulationSnapshot buildGuiSimulationSnapshot(int timestep) {
 			}
 		}
 	}
+	for (const SimulationIncident& incident : simulationIncidents) {
+		if (incident.type != "signal_failure"
+			|| timestep < incident.startSeconds || timestep > incident.endSeconds)
+			continue;
+		for (const std::string& id : incident.resolvedSectionIDs) {
+			if (id.empty())
+				continue;
+			auto& state = sectionStates[id];
+			state.sectionId = id;
+			state.blocked = true;
+		}
+	}
+	snapshot.sectionStates.reserve(sectionStates.size());
+	for (auto& entry : sectionStates)
+		snapshot.sectionStates.push_back(std::move(entry.second));
 
 	for (const StationPlatform& platform : AllStationPlatforms) {
 		GuiPlatformState state;

--- a/EGTRAIN/QEGTRAIN/app/GuiSimulationSnapshot.h
+++ b/EGTRAIN/QEGTRAIN/app/GuiSimulationSnapshot.h
@@ -31,6 +31,10 @@ struct GuiTrainState {
 	std::vector<GuiOccupiedArc> occupiedArcs;
 };
 
+inline bool guiTrainPublishesOccupiedArcs(const GuiTrainState& train) {
+	return !train.outOfSimulation;
+}
+
 struct GuiSignalState {
 	std::string sectionId;
 	int code = 0;

--- a/EGTRAIN/QEGTRAIN/app/GuiSimulationSnapshot.h
+++ b/EGTRAIN/QEGTRAIN/app/GuiSimulationSnapshot.h
@@ -37,6 +37,12 @@ struct GuiSignalState {
 	bool reversedDirection = false;
 };
 
+struct GuiSectionState {
+	std::string sectionId;
+	bool prepared = false;
+	bool blocked = false;
+};
+
 struct GuiPlatformState {
 	std::string stationId;
 	std::string platformId;
@@ -63,6 +69,7 @@ struct GuiSimulationSnapshot {
 	int totalTimesteps = 0;
 	std::vector<GuiTrainState> trains;
 	std::vector<GuiSignalState> signalStates;
+	std::vector<GuiSectionState> sectionStates;
 	std::vector<GuiPlatformState> platforms;
 	std::vector<GuiPassengerState> passengers;
 	std::vector<GuiVirtualCouplingState> virtualCouplingMessages;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -53,6 +53,8 @@ extern InitialParameters initial_variables;
 namespace {
 const char* kRecentScenesKey = "recentScenes";
 const int kMaxRecentScenes = 8;
+constexpr qreal kDenseDetailScale = 0.16;
+constexpr int kOverlayMargin = 12;
 
 std::vector<const Train*> runResultTrainPointers() {
 	std::vector<const Train*> trains;
@@ -503,6 +505,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	// create container of items to show on display area
 	scene = new NetworkScene(networkView);
 	networkView->setScene(scene);
+	connect(networkView, &NetworkView::viewportChanged, this, &MainWindow::updateViewportOverlays);
 
 	// zoom
 	networkView->viewport()->installEventFilter(this);
@@ -669,12 +672,23 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 		for (auto* item : m_stationDecorations)
 			if (item)
 				item->setVisible(checked);
+		for (auto* item : m_stationNames)
+			if (item)
+				item->setVisible(checked);
+		updateViewportOverlays();
 	});
 	connect(m_trainLayerCheck, &QCheckBox::toggled, this, [this](bool checked) {
 		m_trainLayerVisible = checked;
 		for (auto* train : allTrains)
 			if (train)
 				train->setVisible(checked && !train->outOfSimulation);
+		for (auto it = m_trainBadges.cbegin(); it != m_trainBadges.cend(); ++it) {
+			if (!it.value())
+				continue;
+			auto trainIt = std::find_if(allTrains.cbegin(), allTrains.cend(),
+				[it](const TrainItemGroup* train) { return train && train->index == it.key(); });
+			it.value()->setVisible(checked && trainIt != allTrains.cend() && !(*trainIt)->outOfSimulation);
+		}
 		for (auto it = m_trainSpeedLabels.cbegin(); it != m_trainSpeedLabels.cend(); ++it)
 			if (it.value()) {
 				auto trainIt = std::find_if(allTrains.cbegin(), allTrains.cend(),
@@ -685,9 +699,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	});
 	connect(m_signalLayerCheck, &QCheckBox::toggled, this, [this](bool checked) {
 		m_signalLayerVisible = checked;
-		for (auto* group : m_signalGroups)
-			if (group)
-				group->setVisible(checked);
+		for (auto* item : m_signalDecorations)
+			if (item)
+				item->setVisible(checked);
 	});
 	connect(m_passengerLayerCheck, &QCheckBox::toggled, this, [this](bool checked) {
 		m_passengerLayerVisible = checked;
@@ -3584,12 +3598,6 @@ void MainWindow::runVisualPolishE2E() {
 		failures << "missing follow controls";
 	} else {
 		m_followTrainCombo->setCurrentIndex(0);
-		m_followAction->setChecked(true);
-		QApplication::processEvents();
-		if (!m_followAction->isChecked() || m_followTrainIndex < 0) {
-			ok = false;
-			failures << "follow mode did not activate";
-		}
 	}
 
 	if (allTrains.isEmpty()) {
@@ -3721,7 +3729,7 @@ void MainWindow::runVisualPolishE2E() {
 			}
 		};
 		checkItemLayer(stationLayer, m_stationDecorations, "station decorations");
-		checkItemLayer(signalLayer, m_signalGroups, "signal groups");
+		checkItemLayer(signalLayer, m_signalDecorations, "signal groups");
 		QList<QGraphicsItem*> passengerItems;
 		for (auto* platform : allPlatforms) {
 			if (!platform)
@@ -3742,14 +3750,91 @@ void MainWindow::runVisualPolishE2E() {
 		checkItemLayer(passengerLayer, passengerItems, "passenger load");
 	}
 
-	QString screenshotPath = qEnvironmentVariable("QEGTRAIN_E2E_SCREENSHOT");
-	if (!screenshotPath.isEmpty()) {
-		QPixmap image = grab();
-		if (!image.save(screenshotPath)) {
+	const auto captureScreenshot = [this, &ok, &failures](const char* variable, const char* label) {
+		const QString path = qEnvironmentVariable(variable);
+		if (path.isEmpty())
+			return;
+		QApplication::processEvents();
+		if (!grab().save(path)) {
 			ok = false;
-			failures << "screenshot save failed";
+			failures << QString("%1 screenshot save failed").arg(label);
+		}
+	};
+
+	if (!m_networkLegend || !m_networkLegend->isVisible()) {
+		ok = false;
+		failures << "network legend is missing";
+	}
+	if (m_trainBadges.isEmpty() || std::none_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
+		[](const auto& entry) { return entry && entry->isVisible(); })) {
+		ok = false;
+		failures << "no visible train badge rendered";
+	}
+	if (std::none_of(allArcs.cbegin(), allArcs.cend(), [](const TrackLineItem* item) {
+		return item && item->operationalState() != TrackOperationalState::Free;
+	})) {
+		ok = false;
+		failures << "playback did not render an operational track state";
+	}
+
+	// Capture the readable default view before changing follow or zoom state.
+	captureScreenshot("QEGTRAIN_E2E_SCREENSHOT", "default");
+	if (networkView && !allTrains.isEmpty()) {
+		networkView->centerOn(allTrains.first()->sceneBoundingRect().center());
+		networkView->scale(3.0, 3.0);
+		QApplication::processEvents();
+	} else {
+		ok = false;
+		failures << "cannot create dense view without a train";
+	}
+	captureScreenshot("QEGTRAIN_E2E_DENSE_SCREENSHOT", "dense");
+
+	SignalItem* visibleSignal = nullptr;
+	QGraphicsItem* signalHit = nullptr;
+	bool anyVisibleSignal = false;
+	for (auto* signal : allSignals) {
+		if (!signal || !signal->isVisible())
+			continue;
+		anyVisibleSignal = true;
+		QGraphicsItem* hit = scene->itemAt(signal->sceneBoundingRect().center(), networkView->viewportTransform());
+		if (qgraphicsitem_cast<SignalItem*>(hit) == signal) {
+			visibleSignal = signal;
+			signalHit = hit;
+			break;
 		}
 	}
+	if (!anyVisibleSignal) {
+		ok = false;
+		failures << "no visible signal rendered";
+	} else if (!visibleSignal) {
+		ok = false;
+		failures << "signal scene hit-test did not resolve any visible glyph";
+	} else {
+		if (qgraphicsitem_cast<SignalItem*>(signalHit) != visibleSignal) {
+			ok = false;
+			failures << "signal scene hit-test did not resolve the glyph";
+		}
+	}
+
+	if (m_followAction && m_followTrainCombo && m_followTrainCombo->count() > 0) {
+		m_followAction->setChecked(true);
+		QApplication::processEvents();
+		if (!m_followAction->isChecked() || m_followTrainIndex < 0) {
+			ok = false;
+			failures << "follow mode did not activate";
+		} else {
+			for (auto* train : allTrains) {
+				if (train && train->index == m_followTrainIndex) {
+					networkView->centerOn(train->sceneBoundingRect().center());
+					break;
+				}
+			}
+		}
+	} else {
+		ok = false;
+		failures << "follow mode controls disappeared";
+	}
+	captureScreenshot("QEGTRAIN_E2E_FOLLOW_SCREENSHOT", "follow");
 
 	if (ok) {
 		std::fprintf(stdout, "E2E_VISUAL_POLISH_OK\n");
@@ -5315,6 +5400,8 @@ void MainWindow::setupGUI() {
 	}
 
 	buildSignalIndex();
+	buildTrackIndexes();
+	updateViewportOverlays();
 
 	// hide objects from unused tracklines
 	hideUnusedTracks();
@@ -5453,21 +5540,23 @@ void MainWindow::teardownGUI() {
 	// Clearing the scene deletes all owned QGraphicsItems.
 	scene->clear();
 
-	// clear() keeps the explicitly pinned scene rect, so fitView would keep
-	// fitting the previous network's extents; unset it to track the new items
-	scene->setSceneRect(QRectF());
-
 	// Clear list pointers - the items were owned by the scene and are now deleted.
 	m_trainSpeedLabels.clear(); // items deleted by scene->clear() above
+	m_trainBadges.clear(); // items deleted by scene->clear() above
 	m_prevTrainPositions.clear();
 	allTrains.clear();
 	allSignals.clear();
-	m_signalGroups.clear();
+	m_signalDecorations.clear();
+	m_stationNames.clear();
 	m_vcMessageItems.clear();
 	m_stationDecorations.clear();
 	m_signalsByAheadId.clear();
 	allArcs.clear();
 	allPlatforms.clear();
+	m_networkLegend = nullptr;
+	m_tracksBySectionId.clear();
+	m_tracksByOccupiedArc.clear();
+	m_activeTrackItems.clear();
 	trainPaxInfoItem = nullptr;
 	trainPaxItem = nullptr;
 	paxIconInfoItem = nullptr;
@@ -5485,6 +5574,11 @@ void MainWindow::teardownGUI() {
 		m_followTrainCombo->clear();
 
 	m_snapshot.reset();
+
+	// clear() keeps the explicitly pinned scene rect, so fitView would keep
+	// fitting the previous network's extents; unset it after invalidating the
+	// overlay caches because this emits viewportChanged().
+	scene->setSceneRect(QRectF());
 }
 
 void MainWindow::chooseOutputFolder() {
@@ -5739,12 +5833,14 @@ void MainWindow::paintStationNode(QPointF coord, int size, int pen_width, int tr
 
 // draws a station icon above the track
 void MainWindow::paintStationIcon(QPointF coord, int size) {
-	IconItem* item = new IconItem(station_pixmap.scaled(QSize(size, size), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+	const int pinSize = std::clamp(size / 12, 16, 32);
+	IconItem* item = new IconItem(station_pixmap.scaled(QSize(pinSize, pinSize), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+	item->setFlag(QGraphicsItem::ItemIgnoresTransformations);
 	scene->addItem(item);
 	m_stationDecorations.push_back(item);
 	item->setVisible(m_stationLayerVisible);
 
-	item->setPos(coord.x() - (size / 2), coord.y() - (size / 2));
+	item->setPos(coord.x() - (pinSize / 2), coord.y() - (pinSize / 2));
 	item->setTransformationMode(Qt::SmoothTransformation);
 
 	// fit to window
@@ -5780,7 +5876,7 @@ void MainWindow::paintStationName(QPointF coord, string sname, int size) {
 	station_name->setDefaultTextColor(Qt::white);
 	station_name->setZValue(3); // draw on top of every item
 	scene->addItem(station_name);
-	m_stationDecorations.push_back(station_name);
+	m_stationNames.push_back(station_name);
 	station_name->setVisible(m_stationLayerVisible);
 
 	// fit to window
@@ -6143,6 +6239,7 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	penPlate.setWidth(0);
 	// draws using rectangle with center on top-left corner (center_x,center_y,width,height)
 	QRectF rect = QRectF(0, 0, size, size);
+	rect.moveCenter(QPointF(0.0, 0.0));
 
 	// post #1
 	QGraphicsLineItem* post1 = new QGraphicsLineItem(QLineF(postStartX, postStartY, postEndX, postEndY));
@@ -6151,9 +6248,10 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	// plate #1
 	plateCenterX = postEndX;
 	plateCenterY = postEndY;
-	rect.moveCenter(QPoint(plateCenterX, plateCenterY));
 
 	SignalItem* plate1 = new SignalItem(rect);
+	plate1->setZValue(3);
+	plate1->setPos(QPointF(plateCenterX, plateCenterY));
 	plate1->setPen(penPlate);
 	plate1->setBrush(Qt::green);
 
@@ -6202,9 +6300,10 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	// plate #2
 	plateCenterX = postEndX;
 	plateCenterY = postEndY;
-	rect.moveCenter(QPoint(plateCenterX, plateCenterY));
 
 	SignalItem* plate2 = new SignalItem(rect);
+	plate2->setZValue(3);
+	plate2->setPos(QPointF(plateCenterX, plateCenterY));
 	plate2->setPen(penPlate);
 	plate2->setBrush(Qt::green);
 
@@ -6233,19 +6332,19 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	QGraphicsLineItem* basis2 = new QGraphicsLineItem(QLineF(basisStartX, basisStartY, basisEndX, basisEndY));
 	basis2->setPen(penPost);
 
-	// create group
-	QGraphicsItemGroup* signalGroup = new QGraphicsItemGroup();
-	signalGroup->addToGroup(post1);
-	signalGroup->addToGroup(plate1);
-	signalGroup->addToGroup(basis1);
-	signalGroup->addToGroup(post2);
-	signalGroup->addToGroup(plate2);
-	signalGroup->addToGroup(basis2);
-
-	// add signal to scene
-	scene->addItem(signalGroup);
-	m_signalGroups.push_back(signalGroup);
-	signalGroup->setVisible(m_signalLayerVisible);
+	const auto addSignalDecoration = [this, track](QGraphicsItem* item) {
+		item->setData(0, true);
+		item->setData(1, track);
+		scene->addItem(item);
+		m_signalDecorations.push_back(item);
+		item->setVisible(m_signalLayerVisible);
+	};
+	addSignalDecoration(post1);
+	addSignalDecoration(plate1);
+	addSignalDecoration(basis1);
+	addSignalDecoration(post2);
+	addSignalDecoration(plate2);
+	addSignalDecoration(basis2);
 
 	// fit to window
 	networkView->fitInView(scene->sceneRect(), Qt::KeepAspectRatio);
@@ -6305,6 +6404,18 @@ void MainWindow::paintTrain(const GuiTrainState& train, int size, int pen_width)
 
 	// add train to allTrains list
 	allTrains.push_back(trainPolygonGroup);
+
+	TrainBadgeItem* badge = new TrainBadgeItem();
+	badge->setIdentifier(QString::fromStdString(train.description));
+	badge->setSpeedText(QString::fromStdString(formatSpeedLabel(train.speedKmh)));
+	badge->setTrainVisual(visual);
+	badge->setReversed(train.reversedDirection);
+	badge->setCompact(!networkView || qAbs(networkView->transform().m11()) < kDenseDetailScale);
+	badge->setAcceptedMouseButtons(Qt::NoButton);
+	scene->addItem(badge);
+	badge->setVisible(m_trainLayerVisible && !train.outOfSimulation);
+	badge->setPos(trainPolygonGroup->sceneBoundingRect().center() + QPointF(8.0, -24.0));
+	m_trainBadges[train.index] = badge;
 }
 
 // converts geodetic to cartesian coordinates
@@ -6942,9 +7053,20 @@ void MainWindow::hideNetwork() {
 
 // fit view
 void MainWindow::fitView() {
+	ensureNetworkLegend();
 	// fit the items actually on the scene; the scene rect is unreliable after
 	// a reload because Qt's automatic rect only ever grows across loads
-	QRectF initialSceneRect = scene->itemsBoundingRect();
+	QRectF initialSceneRect;
+	bool hasSceneBounds = false;
+	for (auto* item : scene->items()) {
+		if (!item || item == m_networkLegend)
+			continue;
+		const QRectF itemBounds = item->sceneBoundingRect();
+		if (itemBounds.isEmpty())
+			continue;
+		initialSceneRect = hasSceneBounds ? initialSceneRect.united(itemBounds) : itemBounds;
+		hasSceneBounds = true;
+	}
 	if (initialSceneRect.isEmpty())
 		initialSceneRect = scene->sceneRect();
 	qreal expansionFactorX = 0.05;
@@ -6953,6 +7075,11 @@ void MainWindow::fitView() {
 
 	// fit to window
 	networkView->fitInView(initialSceneRect, Qt::KeepAspectRatio);
+	const qreal currentScale = qAbs(networkView->transform().m22());
+	const qreal minimumScale = track_separation > 0 ? 8.0 / track_separation : 0.0;
+	if (currentScale > 0.0 && currentScale < minimumScale)
+		networkView->scale(minimumScale / currentScale, minimumScale / currentScale);
+	updateViewportOverlays();
 }
 
 bool MainWindow::hasTrackGeometry(int track) const {
@@ -7265,32 +7392,23 @@ void MainWindow::removePaxInfoIcon() {
 }
 
 void MainWindow::updateBlockOccupationStatus(const GuiTrainState& train) {
-	TrackLineItem* track;
-	for (int i = 0; i < allArcs.size(); i++) {
-		for (const GuiOccupiedArc& occupiedArc : train.occupiedArcs) {
-
-			track = allArcs.at(i);
-
-			if ((track->arc->startNode.X == occupiedArc.startX) && (track->track == occupiedArc.trackId)) {
-				//  effect on clicked item
-				effect = new HighlightEffect(Qt::red, 1);
-				track->setGraphicsEffect(effect);
-			}
+	for (const GuiOccupiedArc& occupiedArc : train.occupiedArcs) {
+		auto it = m_tracksByOccupiedArc.find({occupiedArc.trackId, occupiedArc.startX});
+		if (it == m_tracksByOccupiedArc.end() || !it->second)
+			continue;
+		TrackLineItem* track = it->second;
+		if (trackStatePriority(TrackOperationalState::Occupied) >= trackStatePriority(track->operationalState())) {
+			track->setOperationalState(TrackOperationalState::Occupied);
+			m_activeTrackItems.insert(track);
 		}
 	}
 }
 
 void MainWindow::releaseBlockOccupationStatus() {
-	TrackLineItem* track;
-	// std::cout << regional_train.Bs.arcs_in_signalling_block_section[0].endNode.X << " " << regional_train.trainDescription << "\n";
-
-	// for (int i = 0; i < allArcs.size(); i++) {
-	//	track = allArcs.at(i);
-	for (int i = 0; i < allArcs.size(); i++) {
-		track = allArcs.at(i);
-		effect = new HighlightEffect(Qt::white, 1);
-		track->setGraphicsEffect(effect);
-	}
+	for (auto* track : m_activeTrackItems)
+		if (track)
+			track->setOperationalState(TrackOperationalState::Free);
+	m_activeTrackItems.clear();
 }
 
 void MainWindow::updateSignalAspect(const std::string& ID, double code, bool reversed) {
@@ -7298,6 +7416,7 @@ void MainWindow::updateSignalAspect(const std::string& ID, double code, bool rev
 		return;
 	for (auto* signal : m_signalsByAheadId.at(ID)) {
 		if (signal->reversedDirection == reversed) {
+			signal->setAspectCode(static_cast<int>(code));
 			if (code == 270 || code == 180) {
 				signal->setBrush(Qt::green);
 			} else if (code == 75) {
@@ -7322,7 +7441,27 @@ void MainWindow::updateTrainPosition(int t) {
 	}
 	m_vcMessageItems.clear();
 	// update every train
-	releaseBlockOccupationStatus(); //
+	releaseBlockOccupationStatus();
+	const auto applySectionState = [this](const GuiSectionState& state, TrackOperationalState visualState) {
+		if (!state.prepared && visualState == TrackOperationalState::Prepared)
+			return;
+		if (!state.blocked && visualState == TrackOperationalState::Blocked)
+			return;
+		auto tracks = m_tracksBySectionId.find(state.sectionId);
+		if (tracks == m_tracksBySectionId.end())
+			return;
+		for (auto* track : tracks->second) {
+			if (!track || trackStatePriority(visualState) < trackStatePriority(track->operationalState()))
+				continue;
+			track->setOperationalState(visualState);
+			m_activeTrackItems.insert(track);
+		}
+	};
+	for (const GuiSectionState& state : m_snapshot->sectionStates)
+		if (state.prepared)
+			applySectionState(state, TrackOperationalState::Prepared);
+	for (const GuiTrainState& state : m_snapshot->trains)
+		updateBlockOccupationStatus(state);
 	for (const GuiTrainState& state : m_snapshot->trains) {
 		const int train = state.index;
 		// check if train item exists
@@ -7353,39 +7492,36 @@ void MainWindow::updateTrainPosition(int t) {
 				getTrainPolygonItemList(trainItem->trainPolygonItemList, state);
 				checkVCouplingMsg(trainItem, state, t);
 
-				updateBlockOccupationStatus(state);
-
 				// animate smooth transition from old position to new position
 				QPointF newCenter = trainItem->sceneBoundingRect().center();
 
-				// update or create the speed label for this train
-				QString speedText = QString::fromStdString(
-					formatSpeedLabel(state.speedKmh));
-				QGraphicsSimpleTextItem* speedLabel = m_trainSpeedLabels.value(train, nullptr);
-				if (!speedLabel) {
-					speedLabel = scene->addSimpleText(speedText);
-					speedLabel->setZValue(1000);
-					speedLabel->setBrush(Qt::black);
-					m_trainSpeedLabels[train] = speedLabel;
+				TrainBadgeItem* badge = m_trainBadges.value(train, nullptr);
+				if (badge) {
+					badge->setIdentifier(QString::fromStdString(state.description));
+					badge->setSpeedText(QString::fromStdString(formatSpeedLabel(state.speedKmh)));
+					badge->setTrainVisual(classifyTrainType(state.type, state.description));
+					badge->setReversed(state.reversedDirection);
+					badge->setVisible(m_trainLayerVisible);
 				}
-				speedLabel->setText(speedText);
-				speedLabel->setVisible(m_trainLayerVisible);
 				m_prevTrainPositions[train] = newCenter;
 				QPointF delta = oldCenter - newCenter;
+				const QPointF badgeBase = newCenter + QPointF(8.0, -24.0);
 				if (delta.manhattanLength() > 0.5) {
 					stopTrainAnimation(train);
 					trainItem->setPos(delta);
-					speedLabel->setPos(newCenter.x() + delta.x() + 6, newCenter.y() + delta.y() - 18);
+					if (badge)
+						badge->setPos(badgeBase + delta);
 					QVariantAnimation* interp = new QVariantAnimation(this);
 					m_trainAnimations[train] = interp;
 					interp->setDuration(120);
 					interp->setStartValue(QVariant::fromValue(delta));
 					interp->setEndValue(QVariant::fromValue(QPointF(0, 0)));
 					interp->setEasingCurve(QEasingCurve::Linear);
-					connect(interp, &QVariantAnimation::valueChanged, this, [trainItem, speedLabel, newCenter](const QVariant& val) {
+					connect(interp, &QVariantAnimation::valueChanged, this, [trainItem, badge, badgeBase](const QVariant& val) {
 						QPointF offset = val.toPointF();
 						trainItem->setPos(offset);
-						speedLabel->setPos(newCenter.x() + offset.x() + 6, newCenter.y() + offset.y() - 18);
+						if (badge)
+							badge->setPos(badgeBase + offset);
 					});
 					connect(interp, &QVariantAnimation::finished, this, [this, train, interp]() {
 						if (m_trainAnimations.value(train, nullptr) == interp)
@@ -7396,7 +7532,8 @@ void MainWindow::updateTrainPosition(int t) {
 				} else {
 					stopTrainAnimation(train);
 					trainItem->setPos(QPointF(0, 0));
-					speedLabel->setPos(newCenter.x() + 6, newCenter.y() - 18);
+					if (badge)
+						badge->setPos(badgeBase);
 				}
 				if (m_followAction && m_followAction->isChecked() && m_followTrainIndex == train)
 					networkView->centerOn(newCenter);
@@ -7405,6 +7542,8 @@ void MainWindow::updateTrainPosition(int t) {
 			else {
 				stopTrainAnimation(train);
 				trainItem->hide();
+				if (m_trainBadges.contains(train))
+					m_trainBadges[train]->setVisible(false);
 				if (m_trainSpeedLabels.contains(train))
 					m_trainSpeedLabels[train]->setVisible(false);
 			}
@@ -7418,6 +7557,9 @@ void MainWindow::updateTrainPosition(int t) {
 				networkView->centerOn(allTrains.last());
 		}
 	}
+	for (const GuiSectionState& state : m_snapshot->sectionStates)
+		if (state.blocked)
+			applySectionState(state, TrackOperationalState::Blocked);
 
 }
 
@@ -8057,19 +8199,25 @@ void MainWindow::hideUnusedTracks() {
 			}
 		}
 
-		// filter signals (signalling group items)
+		if (item->data(0).toBool()) {
+			if (std::find(unusedTracks.begin(), unusedTracks.end(), item->data(1).toInt()) != unusedTracks.end())
+				item->hide();
+			continue;
+		}
+
+		// filter signals
 		SignalItem* signal = qgraphicsitem_cast<SignalItem*>(item);
 
 		if (signal) {
 			if (!signal->sectionAheadId.empty()) {
 				auto itAhead = std::find(unusedTracks.begin(), unusedTracks.end(), signal->sectionAheadTrackId);
 				if (itAhead != unusedTracks.end()) {
-					signal->parentItem()->hide(); // hide group
+					signal->hide();
 				}
 			} else if (!signal->sectionBehindId.empty()) {
 				auto itBehind = std::find(unusedTracks.begin(), unusedTracks.end(), signal->sectionBehindTrackId);
 				if (itBehind != unusedTracks.end()) {
-					signal->parentItem()->hide(); // hide group
+					signal->hide();
 				}
 			}
 		}
@@ -8611,5 +8759,77 @@ void MainWindow::buildSignalIndex() {
 		if (!signal->sectionAheadId.empty()) {
 			m_signalsByAheadId[signal->sectionAheadId].push_back(signal);
 		}
+	}
+}
+
+void MainWindow::buildTrackIndexes() {
+	m_tracksBySectionId.clear();
+	m_tracksByOccupiedArc.clear();
+
+	for (auto* item : allArcs) {
+		if (!item || !item->arc)
+			continue;
+		m_tracksByOccupiedArc[{item->track, item->arc->startNode.X}] = item;
+	}
+
+	const auto sameArc = [](const Arc& left, const Arc& right) {
+		return (left.ID == right.ID && left.startNode.X == right.startNode.X && left.endNode.X == right.endNode.X)
+			|| (left.startNode.X == right.startNode.X && left.endNode.X == right.endNode.X
+				&& left.length == right.length);
+	};
+	for (int sectionIndex = 0; sectionIndex < Blocks; ++sectionIndex) {
+		const Section& section = signalling_block_sections[sectionIndex];
+		if (section.ID.empty())
+			continue;
+		const int arcCount = std::min(section.total_arcs,
+			static_cast<int>(sizeof(section.arcs_in_signalling_block_section)
+				/ sizeof(section.arcs_in_signalling_block_section[0])));
+		auto& tracks = m_tracksBySectionId[section.ID];
+		for (int arcIndex = 0; arcIndex < arcCount; ++arcIndex) {
+			const Arc& sectionArc = section.arcs_in_signalling_block_section[arcIndex];
+			for (auto* item : allArcs) {
+				if (!item || !item->arc || !sameArc(*item->arc, sectionArc))
+					continue;
+				const bool trackMatches = section.trackLineId < 0
+					|| item->track == section.trackLineId
+					|| item->track == section.FirstConnectedTrackLineID
+					|| item->track == section.SecondConnectedTrackLineID;
+				if (!trackMatches || std::find(tracks.begin(), tracks.end(), item) != tracks.end())
+					continue;
+				tracks.push_back(item);
+			}
+		}
+		if (tracks.empty())
+			m_tracksBySectionId.erase(section.ID);
+	}
+}
+
+void MainWindow::ensureNetworkLegend() {
+	if (m_networkLegend || !scene)
+		return;
+	m_networkLegend = new NetworkLegendItem();
+	scene->addItem(m_networkLegend);
+	m_networkLegend->setVisible(true);
+}
+
+void MainWindow::updateViewportOverlays() {
+	if (!networkView)
+		return;
+	const qreal scale = qAbs(networkView->transform().m11());
+	const bool dense = scale >= kDenseDetailScale;
+	for (auto* name : m_stationNames) {
+		if (name)
+			name->setVisible(m_stationLayerVisible && dense);
+	}
+	for (auto it = m_trainBadges.cbegin(); it != m_trainBadges.cend(); ++it) {
+		if (it.value())
+			it.value()->setCompact(!dense);
+	}
+	if (m_networkLegend) {
+		const QRect viewportRect = networkView->viewport()->rect();
+		const QSize legendSize = m_networkLegend->boundingRect().size().toSize();
+		const QPoint bottomRight = viewportRect.bottomRight() - QPoint(kOverlayMargin, kOverlayMargin);
+		const QPoint topLeft = bottomRight - QPoint(legendSize.width(), legendSize.height());
+		m_networkLegend->setPos(networkView->mapToScene(topLeft));
 	}
 }

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3786,16 +3786,42 @@ void MainWindow::runVisualPolishE2E() {
 		ok = false;
 		failures << "network legend is missing";
 	}
-	if (m_trainBadges.isEmpty() || std::none_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
-		[](const auto& entry) { return entry && entry->isVisible(); })) {
+	if (!networkView) {
 		ok = false;
-		failures << "no visible train badge rendered";
-	}
-	if (std::none_of(allArcs.cbegin(), allArcs.cend(), [](const TrackLineItem* item) {
-		return item && item->operationalState() != TrackOperationalState::Free;
-	})) {
-		ok = false;
-		failures << "playback did not render an operational track state";
+		failures << "network viewport is missing before default capture";
+	} else {
+		const QRectF visibleViewport = networkView->mapToScene(networkView->viewport()->rect()).boundingRect();
+		const bool visibleBadge = std::any_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
+			[](const auto& entry) { return entry && entry->isVisible(); });
+		const bool badgeInViewport = std::any_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
+			[&visibleViewport](const auto& entry) {
+				return entry && entry->isVisible()
+					&& visibleViewport.contains(entry->sceneBoundingRect().center());
+			});
+		if (!visibleBadge) {
+			ok = false;
+			failures << "no visible train badge rendered";
+		} else if (!badgeInViewport) {
+			ok = false;
+			failures << "visible train badge center is outside default viewport";
+		}
+
+		const bool operationalTrack = std::any_of(allArcs.cbegin(), allArcs.cend(),
+			[](const TrackLineItem* item) {
+				return item && item->operationalState() != TrackOperationalState::Free;
+			});
+		const bool operationalTrackInViewport = std::any_of(allArcs.cbegin(), allArcs.cend(),
+			[&visibleViewport](const TrackLineItem* item) {
+				return item && item->operationalState() != TrackOperationalState::Free
+					&& visibleViewport.intersects(item->sceneBoundingRect());
+			});
+		if (!operationalTrack) {
+			ok = false;
+			failures << "playback did not render an operational track state";
+		} else if (!operationalTrackInViewport) {
+			ok = false;
+			failures << "no non-free track intersects default viewport";
+		}
 	}
 
 	// Capture the readable default view before changing follow or zoom state.
@@ -7569,7 +7595,10 @@ void MainWindow::updateTrainPosition(int t) {
 		// the exact departure frame, and the recorded trajectory (not the live
 		// train state) is what says whether the train is on the network at t
 		else if (t >= state.departureTime && state.routeAxisPosition != -9999) {
+			const bool firstTrain = allTrains.isEmpty();
 			paintTrain(state, node_size, line_width);
+			if (firstTrain && !allTrains.isEmpty())
+				networkView->centerOn(allTrains.last()->sceneBoundingRect().center());
 			if (m_followAction && m_followAction->isChecked() && m_followTrainIndex == train && !allTrains.isEmpty())
 				networkView->centerOn(allTrains.last());
 		}

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -4791,14 +4791,41 @@ void MainWindow::runTrackPreviewE2E() {
 		}
 		return false;
 	};
+	struct PreviewContentSnapshot {
+		QList<QGraphicsItem*> items;
+		QList<QRectF> itemBounds;
+		QRectF bounds;
+	};
+	auto snapshotPreviewContent = [&]() {
+		PreviewContentSnapshot snapshot;
+		if (!scene)
+			return snapshot;
+		bool hasBounds = false;
+		for (auto* item : scene->items()) {
+			if (!item || item == m_networkLegend)
+				continue;
+			snapshot.items.push_back(item);
+			const QRectF itemBounds = item->sceneBoundingRect();
+			snapshot.itemBounds.push_back(itemBounds);
+			if (itemBounds.isEmpty())
+				continue;
+			snapshot.bounds = hasBounds ? snapshot.bounds.united(itemBounds) : itemBounds;
+			hasBounds = true;
+		}
+		return snapshot;
+	};
+	auto samePreviewContent = [](const PreviewContentSnapshot& left, const PreviewContentSnapshot& right) {
+		return left.items == right.items && left.itemBounds == right.itemBounds && left.bounds == right.bounds;
+	};
 
 	const QString scenePath = qEnvironmentVariable("QEGTRAIN_E2E_SCENE");
 	const bool opened = !scenePath.isEmpty() && openSceneDirectory(scenePath);
 	if (!opened || !m_sceneLoaded) {
 		fail("open", "incomplete scene did not open");
 	} else {
-		const int itemCount = scene->items().size();
-		const QRectF bounds = scene->itemsBoundingRect();
+		const PreviewContentSnapshot preview = snapshotPreviewContent();
+		const int itemCount = preview.items.size();
+		const QRectF bounds = preview.bounds;
 		const QRectF visible = networkView->mapToScene(networkView->viewport()->rect()).boundingRect();
 		const bool diagnosticsOk = hasDiagnosticCode(m_sceneDiagnostics, "scene.trains.none")
 			&& hasDiagnosticCode(m_sceneDiagnostics, "scene.services.none")
@@ -4856,15 +4883,19 @@ void MainWindow::runTrackPreviewE2E() {
 			|| !ui->actionSimulationStart || ui->actionSimulationStart->isEnabled())
 			runFacetOk = false;
 	}
-	const int previewItemCount = scene->items().size();
-	const QRectF previewBounds = scene->itemsBoundingRect();
+	const PreviewContentSnapshot previewBeforeRun = snapshotPreviewContent();
+	const QRectF previewBounds = previewBeforeRun.bounds;
+	if (m_networkLegend)
+		// Simulate viewport repositioning changing the whole-scene bounds.
+		m_networkLegend->setPos(previewBounds.bottomRight() + QPointF(100000.0, 100000.0));
 	runScene();
+	const bool workerStarted = m_worker != nullptr;
 	QApplication::processEvents();
-	if (m_worker) {
+	if (workerStarted || m_worker) {
 		runFacetOk = false;
 		fail("run gating", "invalid scene started simulation");
 	}
-	if (scene->items().size() != previewItemCount || scene->itemsBoundingRect() != previewBounds) {
+	if (!samePreviewContent(previewBeforeRun, snapshotPreviewContent())) {
 		runFacetOk = false;
 		fail("run gating", "blocked run removed the preview");
 	}
@@ -4906,16 +4937,15 @@ void MainWindow::runTrackPreviewE2E() {
 	if (structuralOk) {
 		const SceneModel expectedCurrent = m_sceneModel;
 		const QString expectedDir = QDir(m_sceneDir).absolutePath();
-		const int expectedItems = scene->items().size();
-		const QRectF expectedBounds = scene->itemsBoundingRect();
+		const PreviewContentSnapshot expectedContent = snapshotPreviewContent();
 		auto rejectedWithoutReplacement = [&](const QString& candidate, const char* label) {
 			if (openSceneDirectory(candidate)) {
 				fail("structural rejection", QString("%1 scene unexpectedly opened").arg(label));
 				return false;
 			}
 			const bool preserved = QDir(m_sceneDir).absolutePath() == expectedDir
-				&& sameSceneModel(m_sceneModel, expectedCurrent) && scene->items().size() == expectedItems
-				&& scene->itemsBoundingRect() == expectedBounds;
+				&& sameSceneModel(m_sceneModel, expectedCurrent)
+				&& samePreviewContent(expectedContent, snapshotPreviewContent());
 			if (!preserved)
 				fail("structural rejection", QString("%1 failure replaced current state").arg(label));
 			return preserved;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3605,6 +3605,27 @@ void MainWindow::runVisualPolishE2E() {
 		failures << "no train items rendered";
 	}
 
+	if (qEnvironmentVariableIsSet("QEGTRAIN_E2E_VISUAL_POLISH") && scene && !allTrains.isEmpty()) {
+		TrainItemGroup* testTrain = allTrains.first();
+		if (!testTrain || !testTrain->trainPolygonItemList || testTrain->trainPolygonItemList->isEmpty()
+			|| !testTrain->trainPolygonItemList->first()
+			|| testTrain->trainPolygonItemList->first()->polygon().isEmpty()) {
+			ok = false;
+			failures << "cannot inject virtual coupling overlay";
+		} else {
+			paintVCouplingMsg(testTrain, "E2E virtual coupling overlay");
+			const int afterFirst = scene->items().size();
+			paintVCouplingMsg(testTrain, "E2E virtual coupling overlay");
+			const int afterSecond = scene->items().size();
+			if (afterSecond != afterFirst) {
+				ok = false;
+				failures << "virtual coupling overlay recreated between updates";
+			}
+			if (auto* overlay = m_vcMessageItems.value(testTrain->index, nullptr))
+				overlay->setVisible(false);
+		}
+	}
+
 	// Shell contract: the visual smoke must cover the controls users see before
 	// opening any secondary panel, not only the network scene.
 	if (!m_toolBar || m_toolBar->toolButtonStyle() != Qt::ToolButtonTextBesideIcon) {
@@ -7433,13 +7454,9 @@ void MainWindow::updateSignalAspect(const std::string& ID, double code, bool rev
 void MainWindow::updateTrainPosition(int t) {
 	if (!m_snapshot)
 		return;
-	for (auto* group : m_vcMessageItems) {
-		if (group) {
-			qDeleteAll(group->childItems());
-			scene->destroyItemGroup(group);
-		}
-	}
-	m_vcMessageItems.clear();
+	for (auto* group : m_vcMessageItems)
+		if (group)
+			group->setVisible(false);
 	// update every train
 	releaseBlockOccupationStatus();
 	const auto applySectionState = [this](const GuiSectionState& state, TrackOperationalState visualState) {
@@ -8109,17 +8126,43 @@ void MainWindow::paintVCouplingMsg(TrainItemGroup* trainItem, const std::string&
 	QPen pen = QPen(QColor(242, 161, 106));
 	pen.setWidth(line_width);
 	pen.setCosmetic(true);
-	QGraphicsLineItem* line = new QGraphicsLineItem(QLineF(start.x(), start.y(), end.x(), end.y()));
+	QGraphicsItemGroup* msgGroup = m_vcMessageItems.value(trainItem->index, nullptr);
+	QGraphicsLineItem* line = nullptr;
+	QGraphicsTextItem* text = nullptr;
+	QGraphicsRectItem* textBox = nullptr;
+	if (!msgGroup) {
+		msgGroup = new QGraphicsItemGroup;
+		line = new QGraphicsLineItem;
+		textBox = new QGraphicsRectItem;
+		text = new QGraphicsTextItem;
+		msgGroup->addToGroup(line);
+		msgGroup->addToGroup(textBox);
+		msgGroup->addToGroup(text);
+		msgGroup->setZValue(5);
+		scene->addItem(msgGroup);
+		m_vcMessageItems.insert(trainItem->index, msgGroup);
+	} else {
+		for (QGraphicsItem* child : msgGroup->childItems()) {
+			if (auto* item = qgraphicsitem_cast<QGraphicsLineItem*>(child))
+				line = item;
+			else if (auto* item = qgraphicsitem_cast<QGraphicsRectItem*>(child))
+				textBox = item;
+			else if (auto* item = qgraphicsitem_cast<QGraphicsTextItem*>(child))
+				text = item;
+		}
+	}
+	if (!line || !text || !textBox)
+		return;
+
+	line->setLine(QLineF(start.x(), start.y(), end.x(), end.y()));
 	line->setPen(pen);
 
 	QFont font = QFont();
 	font.setPixelSize((int)station_size / 6);
-	QGraphicsTextItem* text = new QGraphicsTextItem;
 	text->setPlainText(QString::fromStdString(message));
 	text->setDefaultTextColor(Qt::white);
 	text->setFont(font);
 
-	QGraphicsRectItem* textBox = new QGraphicsRectItem;
 	textBox->setRect(QRectF(0, 0, 1.25 * text->boundingRect().width(), 1.25 * text->boundingRect().height()));
 	textBox->setBrush(QColor(242, 161, 106));
 	textBox->setPos(end.x() - (textBox->boundingRect().width() / 2), end.y() - textBox->boundingRect().height());
@@ -8128,14 +8171,7 @@ void MainWindow::paintVCouplingMsg(TrainItemGroup* trainItem, const std::string&
 	textPos.rx() += 0.5 * (textBox->boundingRect().width() - text->boundingRect().width());
 	textPos.ry() += 0.5 * (textBox->boundingRect().height() - text->boundingRect().height());
 	text->setPos(textPos);
-
-	QGraphicsItemGroup* msgGroup = new QGraphicsItemGroup;
-	msgGroup->addToGroup(line);
-	msgGroup->addToGroup(textBox);
-	msgGroup->addToGroup(text);
-	msgGroup->setZValue(5);
-	scene->addItem(msgGroup);
-	m_vcMessageItems.push_back(msgGroup);
+	msgGroup->setVisible(true);
 }
 
 // hides all objects of unused tracks (including connections)

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -65,6 +65,8 @@
 #include <list>
 #include <vector>
 #include <map>
+#include <set>
+#include <utility>
 #include <unordered_map>
 #include <tuple>
 #include <QStatusBar>
@@ -108,6 +110,8 @@ class QTemporaryDir; // forward declaration for m_runStagingDir
 #include "graphics/items/SignalItem.h"
 #include "graphics/items/TrainBodyItem.h"
 #include "graphics/items/TrainItemGroup.h"
+#include "graphics/items/TrainBadgeItem.h"
+#include "graphics/items/NetworkLegendItem.h"
 #include "widgets/InfoDockWidget.h"
 #include "graphics/items/HighlightEffect.h"
 #include "widgets/TimeProgressBar.h"
@@ -364,8 +368,12 @@ private:
 	bool m_editorE2eFinished = false;
 	QMap<int, QPointF> m_prevTrainPositions;
 	QMap<int, QGraphicsSimpleTextItem*> m_trainSpeedLabels; // per-train speed overlay
+	QMap<int, TrainBadgeItem*> m_trainBadges;
 	QMap<int, QVariantAnimation*> m_trainAnimations;
 	qint64 m_lastRenderMs = 0;
+	std::map<std::string, std::vector<TrackLineItem*>> m_tracksBySectionId;
+	std::map<std::pair<int, double>, TrackLineItem*> m_tracksByOccupiedArc;
+	std::set<TrackLineItem*> m_activeTrackItems;
 
 	// toolbar
 	QToolBar* m_toolBar;
@@ -478,8 +486,10 @@ private:
 	bool m_signalLayerVisible = true;
 	bool m_passengerLayerVisible = true;
 	QList<QGraphicsItem*> m_stationDecorations;
-	QList<QGraphicsItemGroup*> m_signalGroups;
+	QList<QGraphicsTextItem*> m_stationNames;
+	QList<QGraphicsItem*> m_signalDecorations;
 	QList<QGraphicsItemGroup*> m_vcMessageItems;
+	NetworkLegendItem* m_networkLegend = nullptr;
 	std::shared_ptr<const GuiSimulationSnapshot> m_snapshot;
 
 	void buildPerTrainDiagram(int mode); // 0 speed/distance, 1 speed/time, 2 time/distance
@@ -587,6 +597,9 @@ private:
 	QList<SignalItem*> allSignals;
 	std::unordered_map<std::string, QList<SignalItem*>> m_signalsByAheadId;
 	void buildSignalIndex();
+	void buildTrackIndexes();
+	void updateViewportOverlays();
+	void ensureNetworkLegend();
 
 	// list of train items (whose simulation is running)
 	QList<TrainItemGroup*> allTrains;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -488,7 +488,7 @@ private:
 	QList<QGraphicsItem*> m_stationDecorations;
 	QList<QGraphicsTextItem*> m_stationNames;
 	QList<QGraphicsItem*> m_signalDecorations;
-	QList<QGraphicsItemGroup*> m_vcMessageItems;
+	QMap<int, QGraphicsItemGroup*> m_vcMessageItems;
 	NetworkLegendItem* m_networkLegend = nullptr;
 	std::shared_ptr<const GuiSimulationSnapshot> m_snapshot;
 

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
@@ -1,5 +1,7 @@
 #include "graphics/NetworkScene.h"
 
+#include <QGraphicsView>
+
 NetworkScene::NetworkScene(QObject* parent)
 	: QGraphicsScene(parent) {
 }
@@ -15,7 +17,14 @@ void NetworkScene::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) {
 		bool itemClicked = false;
 
 		// clicked item
-		QGraphicsItem* item = itemAt(mouseEvent->scenePos(), QTransform());
+		QTransform viewTransform;
+		for (QGraphicsView* view : views()) {
+			if (view->viewport() == mouseEvent->widget()) {
+				viewTransform = view->transform();
+				break;
+			}
+		}
+		QGraphicsItem* item = itemAt(mouseEvent->scenePos(), viewTransform);
 
 		// filter nodes
 		NodeItem* Node = qgraphicsitem_cast<NodeItem*>(item);

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
@@ -20,7 +20,7 @@ void NetworkScene::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) {
 		QTransform viewTransform;
 		for (QGraphicsView* view : views()) {
 			if (view->viewport() == mouseEvent->widget()) {
-				viewTransform = view->transform();
+				viewTransform = view->viewportTransform();
 				break;
 			}
 		}

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
@@ -12,7 +12,7 @@ NetworkView::NetworkView(QWidget* parent)
 
 	setMouseTracking(true);
 	setSceneRect(QRectF(0, 0, 0, 0));
-	setBackgroundBrush(QColor("#171d24"));
+	setBackgroundBrush(QColor("#101A22"));
 	setRenderHints(QPainter::Antialiasing | QPainter::HighQualityAntialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
 	setDragMode(QGraphicsView::ScrollHandDrag);
 	setTransformationAnchor(QGraphicsView::AnchorViewCenter);
@@ -45,7 +45,7 @@ void NetworkView::wheelEvent(QWheelEvent* event) {
 }
 
 void NetworkView::drawBackground(QPainter* painter, const QRectF& rect) {
-	painter->fillRect(rect, QColor("#171d24"));
+	painter->fillRect(rect, QColor("#101A22"));
 
 	const qreal viewScale = qAbs(transform().m11());
 	if (viewScale <= 0.0)
@@ -57,7 +57,7 @@ void NetworkView::drawBackground(QPainter* painter, const QRectF& rect) {
 	while (spacing * viewScale > 96.0)
 		spacing /= 2.0;
 
-	QPen gridPen(QColor("#2a3743"));
+	QPen gridPen(QColor("#1B2A35"));
 	gridPen.setCosmetic(true);
 	gridPen.setWidth(0);
 	painter->setPen(gridPen);

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
@@ -1,5 +1,7 @@
 #include "graphics/NetworkView.h"
 
+#include <cmath>
+
 NetworkView::NetworkView(QWidget* parent)
 	: QGraphicsView(parent) {
 	sizePolicy().setHorizontalPolicy(QSizePolicy::Preferred);
@@ -10,6 +12,7 @@ NetworkView::NetworkView(QWidget* parent)
 
 	setMouseTracking(true);
 	setSceneRect(QRectF(0, 0, 0, 0));
+	setBackgroundBrush(QColor("#171d24"));
 	setRenderHints(QPainter::Antialiasing | QPainter::HighQualityAntialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
 	setDragMode(QGraphicsView::ScrollHandDrag);
 	setTransformationAnchor(QGraphicsView::AnchorViewCenter);
@@ -24,8 +27,54 @@ void NetworkView::mousePressEvent(QMouseEvent* mouseEvent) {
 	QGraphicsView::mousePressEvent(mouseEvent);
 }
 
+void NetworkView::scale(qreal sx, qreal sy) {
+	QGraphicsView::scale(sx, sy);
+	emit viewportChanged();
+}
+
 void NetworkView::wheelEvent(QWheelEvent* event) {
 	// press CTRL to use scroll bars
-	if (event->modifiers() & Qt::ControlModifier)
+	if (event->modifiers() & Qt::ControlModifier) {
 		QGraphicsView::wheelEvent(event);
+	} else if (event->angleDelta().y() != 0) {
+		const qreal factor = event->angleDelta().y() > 0 ? 1.15 : 1.0 / 1.15;
+		QGraphicsView::scale(factor, factor);
+		event->accept();
+	}
+	emit viewportChanged();
+}
+
+void NetworkView::drawBackground(QPainter* painter, const QRectF& rect) {
+	painter->fillRect(rect, QColor("#171d24"));
+
+	const qreal viewScale = qAbs(transform().m11());
+	if (viewScale <= 0.0)
+		return;
+
+	qreal spacing = 80.0;
+	while (spacing * viewScale < 24.0)
+		spacing *= 2.0;
+	while (spacing * viewScale > 96.0)
+		spacing /= 2.0;
+
+	QPen gridPen(QColor("#2a3743"));
+	gridPen.setCosmetic(true);
+	gridPen.setWidth(0);
+	painter->setPen(gridPen);
+	const qreal left = std::floor(rect.left() / spacing) * spacing;
+	const qreal top = std::floor(rect.top() / spacing) * spacing;
+	for (qreal x = left; x <= rect.right(); x += spacing)
+		painter->drawLine(QLineF(x, rect.top(), x, rect.bottom()));
+	for (qreal y = top; y <= rect.bottom(); y += spacing)
+		painter->drawLine(QLineF(rect.left(), y, rect.right(), y));
+}
+
+void NetworkView::resizeEvent(QResizeEvent* event) {
+	QGraphicsView::resizeEvent(event);
+	emit viewportChanged();
+}
+
+void NetworkView::scrollContentsBy(int dx, int dy) {
+	QGraphicsView::scrollContentsBy(dx, dy);
+	emit viewportChanged();
 }

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
@@ -10,6 +10,9 @@
 #include <QGraphicsEllipseItem>
 #include <QBrush>
 #include <QTransform>
+#include <QPainter>
+#include <QResizeEvent>
+#include <QWheelEvent>
 #include <QDebug>
 #include <QScrollBar>
 #include <iostream>
@@ -21,14 +24,19 @@ public:
 	NetworkView(QWidget* parent = 0);
 	~NetworkView();
 
-	void mousePressEvent(QMouseEvent* mouseEvent);
+	void mousePressEvent(QMouseEvent* mouseEvent) override;
+	void scale(qreal sx, qreal sy);
 
 protected:
-	virtual void wheelEvent(QWheelEvent* event);
+	void wheelEvent(QWheelEvent* event) override;
+	void drawBackground(QPainter* painter, const QRectF& rect) override;
+	void resizeEvent(QResizeEvent* event) override;
+	void scrollContentsBy(int dx, int dy) override;
 
 private:
 signals:
 	void MousePressedOnView();
+	void viewportChanged();
 };
 
 #endif // NETWORKVIEW_H

--- a/EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp
@@ -33,14 +33,40 @@ TrackVisual classifyTrackSpeed(double speedLimitMetersPerSecond) {
 TrackStateVisual classifyTrackState(TrackOperationalState state) {
 	switch (state) {
 	case TrackOperationalState::Prepared:
-		return {QColor("#3aa675"), 8, Qt::SolidLine};
+		return {QColor("#2ECC71"), 8, Qt::SolidLine};
 	case TrackOperationalState::Occupied:
-		return {QColor("#d95550"), 8, Qt::SolidLine};
+		return {QColor("#EF5350"), 10, Qt::SolidLine};
 	case TrackOperationalState::Blocked:
-		return {QColor("#e4a23a"), 8, Qt::DashLine};
+		return {QColor("#F2A516"), 8, Qt::DashLine};
 	case TrackOperationalState::Free:
 	default:
 		return {Qt::transparent, 0, Qt::NoPen};
+	}
+}
+
+TrainBadgeShape classifyTrainBadgeShape(TrainVisualKind kind) {
+	switch (kind) {
+	case TrainVisualKind::Intercity:
+		return TrainBadgeShape::Capsule;
+	case TrainVisualKind::Freight:
+		return TrainBadgeShape::Square;
+	case TrainVisualKind::Passenger:
+	case TrainVisualKind::Sprinter:
+	case TrainVisualKind::HighSpeed:
+	default:
+		return TrainBadgeShape::Rounded;
+	}
+}
+
+int trainBadgeCornerRadius(TrainBadgeShape shape) {
+	switch (shape) {
+	case TrainBadgeShape::Capsule:
+		return 8;
+	case TrainBadgeShape::Rounded:
+		return 3;
+	case TrainBadgeShape::Square:
+	default:
+		return 0;
 	}
 }
 
@@ -61,24 +87,34 @@ int trackStatePriority(TrackOperationalState state) {
 TrainVisual classifyTrainType(const std::string& type, const std::string& description) {
 	std::string text = lower(type + " " + description);
 	if (containsAny(text, {"freight", "cargo", "goederen"}))
-		return {TrainVisualKind::Freight, QColor(120, 95, 70), QColor(70, 55, 40)};
+		return {TrainVisualKind::Freight, QColor(120, 95, 70), QColor(70, 55, 40), classifyTrainBadgeShape(TrainVisualKind::Freight)};
 	if (containsAny(text, {"ice", "hst", "highspeed", "high speed"}))
-		return {TrainVisualKind::HighSpeed, QColor(40, 130, 210), QColor(15, 70, 120)};
+		return {TrainVisualKind::HighSpeed, QColor(40, 130, 210), QColor(15, 70, 120), classifyTrainBadgeShape(TrainVisualKind::HighSpeed)};
 	if (containsAny(text, {"sprinter", "spr"}))
-		return {TrainVisualKind::Sprinter, QColor(40, 170, 110), QColor(20, 90, 60)};
+		return {TrainVisualKind::Sprinter, QColor(40, 170, 110), QColor(20, 90, 60), classifyTrainBadgeShape(TrainVisualKind::Sprinter)};
 	if (containsAny(text, {"intercity", " ic", "ic "}))
-		return {TrainVisualKind::Intercity, QColor(235, 190, 45), QColor(120, 90, 20)};
-	return {TrainVisualKind::Passenger, QColor(235, 210, 55), QColor(110, 90, 20)};
+		return {TrainVisualKind::Intercity, QColor(235, 190, 45), QColor(120, 90, 20), classifyTrainBadgeShape(TrainVisualKind::Intercity)};
+	return {TrainVisualKind::Passenger, QColor(235, 210, 55), QColor(110, 90, 20), classifyTrainBadgeShape(TrainVisualKind::Passenger)};
+}
+
+SignalCueKind classifySignalCue(int code) {
+	if (code == 0)
+		return SignalCueKind::Stop;
+	if (code == 75)
+		return SignalCueKind::Caution;
+	if (code == 180 || code == 270)
+		return SignalCueKind::Proceed;
+	return SignalCueKind::Neutral;
 }
 
 SignalVisual classifySignalAspect(int code) {
 	if (code == 0)
-		return {QColor(Qt::red)};
+		return {QColor(Qt::red), classifySignalCue(code)};
 	if (code == 75)
-		return {QColor(Qt::yellow)};
+		return {QColor(Qt::yellow), classifySignalCue(code)};
 	if (code == 180 || code == 270)
-		return {QColor(Qt::green)};
-	return {QColor(128, 128, 128)};
+		return {QColor(Qt::green), classifySignalCue(code)};
+	return {QColor(128, 128, 128), classifySignalCue(code)};
 }
 
 StationVisual classifyStation(bool hasPlatformId, int connectionCount) {

--- a/EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp
@@ -30,6 +30,34 @@ TrackVisual classifyTrackSpeed(double speedLimitMetersPerSecond) {
 	return {TrackVisualKind::Local, QColor(120, 120, 120), 2};
 }
 
+TrackStateVisual classifyTrackState(TrackOperationalState state) {
+	switch (state) {
+	case TrackOperationalState::Prepared:
+		return {QColor("#3aa675"), 8, Qt::SolidLine};
+	case TrackOperationalState::Occupied:
+		return {QColor("#d95550"), 8, Qt::SolidLine};
+	case TrackOperationalState::Blocked:
+		return {QColor("#e4a23a"), 8, Qt::DashLine};
+	case TrackOperationalState::Free:
+	default:
+		return {Qt::transparent, 0, Qt::NoPen};
+	}
+}
+
+int trackStatePriority(TrackOperationalState state) {
+	switch (state) {
+	case TrackOperationalState::Prepared:
+		return 1;
+	case TrackOperationalState::Occupied:
+		return 2;
+	case TrackOperationalState::Blocked:
+		return 3;
+	case TrackOperationalState::Free:
+	default:
+		return 0;
+	}
+}
+
 TrainVisual classifyTrainType(const std::string& type, const std::string& description) {
 	std::string text = lower(type + " " + description);
 	if (containsAny(text, {"freight", "cargo", "goederen"}))
@@ -41,6 +69,16 @@ TrainVisual classifyTrainType(const std::string& type, const std::string& descri
 	if (containsAny(text, {"intercity", " ic", "ic "}))
 		return {TrainVisualKind::Intercity, QColor(235, 190, 45), QColor(120, 90, 20)};
 	return {TrainVisualKind::Passenger, QColor(235, 210, 55), QColor(110, 90, 20)};
+}
+
+SignalVisual classifySignalAspect(int code) {
+	if (code == 0)
+		return {QColor(Qt::red)};
+	if (code == 75)
+		return {QColor(Qt::yellow)};
+	if (code == 180 || code == 270)
+		return {QColor(Qt::green)};
+	return {QColor(128, 128, 128)};
 }
 
 StationVisual classifyStation(bool hasPlatformId, int connectionCount) {

--- a/EGTRAIN/QEGTRAIN/graphics/VisualPolish.h
+++ b/EGTRAIN/QEGTRAIN/graphics/VisualPolish.h
@@ -8,8 +8,10 @@
 
 enum class TrackVisualKind { Local, Mainline, HighSpeed };
 enum class TrainVisualKind { Passenger, Sprinter, Intercity, HighSpeed, Freight };
+enum class TrainBadgeShape { Rounded, Capsule, Square };
 enum class StationVisualKind { StopMarker, Platform, Interchange };
 enum class TrackOperationalState { Free, Prepared, Occupied, Blocked };
+enum class SignalCueKind { Neutral, Stop, Caution, Proceed };
 
 struct TrackVisual {
 	TrackVisualKind kind;
@@ -21,6 +23,7 @@ struct TrainVisual {
 	TrainVisualKind kind;
 	QColor fill;
 	QColor outline;
+	TrainBadgeShape shape;
 };
 
 struct StationVisual {
@@ -37,13 +40,17 @@ struct TrackStateVisual {
 
 struct SignalVisual {
 	QColor lamp;
+	SignalCueKind cue;
 };
 
 TrackVisual classifyTrackSpeed(double speedLimitMetersPerSecond);
 TrackStateVisual classifyTrackState(TrackOperationalState state);
 int trackStatePriority(TrackOperationalState state);
 TrainVisual classifyTrainType(const std::string& type, const std::string& description);
+TrainBadgeShape classifyTrainBadgeShape(TrainVisualKind kind);
+int trainBadgeCornerRadius(TrainBadgeShape shape);
 SignalVisual classifySignalAspect(int code);
+SignalCueKind classifySignalCue(int code);
 StationVisual classifyStation(bool hasPlatformId, int connectionCount);
 QString simulationSpeedLabel(int delayMs);
 QString simulationSpeedMode(int delayMs);

--- a/EGTRAIN/QEGTRAIN/graphics/VisualPolish.h
+++ b/EGTRAIN/QEGTRAIN/graphics/VisualPolish.h
@@ -2,12 +2,14 @@
 #define VISUALPOLISH_H
 
 #include <QColor>
+#include <QPen>
 #include <QString>
 #include <string>
 
 enum class TrackVisualKind { Local, Mainline, HighSpeed };
 enum class TrainVisualKind { Passenger, Sprinter, Intercity, HighSpeed, Freight };
 enum class StationVisualKind { StopMarker, Platform, Interchange };
+enum class TrackOperationalState { Free, Prepared, Occupied, Blocked };
 
 struct TrackVisual {
 	TrackVisualKind kind;
@@ -27,8 +29,21 @@ struct StationVisual {
 	QColor outline;
 };
 
+struct TrackStateVisual {
+	QColor color;
+	int width;
+	Qt::PenStyle style;
+};
+
+struct SignalVisual {
+	QColor lamp;
+};
+
 TrackVisual classifyTrackSpeed(double speedLimitMetersPerSecond);
+TrackStateVisual classifyTrackState(TrackOperationalState state);
+int trackStatePriority(TrackOperationalState state);
 TrainVisual classifyTrainType(const std::string& type, const std::string& description);
+SignalVisual classifySignalAspect(int code);
 StationVisual classifyStation(bool hasPlatformId, int connectionCount);
 QString simulationSpeedLabel(int delayMs);
 QString simulationSpeedMode(int delayMs);

--- a/EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.cpp
@@ -1,0 +1,62 @@
+#include "graphics/items/NetworkLegendItem.h"
+
+#include "graphics/VisualPolish.h"
+
+namespace {
+
+const QRectF legendRect(0.0, 0.0, 190.0, 154.0);
+
+void drawTrackEntry(QPainter* painter, qreal y, const QString& label, TrackOperationalState state) {
+	const TrackStateVisual visual = classifyTrackState(state);
+	QPen pen(visual.color);
+	pen.setWidth(visual.width > 0 ? visual.width : 2);
+	pen.setStyle(visual.style == Qt::NoPen ? Qt::SolidLine : visual.style);
+	pen.setCosmetic(true);
+	painter->setPen(pen);
+	painter->drawLine(QLineF(12.0, y, 40.0, y));
+	painter->setPen(QColor("#d9e1e8"));
+	painter->drawText(QRectF(50.0, y - 9.0, 126.0, 18.0), Qt::AlignVCenter | Qt::AlignLeft, label);
+}
+
+void drawTrainEntry(QPainter* painter, qreal y, const QString& label, const TrainVisual& visual) {
+	painter->setPen(QPen(visual.outline, 1.0));
+	painter->setBrush(visual.fill);
+	painter->drawRoundedRect(QRectF(12.0, y - 6.0, 28.0, 12.0), 3.0, 3.0);
+	painter->setPen(QColor("#d9e1e8"));
+	painter->drawText(QRectF(50.0, y - 9.0, 126.0, 18.0), Qt::AlignVCenter | Qt::AlignLeft, label);
+}
+
+} // namespace
+
+NetworkLegendItem::NetworkLegendItem(QGraphicsItem* parent)
+	: QGraphicsItem(parent) {
+	setFlag(QGraphicsItem::ItemIgnoresTransformations);
+	setZValue(8);
+}
+
+QRectF NetworkLegendItem::boundingRect() const {
+	return legendRect;
+}
+
+void NetworkLegendItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
+	Q_UNUSED(option);
+	Q_UNUSED(widget);
+
+	painter->setPen(QPen(QColor("#536271"), 1.0));
+	painter->setBrush(QColor(23, 29, 36, 235));
+	painter->drawRoundedRect(legendRect, 5.0, 5.0);
+
+	QFont font = painter->font();
+	font.setPointSize(9);
+	painter->setFont(font);
+	painter->setPen(QColor("#f2f5f7"));
+	painter->drawText(QRectF(12.0, 8.0, 166.0, 18.0), Qt::AlignLeft | Qt::AlignVCenter, "Network legend");
+
+	drawTrackEntry(painter, 34.0, "Prepared route", TrackOperationalState::Prepared);
+	drawTrackEntry(painter, 54.0, "Occupied section", TrackOperationalState::Occupied);
+	drawTrackEntry(painter, 74.0, "Blocked section", TrackOperationalState::Blocked);
+
+	drawTrainEntry(painter, 98.0, "Intercity", classifyTrainType("Intercity", ""));
+	drawTrainEntry(painter, 118.0, "Sprinter", classifyTrainType("Sprinter", ""));
+	drawTrainEntry(painter, 138.0, "Freight", classifyTrainType("Freight", ""));
+}

--- a/EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.cpp
@@ -21,7 +21,8 @@ void drawTrackEntry(QPainter* painter, qreal y, const QString& label, TrackOpera
 void drawTrainEntry(QPainter* painter, qreal y, const QString& label, const TrainVisual& visual) {
 	painter->setPen(QPen(visual.outline, 1.0));
 	painter->setBrush(visual.fill);
-	painter->drawRoundedRect(QRectF(12.0, y - 6.0, 28.0, 12.0), 3.0, 3.0);
+	const qreal radius = trainBadgeCornerRadius(visual.shape);
+	painter->drawRoundedRect(QRectF(12.0, y - 6.0, 28.0, 12.0), radius, radius);
 	painter->setPen(QColor("#d9e1e8"));
 	painter->drawText(QRectF(50.0, y - 9.0, 126.0, 18.0), Qt::AlignVCenter | Qt::AlignLeft, label);
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.h
@@ -1,0 +1,20 @@
+#ifndef NETWORKLEGENDITEM_H
+#define NETWORKLEGENDITEM_H
+
+#include <QGraphicsItem>
+#include <QPainter>
+#include <QStyleOptionGraphicsItem>
+#include <QWidget>
+
+class NetworkLegendItem : public QGraphicsItem {
+public:
+	NetworkLegendItem(QGraphicsItem* parent = nullptr);
+
+	QRectF boundingRect() const override;
+	void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;
+
+	enum { Type = UserType + 12 };
+	int type() const override { return Type; }
+};
+
+#endif // NETWORKLEGENDITEM_H

--- a/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
@@ -2,6 +2,7 @@
 
 SignalItem::SignalItem(const QRectF& rect, QGraphicsItem* parent)
 	: QGraphicsEllipseItem(rect, parent), m_aspectCode(-1) {
+	setFlag(QGraphicsItem::ItemIgnoresTransformations);
 	setZValue(2); // draw over arcs and connections (which have z = 0), and nodes (z = 1)
 	QRectF fixedHousing = rect;
 	fixedHousing.setSize(QSizeF(12.0, 16.0));
@@ -57,6 +58,30 @@ void SignalItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option
 	painter->setPen(Qt::NoPen);
 	painter->setBrush(lamp);
 	painter->drawEllipse(lampRect);
+
+	const QColor cueColor = lamp.lightness() > 150 ? QColor("#101A22") : QColor("#f2f5f7");
+	painter->setPen(QPen(cueColor, 1.2));
+	painter->setBrush(cueColor);
+	switch (visual.cue) {
+	case SignalCueKind::Stop:
+		painter->drawLine(QLineF(lampRect.left() + 1.5, lampRect.center().y(), lampRect.right() - 1.5, lampRect.center().y()));
+		break;
+	case SignalCueKind::Caution: {
+			QPolygonF cue;
+			cue << QPointF(lampRect.center().x(), lampRect.top() + 1.0)
+				<< QPointF(lampRect.right() - 1.0, lampRect.bottom() - 1.0)
+				<< QPointF(lampRect.left() + 1.0, lampRect.bottom() - 1.0);
+			painter->drawPolygon(cue);
+			break;
+		}
+	case SignalCueKind::Proceed:
+		painter->drawLine(QLineF(lampRect.left() + 1.5, lampRect.center().y(), lampRect.center().x(), lampRect.bottom() - 1.5));
+		painter->drawLine(QLineF(lampRect.center().x(), lampRect.bottom() - 1.5, lampRect.right() - 1.5, lampRect.top() + 1.5));
+		break;
+	case SignalCueKind::Neutral:
+	default:
+		break;
+	}
 
 	const qreal y = rect().bottom() - 3.0;
 	QPolygonF cue;

--- a/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
@@ -1,8 +1,12 @@
 #include "graphics/items/SignalItem.h"
 
 SignalItem::SignalItem(const QRectF& rect, QGraphicsItem* parent)
-	: QGraphicsEllipseItem(rect, parent) {
+	: QGraphicsEllipseItem(rect, parent), m_aspectCode(-1) {
 	setZValue(2); // draw over arcs and connections (which have z = 0), and nodes (z = 1)
+	QRectF fixedHousing = rect;
+	fixedHousing.setSize(QSizeF(12.0, 16.0));
+	fixedHousing.moveCenter(rect.center());
+	setRect(fixedHousing);
 
 	// initialize parameters
 	trackID = -1;
@@ -15,21 +19,52 @@ SignalItem::SignalItem(const QRectF& rect, QGraphicsItem* parent)
 SignalItem::~SignalItem() {
 }
 
+void SignalItem::setAspectCode(int code) {
+	if (m_aspectCode == code)
+		return;
+	m_aspectCode = code;
+	update();
+}
+
+int SignalItem::aspectCode() const {
+	return m_aspectCode;
+}
+
+void SignalItem::setReversedDirection(bool reversed) {
+	if (reversedDirection == reversed)
+		return;
+	reversedDirection = reversed;
+	update();
+}
+
 void SignalItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
 	Q_UNUSED(option);
 	Q_UNUSED(widget);
 
-	QPen effectPen = pen();
-	effectPen.setColor(Qt::blue);
+	QPen housingPen(QColor("#0d131a"));
+	housingPen.setWidthF(1.0);
+	if (graphicsEffect())
+		housingPen.setColor(Qt::blue);
+	painter->setPen(housingPen);
+	painter->setBrush(QColor("#26313b"));
+	painter->drawRoundedRect(rect(), 3.0, 3.0);
 
-	// change line color when selected
-	if (graphicsEffect()) {
-		painter->setPen(effectPen);
-		painter->setBrush(effectPen.color());
+	const SignalVisual visual = classifySignalAspect(m_aspectCode);
+	QColor lamp = visual.lamp;
+	if (m_aspectCode < 0 && brush().style() != Qt::NoBrush)
+		lamp = brush().color();
+	QRectF lampRect = rect().adjusted(3.0, 2.0, -3.0, -6.0);
+	painter->setPen(Qt::NoPen);
+	painter->setBrush(lamp);
+	painter->drawEllipse(lampRect);
+
+	const qreal y = rect().bottom() - 3.0;
+	QPolygonF cue;
+	if (reversedDirection) {
+		cue << QPointF(rect().left() + 3.0, y) << QPointF(rect().left() + 7.0, y - 2.5) << QPointF(rect().left() + 7.0, y + 2.5);
 	} else {
-		painter->setPen(pen());
-		painter->setBrush(brush());
+		cue << QPointF(rect().right() - 3.0, y) << QPointF(rect().right() - 7.0, y - 2.5) << QPointF(rect().right() - 7.0, y + 2.5);
 	}
-
-	painter->drawEllipse(rect());
+	painter->setBrush(QColor("#f2f5f7"));
+	painter->drawPolygon(cue);
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.h
@@ -9,12 +9,18 @@
 #include <QPolygonF>
 #include <QtMath>
 
+#include "graphics/VisualPolish.h"
+
 class SignalItem : public QGraphicsEllipseItem {
 	// Q_OBJECT
 
 public:
 	SignalItem(const QRectF& rect, QGraphicsItem* parent = 0);
 	~SignalItem();
+
+	void setAspectCode(int code);
+	int aspectCode() const;
+	void setReversedDirection(bool reversed);
 
 	// reimplemented functions
 	void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget);
@@ -41,6 +47,9 @@ public:
 		// Enable the use of qgraphicsitem_cast with this item.
 		return Type;
 	}
+
+private:
+	int m_aspectCode;
 };
 
 #endif // SIGNALITEM_H

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrackLineItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrackLineItem.cpp
@@ -2,11 +2,22 @@
 
 // adjust value of selectionOffset to control the margin used when clicking on the line item
 TrackLineItem::TrackLineItem(const QLineF& line, QGraphicsItem* parent)
-	: QGraphicsLineItem(line, parent), selectionOffset(20) {
+	: QGraphicsLineItem(line, parent), selectionOffset(20), m_operationalState(TrackOperationalState::Free) {
 	createSelectionPolygon();
 }
 
 TrackLineItem::~TrackLineItem() {
+}
+
+void TrackLineItem::setOperationalState(TrackOperationalState state) {
+	if (m_operationalState == state)
+		return;
+	m_operationalState = state;
+	update();
+}
+
+TrackOperationalState TrackLineItem::operationalState() const {
+	return m_operationalState;
 }
 
 void TrackLineItem::createSelectionPolygon() {
@@ -37,6 +48,16 @@ QPainterPath TrackLineItem::shape() const {
 void TrackLineItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
 	Q_UNUSED(option);
 	Q_UNUSED(widget);
+
+	const TrackStateVisual stateVisual = classifyTrackState(m_operationalState);
+	if (stateVisual.style != Qt::NoPen && stateVisual.width > 0) {
+		QPen underlay(stateVisual.color);
+		underlay.setWidth(stateVisual.width);
+		underlay.setStyle(stateVisual.style);
+		underlay.setCosmetic(true);
+		painter->setPen(underlay);
+		painter->drawLine(line());
+	}
 
 	QPen effectPen = pen();
 	effectPen.setColor(Qt::blue);

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrackLineItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrackLineItem.h
@@ -18,6 +18,7 @@
 #include <QtMath>
 
 #include "simulation/Infrastructure.h"
+#include "graphics/VisualPolish.h"
 
 using namespace std;
 
@@ -27,6 +28,9 @@ class TrackLineItem : public QGraphicsLineItem {
 public:
 	TrackLineItem(const QLineF& line, QGraphicsItem* parent = 0);
 	~TrackLineItem();
+
+	void setOperationalState(TrackOperationalState state);
+	TrackOperationalState operationalState() const;
 
 	// reimplemented functions
 	QPainterPath shape() const;
@@ -51,6 +55,9 @@ protected:
 	const qreal selectionOffset;
 	QPolygonF selectionPolygon;
 	void createSelectionPolygon();
+
+private:
+	TrackOperationalState m_operationalState;
 };
 
 #endif // TRACKLINEITEM_H

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.cpp
@@ -81,8 +81,11 @@ void TrainBadgeItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* op
 	font.setPointSize(m_compact ? 8 : 9);
 	font.setBold(true);
 	painter->setFont(font);
-	const qreal textLeft = m_reversed ? 16.0 : 8.0;
-	painter->drawText(QRectF(textLeft, 1.0, body.width() - 24.0, body.height() - 2.0), Qt::AlignVCenter | Qt::AlignLeft, m_identifier);
+	const QFontMetricsF metrics(font);
+	const QRectF identifierRect = identifierTextRect(body, m_compact, m_reversed, metrics, m_speedText);
+	painter->drawText(identifierRect, Qt::AlignVCenter | Qt::AlignLeft,
+		elidedIdentifier(m_identifier, metrics, identifierRect));
 	if (!m_compact)
-		painter->drawText(QRectF(body.left() + 8.0, body.top() + 1.0, body.width() - 16.0, body.height() - 2.0), Qt::AlignVCenter | Qt::AlignRight, m_speedText);
+		painter->drawText(speedTextRect(body, m_compact, m_reversed, metrics, m_speedText),
+			Qt::AlignVCenter | Qt::AlignRight, m_speedText);
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.cpp
@@ -1,0 +1,87 @@
+#include "graphics/items/TrainBadgeItem.h"
+
+TrainBadgeItem::TrainBadgeItem(QGraphicsItem* parent)
+	: QGraphicsItem(parent), m_visual(classifyTrainType("", "")), m_reversed(false), m_compact(false) {
+	setFlag(QGraphicsItem::ItemIgnoresTransformations);
+	setZValue(5);
+}
+
+void TrainBadgeItem::setIdentifier(const QString& identifier) {
+	if (m_identifier == identifier)
+		return;
+	m_identifier = identifier;
+	update();
+}
+
+void TrainBadgeItem::setSpeedText(const QString& speedText) {
+	if (m_speedText == speedText)
+		return;
+	m_speedText = speedText;
+	update();
+}
+
+void TrainBadgeItem::setTrainVisual(const TrainVisual& visual) {
+	m_visual = visual;
+	update();
+}
+
+void TrainBadgeItem::setReversed(bool reversed) {
+	if (m_reversed == reversed)
+		return;
+	m_reversed = reversed;
+	update();
+}
+
+void TrainBadgeItem::setCompact(bool compact) {
+	if (m_compact == compact)
+		return;
+	prepareGeometryChange();
+	m_compact = compact;
+	update();
+}
+
+QRectF TrainBadgeItem::badgeRect() const {
+	return QRectF(0.0, 0.0, m_compact ? 76.0 : 132.0, m_compact ? 20.0 : 28.0);
+}
+
+QRectF TrainBadgeItem::boundingRect() const {
+	return badgeRect();
+}
+
+void TrainBadgeItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
+	Q_UNUSED(option);
+	Q_UNUSED(widget);
+
+	const QRectF body = badgeRect().adjusted(1.0, 1.0, -1.0, -1.0);
+	QPen outline(m_visual.outline);
+	outline.setWidthF(1.2);
+	painter->setPen(outline);
+	painter->setBrush(m_visual.fill);
+	painter->drawRoundedRect(body, 4.0, 4.0);
+
+	QPolygonF direction;
+	const qreal centerY = body.center().y();
+	if (m_reversed) {
+		direction << QPointF(body.left() + 5.0, centerY)
+				  << QPointF(body.left() + 11.0, centerY - 4.0)
+				  << QPointF(body.left() + 11.0, centerY + 4.0);
+	} else {
+		direction << QPointF(body.right() - 5.0, centerY)
+				  << QPointF(body.right() - 11.0, centerY - 4.0)
+				  << QPointF(body.right() - 11.0, centerY + 4.0);
+	}
+	painter->setPen(Qt::NoPen);
+	painter->setBrush(m_visual.outline);
+	painter->drawPolygon(direction);
+
+	const QColor textColor = m_visual.fill.lightness() < 150 ? QColor(Qt::white) : QColor("#16202a");
+	painter->setPen(textColor);
+	QFont font = painter->font();
+	font.setPointSize(m_compact ? 8 : 9);
+	font.setBold(true);
+	painter->setFont(font);
+	const qreal textLeft = m_reversed ? 16.0 : 8.0;
+	painter->drawText(QRectF(textLeft, 1.0, body.width() - 24.0, body.height() - 2.0), Qt::AlignVCenter | Qt::AlignLeft, m_identifier);
+	if (!m_compact)
+		painter->drawText(QRectF(body.left() + 8.0, body.top() + 1.0, body.width() - 16.0, body.height() - 2.0), Qt::AlignVCenter | Qt::AlignRight, m_speedText);
+}

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.cpp
@@ -57,7 +57,8 @@ void TrainBadgeItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* op
 	outline.setWidthF(1.2);
 	painter->setPen(outline);
 	painter->setBrush(m_visual.fill);
-	painter->drawRoundedRect(body, 4.0, 4.0);
+	const qreal radius = trainBadgeCornerRadius(m_visual.shape);
+	painter->drawRoundedRect(body, radius, radius);
 
 	QPolygonF direction;
 	const qreal centerY = body.center().y();

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.h
@@ -1,10 +1,11 @@
 #ifndef TRAINBADGEITEM_H
 #define TRAINBADGEITEM_H
 
-#include <QGraphicsItem>
+#include <QFontMetricsF>
+#include <QtWidgets/QGraphicsItem>
 #include <QPainter>
-#include <QStyleOptionGraphicsItem>
-#include <QWidget>
+#include <QtWidgets/QStyleOptionGraphicsItem>
+#include <QtWidgets/QWidget>
 
 #include "graphics/VisualPolish.h"
 
@@ -17,6 +18,30 @@ public:
 	void setTrainVisual(const TrainVisual& visual);
 	void setReversed(bool reversed);
 	void setCompact(bool compact);
+
+	static QRectF speedTextRect(const QRectF& body, bool compact, bool reversed,
+		const QFontMetricsF& metrics, const QString& speedText) {
+		if (compact || speedText.isEmpty())
+			return QRectF();
+		const qreal right = body.right() - (reversed ? 8.0 : 16.0);
+		const qreal left = body.left() + 8.0;
+		const qreal width = qMin(metrics.horizontalAdvance(speedText), qMax(0.0, right - left));
+		return QRectF(right - width, body.top() + 1.0, width, body.height() - 2.0);
+	}
+
+	static QRectF identifierTextRect(const QRectF& body, bool compact, bool reversed,
+		const QFontMetricsF& metrics, const QString& speedText) {
+		const qreal left = body.left() + (reversed ? 15.0 : 7.0);
+		const QRectF speed = speedTextRect(body, compact, reversed, metrics, speedText);
+		const qreal defaultRight = body.right() - (reversed ? 9.0 : 17.0);
+		const qreal right = speed.isEmpty() ? defaultRight : speed.left() - 4.0;
+		return QRectF(left, body.top() + 1.0, qMax(0.0, right - left), body.height() - 2.0);
+	}
+
+	static QString elidedIdentifier(const QString& identifier, const QFontMetricsF& metrics,
+		const QRectF& region) {
+		return metrics.elidedText(identifier, Qt::ElideRight, qMax(0.0, region.width()));
+	}
 
 	QRectF boundingRect() const override;
 	void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.h
@@ -1,0 +1,37 @@
+#ifndef TRAINBADGEITEM_H
+#define TRAINBADGEITEM_H
+
+#include <QGraphicsItem>
+#include <QPainter>
+#include <QStyleOptionGraphicsItem>
+#include <QWidget>
+
+#include "graphics/VisualPolish.h"
+
+class TrainBadgeItem : public QGraphicsItem {
+public:
+	TrainBadgeItem(QGraphicsItem* parent = nullptr);
+
+	void setIdentifier(const QString& identifier);
+	void setSpeedText(const QString& speedText);
+	void setTrainVisual(const TrainVisual& visual);
+	void setReversed(bool reversed);
+	void setCompact(bool compact);
+
+	QRectF boundingRect() const override;
+	void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;
+
+	enum { Type = UserType + 11 };
+	int type() const override { return Type; }
+
+private:
+	QRectF badgeRect() const;
+
+	QString m_identifier;
+	QString m_speedText;
+	TrainVisual m_visual;
+	bool m_reversed;
+	bool m_compact;
+};
+
+#endif // TRAINBADGEITEM_H

--- a/EGTRAIN/QEGTRAIN/tests/test_guisimulationsnapshot.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_guisimulationsnapshot.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <set>
 
 namespace {
 void require(bool condition, const char* message) {
@@ -18,12 +19,21 @@ int main() {
 	first.timestep = 1;
 	first.trains.push_back(GuiTrainState{});
 	first.trains.front().description = "first";
+	first.sectionStates.push_back({"section-a", true, true});
+	first.sectionStates.push_back({"section-b", false, false});
+	std::set<std::string> sectionIds;
+	for (const GuiSectionState& section : first.sectionStates)
+		sectionIds.insert(section.sectionId);
+	require(sectionIds.size() == first.sectionStates.size(), "section states contain duplicate IDs");
+	require(first.sectionStates.front().prepared && first.sectionStates.front().blocked,
+		"section state flags were not retained");
 	auto firstSnapshot = std::make_shared<const GuiSimulationSnapshot>(first);
 
 	GuiSimulationSnapshot second;
 	second.timestep = 2;
 	second.trains.push_back(GuiTrainState{});
 	second.trains.front().description = "second";
+	second.sectionStates.push_back({"section-a", false, true});
 	auto secondSnapshot = std::make_shared<const GuiSimulationSnapshot>(second);
 
 	GuiSimulationSnapshotMailbox mailbox;
@@ -35,6 +45,8 @@ int main() {
 	require(latest != nullptr, "take returned no snapshot");
 	require(latest->timestep == 2, "take did not return the latest snapshot");
 	require(latest->trains.front().description == "second", "snapshot changed after source mutation");
+	require(latest->sectionStates.size() == 1 && latest->sectionStates.front().sectionId == "section-a",
+		"section state payload was not copied into immutable snapshot");
 
 	require(mailbox.publish(firstSnapshot), "publish after take did not request a notification");
 	require(mailbox.take()->timestep == 1, "second take returned the wrong snapshot");

--- a/EGTRAIN/QEGTRAIN/tests/test_guisimulationsnapshot.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_guisimulationsnapshot.cpp
@@ -15,6 +15,15 @@ void require(bool condition, const char* message) {
 }
 
 int main() {
+	GuiTrainState activeTrain;
+	activeTrain.occupiedArcs.push_back({7, 2.5});
+	GuiTrainState exitedTrain = activeTrain;
+	exitedTrain.outOfSimulation = true;
+	require(guiTrainPublishesOccupiedArcs(activeTrain),
+		"active train occupation was filtered");
+	require(!guiTrainPublishesOccupiedArcs(exitedTrain),
+		"out-of-simulation train occupation was retained");
+
 	GuiSimulationSnapshot first;
 	first.timestep = 1;
 	first.trains.push_back(GuiTrainState{});

--- a/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
@@ -1,5 +1,10 @@
 #include "graphics/VisualPolish.h"
 
+#include <QGuiApplication>
+#include <QFontMetricsF>
+
+#include "graphics/items/TrainBadgeItem.h"
+
 #include <iostream>
 
 static bool expect(bool condition, const char* message) {
@@ -8,7 +13,9 @@ static bool expect(bool condition, const char* message) {
 	return condition;
 }
 
-int main() {
+int main(int argc, char* argv[]) {
+	qputenv("QT_QPA_PLATFORM", "offscreen");
+	QGuiApplication app(argc, argv);
 	bool ok = true;
 	ok &= expect(classifyTrackSpeed(83.4).kind == TrackVisualKind::HighSpeed, "high-speed track classification");
 	ok &= expect(classifyTrackSpeed(44.5).kind == TrackVisualKind::Mainline, "mainline track classification");
@@ -61,6 +68,26 @@ int main() {
 	ok &= expect(simulationSpeedLabel(250) == "Speed: +250 ms", "delayed speed label");
 	ok &= expect(simulationSpeedMode(0) == "Compressed", "compressed speed mode");
 	ok &= expect(simulationSpeedMode(500) == "Slowed", "slowed speed mode");
+
+	QFont badgeFont;
+	badgeFont.setPointSize(9);
+	badgeFont.setBold(true);
+	const QFontMetricsF badgeMetrics(badgeFont);
+	const QRectF denseBody(1.0, 1.0, 130.0, 26.0);
+	const QString longIdentifier = "Intercity 2201 Northbound";
+	const QString speedText = "0 km/h";
+	const QRectF identifierRegion = TrainBadgeItem::identifierTextRect(
+		denseBody, false, false, badgeMetrics, speedText);
+	const QRectF speedRegion = TrainBadgeItem::speedTextRect(
+		denseBody, false, false, badgeMetrics, speedText);
+	const QString displayedIdentifier = TrainBadgeItem::elidedIdentifier(
+		longIdentifier, badgeMetrics, identifierRegion);
+	ok &= expect(badgeMetrics.horizontalAdvance(longIdentifier) > identifierRegion.width(),
+		"long identifier needs elision");
+	ok &= expect(badgeMetrics.horizontalAdvance(displayedIdentifier) <= identifierRegion.width(),
+		"elided identifier fits its region");
+	ok &= expect(identifierRegion.right() <= speedRegion.left(),
+		"identifier and speed regions do not overlap");
 
 	if (!ok)
 		return 1;

--- a/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
@@ -14,10 +14,35 @@ int main() {
 	ok &= expect(classifyTrackSpeed(44.5).kind == TrackVisualKind::Mainline, "mainline track classification");
 	ok &= expect(classifyTrackSpeed(19.0).kind == TrackVisualKind::Local, "local track classification");
 
+	const TrackStateVisual freeTrack = classifyTrackState(TrackOperationalState::Free);
+	const TrackStateVisual preparedTrack = classifyTrackState(TrackOperationalState::Prepared);
+	const TrackStateVisual occupiedTrack = classifyTrackState(TrackOperationalState::Occupied);
+	const TrackStateVisual blockedTrack = classifyTrackState(TrackOperationalState::Blocked);
+	ok &= expect(freeTrack.style == Qt::NoPen && freeTrack.width == 0, "free track has no underlay");
+	ok &= expect(preparedTrack.style == Qt::SolidLine && preparedTrack.width > freeTrack.width, "prepared track underlay");
+	ok &= expect(occupiedTrack.style == Qt::SolidLine && occupiedTrack.width > freeTrack.width, "occupied track underlay");
+	ok &= expect(blockedTrack.style != Qt::SolidLine && blockedTrack.width > freeTrack.width, "blocked track has non-color cue");
+	ok &= expect(preparedTrack.color == QColor("#3aa675"), "prepared track color");
+	ok &= expect(occupiedTrack.color == QColor("#d95550"), "occupied track color");
+	ok &= expect(blockedTrack.color == QColor("#e4a23a"), "blocked track color");
+	ok &= expect(trackStatePriority(TrackOperationalState::Free) < trackStatePriority(TrackOperationalState::Prepared), "free track priority");
+	ok &= expect(trackStatePriority(TrackOperationalState::Prepared) < trackStatePriority(TrackOperationalState::Occupied), "prepared track priority");
+	ok &= expect(trackStatePriority(TrackOperationalState::Occupied) < trackStatePriority(TrackOperationalState::Blocked), "occupied track priority");
+
+	ok &= expect(classifySignalAspect(0).lamp == QColor(Qt::red), "red signal aspect");
+	ok &= expect(classifySignalAspect(75).lamp == QColor(Qt::yellow), "yellow signal aspect");
+	ok &= expect(classifySignalAspect(180).lamp == QColor(Qt::green), "green signal aspect 180");
+	ok &= expect(classifySignalAspect(270).lamp == QColor(Qt::green), "green signal aspect 270");
+
 	ok &= expect(classifyTrainType("freight", "F01").kind == TrainVisualKind::Freight, "freight train classification");
 	ok &= expect(classifyTrainType("IC", "IC 2201").kind == TrainVisualKind::Intercity, "intercity train classification");
 	ok &= expect(classifyTrainType("", "sprinter 301").kind == TrainVisualKind::Sprinter, "sprinter train classification");
 	ok &= expect(classifyTrainType("", "ICE 10").kind == TrainVisualKind::HighSpeed, "high-speed train classification");
+	const TrainVisual intercity = classifyTrainType("IC", "IC 2201");
+	const TrainVisual sprinter = classifyTrainType("", "sprinter 301");
+	const TrainVisual freight = classifyTrainType("freight", "F01");
+	ok &= expect(intercity.fill != sprinter.fill && intercity.fill != freight.fill && sprinter.fill != freight.fill,
+		"train category contrast");
 
 	ok &= expect(classifyStation(true, 4).kind == StationVisualKind::Interchange, "interchange station classification");
 	ok &= expect(classifyStation(true, 1).kind == StationVisualKind::Platform, "platform station classification");

--- a/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
@@ -19,20 +19,24 @@ int main() {
 	const TrackStateVisual occupiedTrack = classifyTrackState(TrackOperationalState::Occupied);
 	const TrackStateVisual blockedTrack = classifyTrackState(TrackOperationalState::Blocked);
 	ok &= expect(freeTrack.style == Qt::NoPen && freeTrack.width == 0, "free track has no underlay");
-	ok &= expect(preparedTrack.style == Qt::SolidLine && preparedTrack.width > freeTrack.width, "prepared track underlay");
-	ok &= expect(occupiedTrack.style == Qt::SolidLine && occupiedTrack.width > freeTrack.width, "occupied track underlay");
-	ok &= expect(blockedTrack.style != Qt::SolidLine && blockedTrack.width > freeTrack.width, "blocked track has non-color cue");
-	ok &= expect(preparedTrack.color == QColor("#3aa675"), "prepared track color");
-	ok &= expect(occupiedTrack.color == QColor("#d95550"), "occupied track color");
-	ok &= expect(blockedTrack.color == QColor("#e4a23a"), "blocked track color");
+	ok &= expect(preparedTrack.style == Qt::SolidLine && preparedTrack.width == 8, "prepared track underlay");
+	ok &= expect(occupiedTrack.style == Qt::SolidLine && occupiedTrack.width == 10, "occupied track underlay");
+	ok &= expect(blockedTrack.style == Qt::DashLine && blockedTrack.width == 8, "blocked track has non-color cue");
+	ok &= expect(preparedTrack.color == QColor("#2ECC71"), "prepared track color");
+	ok &= expect(occupiedTrack.color == QColor("#EF5350"), "occupied track color");
+	ok &= expect(blockedTrack.color == QColor("#F2A516"), "blocked track color");
 	ok &= expect(trackStatePriority(TrackOperationalState::Free) < trackStatePriority(TrackOperationalState::Prepared), "free track priority");
 	ok &= expect(trackStatePriority(TrackOperationalState::Prepared) < trackStatePriority(TrackOperationalState::Occupied), "prepared track priority");
 	ok &= expect(trackStatePriority(TrackOperationalState::Occupied) < trackStatePriority(TrackOperationalState::Blocked), "occupied track priority");
 
-	ok &= expect(classifySignalAspect(0).lamp == QColor(Qt::red), "red signal aspect");
-	ok &= expect(classifySignalAspect(75).lamp == QColor(Qt::yellow), "yellow signal aspect");
-	ok &= expect(classifySignalAspect(180).lamp == QColor(Qt::green), "green signal aspect 180");
-	ok &= expect(classifySignalAspect(270).lamp == QColor(Qt::green), "green signal aspect 270");
+	const SignalVisual stopSignal = classifySignalAspect(0);
+	const SignalVisual cautionSignal = classifySignalAspect(75);
+	const SignalVisual proceed180Signal = classifySignalAspect(180);
+	const SignalVisual proceed270Signal = classifySignalAspect(270);
+	ok &= expect(stopSignal.lamp == QColor(Qt::red) && stopSignal.cue == SignalCueKind::Stop, "red stop signal cue");
+	ok &= expect(cautionSignal.lamp == QColor(Qt::yellow) && cautionSignal.cue == SignalCueKind::Caution, "yellow caution signal cue");
+	ok &= expect(proceed180Signal.lamp == QColor(Qt::green) && proceed180Signal.cue == SignalCueKind::Proceed, "green proceed signal cue 180");
+	ok &= expect(proceed270Signal.lamp == QColor(Qt::green) && proceed270Signal.cue == SignalCueKind::Proceed, "green proceed signal cue 270");
 
 	ok &= expect(classifyTrainType("freight", "F01").kind == TrainVisualKind::Freight, "freight train classification");
 	ok &= expect(classifyTrainType("IC", "IC 2201").kind == TrainVisualKind::Intercity, "intercity train classification");
@@ -43,6 +47,11 @@ int main() {
 	const TrainVisual freight = classifyTrainType("freight", "F01");
 	ok &= expect(intercity.fill != sprinter.fill && intercity.fill != freight.fill && sprinter.fill != freight.fill,
 		"train category contrast");
+	ok &= expect(intercity.shape == TrainBadgeShape::Capsule, "intercity badge shape");
+	ok &= expect(sprinter.shape == TrainBadgeShape::Rounded, "sprinter badge shape");
+	ok &= expect(freight.shape == TrainBadgeShape::Square, "freight badge shape");
+	ok &= expect(intercity.shape != sprinter.shape && intercity.shape != freight.shape && sprinter.shape != freight.shape,
+		"train category silhouettes");
 
 	ok &= expect(classifyStation(true, 4).kind == StationVisualKind::Interchange, "interchange station classification");
 	ok &= expect(classifyStation(true, 1).kind == StationVisualKind::Platform, "platform station classification");

--- a/docs/ui/renderer-style-map.md
+++ b/docs/ui/renderer-style-map.md
@@ -1,0 +1,40 @@
+# Renderer style map
+
+This map is the visual contract for the network playback primitives. State colors stay restrained so topology remains visible below the overlay.
+
+## Track operational state
+
+`trackStatePriority()` orders overlays from base topology to the most restrictive state. A higher value wins when more than one state is available.
+
+| State | Priority | Color | Pen | Meaning |
+| --- | ---: | --- | --- | --- |
+| Free | 0 | none (`#00000000`) | no underlay | No operational reservation or occupation is reported. |
+| Prepared | 1 | `#3aa675` | solid, 8 px | A route is prepared for movement. |
+| Occupied | 2 | `#d95550` | solid, 8 px | A train or other movement occupies the section. |
+| Blocked | 3 | `#e4a23a` | dashed, 8 px | The section is unavailable or restricted. The dash pattern remains visible in monochrome output. |
+
+`TrackLineItem` paints the operational underlay first, then its normal track pen. Free sections skip the underlay, so the existing topology pen remains the only stroke.
+
+## Signal aspect
+
+`classifySignalAspect()` maps the simulator aspect codes to lamp colors:
+
+| Code | Lamp |
+| ---: | --- |
+| 0 | red (`#ff0000`) |
+| 75 | yellow (`#ffff00`) |
+| 180 | green (`#00ff00`) |
+| 270 | green (`#00ff00`) |
+| other | neutral gray (`#808080`) |
+
+`SignalItem` draws a fixed 12 by 16 scene-unit housing, a lamp, and a direction cue. `setReversedDirection(true)` points the cue left; `false` points it right. Existing callers that still set the public `reversedDirection` field are supported.
+
+## Train categories
+
+Train badges reuse the existing `TrainVisual` palette. Intercity is ochre (`#ebbe2d`), Sprinter is green (`#28aa6e`), and Freight is brown (`#785f46`). The badge keeps its identifier and optional speed text in one `QGraphicsItem` with `ItemIgnoresTransformations`, so labels stay readable while the map zooms.
+
+## Surface, grid, and low zoom
+
+`NetworkView` paints a dark neutral surface (`#171d24`) and a grid (`#2a3743`) in `drawBackground()`. The grid uses no scene items. Its scene spacing doubles or halves around an 80-unit base so grid lines stay between 24 and 96 device pixels apart. At low zoom the grid therefore thins instead of filling the viewport, while badges and the legend remain screen-sized.
+
+`NetworkLegendItem` uses the same track and train colors for prepared, occupied, blocked, Intercity, Sprinter, and Freight entries. It also ignores view transformations.

--- a/docs/ui/renderer-style-map.md
+++ b/docs/ui/renderer-style-map.md
@@ -9,32 +9,32 @@ This map is the visual contract for the network playback primitives. State color
 | State | Priority | Color | Pen | Meaning |
 | --- | ---: | --- | --- | --- |
 | Free | 0 | none (`#00000000`) | no underlay | No operational reservation or occupation is reported. |
-| Prepared | 1 | `#3aa675` | solid, 8 px | A route is prepared for movement. |
-| Occupied | 2 | `#d95550` | solid, 8 px | A train or other movement occupies the section. |
-| Blocked | 3 | `#e4a23a` | dashed, 8 px | The section is unavailable or restricted. The dash pattern remains visible in monochrome output. |
+| Prepared | 1 | `#2ECC71` | solid, 8 px | A route is prepared for movement. |
+| Occupied | 2 | `#EF5350` | solid, 10 px | A train or other movement occupies the section. |
+| Blocked | 3 | `#F2A516` | dashed, 8 px | The section is unavailable or restricted. The dash pattern remains visible in monochrome output. |
 
 `TrackLineItem` paints the operational underlay first, then its normal track pen. Free sections skip the underlay, so the existing topology pen remains the only stroke.
 
 ## Signal aspect
 
-`classifySignalAspect()` maps the simulator aspect codes to lamp colors:
+`classifySignalAspect()` maps the simulator aspect codes to lamp colors and a non-color cue:
 
-| Code | Lamp |
-| ---: | --- |
-| 0 | red (`#ff0000`) |
-| 75 | yellow (`#ffff00`) |
-| 180 | green (`#00ff00`) |
-| 270 | green (`#00ff00`) |
-| other | neutral gray (`#808080`) |
+| Code | Lamp | Cue |
+| ---: | --- | --- |
+| 0 | red (`#ff0000`) | stop bar |
+| 75 | yellow (`#ffff00`) | caution triangle |
+| 180 | green (`#00ff00`) | proceed chevron |
+| 270 | green (`#00ff00`) | proceed chevron |
+| other | neutral gray (`#808080`) | none |
 
-`SignalItem` draws a fixed 12 by 16 scene-unit housing, a lamp, and a direction cue. `setReversedDirection(true)` points the cue left; `false` points it right. Existing callers that still set the public `reversedDirection` field are supported.
+`SignalItem` draws a fixed 12 by 16 housing, a lamp cue, and a direction cue while ignoring view transformations. `setReversedDirection(true)` points the direction cue left; `false` points it right. Existing callers that still set the public `reversedDirection` field are supported.
 
 ## Train categories
 
-Train badges reuse the existing `TrainVisual` palette. Intercity is ochre (`#ebbe2d`), Sprinter is green (`#28aa6e`), and Freight is brown (`#785f46`). The badge keeps its identifier and optional speed text in one `QGraphicsItem` with `ItemIgnoresTransformations`, so labels stay readable while the map zooms.
+Train badges reuse the existing `TrainVisual` palette and a shape classification. Intercity is a capsule, Sprinter is rounded, and Freight is square, so the categories remain distinct without relying on color alone. The badge keeps its identifier and optional speed text in one `QGraphicsItem` with `ItemIgnoresTransformations`, so labels stay readable while the map zooms.
 
 ## Surface, grid, and low zoom
 
-`NetworkView` paints a dark neutral surface (`#171d24`) and a grid (`#2a3743`) in `drawBackground()`. The grid uses no scene items. Its scene spacing doubles or halves around an 80-unit base so grid lines stay between 24 and 96 device pixels apart. At low zoom the grid therefore thins instead of filling the viewport, while badges and the legend remain screen-sized.
+`NetworkView` paints a dark neutral surface (`#101A22`) and a grid (`#1B2A35`) in `drawBackground()`. The grid uses no scene items. Its scene spacing doubles or halves around an 80-unit base so grid lines stay between 24 and 96 device pixels apart. At low zoom the grid therefore thins instead of filling the viewport, while badges and the legend remain screen-sized.
 
 `NetworkLegendItem` uses the same track and train colors for prepared, occupied, blocked, Intercity, Sprinter, and Freight entries. It also ignores view transformations.

--- a/tools/e2e/visual_polish_smoke.sh
+++ b/tools/e2e/visual_polish_smoke.sh
@@ -5,6 +5,8 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 APP="$ROOT/build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN"
 OUT="${TMPDIR:-/tmp}/qegtrain-visual-polish-e2e.log"
 SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-e2e.png"
+DENSE_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dense-e2e.png"
+FOLLOW_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-follow-e2e.png"
 
 if [[ ! -x "$APP" ]]; then
 	echo "QEGTRAIN app not found or not executable: $APP" >&2
@@ -15,10 +17,14 @@ cd "$ROOT/EGTRAIN/QEGTRAIN"
 QEGTRAIN_AUTOSTART=1 \
 QEGTRAIN_E2E_VISUAL_POLISH=1 \
 QEGTRAIN_E2E_SCREENSHOT="$SHOT" \
+QEGTRAIN_E2E_DENSE_SCREENSHOT="$DENSE_SHOT" \
+QEGTRAIN_E2E_FOLLOW_SCREENSHOT="$FOLLOW_SHOT" \
 "$APP" -n 3 -h 8000 -g 1 -pax 1 -TSM 0 -RC 0 >"$OUT" 2>&1
 
 grep -q "E2E_VISUAL_POLISH_OK" "$OUT"
 test -s "$SHOT"
+test -s "$DENSE_SHOT"
+test -s "$FOLLOW_SHOT"
 for label in "Planned arrival" "Planned departure" "Simulated arrival" "Simulated departure" "Arrival delay" "Departure delay"; do
 	if ! grep -Fqi "$label" "$ROOT/EGTRAIN/QEGTRAIN/app/MainWindow.cpp"; then
 		echo "missing timetable label in MainWindow.cpp: $label" >&2
@@ -29,4 +35,4 @@ if grep -Fq 'name="actionShow_Graph"' "$ROOT/EGTRAIN/QEGTRAIN/app/MainWindow.ui"
 	echo "dead Show Graph action still present in MainWindow.ui" >&2
 	exit 1
 fi
-echo "visual polish e2e passed: $SHOT"
+echo "visual polish e2e passed: $SHOT $DENSE_SHOT $FOLLOW_SHOT"


### PR DESCRIPTION
## Summary

- Adds prepared, occupied, and blocked track states without covering the base topology.
- Replaces grouped signal decorations with reusable fixed-size signal glyphs.
- Adds train badges, constant-size station pins, and an anchored network legend.
- Publishes immutable section state and filters exited trains from occupation snapshots.
- Captures default, dense-station, and follow-train views in the visual smoke test.

## Verification

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (34 of 34 passed)
- `tools/e2e/visual_polish_smoke.sh`
- `git diff be36c78..HEAD --check`

Closes #80