### PR TITLE
Fix Qt 5 list comparison on Windows

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -4815,7 +4815,16 @@ void MainWindow::runTrackPreviewE2E() {
 		return snapshot;
 	};
 	auto samePreviewContent = [](const PreviewContentSnapshot& left, const PreviewContentSnapshot& right) {
-		return left.items == right.items && left.itemBounds == right.itemBounds && left.bounds == right.bounds;
+		if (left.items.size() != right.items.size() || left.itemBounds.size() != right.itemBounds.size())
+			return false;
+		for (int index = 0; index < left.items.size(); ++index) {
+			if (left.items.at(index) != right.items.at(index)
+				|| left.itemBounds.at(index) != right.itemBounds.at(index))
+				return false;
+		}
+		if (left.bounds != right.bounds)
+			return false;
+		return true;
 	};
 
 	const QString scenePath = qEnvironmentVariable("QEGTRAIN_E2E_SCENE");

--- a/tools/e2e/test_windows_subsystem_config.py
+++ b/tools/e2e/test_windows_subsystem_config.py
@@ -1,7 +1,37 @@
 #!/usr/bin/env python3
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_preview_snapshot_comparator() -> None:
+    source = (ROOT / "EGTRAIN/QEGTRAIN/app/MainWindow.cpp").read_text(encoding="utf-8")
+    match = re.search(
+        r"auto samePreviewContent = \[\]\(const PreviewContentSnapshot& left, "
+        r"const PreviewContentSnapshot& right\) \{(?P<body>.*?)\n\t\};",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise SystemExit("samePreviewContent lambda is missing")
+    comparator = match.group("body")
+
+    if "left.items == right.items" in comparator:
+        raise SystemExit("samePreviewContent still compares QList items directly")
+    if "left.itemBounds == right.itemBounds" in comparator:
+        raise SystemExit("samePreviewContent still compares QList item bounds directly")
+    for requirement in (
+        "left.items.size() != right.items.size()",
+        "left.itemBounds.size() != right.itemBounds.size()",
+        "left.items.at(index) != right.items.at(index)",
+        "left.itemBounds.at(index) != right.itemBounds.at(index)",
+        "left.bounds != right.bounds",
+        "return false;",
+        "return true;",
+    ):
+        if requirement not in comparator:
+            raise SystemExit(f"samePreviewContent is missing: {requirement}")
 
 
 def main() -> None:
@@ -16,6 +46,8 @@ def main() -> None:
 
     if vcxproj.count("<SubSystem>Windows</SubSystem>") < 2:
         raise SystemExit("Visual Studio Debug and Release configurations must use Windows subsystem")
+
+    test_preview_snapshot_comparator()
 
 
 if __name__ == "__main__":

--- a/tools/e2e/test_windows_subsystem_config.py
+++ b/tools/e2e/test_windows_subsystem_config.py
@@ -5,7 +5,23 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def _has_direct_qlist_equality(text: str) -> bool:
+    normalized = re.sub(r"[\s()]", "", text)
+    return any(
+        f"{left}.{field}=={right}.{field}" in normalized
+        for field in ("items", "itemBounds")
+        for left, right in (("left", "right"), ("right", "left"))
+    )
+
+
 def test_preview_snapshot_comparator() -> None:
+    for sample in (
+        "( ( left . items ) ) == ( right.items )",
+        "right . itemBounds\n== ((left.itemBounds))",
+    ):
+        if not _has_direct_qlist_equality(sample):
+            raise SystemExit("QList equality detector misses reversed or parenthesized operands")
+
     source = (ROOT / "EGTRAIN/QEGTRAIN/app/MainWindow.cpp").read_text(encoding="utf-8")
     match = re.search(
         r"auto samePreviewContent = \[\]\(const PreviewContentSnapshot& left, "
@@ -17,10 +33,8 @@ def test_preview_snapshot_comparator() -> None:
         raise SystemExit("samePreviewContent lambda is missing")
     comparator = match.group("body")
 
-    if "left.items == right.items" in comparator:
-        raise SystemExit("samePreviewContent still compares QList items directly")
-    if "left.itemBounds == right.itemBounds" in comparator:
-        raise SystemExit("samePreviewContent still compares QList item bounds directly")
+    if _has_direct_qlist_equality(comparator):
+        raise SystemExit("samePreviewContent still compares QList fields directly")
     for requirement in (
         "left.items.size() != right.items.size()",
         "left.itemBounds.size() != right.itemBounds.size()",


### PR DESCRIPTION
Closes #190

## Change

`runTrackPreviewE2E()` now compares preview snapshot lists by size and index. This keeps item order, pointer identity, per-item bounds, and aggregate bounds without calling `QList::operator==`.

The Windows portability check rejects direct equality on both snapshot lists, including reversed operands and extra whitespace or parentheses.

## Cause

Qt 5.15.2 implements this `QList` equality path with `stdext::make_checked_array_iterator`. MSVC 14.51 no longer provides that helper, so the Windows release build failed in `MainWindow.cpp`.

## Checks

- CMake configure and build
- CTest, 34 of 34 passed
- Track preview smoke
- Focused Windows portability check
- Manual release packaging on macOS, Windows, and Linux: https://github.com/Ancientkingg/EGTRAIN/actions/runs/29496521564
- Diff check
