### PR TITLE
Add network scene selection actions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,14 @@ if(EGTRAIN_BUILD_TESTS)
     set_tests_properties(test_networkscene_selection PROPERTIES
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+	    add_executable(test_highlighteffect
+	        ${SRC_DIR}/tests/test_highlighteffect.cpp
+	        ${SRC_DIR}/graphics/items/HighlightEffect.cpp)
+	    target_link_libraries(test_highlighteffect PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets)
+	    add_test(NAME test_highlighteffect COMMAND test_highlighteffect)
+	    set_tests_properties(test_highlighteffect PROPERTIES
+	        ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
     add_executable(test_csvwriter
         ${SRC_DIR}/tests/test_csvwriter.cpp
         ${SRC_DIR}/util/CsvWriter.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,26 @@ if(EGTRAIN_BUILD_TESTS)
     target_link_libraries(test_visualpolish PRIVATE Qt5::Core Qt5::Gui)
     add_test(NAME test_visualpolish COMMAND test_visualpolish)
 
+    add_executable(test_networkscene_selection
+        ${SRC_DIR}/tests/test_networkscene_selection.cpp
+        ${SRC_DIR}/graphics/NetworkScene.cpp
+        ${SRC_DIR}/graphics/items/NodeItem.cpp
+        ${SRC_DIR}/graphics/items/StationNodeItem.cpp
+        ${SRC_DIR}/graphics/items/TrackLineItem.cpp
+        ${SRC_DIR}/graphics/items/ConnectionItem.cpp
+        ${SRC_DIR}/graphics/items/SignalItem.cpp
+        ${SRC_DIR}/graphics/items/TrainBodyItem.cpp
+        ${SRC_DIR}/graphics/items/PassengerItem.cpp
+        ${SRC_DIR}/graphics/VisualPolish.cpp)
+    if(EGTRAIN_OPENMP_INCLUDE)
+        target_include_directories(test_networkscene_selection PRIVATE ${EGTRAIN_OPENMP_INCLUDE})
+    endif()
+    target_link_libraries(test_networkscene_selection PRIVATE
+        Qt5::Core Qt5::Gui Qt5::Widgets cppzmq nlohmann_json::nlohmann_json)
+    add_test(NAME test_networkscene_selection COMMAND test_networkscene_selection)
+    set_tests_properties(test_networkscene_selection PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
     add_executable(test_csvwriter
         ${SRC_DIR}/tests/test_csvwriter.cpp
         ${SRC_DIR}/util/CsvWriter.cpp)

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3576,6 +3576,10 @@ void MainWindow::runVisualPolishE2E() {
 
 	bool ok = true;
 	QStringList failures;
+	TrainItemGroup* selectedTrain = nullptr;
+	TrainBodyItem* selectedTrainBody = nullptr;
+	QPen selectedTrainPen;
+	QBrush selectedTrainBrush;
 
 	if (!m_speedSlider || !m_speedLabel) {
 		ok = false;
@@ -3673,9 +3677,133 @@ void MainWindow::runVisualPolishE2E() {
 	if (!networkView || !caseDock || defaultNetworkWidth <= caseDockWidth) {
 		ok = false;
 		failures << QString("network viewport (%1px) is not wider than case/layers dock (%2px)")
-					.arg(defaultNetworkWidth)
-					.arg(caseDockWidth);
+						.arg(defaultNetworkWidth)
+						.arg(caseDockWidth);
 	}
+	if (!scene || !networkView) {
+		ok = false;
+		failures << "cannot click a train without a scene and viewport";
+	} else {
+		for (auto* candidate : allTrains) {
+			if (!candidate || !candidate->isVisible() || !candidate->trainPolygonItemList)
+				continue;
+			for (auto* body : *candidate->trainPolygonItemList) {
+				if (body && body->isVisible() && !body->polygon().isEmpty()) {
+					selectedTrain = candidate;
+					selectedTrainBody = body;
+					break;
+				}
+			}
+			if (selectedTrainBody)
+				break;
+		}
+		if (!selectedTrain || !selectedTrainBody) {
+			ok = false;
+			failures << "no visible train body available for scene click";
+		} else {
+			selectedTrainPen = selectedTrainBody->pen();
+			selectedTrainBrush = selectedTrainBody->brush();
+			QGraphicsSceneMouseEvent event(QEvent::GraphicsSceneMousePress);
+			event.setButton(Qt::LeftButton);
+			event.setButtons(Qt::LeftButton);
+			event.setScenePos(selectedTrainBody->sceneBoundingRect().center());
+			event.setWidget(networkView->viewport());
+			scene->mousePressEvent(&event);
+			QApplication::processEvents();
+			const int comboIndex = m_followTrainCombo ? m_followTrainCombo->findData(selectedTrain->index) : -1;
+			if (!m_followTrainCombo || comboIndex < 0 || m_followTrainCombo->currentIndex() != comboIndex) {
+				ok = false;
+				failures << "train scene click did not select its combo row";
+			}
+			if (!m_followAction || !m_followAction->isChecked() || m_followTrainIndex != selectedTrain->index) {
+				ok = false;
+				failures << "train scene click did not activate follow";
+			}
+			if (!trainInfoWidget || !trainInfoWidget->isVisible() || trainIDText->text().trimmed().isEmpty()) {
+				ok = false;
+				failures << "train scene click did not populate train info";
+			}
+			if (!selectedTrain->graphicsEffect()) {
+				ok = false;
+				failures << "selected train has no halo effect";
+			}
+			if (selectedTrainBody->pen() != selectedTrainPen || selectedTrainBody->brush() != selectedTrainBrush) {
+				ok = false;
+				failures << "train source paint changed under halo effect";
+			}
+			const QPointF viewportCenter = networkView->mapToScene(networkView->viewport()->rect().center());
+			const QRectF visibleScene = networkView->mapToScene(networkView->viewport()->rect()).boundingRect();
+			const QRectF sceneBounds = scene->sceneRect();
+			const QPointF requestedCenter = selectedTrain->sceneBoundingRect().center();
+			const auto clampedCenter = [](qreal value, qreal low, qreal high, qreal halfSpan) {
+				if (high - low <= halfSpan * 2.0)
+					return (low + high) / 2.0;
+				return qBound(low + halfSpan, value, high - halfSpan);
+			};
+			const QPointF expectedCenter(
+				clampedCenter(requestedCenter.x(), sceneBounds.left(), sceneBounds.right(), visibleScene.width() / 2.0),
+				clampedCenter(requestedCenter.y(), sceneBounds.top(), sceneBounds.bottom(), visibleScene.height() / 2.0));
+			const qreal centerTolerance = std::max<qreal>(200.0, selectedTrain->sceneBoundingRect().width() * 2.0);
+			const qreal centerDistance = QLineF(viewportCenter, expectedCenter).length();
+			if (centerDistance > centerTolerance) {
+				ok = false;
+				failures << QString("train scene click did not center the view (distance=%1 tolerance=%2 view=%3,%4 expected=%5,%6)")
+						.arg(centerDistance, 0, 'f', 1)
+						.arg(centerTolerance, 0, 'f', 1)
+						.arg(viewportCenter.x(), 0, 'f', 1)
+						.arg(viewportCenter.y(), 0, 'f', 1)
+						.arg(expectedCenter.x(), 0, 'f', 1)
+						.arg(expectedCenter.y(), 0, 'f', 1);
+			}
+		}
+	}
+	if (!allArcs.isEmpty() && allArcs.first() && allArcs.first()->arc) {
+		displayArcInfo(allArcs.first());
+		if (!arcOperationalStateText || arcOperationalStateText->text().trimmed().isEmpty()
+			|| !arcConnectedSignalsText || arcConnectedSignalsText->text().trimmed().isEmpty()) {
+			ok = false;
+			failures << "arc inspector fields are empty";
+		}
+	}
+	StationNodeItem* stationItem = nullptr;
+	if (scene) {
+		for (auto* item : scene->items()) {
+			StationNodeItem* candidate = qgraphicsitem_cast<StationNodeItem*>(item);
+			if (candidate && candidate->node && !candidate->node->stationName.empty()) {
+				stationItem = candidate;
+				break;
+			}
+		}
+	}
+	if (stationItem) {
+		displayStationNodeInfo(stationItem);
+		if (!nodeStationNameText || nodeStationNameText->text().trimmed().isEmpty()
+			|| !nodeRegionText || nodeRegionText->text().trimmed().isEmpty()
+			|| !nodeConnectedTracksText || nodeConnectedTracksText->text().trimmed().isEmpty()
+			|| !nodeSignalledText || nodeSignalledText->text().trimmed().isEmpty()) {
+			ok = false;
+			failures << "station inspector fields are empty";
+		}
+	}
+	SignalItem* inspectorSignal = nullptr;
+	for (auto* candidate : allSignals) {
+		if (candidate && candidate->isVisible()) {
+			inspectorSignal = candidate;
+			break;
+		}
+	}
+	if (inspectorSignal) {
+		displaySignallingInfo(inspectorSignal);
+		if (!signallingAspectText || signallingAspectText->text().trimmed().isEmpty()
+			|| !signallingProtectedSectionText || signallingProtectedSectionText->text().trimmed().isEmpty()
+			|| !signallingNextTrackText || signallingNextTrackText->text().trimmed().isEmpty()) {
+			ok = false;
+			failures << "signal inspector fields are empty";
+		}
+	}
+	handleCloseInfoDockWidget();
+	infoDockWidget->hide();
+
 	if (!networkView || !m_incidentDock) {
 		ok = false;
 		failures << "incident geometry controls are missing";
@@ -3879,6 +4007,53 @@ void MainWindow::runVisualPolishE2E() {
 		failures << "follow mode controls disappeared";
 	}
 	captureScreenshot("QEGTRAIN_E2E_FOLLOW_SCREENSHOT", "follow");
+	if (scene && networkView && selectedTrainBody) {
+		QGraphicsSceneMouseEvent reselectionEvent(QEvent::GraphicsSceneMousePress);
+		reselectionEvent.setButton(Qt::LeftButton);
+		reselectionEvent.setButtons(Qt::LeftButton);
+		reselectionEvent.setScenePos(selectedTrainBody->sceneBoundingRect().center());
+		reselectionEvent.setWidget(networkView->viewport());
+		scene->mousePressEvent(&reselectionEvent);
+		QApplication::processEvents();
+		if (!effect || !infoDockWidget || !infoDockWidget->isVisible() || !trainInfoWidget->isVisible()) {
+			ok = false;
+			failures << "reselection did not restore the train selection state";
+		}
+	}
+	if (!scene || !networkView) {
+		ok = false;
+		failures << "cannot clear selection without a scene and viewport";
+	} else {
+		const QRectF contentBounds = scene->itemsBoundingRect();
+		QGraphicsSceneMouseEvent emptyEvent(QEvent::GraphicsSceneMousePress);
+		emptyEvent.setButton(Qt::LeftButton);
+		emptyEvent.setButtons(Qt::LeftButton);
+		emptyEvent.setScenePos(contentBounds.bottomRight() + QPointF(1000.0, 1000.0));
+		emptyEvent.setWidget(networkView->viewport());
+		scene->mousePressEvent(&emptyEvent);
+		QApplication::processEvents();
+		if (effect || (infoDockWidget && infoDockWidget->isVisible())) {
+			ok = false;
+			failures << "empty scene click did not clear selection";
+		}
+		if (arcInfoWidget->isVisible() || nodeInfoWidget->isVisible() || connectionInfoWidget->isVisible()
+			|| signallingInfoWidget->isVisible() || trainInfoWidget->isVisible()) {
+			ok = false;
+			failures << "empty scene click left an entity pane visible";
+		}
+		if (trainPaxInfoItem || paxIconInfoItem) {
+			ok = false;
+			failures << "empty scene click left a temporary passenger overlay";
+		}
+	}
+	if (m_followAction) {
+		m_followAction->setChecked(false);
+		QApplication::processEvents();
+	}
+	if (m_followTrainIndex != -1) {
+		ok = false;
+		failures << "follow toggle did not clear its train index";
+	}
 
 	if (ok) {
 		std::fprintf(stdout, "E2E_VISUAL_POLISH_OK\n");
@@ -6659,6 +6834,10 @@ void MainWindow::setupInfoDockWidget() {
 	arcCurvatureText = new QLineEdit(arcInfoWidget);
 	arcGradientText = new QLineEdit(arcInfoWidget);
 	arcSpeedLimitText = new QLineEdit(arcInfoWidget);
+	arcOperationalStateText = new QLineEdit(arcInfoWidget);
+	arcOperationalStateText->setObjectName("arcOperationalStateText");
+	arcConnectedSignalsText = new QLineEdit(arcInfoWidget);
+	arcConnectedSignalsText->setObjectName("arcConnectedSignalsText");
 	arcFormLayout = new QFormLayout();
 	arcFormLayout->addRow("Arc ID", arcIDText);
 	arcFormLayout->addRow("First Node ID", arcFirstNodeIDText);
@@ -6668,6 +6847,8 @@ void MainWindow::setupInfoDockWidget() {
 	arcFormLayout->addRow("Curvature (m)", arcCurvatureText);
 	arcFormLayout->addRow("Gradient", arcGradientText);
 	arcFormLayout->addRow("Speed Limit (m/s)", arcSpeedLimitText);
+	arcFormLayout->addRow("Operational state", arcOperationalStateText);
+	arcFormLayout->addRow("Connected signals", arcConnectedSignalsText);
 	arcInfoWidget->setLayout(arcFormLayout);
 
 	// Node info widget
@@ -6676,11 +6857,23 @@ void MainWindow::setupInfoDockWidget() {
 	nodeTrackIDText = new QLineEdit(nodeInfoWidget);
 	nodeXText = new QLineEdit(nodeInfoWidget);
 	nodeYText = new QLineEdit(nodeInfoWidget);
+	nodeStationNameText = new QLineEdit(nodeInfoWidget);
+	nodeStationNameText->setObjectName("nodeStationNameText");
+	nodeRegionText = new QLineEdit(nodeInfoWidget);
+	nodeRegionText->setObjectName("nodeRegionText");
+	nodeConnectedTracksText = new QLineEdit(nodeInfoWidget);
+	nodeConnectedTracksText->setObjectName("nodeConnectedTracksText");
+	nodeSignalledText = new QLineEdit(nodeInfoWidget);
+	nodeSignalledText->setObjectName("nodeSignalledText");
 	nodeFormLayout = new QFormLayout();
 	nodeFormLayout->addRow("Node ID", nodeIDText);
 	nodeFormLayout->addRow("Track ID", nodeTrackIDText);
 	nodeFormLayout->addRow("X (m)", nodeXText);
 	nodeFormLayout->addRow("Y (m)", nodeYText);
+	nodeFormLayout->addRow("Name", nodeStationNameText);
+	nodeFormLayout->addRow("Region", nodeRegionText);
+	nodeFormLayout->addRow("Connected tracks", nodeConnectedTracksText);
+	nodeFormLayout->addRow("Signalled", nodeSignalledText);
 	nodeInfoWidget->setLayout(nodeFormLayout);
 
 	// connection info widget
@@ -6702,11 +6895,20 @@ void MainWindow::setupInfoDockWidget() {
 	signallingXText = new QLineEdit(signallingInfoWidget);
 	signallingIDSectionAheadText = new QLineEdit(signallingInfoWidget);
 	signallingLengthSectionAheadText = new QLineEdit(signallingInfoWidget);
+	signallingAspectText = new QLineEdit(signallingInfoWidget);
+	signallingAspectText->setObjectName("signallingAspectText");
+	signallingProtectedSectionText = new QLineEdit(signallingInfoWidget);
+	signallingProtectedSectionText->setObjectName("signallingProtectedSectionText");
+	signallingNextTrackText = new QLineEdit(signallingInfoWidget);
+	signallingNextTrackText->setObjectName("signallingNextTrackText");
 	signallingFormLayout = new QFormLayout();
 	signallingFormLayout->addRow("Track ID", signallingTrackIDText);
 	signallingFormLayout->addRow("X (m)", signallingXText);
 	signallingFormLayout->addRow("ID of Block Section", signallingIDSectionAheadText);
 	signallingFormLayout->addRow("Length of Block Section (m)", signallingLengthSectionAheadText);
+	signallingFormLayout->addRow("Aspect", signallingAspectText);
+	signallingFormLayout->addRow("Protected section", signallingProtectedSectionText);
+	signallingFormLayout->addRow("Next track", signallingNextTrackText);
 	signallingInfoWidget->setLayout(signallingFormLayout);
 
 	// train info widget
@@ -6780,11 +6982,19 @@ void MainWindow::handleCloseInfoDockWidget() {
 
 // shows Node info on dock widget
 void MainWindow::displayNodeInfo(NodeItem* el) {
+	if (!el || !el->node)
+		return;
+	handleCloseInfoDockWidget();
+
 	// update Node info displayed on widget
 	nodeIDText->setText(QString::fromStdString(to_string_precision(el->node->ID, 0)));
 	nodeXText->setText(QString::fromStdString(to_string_precision(1000 * el->node->X, 2))); // km to m
 	nodeYText->setText(QString::fromStdString(to_string_precision(1000 * el->node->Y, 2))); // km to m
 	nodeTrackIDText->setText(QString::fromStdString(to_string_precision(el->track, 0)));
+	nodeStationNameText->clear();
+	nodeRegionText->clear();
+	nodeConnectedTracksText->clear();
+	nodeSignalledText->clear();
 
 	// hide other widgets
 	arcInfoWidget->hide();
@@ -6808,11 +7018,32 @@ void MainWindow::displayNodeInfo(NodeItem* el) {
 
 // shows station Node info on dock widget
 void MainWindow::displayStationNodeInfo(StationNodeItem* re) {
+	if (!re || !re->node)
+		return;
+	handleCloseInfoDockWidget();
+
 	// update Node info displayed on widget
 	nodeIDText->setText(QString::fromStdString(to_string_precision(re->node->ID, 0)));
 	nodeXText->setText(QString::fromStdString(to_string_precision(1000 * re->node->X, 2))); // km to m
 	nodeYText->setText(QString::fromStdString(to_string_precision(1000 * re->node->Y, 2))); // km to m
 	nodeTrackIDText->setText(QString::fromStdString(to_string_precision(re->track, 0)));
+	nodeStationNameText->setText(QString::fromStdString(re->node->stationName));
+	if (re->track >= 0 && re->track < 268)
+		nodeRegionText->setText(QString::number(blockSets[re->track].region));
+	else
+		nodeRegionText->setText("None");
+	QStringList connectedTracks;
+	if (re->track >= 0 && re->track < 268)
+		connectedTracks << QString::number(re->track);
+	const int connectionCount = std::max(0, std::min(re->node->numConnections, 6));
+	for (int i = 0; i < connectionCount; ++i) {
+		const int connectedTrack = re->node->connectIdBlockSet[i];
+		if (connectedTrack >= 0 && connectedTrack < 268
+			&& !connectedTracks.contains(QString::number(connectedTrack)))
+			connectedTracks << QString::number(connectedTrack);
+	}
+	nodeConnectedTracksText->setText(connectedTracks.join(", "));
+	nodeSignalledText->setText(re->node->isSignalled ? "Yes" : "No");
 
 	// hide other widgets
 	arcInfoWidget->hide();
@@ -6836,6 +7067,10 @@ void MainWindow::displayStationNodeInfo(StationNodeItem* re) {
 
 // shows Arc info on dock widget
 void MainWindow::displayArcInfo(TrackLineItem* line) {
+	if (!line || !line->arc)
+		return;
+	handleCloseInfoDockWidget();
+
 	// update Arc info displayed on widget
 	arcIDText->setText(QString::fromStdString(to_string_precision(line->arc->ID, 0)));
 	arcFirstNodeIDText->setText(QString::fromStdString(to_string_precision(line->arc->startNode.ID, 0)));
@@ -6845,6 +7080,44 @@ void MainWindow::displayArcInfo(TrackLineItem* line) {
 	arcCurvatureText->setText(QString::fromStdString(to_string_precision(line->arc->curvature, 2)));
 	arcGradientText->setText(QString::fromStdString(to_string_precision(line->arc->gradient, 3)));
 	arcSpeedLimitText->setText(QString::fromStdString(to_string_precision(line->arc->speedLimit, 2)));
+	const auto operationalStateName = [](TrackOperationalState state) {
+		switch (state) {
+			case TrackOperationalState::Prepared:
+				return QStringLiteral("Prepared");
+			case TrackOperationalState::Occupied:
+				return QStringLiteral("Occupied");
+			case TrackOperationalState::Blocked:
+				return QStringLiteral("Blocked");
+			case TrackOperationalState::Free:
+			default:
+				return QStringLiteral("Free");
+		}
+	};
+	arcOperationalStateText->setText(operationalStateName(line->operationalState()));
+	QStringList sectionIds;
+	const double arcStart = std::min(line->arc->startNode.X, line->arc->endNode.X);
+	const double arcEnd = std::max(line->arc->startNode.X, line->arc->endNode.X);
+	const auto appendSection = [&sectionIds](const std::string& sectionId) {
+		if (!sectionId.empty() && !sectionIds.contains(QString::fromStdString(sectionId)))
+			sectionIds << QString::fromStdString(sectionId);
+	};
+	const std::string startSection = line->arc->startNode.tdsbId;
+	const std::string endSection = line->arc->endNode.tdsbId;
+	const auto sectionTouchesArc = [&startSection, &endSection](const std::string& sectionId) {
+		return !sectionId.empty() && (sectionId == startSection || sectionId == endSection);
+	};
+	for (auto* candidate : allSignals) {
+		if (!candidate || candidate->trackID != line->track)
+			continue;
+		const bool positionMatches = candidate->X >= arcStart - 1e-9 && candidate->X <= arcEnd + 1e-9;
+		const bool sectionMatches = sectionTouchesArc(candidate->sectionAheadId)
+			|| sectionTouchesArc(candidate->sectionBehindId);
+		if (!positionMatches && !sectionMatches)
+			continue;
+		appendSection(candidate->sectionAheadId);
+		appendSection(candidate->sectionBehindId);
+	}
+	arcConnectedSignalsText->setText(sectionIds.isEmpty() ? QStringLiteral("None") : sectionIds.join(", "));
 
 	// hide other widgets
 	nodeInfoWidget->hide();
@@ -6868,6 +7141,10 @@ void MainWindow::displayArcInfo(TrackLineItem* line) {
 
 // shows connection info on dock widget
 void MainWindow::displayConnectionInfo(ConnectionItem* line) {
+	if (!line || !line->connection)
+		return;
+	handleCloseInfoDockWidget();
+
 	// update connection info displayed on widget
 	connectionFirstTrackIDText->setText(QString::fromStdString(to_string_precision(line->connection->idFirstTrackLine, 0)));
 	connectionSecondTrackIDText->setText(QString::fromStdString(to_string_precision(line->connection->idSecondTrackLine, 0)));
@@ -6896,17 +7173,45 @@ void MainWindow::displayConnectionInfo(ConnectionItem* line) {
 
 // shows signalling info on dock widget
 void MainWindow::displaySignallingInfo(SignalItem* signal) {
+	if (!signal)
+		return;
+	handleCloseInfoDockWidget();
+
 	// update signalling info displayed on widget
 	signallingTrackIDText->setText(QString::fromStdString(to_string_precision(signal->trackID, 0)));
 	signallingXText->setText(QString::fromStdString(to_string_precision(1000 * signal->X, 2))); // km to m
+	const auto aspectName = [](int code) {
+		switch (classifySignalAspect(code).cue) {
+			case SignalCueKind::Stop:
+				return QStringLiteral("Stop");
+			case SignalCueKind::Caution:
+				return QStringLiteral("Caution");
+			case SignalCueKind::Proceed:
+				return QStringLiteral("Proceed");
+			case SignalCueKind::Neutral:
+			default:
+				return QStringLiteral("Neutral");
+		}
+	};
+	signallingAspectText->setText(aspectName(signal->aspectCode()));
+	const std::string protectedSection = !signal->sectionAheadId.empty()
+		? signal->sectionAheadId
+		: signal->sectionBehindId;
+	const int nextTrack = signal->sectionAheadTrackId >= 0
+		? signal->sectionAheadTrackId
+		: signal->sectionBehindTrackId;
+	signallingProtectedSectionText->setText(protectedSection.empty()
+		? QStringLiteral("None")
+		: QString::fromStdString(protectedSection));
+	signallingNextTrackText->setText(nextTrack < 0 ? QStringLiteral("None") : QString::number(nextTrack));
 
 	// check if section ahead exists
 	if (!signal->sectionAheadId.empty()) {
 		signallingIDSectionAheadText->setText(QString::fromStdString(signal->sectionAheadId));
 		signallingLengthSectionAheadText->setText(QString::fromStdString(to_string_precision(1000 * signal->sectionAheadLength, 2))); // km to m
 	} else {
-		signallingIDSectionAheadText->setText("");
-		signallingLengthSectionAheadText->setText("");
+		signallingIDSectionAheadText->setText("None");
+		signallingLengthSectionAheadText->setText("None");
 	}
 
 	// hide other widgets
@@ -6931,10 +7236,13 @@ void MainWindow::displaySignallingInfo(SignalItem* signal) {
 
 // shows train info on dock widget
 void MainWindow::displayTrainInfo(TrainBodyItem* trainItem) {
+	if (!trainItem)
+		return;
 	// update train info displayed on widget
 	TrainItemGroup* groupItem = qgraphicsitem_cast<TrainItemGroup*>(trainItem->parentItem());
 	if (!groupItem)
 		return;
+	handleCloseInfoDockWidget();
 	trainIDText->setText(QString::fromStdString(to_string_precision(groupItem->trainId, 0)));
 	trainTypeText->setText(QString::fromStdString(groupItem->trainType));
 	trainLengthText->setText(QString::fromStdString(to_string_precision(groupItem->trainLength, 0)));
@@ -6957,6 +7265,18 @@ void MainWindow::displayTrainInfo(TrainBodyItem* trainItem) {
 	infoDockWidget->setWindowTitle("Train Info");
 	infoDockWidget->show();
 	trainInfoWidget->show();
+	if (m_followTrainCombo) {
+		const int comboIndex = m_followTrainCombo->findData(trainItem->index);
+		if (comboIndex >= 0) {
+			const QSignalBlocker blocker(m_followTrainCombo);
+			m_followTrainCombo->setCurrentIndex(comboIndex);
+		}
+	}
+	if (m_followAction)
+		m_followAction->setChecked(true);
+	m_followTrainIndex = trainItem->index;
+	if (networkView)
+		networkView->centerOn(groupItem->sceneBoundingRect().center());
 
 	// effect on clicked item
 	if (!effect) {
@@ -6969,6 +7289,9 @@ void MainWindow::displayTrainInfo(TrainBodyItem* trainItem) {
 
 // show text icon on top of passenger icon
 void MainWindow::displayPassengerInfo(PassengerItem* paxItem) {
+	if (!paxItem)
+		return;
+	handleCloseInfoDockWidget();
 	// hide other widgets
 	infoDockWidget->hide();
 	arcInfoWidget->hide();
@@ -6983,7 +7306,11 @@ void MainWindow::displayPassengerInfo(PassengerItem* paxItem) {
 	paintPassengerInfoIcon(paxItem);
 }
 
-void MainWindow::handleDisableHighlight() {}
+void MainWindow::handleDisableHighlight() {
+	handleCloseInfoDockWidget();
+	if (infoDockWidget)
+		infoDockWidget->hide();
+}
 
 // interpolate cartesian coordinates
 QPointF MainWindow::interpolateCartesian(QPointF start, QPointF end, qreal x1, qreal x2, qreal x) {

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -56,7 +56,6 @@
 #include <QFont>
 #include <QFormLayout>
 #include <QGraphicsEffect>
-#include <QGraphicsColorizeEffect>
 #include <QTimer>
 #include <QTime>
 #include <algorithm>
@@ -321,12 +320,18 @@ private:
 	QLineEdit* arcCurvatureText;
 	QLineEdit* arcGradientText;
 	QLineEdit* arcSpeedLimitText;
+	QLineEdit* arcOperationalStateText;
+	QLineEdit* arcConnectedSignalsText;
 	QFormLayout* arcFormLayout;
 	QWidget* nodeInfoWidget;
 	QLineEdit* nodeIDText;
 	QLineEdit* nodeTrackIDText;
 	QLineEdit* nodeXText;
 	QLineEdit* nodeYText;
+	QLineEdit* nodeStationNameText;
+	QLineEdit* nodeRegionText;
+	QLineEdit* nodeConnectedTracksText;
+	QLineEdit* nodeSignalledText;
 	QFormLayout* nodeFormLayout;
 	QWidget* connectionInfoWidget;
 	QLineEdit* connectionFirstTrackIDText;
@@ -339,6 +344,9 @@ private:
 	QLineEdit* signallingXText;
 	QLineEdit* signallingIDSectionAheadText;
 	QLineEdit* signallingLengthSectionAheadText;
+	QLineEdit* signallingAspectText;
+	QLineEdit* signallingProtectedSectionText;
+	QLineEdit* signallingNextTrackText;
 	QFormLayout* signallingFormLayout;
 	QWidget* trainInfoWidget;
 	QLineEdit* trainIDText;

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
@@ -13,10 +13,7 @@ NetworkScene::~NetworkScene() {
 void NetworkScene::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) {
 	// emit signal according to clicked item (mouse left button pressed)
 	if (mouseEvent->button() == Qt::LeftButton) {
-		// used to disable highlight if no item is clicked
 		bool itemClicked = false;
-
-		// clicked item
 		QTransform viewTransform;
 		for (QGraphicsView* view : views()) {
 			if (view->viewport() == mouseEvent->widget()) {
@@ -24,70 +21,43 @@ void NetworkScene::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) {
 				break;
 			}
 		}
-		QGraphicsItem* item = itemAt(mouseEvent->scenePos(), viewTransform);
 
-		// filter nodes
-		NodeItem* Node = qgraphicsitem_cast<NodeItem*>(item);
+		const QList<QGraphicsItem*> hitItems = items(
+			mouseEvent->scenePos(), Qt::IntersectsItemShape, Qt::DescendingOrder, viewTransform);
+		for (QGraphicsItem* item : hitItems) {
+			for (QGraphicsItem* candidate = item; candidate; candidate = candidate->parentItem()) {
+				if (NodeItem* node = qgraphicsitem_cast<NodeItem*>(candidate)) {
+					emit MousePressedOnNode(node);
+					itemClicked = true;
+				} else if (StationNodeItem* stationNode = qgraphicsitem_cast<StationNodeItem*>(candidate)) {
+					emit MousePressedOnStationNode(stationNode);
+					itemClicked = true;
+				} else if (TrackLineItem* arc = qgraphicsitem_cast<TrackLineItem*>(candidate)) {
+					emit MousePressedOnArc(arc);
+					itemClicked = true;
+				} else if (ConnectionItem* connection = qgraphicsitem_cast<ConnectionItem*>(candidate)) {
+					emit MousePressedOnConnection(connection);
+					itemClicked = true;
+				} else if (SignalItem* signal = qgraphicsitem_cast<SignalItem*>(candidate)) {
+					emit MousePressedOnSignal(signal);
+					itemClicked = true;
+				} else if (TrainBodyItem* train = qgraphicsitem_cast<TrainBodyItem*>(candidate)) {
+					emit MousePressedOnTrain(train);
+					itemClicked = true;
+				} else if (PassengerItem* passenger = qgraphicsitem_cast<PassengerItem*>(candidate)) {
+					emit MousePressedOnPassenger(passenger);
+					itemClicked = true;
+				}
 
-		if (Node) {
-			// display info of clicked Node (sends Node info on pointer)
-			emit MousePressedOnNode(Node);
-			itemClicked = true;
+				if (itemClicked)
+					break;
+			}
+			if (itemClicked)
+				break;
 		}
 
-		// filter station nodes
-		StationNodeItem* stationNode = qgraphicsitem_cast<StationNodeItem*>(item);
-
-		if (stationNode) {
-			// display info of clicked Node (sends Node info on pointer)
-			emit MousePressedOnStationNode(stationNode);
-			itemClicked = true;
-		}
-
-		// filter arcs (Arc line items)
-		TrackLineItem* Arc = qgraphicsitem_cast<TrackLineItem*>(item);
-
-		if (Arc) {
-			// display info of clicked Arc (sends Arc info on pointer)
-			emit MousePressedOnArc(Arc);
-			itemClicked = true;
-		}
-
-		// filter connections (connection line items)
-		ConnectionItem* connection = qgraphicsitem_cast<ConnectionItem*>(item);
-
-		if (connection) {
-			// display info of clicked connection (sends connection info on pointer)
-			emit MousePressedOnConnection(connection);
-			itemClicked = true;
-		}
-
-		// filter signals (signalling group items)
-		SignalItem* signal = qgraphicsitem_cast<SignalItem*>(item);
-
-		if (signal) {
-			// display info of clicked signal plate (sends signal info on pointer)
-			emit MousePressedOnSignal(signal);
-			itemClicked = true;
-		}
-
-		// filter trains (train polygon items (wagons))
-		TrainBodyItem* train = qgraphicsitem_cast<TrainBodyItem*>(item);
-
-		if (train) {
-			// display info of clicked train (sends train info on pointer)
-			emit MousePressedOnTrain(train);
-			itemClicked = true;
-		}
-
-		// filter passengers (individual pax items)
-		PassengerItem* passenger = qgraphicsitem_cast<PassengerItem*>(item);
-
-		if (passenger) {
-			// display info of clicked passenger (sends pax info on pointer)
-			emit MousePressedOnPassenger(passenger);
-			itemClicked = true;
-		}
+		if (!itemClicked)
+			emit DisableHighlight();
 	}
 
 	// send signal

--- a/EGTRAIN/QEGTRAIN/graphics/items/ConnectionItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/ConnectionItem.cpp
@@ -38,15 +38,6 @@ void ConnectionItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* op
 	Q_UNUSED(option);
 	Q_UNUSED(widget);
 
-	QPen effectPen = pen();
-	effectPen.setColor(Qt::blue);
-
-	// change line color when selected
-	if (graphicsEffect()) {
-		painter->setPen(effectPen);
-	} else {
-		painter->setPen(pen());
-	}
-
+	painter->setPen(pen());
 	painter->drawLine(line());
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/HighlightEffect.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/HighlightEffect.cpp
@@ -1,9 +1,11 @@
 #include "graphics/items/HighlightEffect.h"
 
 HighlightEffect::HighlightEffect(QColor color, qreal strength, QObject* parent)
-	: QGraphicsColorizeEffect(parent) {
+	: QGraphicsDropShadowEffect(parent) {
+	setOffset(0.0, 0.0);
+	setBlurRadius(qBound<qreal>(8.0, 8.0 + strength * 4.0, 16.0));
+	color.setAlphaF(qBound<qreal>(0.25, strength, 1.0) * 0.55);
 	setColor(color);
-	setStrength(strength);
 }
 
 HighlightEffect::~HighlightEffect() {

--- a/EGTRAIN/QEGTRAIN/graphics/items/HighlightEffect.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/HighlightEffect.h
@@ -1,9 +1,9 @@
 #ifndef HIGHLIGHTEFFECT_H
 #define HIGHLIGHTEFFECT_H
 
-#include <QGraphicsColorizeEffect>
+#include <QGraphicsDropShadowEffect>
 
-class HighlightEffect : public QGraphicsColorizeEffect {
+class HighlightEffect : public QGraphicsDropShadowEffect {
 	Q_OBJECT
 
 public:

--- a/EGTRAIN/QEGTRAIN/graphics/items/NodeItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/NodeItem.cpp
@@ -12,17 +12,8 @@ void NodeItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, 
 	Q_UNUSED(option);
 	Q_UNUSED(widget);
 
-	QPen effectPen = pen();
-	effectPen.setColor(Qt::blue);
-
-	// change line color when selected
-	if (graphicsEffect()) {
-		painter->setPen(effectPen);
-		painter->setBrush(effectPen.color());
-	} else {
-		painter->setPen(pen());
-		painter->setBrush(brush());
-	}
+	painter->setPen(pen());
+	painter->setBrush(brush());
 
 	painter->drawEllipse(rect());
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
@@ -46,8 +46,6 @@ void SignalItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option
 
 	QPen housingPen(QColor("#0d131a"));
 	housingPen.setWidthF(1.0);
-	if (graphicsEffect())
-		housingPen.setColor(Qt::blue);
 	painter->setPen(housingPen);
 	painter->setBrush(QColor("#26313b"));
 	painter->drawRoundedRect(rect(), 3.0, 3.0);

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationNodeItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationNodeItem.cpp
@@ -12,17 +12,8 @@ void StationNodeItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* o
 	Q_UNUSED(option);
 	Q_UNUSED(widget);
 
-	QPen effectPen = pen();
-	effectPen.setColor(Qt::blue);
-
-	// change line color when selected
-	if (graphicsEffect()) {
-		painter->setPen(effectPen);
-		painter->setBrush(effectPen.color());
-	} else {
-		painter->setPen(pen());
-		painter->setBrush(brush());
-	}
+	painter->setPen(pen());
+	painter->setBrush(brush());
 
 	painter->drawRect(rect());
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrackLineItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrackLineItem.cpp
@@ -59,15 +59,6 @@ void TrackLineItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
 		painter->drawLine(line());
 	}
 
-	QPen effectPen = pen();
-	effectPen.setColor(Qt::blue);
-
-	// change line color when selected
-	if (graphicsEffect()) {
-		painter->setPen(effectPen);
-	} else {
-		painter->setPen(pen());
-	}
-
+	painter->setPen(pen());
 	painter->drawLine(line());
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrainBodyItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrainBodyItem.cpp
@@ -14,17 +14,8 @@ void TrainBodyItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* opt
 	Q_UNUSED(option);
 	Q_UNUSED(widget);
 
-	QPen effectPen = pen();
-	effectPen.setColor(Qt::blue);
-
-	// change line color when selected
-	if (graphicsEffect()) {
-		painter->setPen(effectPen);
-		painter->setBrush(effectPen.color());
-	} else {
-		painter->setPen(pen());
-		painter->setBrush(brush());
-	}
+	painter->setPen(pen());
+	painter->setBrush(brush());
 
 	painter->drawPolygon(polygon());
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/VirtualArcItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/VirtualArcItem.cpp
@@ -60,16 +60,7 @@ void VirtualArcItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* op
 	Q_UNUSED(option);
 	Q_UNUSED(widget);
 
-	QPen effectPen = pen();
-	effectPen.setColor(Qt::blue);
-
-	// change line color when selected
-	if (graphicsEffect()) {
-		painter->setPen(effectPen);
-	} else {
-		painter->setPen(pen());
-	}
-
+	painter->setPen(pen());
 	painter->drawLine(line());
 	painter->drawLine(secondLine);
 }

--- a/EGTRAIN/QEGTRAIN/tests/test_highlighteffect.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_highlighteffect.cpp
@@ -1,0 +1,44 @@
+#include "graphics/items/HighlightEffect.h"
+
+#include <QApplication>
+#include <QBrush>
+#include <QGraphicsDropShadowEffect>
+#include <QGraphicsRectItem>
+#include <QPen>
+
+#include <iostream>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+int main(int argc, char* argv[]) {
+	qputenv("QT_QPA_PLATFORM", "offscreen");
+	QApplication app(argc, argv);
+
+	HighlightEffect* effect = new HighlightEffect(Qt::blue, 1.0);
+	QGraphicsDropShadowEffect* halo = dynamic_cast<QGraphicsDropShadowEffect*>(effect);
+	bool ok = expect(halo != nullptr, "highlight effect is a drop shadow");
+	if (halo) {
+		ok &= expect(halo->offset() == QPointF(0.0, 0.0), "highlight effect has zero offset");
+		ok &= expect(halo->blurRadius() > 0.0, "highlight effect has visible blur");
+		ok &= expect(halo->color().alpha() > 0, "highlight effect color is visible");
+	}
+
+	QGraphicsRectItem item(QRectF(0.0, 0.0, 10.0, 10.0));
+	const QPen sourcePen(Qt::darkGray);
+	const QBrush sourceBrush(Qt::yellow);
+	item.setPen(sourcePen);
+	item.setBrush(sourceBrush);
+	item.setGraphicsEffect(effect);
+	ok &= expect(item.pen() == sourcePen, "highlight effect preserves source pen");
+	ok &= expect(item.brush() == sourceBrush, "highlight effect preserves source brush");
+
+	if (!ok)
+		return 1;
+
+	std::cout << "all HighlightEffect tests passed\n";
+	return 0;
+}

--- a/EGTRAIN/QEGTRAIN/tests/test_networkscene_selection.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networkscene_selection.cpp
@@ -1,0 +1,126 @@
+#include "graphics/NetworkScene.h"
+
+#include <QApplication>
+#include <QGraphicsPixmapItem>
+#include <QGraphicsTextItem>
+#include <QGraphicsView>
+
+#include <iostream>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+static void sendLeftClick(NetworkScene& scene, QGraphicsView& view, const QPointF& scenePos) {
+	QGraphicsSceneMouseEvent event(QEvent::GraphicsSceneMousePress);
+	event.setButton(Qt::LeftButton);
+	event.setButtons(Qt::LeftButton);
+	event.setScenePos(scenePos);
+	event.setWidget(view.viewport());
+	scene.mousePressEvent(&event);
+}
+
+static void scaleView(QGraphicsView& view) {
+	view.resize(240, 180);
+	view.scale(2.0, 2.0);
+}
+
+int main(int argc, char* argv[]) {
+	qputenv("QT_QPA_PLATFORM", "offscreen");
+	QApplication app(argc, argv);
+	bool ok = true;
+
+	{
+		NetworkScene scene(nullptr);
+		QGraphicsView view(&scene);
+		scaleView(view);
+
+		StationNodeItem station(QRectF(-10.0, -10.0, 20.0, 20.0));
+		QPixmap decorationPixmap(24, 24);
+		decorationPixmap.fill(Qt::white);
+		QGraphicsPixmapItem decoration(decorationPixmap);
+		decoration.setPos(-12.0, -12.0);
+		decoration.setFlag(QGraphicsItem::ItemIgnoresTransformations);
+		decoration.setZValue(10.0);
+		scene.addItem(&station);
+		scene.addItem(&decoration);
+
+		int stationClicks = 0;
+		int disableHighlight = 0;
+		QObject::connect(&scene, &NetworkScene::MousePressedOnStationNode, [&](StationNodeItem*) { ++stationClicks; });
+		QObject::connect(&scene, &NetworkScene::DisableHighlight, [&]() { ++disableHighlight; });
+
+		sendLeftClick(scene, view, QPointF(0.0, 0.0));
+		ok &= expect(stationClicks == 1, "station click passes through higher-z ignored-transform decoration");
+		ok &= expect(disableHighlight == 0, "station click does not disable highlight");
+	}
+
+	{
+		NetworkScene scene(nullptr);
+		QGraphicsView view(&scene);
+		scaleView(view);
+
+		StationNodeItem station(QRectF(-10.0, -10.0, 20.0, 20.0));
+		QGraphicsRectItem child(QRectF(-8.0, -8.0, 16.0, 16.0), &station);
+		child.setZValue(10.0);
+		scene.addItem(&station);
+
+		int stationClicks = 0;
+		QObject::connect(&scene, &NetworkScene::MousePressedOnStationNode, [&](StationNodeItem*) { ++stationClicks; });
+
+		sendLeftClick(scene, view, QPointF(0.0, 0.0));
+		ok &= expect(stationClicks == 1, "station click resolves through unrecognized child");
+	}
+
+	{
+		NetworkScene scene(nullptr);
+		QGraphicsView view(&scene);
+		scaleView(view);
+
+		TrackLineItem track(QLineF(-60.0, 0.0, 60.0, 0.0));
+		QGraphicsTextItem decoration;
+		decoration.setPlainText("label");
+		decoration.setPos(-20.0, -10.0);
+		decoration.setZValue(10.0);
+		scene.addItem(&track);
+		scene.addItem(&decoration);
+
+		int arcClicks = 0;
+		int disableHighlight = 0;
+		QObject::connect(&scene, &NetworkScene::MousePressedOnArc, [&](TrackLineItem*) { ++arcClicks; });
+		QObject::connect(&scene, &NetworkScene::DisableHighlight, [&]() { ++disableHighlight; });
+
+		sendLeftClick(scene, view, QPointF(0.0, 0.0));
+		ok &= expect(arcClicks == 1, "track click passes through higher-z text decoration");
+		ok &= expect(disableHighlight == 0, "track click does not disable highlight");
+	}
+
+	{
+		NetworkScene scene(nullptr);
+		QGraphicsView view(&scene);
+		scaleView(view);
+
+		int entitySignals = 0;
+		int disableHighlight = 0;
+		QObject::connect(&scene, &NetworkScene::MousePressedOnNode, [&](NodeItem*) { ++entitySignals; });
+		QObject::connect(&scene, &NetworkScene::MousePressedOnStationNode, [&](StationNodeItem*) { ++entitySignals; });
+		QObject::connect(&scene, &NetworkScene::MousePressedOnArc, [&](TrackLineItem*) { ++entitySignals; });
+		QObject::connect(&scene, &NetworkScene::MousePressedOnConnection, [&](ConnectionItem*) { ++entitySignals; });
+		QObject::connect(&scene, &NetworkScene::MousePressedOnSignal, [&](SignalItem*) { ++entitySignals; });
+		QObject::connect(&scene, &NetworkScene::MousePressedOnTrain, [&](TrainBodyItem*) { ++entitySignals; });
+		QObject::connect(&scene, &NetworkScene::MousePressedOnPassenger, [&](PassengerItem*) { ++entitySignals; });
+		QObject::connect(&scene, &NetworkScene::DisableHighlight, [&]() { ++disableHighlight; });
+
+		sendLeftClick(scene, view, QPointF(100.0, 100.0));
+		ok &= expect(entitySignals == 0, "empty click emits no entity signal");
+		ok &= expect(disableHighlight == 1, "empty click disables highlight once");
+	}
+
+	if (!ok)
+		return 1;
+
+	std::cout << "all NetworkScene selection tests passed\n";
+	return 0;
+}


### PR DESCRIPTION
Closes #113

## What changed

- Route clicks through scene labels and icons to the topmost network entity.
- Show station, track, and signal data in the existing inspector.
- Select, center, and follow a clicked train. Empty clicks clear the inspector and temporary highlights.
- Draw selection as a halo so train, track, and signal state colors remain visible.

## Verification

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (36 tests passed)
- `bash tools/e2e/visual_polish_smoke.sh`

## Remaining risk

Connected-signal details depend on legacy section metadata. The inspector shows `None` when a case omits that data.
