### PR TITLE
Add scene entity context menus

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3576,6 +3576,20 @@ TrainItemGroup* MainWindow::resolveTrainItem(int trainIndex) const {
 	return nullptr;
 }
 
+TrainBodyItem* MainWindow::resolveTrainBodyItem(int trainIndex) const {
+	if (!scene)
+		return nullptr;
+	for (auto* item : scene->items()) {
+		auto* body = qgraphicsitem_cast<TrainBodyItem*>(item);
+		if (!body || body->scene() != scene)
+			continue;
+		auto* group = qgraphicsitem_cast<TrainItemGroup*>(body->parentItem());
+		if (group && group->scene() == scene && group->index == trainIndex)
+			return body;
+	}
+	return nullptr;
+}
+
 StationNodeItem* MainWindow::resolveStationNodeItem(double nodeId, int track) const {
 	if (!scene)
 		return nullptr;
@@ -3688,13 +3702,8 @@ void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& sceneP
 		QAction* details = menu->addAction("Show details");
 		details->setIcon(QIcon(classifyTrainType(group->trainType, group->trainDescription).iconResource));
 		connect(details, &QAction::triggered, this, [this, trainIndex]() {
-			auto* current = resolveTrainItem(trainIndex);
-			if (!current || !current->trainPolygonItemList || current->trainPolygonItemList->isEmpty())
-				return;
-			auto* body = current->trainPolygonItemList->first();
-			if (!body || body->scene() != scene)
-				return;
-			displayTrainDetails(body, false);
+			if (auto* body = resolveTrainBodyItem(trainIndex))
+				displayTrainDetails(body, false);
 		});
 		QAction* center = menu->addAction("Center in view");
 		connect(center, &QAction::triggered, this, [this, trainIndex]() {
@@ -3850,7 +3859,11 @@ void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& sceneP
 	QAction* fit = menu->addAction("Fit whole network");
 	connect(fit, &QAction::triggered, this, &MainWindow::fitView);
 	QAction* clear = menu->addAction("Clear selection");
-	connect(clear, &QAction::triggered, this, &MainWindow::handleDisableHighlight);
+	connect(clear, &QAction::triggered, this, [this]() {
+		if (scene)
+			scene->clearSelection();
+		handleDisableHighlight();
+	});
 	QAction* stop = menu->addAction("Stop following train");
 	connect(stop, &QAction::triggered, this, [this]() { setFollowTrain(-1); });
 	openMenu();
@@ -4380,6 +4393,49 @@ void MainWindow::runVisualPolishE2E() {
 		failures << "cannot open train context menu without a train body";
 	}
 
+	if (scene && networkView) {
+		const int staleTrainIndex = 2147483001;
+		auto* staleGroup = new TrainItemGroup();
+		staleGroup->index = staleTrainIndex;
+		staleGroup->trainDescription = "__e2e_stale_train__";
+		staleGroup->trainType = "E2E";
+		staleGroup->trainId = 1.0;
+		auto* staleBody = new TrainBodyItem(QPolygonF({QPointF(0.0, 0.0), QPointF(20.0, 0.0),
+			QPointF(20.0, 10.0), QPointF(0.0, 10.0)}));
+		staleBody->index = staleTrainIndex;
+		staleGroup->addToGroup(staleBody);
+		staleGroup->trainPolygonItemList = new QList<TrainBodyItem*>();
+		staleGroup->trainPolygonItemList->append(staleBody);
+		staleGroup->setPos(scene->itemsBoundingRect().bottomRight() + QPointF(100.0, 100.0));
+		scene->addItem(staleGroup);
+		QMenu* menu = requestContextMenu(staleBody->sceneBoundingRect().center(), false);
+		QAction* details = findMenuAction(menu, "Show details");
+		const bool infoVisibleBefore = infoDockWidget && infoDockWidget->isVisible();
+		const bool trainInfoVisibleBefore = trainInfoWidget && trainInfoWidget->isVisible();
+		const QString infoTitleBefore = infoDockWidget ? infoDockWidget->windowTitle() : QString();
+		const bool effectPresentBefore = effect != nullptr;
+		staleGroup->removeFromGroup(staleBody);
+		delete staleBody;
+		if (details)
+			details->trigger();
+		QApplication::processEvents();
+		if ((infoDockWidget && infoDockWidget->isVisible()) != infoVisibleBefore
+			|| (trainInfoWidget && trainInfoWidget->isVisible()) != trainInfoVisibleBefore
+			|| (infoDockWidget && infoDockWidget->windowTitle() != infoTitleBefore)
+			|| (effect != nullptr) != effectPresentBefore) {
+			ok = false;
+			failures << "stale train context action changed application state";
+		}
+		closeContextMenu();
+		if (staleGroup->trainPolygonItemList) {
+			staleGroup->trainPolygonItemList->clear();
+			delete staleGroup->trainPolygonItemList;
+			staleGroup->trainPolygonItemList = nullptr;
+		}
+		scene->removeItem(staleGroup);
+		delete staleGroup;
+	}
+
 	if (stationItem) {
 		QMenu* menu = requestContextMenu(stationItem->sceneBoundingRect().center(), false);
 		QAction* details = findMenuAction(menu, "Show details");
@@ -4571,6 +4627,10 @@ void MainWindow::runVisualPolishE2E() {
 
 	if (scene && networkView) {
 		const QPointF emptyPos = scene->itemsBoundingRect().bottomRight() + QPointF(1000.0, 1000.0);
+		auto* temporarySelectionItem = new QGraphicsRectItem(QRectF(0.0, 0.0, 10.0, 10.0));
+		temporarySelectionItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+		temporarySelectionItem->setPos(emptyPos);
+		scene->addItem(temporarySelectionItem);
 		if (!selectedTrainBody) {
 			ok = false;
 			failures << "cannot establish selection for empty-space context menu";
@@ -4588,6 +4648,7 @@ void MainWindow::runVisualPolishE2E() {
 				failures << "empty-space context menu could not establish selection and follow mode";
 			}
 		}
+		temporarySelectionItem->setSelected(true);
 		QMenu* menu = requestContextMenu(emptyPos, false);
 		QAction* fit = findMenuAction(menu, "Fit whole network");
 		QAction* clear = findMenuAction(menu, "Clear selection");
@@ -4607,8 +4668,14 @@ void MainWindow::runVisualPolishE2E() {
 				ok = false;
 				failures << "empty-space context actions did not clear selection and follow mode";
 			}
+			if (temporarySelectionItem->isSelected()) {
+				ok = false;
+				failures << "empty-space context action left a temporary scene item selected";
+			}
 		}
 		closeContextMenu();
+		scene->removeItem(temporarySelectionItem);
+		delete temporarySelectionItem;
 	} else {
 		ok = false;
 		failures << "cannot open empty-space context menu without a scene and viewport";

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -4393,8 +4393,14 @@ void MainWindow::runVisualPolishE2E() {
 		failures << "cannot open track context menu";
 	} else {
 		QAction* details = findMenuAction(trackMenu, "Show details");
-		if (details)
+		if (details) {
 			details->trigger();
+			QApplication::processEvents();
+			if (!arcInfoWidget || !arcInfoWidget->isVisible()) {
+				ok = false;
+				failures << "track context details did not open arc info";
+			}
+		}
 		QAction* copy = findMenuAction(trackMenu, "Copy arc ID");
 		if (copy)
 			copy->trigger();
@@ -4446,6 +4452,7 @@ void MainWindow::runVisualPolishE2E() {
 		temporaryContextPassenger = true;
 	}
 	if (contextPassenger) {
+		const QString passengerId = QString::fromStdString(contextPassenger->passengerId);
 		QMenu* menu = requestContextMenu(contextPassenger->sceneBoundingRect().center(), false);
 		QAction* details = findMenuAction(menu, "Show details");
 		if (!details || details->icon().isNull()) {
@@ -4456,8 +4463,14 @@ void MainWindow::runVisualPolishE2E() {
 			QApplication::processEvents();
 		}
 		QAction* copy = findMenuAction(menu, "Copy passenger ID");
-		if (copy)
+		if (copy) {
 			copy->trigger();
+			QApplication::processEvents();
+			if (!QApplication::clipboard() || QApplication::clipboard()->text() != passengerId) {
+				ok = false;
+				failures << "passenger context copy action did not copy passenger ID";
+			}
+		}
 		closeContextMenu();
 		if (temporaryContextPassenger) {
 			scene->removeItem(contextPassenger);
@@ -4469,14 +4482,42 @@ void MainWindow::runVisualPolishE2E() {
 
 	if (scene && networkView) {
 		const QPointF emptyPos = scene->itemsBoundingRect().bottomRight() + QPointF(1000.0, 1000.0);
+		if (!selectedTrainBody) {
+			ok = false;
+			failures << "cannot establish selection for empty-space context menu";
+		} else {
+			QGraphicsSceneMouseEvent selectionEvent(QEvent::GraphicsSceneMousePress);
+			selectionEvent.setButton(Qt::LeftButton);
+			selectionEvent.setButtons(Qt::LeftButton);
+			selectionEvent.setScenePos(selectedTrainBody->sceneBoundingRect().center());
+			selectionEvent.setWidget(networkView->viewport());
+			scene->mousePressEvent(&selectionEvent);
+			QApplication::processEvents();
+			if (!effect || !infoDockWidget || !infoDockWidget->isVisible()
+				|| !m_followAction || !m_followAction->isChecked() || m_followTrainIndex != selectedTrain->index) {
+				ok = false;
+				failures << "empty-space context menu could not establish selection and follow mode";
+			}
+		}
 		QMenu* menu = requestContextMenu(emptyPos, false);
-		if (!menu || !findMenuAction(menu, "Fit whole network") || !findMenuAction(menu, "Clear selection")
-			|| !findMenuAction(menu, "Stop following train")) {
+		QAction* fit = findMenuAction(menu, "Fit whole network");
+		QAction* clear = findMenuAction(menu, "Clear selection");
+		QAction* stop = findMenuAction(menu, "Stop following train");
+		if (!menu || !fit || !clear || !stop) {
 			ok = false;
 			failures << "empty-space context menu is incomplete";
 		} else {
-			findMenuAction(menu, "Fit whole network")->trigger();
+			fit->trigger();
 			QApplication::processEvents();
+			clear->trigger();
+			QApplication::processEvents();
+			stop->trigger();
+			QApplication::processEvents();
+			if ((infoDockWidget && infoDockWidget->isVisible()) || effect
+				|| (m_followAction && m_followAction->isChecked()) || m_followTrainIndex != -1) {
+				ok = false;
+				failures << "empty-space context actions did not clear selection and follow mode";
+			}
 		}
 		closeContextMenu();
 	} else {

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -557,6 +557,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	connect(scene, &NetworkScene::MousePressedOnSignal, this, &MainWindow::displaySignallingInfo);
 	connect(scene, &NetworkScene::MousePressedOnTrain, this, &MainWindow::displayTrainInfo);
 	connect(scene, &NetworkScene::MousePressedOnPassenger, this, &MainWindow::displayPassengerInfo);
+	connect(scene, &NetworkScene::ContextMenuRequested, this, &MainWindow::showSceneContextMenu);
 	connect(scene, &NetworkScene::DisableHighlight, this, &MainWindow::handleDisableHighlight);
 
 	// connect signals from EGTRAIN simulation
@@ -3564,6 +3565,280 @@ void MainWindow::refreshFollowTrainChoices() {
 	m_updatingFollowCombo = false;
 }
 
+TrainItemGroup* MainWindow::resolveTrainItem(int trainIndex) const {
+	for (auto* train : allTrains) {
+		if (train && train->scene() == scene && train->index == trainIndex)
+			return train;
+	}
+	return nullptr;
+}
+
+StationNodeItem* MainWindow::resolveStationNodeItem(double nodeId, int track) const {
+	if (!scene)
+		return nullptr;
+	for (auto* item : scene->items()) {
+		auto* station = qgraphicsitem_cast<StationNodeItem*>(item);
+		if (station && station->scene() == scene && station->track == track && station->node
+			&& station->node->ID == nodeId)
+			return station;
+	}
+	return nullptr;
+}
+
+TrackLineItem* MainWindow::resolveArcItem(double arcId, int track) const {
+	for (auto* arc : allArcs) {
+		if (arc && arc->scene() == scene && arc->track == track && arc->arc && arc->arc->ID == arcId)
+			return arc;
+	}
+	return nullptr;
+}
+
+SignalItem* MainWindow::resolveSignalItem(int track, double position, bool reversed) const {
+	for (auto* signal : allSignals) {
+		if (signal && signal->scene() == scene && signal->trackID == track && signal->X == position
+			&& signal->reversedDirection == reversed)
+			return signal;
+	}
+	return nullptr;
+}
+
+PassengerItem* MainWindow::resolvePassengerItem(const std::string& passengerId) const {
+	if (!scene)
+		return nullptr;
+	for (auto* item : scene->items()) {
+		auto* passenger = qgraphicsitem_cast<PassengerItem*>(item);
+		if (passenger && passenger->scene() == scene && passenger->passengerId == passengerId)
+			return passenger;
+	}
+	return nullptr;
+}
+
+void MainWindow::centerSceneItem(QGraphicsItem* item) {
+	if (networkView && item && item->scene() == scene)
+		networkView->centerOn(item->sceneBoundingRect().center());
+}
+
+void MainWindow::setFollowTrain(int trainIndex) {
+	if (trainIndex < 0) {
+		if (m_followAction) {
+			const QSignalBlocker blocker(m_followAction);
+			m_followAction->setChecked(false);
+		}
+		m_followTrainIndex = -1;
+		return;
+	}
+	if (!resolveTrainItem(trainIndex))
+		return;
+	if (m_followTrainCombo) {
+		const int comboIndex = m_followTrainCombo->findData(trainIndex);
+		if (comboIndex >= 0) {
+			const QSignalBlocker blocker(m_followTrainCombo);
+			m_followTrainCombo->setCurrentIndex(comboIndex);
+		}
+	}
+	if (m_followAction) {
+		const QSignalBlocker blocker(m_followAction);
+		m_followAction->setChecked(true);
+	}
+	m_followTrainIndex = trainIndex;
+}
+
+void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& scenePos, const QPoint& screenPos, bool keyboard) {
+	Q_UNUSED(scenePos);
+	Q_UNUSED(keyboard);
+	if (m_sceneContextMenu) {
+		m_sceneContextMenu->close();
+		m_sceneContextMenu.clear();
+	}
+	if (qgraphicsitem_cast<NodeItem*>(item) || qgraphicsitem_cast<ConnectionItem*>(item))
+		return;
+
+	QMenu* menu = new QMenu(this);
+	menu->setAttribute(Qt::WA_DeleteOnClose);
+	menu->setToolTipsVisible(true);
+	auto addDeferred = [menu](const QString& text, const QString& explanation) {
+		QAction* action = menu->addAction(text);
+		action->setEnabled(false);
+		action->setToolTip(explanation);
+		action->setStatusTip(explanation);
+		return action;
+	};
+	auto openMenu = [this, menu, screenPos]() {
+		m_sceneContextMenu = menu;
+		menu->popup(screenPos);
+	};
+
+	if (auto* trainBody = qgraphicsitem_cast<TrainBodyItem*>(item)) {
+		auto* group = qgraphicsitem_cast<TrainItemGroup*>(trainBody->parentItem());
+		if (!group || group->scene() != scene) {
+			delete menu;
+			return;
+		}
+		const int trainIndex = group->index;
+		menu->setTitle("Train");
+		QAction* details = menu->addAction("Show details");
+		details->setIcon(QIcon(classifyTrainType(group->trainType, group->trainDescription).iconResource));
+		connect(details, &QAction::triggered, this, [this, trainIndex]() {
+			auto* current = resolveTrainItem(trainIndex);
+			if (!current || !current->trainPolygonItemList || current->trainPolygonItemList->isEmpty())
+				return;
+			auto* body = current->trainPolygonItemList->first();
+			if (!body || body->scene() != scene)
+				return;
+			displayTrainDetails(body, false);
+		});
+		QAction* center = menu->addAction("Center in view");
+		connect(center, &QAction::triggered, this, [this, trainIndex]() {
+			if (auto* current = resolveTrainItem(trainIndex))
+				centerSceneItem(current);
+		});
+		QAction* follow = menu->addAction("Follow train");
+		connect(follow, &QAction::triggered, this, [this, trainIndex]() {
+			if (resolveTrainItem(trainIndex))
+				setFollowTrain(trainIndex);
+		});
+		QAction* copy = menu->addAction("Copy train index");
+		connect(copy, &QAction::triggered, this, [this, trainIndex]() {
+			if (resolveTrainItem(trainIndex) && QApplication::clipboard())
+				QApplication::clipboard()->setText(QString::number(trainIndex));
+		});
+		menu->addSeparator();
+		addDeferred("Planned route and related infrastructure", "Planned route and related infrastructure highlighting is not available yet.");
+		openMenu();
+		return;
+	}
+
+	if (auto* station = qgraphicsitem_cast<StationNodeItem*>(item)) {
+		if (!station->node || station->scene() != scene) {
+			delete menu;
+			return;
+		}
+		const double nodeId = station->node->ID;
+		const int track = station->track;
+		menu->setTitle("Station");
+		QAction* details = menu->addAction("Show details");
+		details->setIcon(QIcon(classifyStation(!station->node->stationPlatformId.empty() && station->node->stationPlatformId != "None", station->node->numConnections).iconResource));
+		connect(details, &QAction::triggered, this, [this, nodeId, track]() {
+			if (auto* current = resolveStationNodeItem(nodeId, track))
+				displayStationNodeInfo(current);
+		});
+		QAction* center = menu->addAction("Center in view");
+		connect(center, &QAction::triggered, this, [this, nodeId, track]() {
+			if (auto* current = resolveStationNodeItem(nodeId, track))
+				centerSceneItem(current);
+		});
+		QAction* copy = menu->addAction("Copy node ID");
+		connect(copy, &QAction::triggered, this, [this, nodeId, track]() {
+			if (resolveStationNodeItem(nodeId, track) && QApplication::clipboard())
+				QApplication::clipboard()->setText(QString::number(nodeId, 'g', 15));
+		});
+		menu->addSeparator();
+		addDeferred("Filtered station arrivals and departures", "Filtered station arrivals and departures are not available yet.");
+		openMenu();
+		return;
+	}
+
+	if (auto* arc = qgraphicsitem_cast<TrackLineItem*>(item)) {
+		if (!arc->arc || arc->scene() != scene) {
+			delete menu;
+			return;
+		}
+		const double arcId = arc->arc->ID;
+		const int track = arc->track;
+		menu->setTitle("Track");
+		QAction* details = menu->addAction("Show details");
+		connect(details, &QAction::triggered, this, [this, arcId, track]() {
+			if (auto* current = resolveArcItem(arcId, track))
+				displayArcInfo(current);
+		});
+		QAction* center = menu->addAction("Center in view");
+		connect(center, &QAction::triggered, this, [this, arcId, track]() {
+			if (auto* current = resolveArcItem(arcId, track))
+				centerSceneItem(current);
+		});
+		QAction* copy = menu->addAction("Copy arc ID");
+		connect(copy, &QAction::triggered, this, [this, arcId, track]() {
+			if (resolveArcItem(arcId, track) && QApplication::clipboard())
+				QApplication::clipboard()->setText(QString::number(arcId, 'g', 15));
+		});
+		menu->addSeparator();
+		addDeferred("Trains currently using this track", "Trains currently using this track cannot be determined yet.");
+		addDeferred("Incidents affecting this track", "Incidents affecting this track cannot be determined yet.");
+		openMenu();
+		return;
+	}
+
+	if (auto* signal = qgraphicsitem_cast<SignalItem*>(item)) {
+		if (signal->scene() != scene) {
+			delete menu;
+			return;
+		}
+		const int track = signal->trackID;
+		const double position = signal->X;
+		const bool reversed = signal->reversedDirection;
+		menu->setTitle("Signal");
+		QAction* details = menu->addAction("Show details");
+		details->setIcon(QIcon(classifySignalAspect(signal->aspectCode()).iconResource));
+		connect(details, &QAction::triggered, this, [this, track, position, reversed]() {
+			if (auto* current = resolveSignalItem(track, position, reversed))
+				displaySignallingInfo(current);
+		});
+		QAction* center = menu->addAction("Center in view");
+		connect(center, &QAction::triggered, this, [this, track, position, reversed]() {
+			if (auto* current = resolveSignalItem(track, position, reversed))
+				centerSceneItem(current);
+		});
+		QAction* copy = menu->addAction("Copy signal location");
+		connect(copy, &QAction::triggered, this, [this, track, position, reversed]() {
+			if (resolveSignalItem(track, position, reversed) && QApplication::clipboard())
+				QApplication::clipboard()->setText(QString("track %1 @ %2 (%3)")
+					.arg(track).arg(position, 0, 'g', 15).arg(reversed ? "reverse" : "forward"));
+		});
+		menu->addSeparator();
+		addDeferred("Next train approaching this signal", "The next train approaching this signal is not available yet.");
+		openMenu();
+		return;
+	}
+
+	if (auto* passenger = qgraphicsitem_cast<PassengerItem*>(item)) {
+		if (passenger->scene() != scene) {
+			delete menu;
+			return;
+		}
+		const std::string passengerId = passenger->passengerId;
+		menu->setTitle("Passenger");
+		QAction* details = menu->addAction("Show details");
+		details->setIcon(QIcon(":/icons/passenger.svg"));
+		connect(details, &QAction::triggered, this, [this, passengerId]() {
+			if (auto* current = resolvePassengerItem(passengerId))
+				displayPassengerInfo(current);
+		});
+		QAction* center = menu->addAction("Center in view");
+		connect(center, &QAction::triggered, this, [this, passengerId]() {
+			if (auto* current = resolvePassengerItem(passengerId))
+				centerSceneItem(current);
+		});
+		QAction* copy = menu->addAction("Copy passenger ID");
+		connect(copy, &QAction::triggered, this, [this, passengerId]() {
+			if (resolvePassengerItem(passengerId) && QApplication::clipboard())
+				QApplication::clipboard()->setText(QString::fromStdString(passengerId));
+		});
+		openMenu();
+		return;
+	}
+
+	if (item)
+		return;
+	menu->setTitle("Network");
+	QAction* fit = menu->addAction("Fit whole network");
+	connect(fit, &QAction::triggered, this, &MainWindow::fitView);
+	QAction* clear = menu->addAction("Clear selection");
+	connect(clear, &QAction::triggered, this, &MainWindow::handleDisableHighlight);
+	QAction* stop = menu->addAction("Stop following train");
+	connect(stop, &QAction::triggered, this, [this]() { setFollowTrain(-1); });
+	openMenu();
+}
+
 void MainWindow::runVisualPolishE2E() {
 	if (m_e2eFinished)
 		return;
@@ -3769,13 +4044,13 @@ void MainWindow::runVisualPolishE2E() {
 	if (scene) {
 		for (auto* item : scene->items()) {
 			StationNodeItem* candidate = qgraphicsitem_cast<StationNodeItem*>(item);
-			if (candidate && candidate->node && !candidate->node->stationName.empty()) {
+			if (candidate && candidate->node) {
 				stationItem = candidate;
 				break;
 			}
 		}
 	}
-	if (stationItem) {
+	if (stationItem && stationItem->node && !stationItem->node->stationName.empty()) {
 		displayStationNodeInfo(stationItem);
 		if (!nodeStationNameText || nodeStationNameText->text().trimmed().isEmpty()
 			|| !nodeRegionText || nodeRegionText->text().trimmed().isEmpty()
@@ -3986,6 +4261,257 @@ void MainWindow::runVisualPolishE2E() {
 			ok = false;
 			failures << "signal scene hit-test did not resolve the glyph";
 		}
+	}
+
+	const auto requestContextMenu = [this](const QPointF& scenePos, bool keyboard) -> QMenu* {
+		if (!scene || !networkView)
+			return nullptr;
+		QGraphicsSceneContextMenuEvent event(QEvent::GraphicsSceneContextMenu);
+		event.setReason(keyboard ? QGraphicsSceneContextMenuEvent::Keyboard : QGraphicsSceneContextMenuEvent::Mouse);
+		event.setScenePos(scenePos);
+		event.setScreenPos(networkView->viewport()->mapToGlobal(networkView->mapFromScene(scenePos)));
+		event.setWidget(networkView->viewport());
+		scene->contextMenuEvent(&event);
+		QApplication::processEvents();
+		return m_sceneContextMenu.data();
+	};
+	const auto closeContextMenu = [this]() {
+		if (m_sceneContextMenu) {
+			m_sceneContextMenu->close();
+			QApplication::processEvents();
+		}
+	};
+	const auto findMenuAction = [&ok, &failures](QMenu* menu, const QString& text) -> QAction* {
+		if (!menu) {
+			ok = false;
+			failures << QString("context menu missing while looking for %1").arg(text);
+			return nullptr;
+		}
+		for (auto* action : menu->actions()) {
+			if (action && action->text() == text)
+				return action;
+		}
+		ok = false;
+		failures << QString("context menu missing action %1").arg(text);
+		return nullptr;
+	};
+	const auto checkDeferredAction = [&findMenuAction, &ok, &failures](QMenu* menu, const QString& text) {
+		QAction* action = findMenuAction(menu, text);
+		if (!action)
+			return;
+		if (action->isEnabled() || action->toolTip().trimmed().isEmpty() || action->statusTip().trimmed().isEmpty()) {
+			ok = false;
+			failures << QString("deferred context action is not safely disabled: %1").arg(text);
+		}
+	};
+
+	if (selectedTrainBody) {
+		setFollowTrain(-1);
+		QMenu* menu = requestContextMenu(selectedTrainBody->sceneBoundingRect().center(), true);
+		QAction* details = findMenuAction(menu, "Show details");
+		if (!details || details->icon().isNull()) {
+			ok = false;
+			failures << "train details action is missing refreshed icon";
+		} else {
+			details->trigger();
+			QApplication::processEvents();
+			if (!trainInfoWidget || !trainInfoWidget->isVisible() || (m_followAction && m_followAction->isChecked()) || m_followTrainIndex != -1) {
+				ok = false;
+				failures << "train context details unexpectedly changed follow mode";
+			}
+		}
+		QAction* center = findMenuAction(menu, "Center in view");
+		if (center)
+			center->trigger();
+		QAction* copy = findMenuAction(menu, "Copy train index");
+		if (copy) {
+			copy->trigger();
+			if (!QApplication::clipboard() || QApplication::clipboard()->text() != QString::number(selectedTrain->index)) {
+				ok = false;
+				failures << "train context copy action did not copy the index";
+			}
+		}
+		QAction* follow = findMenuAction(menu, "Follow train");
+		if (follow) {
+			follow->trigger();
+			QApplication::processEvents();
+			if (!m_followAction || !m_followAction->isChecked() || m_followTrainIndex != selectedTrain->index) {
+				ok = false;
+				failures << "train context follow action did not activate follow mode";
+			}
+		}
+		checkDeferredAction(menu, "Planned route and related infrastructure");
+		const QString contextPath = qEnvironmentVariable("QEGTRAIN_E2E_CONTEXT_SCREENSHOT");
+		if (contextPath.isEmpty() || !menu || !menu->grab().save(contextPath)) {
+			ok = false;
+			failures << "context menu screenshot save failed";
+		}
+		closeContextMenu();
+	} else {
+		ok = false;
+		failures << "cannot open train context menu without a train body";
+	}
+
+	if (stationItem) {
+		QMenu* menu = requestContextMenu(stationItem->sceneBoundingRect().center(), false);
+		QAction* details = findMenuAction(menu, "Show details");
+		if (!details || details->icon().isNull()) {
+			ok = false;
+			failures << "station details action is missing refreshed icon";
+		} else {
+			details->trigger();
+			QApplication::processEvents();
+			if (!nodeInfoWidget || !nodeInfoWidget->isVisible()) {
+				ok = false;
+				failures << "station context details did not open station info";
+			}
+		}
+		QAction* copy = findMenuAction(menu, "Copy node ID");
+		if (copy)
+			copy->trigger();
+		checkDeferredAction(menu, "Filtered station arrivals and departures");
+		closeContextMenu();
+	} else {
+		ok = false;
+		failures << "cannot open station context menu without a station";
+	}
+
+	TrackLineItem* contextArc = nullptr;
+	QMenu* trackMenu = nullptr;
+	for (auto* candidate : allArcs) {
+		if (!candidate || candidate->scene() != scene)
+			continue;
+		trackMenu = requestContextMenu(candidate->sceneBoundingRect().center(), false);
+		if (trackMenu && trackMenu->title() == "Track") {
+			contextArc = candidate;
+			break;
+		}
+		closeContextMenu();
+	}
+	if (!contextArc) {
+		ok = false;
+		failures << "cannot open track context menu";
+	} else {
+		QAction* details = findMenuAction(trackMenu, "Show details");
+		if (details)
+			details->trigger();
+		QAction* copy = findMenuAction(trackMenu, "Copy arc ID");
+		if (copy)
+			copy->trigger();
+		checkDeferredAction(trackMenu, "Trains currently using this track");
+		checkDeferredAction(trackMenu, "Incidents affecting this track");
+		closeContextMenu();
+	}
+
+	if (visibleSignal) {
+		QMenu* menu = requestContextMenu(visibleSignal->sceneBoundingRect().center(), false);
+		QAction* details = findMenuAction(menu, "Show details");
+		if (!details || details->icon().isNull()) {
+			ok = false;
+			failures << "signal details action is missing refreshed icon";
+		} else {
+			details->trigger();
+			QApplication::processEvents();
+			if (!signallingInfoWidget || !signallingInfoWidget->isVisible()) {
+				ok = false;
+				failures << "signal context details did not open signal info";
+			}
+		}
+		QAction* copy = findMenuAction(menu, "Copy signal location");
+		if (copy)
+			copy->trigger();
+		checkDeferredAction(menu, "Next train approaching this signal");
+		closeContextMenu();
+	} else {
+		ok = false;
+		failures << "cannot open signal context menu without a signal";
+	}
+
+	PassengerItem* contextPassenger = nullptr;
+	bool temporaryContextPassenger = false;
+	if (scene) {
+		for (auto* candidate : scene->items()) {
+			auto* passenger = qgraphicsitem_cast<PassengerItem*>(candidate);
+			if (passenger && passenger->isVisible()) {
+				contextPassenger = passenger;
+				break;
+			}
+		}
+	}
+	if (!contextPassenger) {
+		contextPassenger = new PassengerItem(pax_pixmap_scaled);
+		contextPassenger->passengerId = "__e2e_context_passenger__";
+		contextPassenger->setPos(scene->itemsBoundingRect().bottomRight() + QPointF(100.0, 100.0));
+		scene->addItem(contextPassenger);
+		temporaryContextPassenger = true;
+	}
+	if (contextPassenger) {
+		QMenu* menu = requestContextMenu(contextPassenger->sceneBoundingRect().center(), false);
+		QAction* details = findMenuAction(menu, "Show details");
+		if (!details || details->icon().isNull()) {
+			ok = false;
+			failures << "passenger details action is missing refreshed icon";
+		} else {
+			details->trigger();
+			QApplication::processEvents();
+		}
+		QAction* copy = findMenuAction(menu, "Copy passenger ID");
+		if (copy)
+			copy->trigger();
+		closeContextMenu();
+		if (temporaryContextPassenger) {
+			scene->removeItem(contextPassenger);
+			delete contextPassenger;
+		}
+		removePaxInfoIcon();
+		paxIconItem = nullptr;
+	}
+
+	if (scene && networkView) {
+		const QPointF emptyPos = scene->itemsBoundingRect().bottomRight() + QPointF(1000.0, 1000.0);
+		QMenu* menu = requestContextMenu(emptyPos, false);
+		if (!menu || !findMenuAction(menu, "Fit whole network") || !findMenuAction(menu, "Clear selection")
+			|| !findMenuAction(menu, "Stop following train")) {
+			ok = false;
+			failures << "empty-space context menu is incomplete";
+		} else {
+			findMenuAction(menu, "Fit whole network")->trigger();
+			QApplication::processEvents();
+		}
+		closeContextMenu();
+	} else {
+		ok = false;
+		failures << "cannot open empty-space context menu without a scene and viewport";
+	}
+
+	if (scene && networkView) {
+		const std::string stalePassengerId = "__e2e_stale_passenger__";
+		auto* temporaryPassenger = new PassengerItem(pax_pixmap_scaled);
+		temporaryPassenger->passengerId = stalePassengerId;
+		temporaryPassenger->setPos(scene->itemsBoundingRect().bottomRight() + QPointF(100.0, 100.0));
+		scene->addItem(temporaryPassenger);
+		QMenu* menu = requestContextMenu(temporaryPassenger->sceneBoundingRect().center(), false);
+		QAction* copy = findMenuAction(menu, "Copy passenger ID");
+		const QString clipboardBefore = QStringLiteral("e2e-stale-sentinel");
+		if (QApplication::clipboard())
+			QApplication::clipboard()->setText(clipboardBefore);
+		const bool infoVisibleBefore = infoDockWidget && infoDockWidget->isVisible();
+		const QString infoTitleBefore = infoDockWidget ? infoDockWidget->windowTitle() : QString();
+		scene->removeItem(temporaryPassenger);
+		delete temporaryPassenger;
+		if (copy)
+			copy->trigger();
+		QApplication::processEvents();
+		if (QApplication::clipboard() && QApplication::clipboard()->text() != clipboardBefore) {
+			ok = false;
+			failures << "stale passenger context action changed the clipboard";
+		}
+		if ((infoDockWidget && infoDockWidget->isVisible()) != infoVisibleBefore
+			|| (infoDockWidget && infoDockWidget->windowTitle() != infoTitleBefore)) {
+			ok = false;
+			failures << "stale passenger context action changed application state";
+		}
+		closeContextMenu();
 	}
 
 	if (m_followAction && m_followTrainCombo && m_followTrainCombo->count() > 0) {
@@ -7234,8 +7760,7 @@ void MainWindow::displaySignallingInfo(SignalItem* signal) {
 	signal->setGraphicsEffect(effect);
 }
 
-// shows train info on dock widget
-void MainWindow::displayTrainInfo(TrainBodyItem* trainItem) {
+void MainWindow::displayTrainDetails(TrainBodyItem* trainItem, bool changeFollowMode) {
 	if (!trainItem)
 		return;
 	// update train info displayed on widget
@@ -7265,18 +7790,10 @@ void MainWindow::displayTrainInfo(TrainBodyItem* trainItem) {
 	infoDockWidget->setWindowTitle("Train Info");
 	infoDockWidget->show();
 	trainInfoWidget->show();
-	if (m_followTrainCombo) {
-		const int comboIndex = m_followTrainCombo->findData(trainItem->index);
-		if (comboIndex >= 0) {
-			const QSignalBlocker blocker(m_followTrainCombo);
-			m_followTrainCombo->setCurrentIndex(comboIndex);
-		}
+	if (changeFollowMode) {
+		setFollowTrain(trainItem->index);
+		centerSceneItem(groupItem);
 	}
-	if (m_followAction)
-		m_followAction->setChecked(true);
-	m_followTrainIndex = trainItem->index;
-	if (networkView)
-		networkView->centerOn(groupItem->sceneBoundingRect().center());
 
 	// effect on clicked item
 	if (!effect) {
@@ -7285,6 +7802,11 @@ void MainWindow::displayTrainInfo(TrainBodyItem* trainItem) {
 	if (trainItem->parentItem()) {
 		trainItem->parentItem()->setGraphicsEffect(effect);
 	} // effect on entire train
+}
+
+// shows train info on dock widget
+void MainWindow::displayTrainInfo(TrainBodyItem* trainItem) {
+	displayTrainDetails(trainItem, true);
 }
 
 // show text icon on top of passenger icon

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3566,7 +3566,10 @@ void MainWindow::refreshFollowTrainChoices() {
 }
 
 TrainItemGroup* MainWindow::resolveTrainItem(int trainIndex) const {
-	for (auto* train : allTrains) {
+	if (!scene)
+		return nullptr;
+	for (auto* item : scene->items()) {
+		auto* train = qgraphicsitem_cast<TrainItemGroup*>(item);
 		if (train && train->scene() == scene && train->index == trainIndex)
 			return train;
 	}
@@ -3586,7 +3589,10 @@ StationNodeItem* MainWindow::resolveStationNodeItem(double nodeId, int track) co
 }
 
 TrackLineItem* MainWindow::resolveArcItem(double arcId, int track) const {
-	for (auto* arc : allArcs) {
+	if (!scene)
+		return nullptr;
+	for (auto* item : scene->items()) {
+		auto* arc = qgraphicsitem_cast<TrackLineItem*>(item);
 		if (arc && arc->scene() == scene && arc->track == track && arc->arc && arc->arc->ID == arcId)
 			return arc;
 	}
@@ -3594,7 +3600,10 @@ TrackLineItem* MainWindow::resolveArcItem(double arcId, int track) const {
 }
 
 SignalItem* MainWindow::resolveSignalItem(int track, double position, bool reversed) const {
-	for (auto* signal : allSignals) {
+	if (!scene)
+		return nullptr;
+	for (auto* item : scene->items()) {
+		auto* signal = qgraphicsitem_cast<SignalItem*>(item);
 		if (signal && signal->scene() == scene && signal->trackID == track && signal->X == position
 			&& signal->reversedDirection == reversed)
 			return signal;
@@ -3703,7 +3712,8 @@ void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& sceneP
 				QApplication::clipboard()->setText(QString::number(trainIndex));
 		});
 		menu->addSeparator();
-		addDeferred("Planned route and related infrastructure", "Planned route and related infrastructure highlighting is not available yet.");
+		addDeferred("Planned route and related infrastructure",
+			"Requires the train-to-route association and an infrastructure query.");
 		openMenu();
 		return;
 	}
@@ -3730,10 +3740,12 @@ void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& sceneP
 		QAction* copy = menu->addAction("Copy node ID");
 		connect(copy, &QAction::triggered, this, [this, nodeId, track]() {
 			if (resolveStationNodeItem(nodeId, track) && QApplication::clipboard())
-				QApplication::clipboard()->setText(QString::number(nodeId, 'g', 15));
+				QApplication::clipboard()->setText(QString::number(nodeId, 'g',
+					std::numeric_limits<double>::max_digits10));
 		});
 		menu->addSeparator();
-		addDeferred("Filtered station arrivals and departures", "Filtered station arrivals and departures are not available yet.");
+		addDeferred("Filtered station arrivals and departures",
+			"Requires the station timetable association and an arrivals/departures query.");
 		openMenu();
 		return;
 	}
@@ -3759,11 +3771,14 @@ void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& sceneP
 		QAction* copy = menu->addAction("Copy arc ID");
 		connect(copy, &QAction::triggered, this, [this, arcId, track]() {
 			if (resolveArcItem(arcId, track) && QApplication::clipboard())
-				QApplication::clipboard()->setText(QString::number(arcId, 'g', 15));
+				QApplication::clipboard()->setText(QString::number(arcId, 'g',
+					std::numeric_limits<double>::max_digits10));
 		});
 		menu->addSeparator();
-		addDeferred("Trains currently using this track", "Trains currently using this track cannot be determined yet.");
-		addDeferred("Incidents affecting this track", "Incidents affecting this track cannot be determined yet.");
+		addDeferred("Trains currently using this track",
+			"Requires the track-occupancy association and an active-train query.");
+		addDeferred("Incidents affecting this track",
+			"Requires the track-incident association and an incident query.");
 		openMenu();
 		return;
 	}
@@ -3792,10 +3807,12 @@ void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& sceneP
 		connect(copy, &QAction::triggered, this, [this, track, position, reversed]() {
 			if (resolveSignalItem(track, position, reversed) && QApplication::clipboard())
 				QApplication::clipboard()->setText(QString("track %1 @ %2 (%3)")
-					.arg(track).arg(position, 0, 'g', 15).arg(reversed ? "reverse" : "forward"));
+					.arg(track).arg(position, 0, 'g', std::numeric_limits<double>::max_digits10)
+					.arg(reversed ? "reverse" : "forward"));
 		});
 		menu->addSeparator();
-		addDeferred("Next train approaching this signal", "The next train approaching this signal is not available yet.");
+		addDeferred("Next train approaching this signal",
+			"Requires the signal route association and an approaching-train query.");
 		openMenu();
 		return;
 	}
@@ -4295,15 +4312,26 @@ void MainWindow::runVisualPolishE2E() {
 		failures << QString("context menu missing action %1").arg(text);
 		return nullptr;
 	};
-	const auto checkDeferredAction = [&findMenuAction, &ok, &failures](QMenu* menu, const QString& text) {
+	const auto checkDeferredAction = [&findMenuAction, &ok, &failures](QMenu* menu, const QString& text,
+		const QString& explanation) {
 		QAction* action = findMenuAction(menu, text);
 		if (!action)
 			return;
-		if (action->isEnabled() || action->toolTip().trimmed().isEmpty() || action->statusTip().trimmed().isEmpty()) {
+		if (action->isEnabled() || action->toolTip() != explanation || action->statusTip() != explanation) {
 			ok = false;
-			failures << QString("deferred context action is not safely disabled: %1").arg(text);
+			failures << QString("deferred context action explanation mismatch: %1").arg(text);
 		}
 	};
+	const QString trainRouteExplanation = QStringLiteral(
+		"Requires the train-to-route association and an infrastructure query.");
+	const QString stationTimetableExplanation = QStringLiteral(
+		"Requires the station timetable association and an arrivals/departures query.");
+	const QString trackOccupancyExplanation = QStringLiteral(
+		"Requires the track-occupancy association and an active-train query.");
+	const QString trackIncidentExplanation = QStringLiteral(
+		"Requires the track-incident association and an incident query.");
+	const QString signalApproachExplanation = QStringLiteral(
+		"Requires the signal route association and an approaching-train query.");
 
 	if (selectedTrainBody) {
 		setFollowTrain(-1);
@@ -4340,7 +4368,7 @@ void MainWindow::runVisualPolishE2E() {
 				failures << "train context follow action did not activate follow mode";
 			}
 		}
-		checkDeferredAction(menu, "Planned route and related infrastructure");
+		checkDeferredAction(menu, "Planned route and related infrastructure", trainRouteExplanation);
 		const QString contextPath = qEnvironmentVariable("QEGTRAIN_E2E_CONTEXT_SCREENSHOT");
 		if (contextPath.isEmpty() || !menu || !menu->grab().save(contextPath)) {
 			ok = false;
@@ -4367,9 +4395,16 @@ void MainWindow::runVisualPolishE2E() {
 			}
 		}
 		QAction* copy = findMenuAction(menu, "Copy node ID");
-		if (copy)
+		if (copy) {
 			copy->trigger();
-		checkDeferredAction(menu, "Filtered station arrivals and departures");
+			const QString expectedNodeId = QString::number(stationItem->node->ID, 'g',
+				std::numeric_limits<double>::max_digits10);
+			if (!QApplication::clipboard() || QApplication::clipboard()->text() != expectedNodeId) {
+				ok = false;
+				failures << "station context copy action did not preserve node precision";
+			}
+		}
+		checkDeferredAction(menu, "Filtered station arrivals and departures", stationTimetableExplanation);
 		closeContextMenu();
 	} else {
 		ok = false;
@@ -4402,10 +4437,17 @@ void MainWindow::runVisualPolishE2E() {
 			}
 		}
 		QAction* copy = findMenuAction(trackMenu, "Copy arc ID");
-		if (copy)
+		if (copy) {
 			copy->trigger();
-		checkDeferredAction(trackMenu, "Trains currently using this track");
-		checkDeferredAction(trackMenu, "Incidents affecting this track");
+			const QString expectedArcId = QString::number(contextArc->arc->ID, 'g',
+				std::numeric_limits<double>::max_digits10);
+			if (!QApplication::clipboard() || QApplication::clipboard()->text() != expectedArcId) {
+				ok = false;
+				failures << "track context copy action did not preserve arc precision";
+			}
+		}
+		checkDeferredAction(trackMenu, "Trains currently using this track", trackOccupancyExplanation);
+		checkDeferredAction(trackMenu, "Incidents affecting this track", trackIncidentExplanation);
 		closeContextMenu();
 	}
 
@@ -4424,13 +4466,60 @@ void MainWindow::runVisualPolishE2E() {
 			}
 		}
 		QAction* copy = findMenuAction(menu, "Copy signal location");
-		if (copy)
+		if (copy) {
 			copy->trigger();
-		checkDeferredAction(menu, "Next train approaching this signal");
+			const QString expectedSignalLocation = QString("track %1 @ %2 (%3)")
+				.arg(visibleSignal->trackID)
+				.arg(visibleSignal->X, 0, 'g', std::numeric_limits<double>::max_digits10)
+				.arg(visibleSignal->reversedDirection ? "reverse" : "forward");
+			if (!QApplication::clipboard() || QApplication::clipboard()->text() != expectedSignalLocation) {
+				ok = false;
+				failures << "signal context copy action did not preserve position precision";
+			}
+		}
+		checkDeferredAction(menu, "Next train approaching this signal", signalApproachExplanation);
 		closeContextMenu();
 	} else {
 		ok = false;
 		failures << "cannot open signal context menu without a signal";
+	}
+
+	if (scene && networkView) {
+		const int temporarySignalTrack = 2147483000;
+		const double temporarySignalPosition = 0.12345678901234566;
+		const bool temporarySignalReversed = true;
+		auto* temporarySignal = new SignalItem(QRectF(-6.0, -8.0, 12.0, 16.0));
+		temporarySignal->trackID = temporarySignalTrack;
+		temporarySignal->X = temporarySignalPosition;
+		temporarySignal->setReversedDirection(temporarySignalReversed);
+		temporarySignal->setPos(scene->itemsBoundingRect().bottomRight() + QPointF(100.0, 100.0));
+		scene->addItem(temporarySignal);
+		allSignals.push_back(temporarySignal);
+		QMenu* menu = requestContextMenu(temporarySignal->sceneBoundingRect().center(), false);
+		QAction* copy = findMenuAction(menu, "Copy signal location");
+		const QString expectedSignalLocation = QStringLiteral(
+			"track 2147483000 @ 0.12345678901234566 (reverse)");
+		if (copy) {
+			copy->trigger();
+			if (!QApplication::clipboard() || QApplication::clipboard()->text() != expectedSignalLocation) {
+				ok = false;
+				failures << "temporary signal context copy action did not preserve exact precision";
+			}
+		}
+		const QString clipboardBeforeStaleTrigger = QApplication::clipboard()
+			? QApplication::clipboard()->text() : QString();
+		SignalItem* staleSignal = temporarySignal;
+		scene->removeItem(temporarySignal);
+		delete temporarySignal;
+		if (copy)
+			copy->trigger();
+		QApplication::processEvents();
+		if (QApplication::clipboard() && QApplication::clipboard()->text() != clipboardBeforeStaleTrigger) {
+			ok = false;
+			failures << "stale signal context action changed the clipboard";
+		}
+		allSignals.removeOne(staleSignal);
+		closeContextMenu();
 	}
 
 	PassengerItem* contextPassenger = nullptr;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -507,6 +507,7 @@ private:
 	void setFollowTrain(int trainIndex);
 	void displayTrainDetails(TrainBodyItem* trainItem, bool changeFollowMode);
 	TrainItemGroup* resolveTrainItem(int trainIndex) const;
+	TrainBodyItem* resolveTrainBodyItem(int trainIndex) const;
 	StationNodeItem* resolveStationNodeItem(double nodeId, int track) const;
 	TrackLineItem* resolveArcItem(double arcId, int track) const;
 	SignalItem* resolveSignalItem(int track, double position, bool reversed) const;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -366,6 +366,7 @@ private:
 	QLabel* m_speedLabel;
 	QAction* m_followAction = nullptr;
 	QComboBox* m_followTrainCombo = nullptr;
+	QPointer<QMenu> m_sceneContextMenu;
 	int m_followTrainIndex = -1;
 	bool m_updatingFollowCombo = false;
 	int m_e2eAttempts = 0;
@@ -501,6 +502,15 @@ private:
 	void refreshFollowTrainChoices();
 	void updateSpeedModeDisplay(int value);
 	void updateSceneActions();
+	void showSceneContextMenu(QGraphicsItem* item, const QPointF& scenePos, const QPoint& screenPos, bool keyboard);
+	void centerSceneItem(QGraphicsItem* item);
+	void setFollowTrain(int trainIndex);
+	void displayTrainDetails(TrainBodyItem* trainItem, bool changeFollowMode);
+	TrainItemGroup* resolveTrainItem(int trainIndex) const;
+	StationNodeItem* resolveStationNodeItem(double nodeId, int track) const;
+	TrackLineItem* resolveArcItem(double arcId, int track) const;
+	SignalItem* resolveSignalItem(int track, double position, bool reversed) const;
+	PassengerItem* resolvePassengerItem(const std::string& passengerId) const;
 	void addRecentScene(const QString& path);
 	void rebuildRecentScenesMenu();
 	bool maybeSaveScene();

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
@@ -9,52 +9,52 @@ NetworkScene::NetworkScene(QObject* parent)
 NetworkScene::~NetworkScene() {
 }
 
+QTransform NetworkScene::viewTransformFor(QWidget* widget) const {
+	for (QGraphicsView* view : views()) {
+		if (view->viewport() == widget)
+			return view->viewportTransform();
+	}
+	return QTransform();
+}
+
+QGraphicsItem* NetworkScene::semanticItemAt(const QPointF& scenePos, QWidget* widget) const {
+	const QList<QGraphicsItem*> hitItems = items(
+		scenePos, Qt::IntersectsItemShape, Qt::DescendingOrder, viewTransformFor(widget));
+	for (QGraphicsItem* item : hitItems) {
+		for (QGraphicsItem* candidate = item; candidate; candidate = candidate->parentItem()) {
+			if (qgraphicsitem_cast<NodeItem*>(candidate)
+				|| qgraphicsitem_cast<StationNodeItem*>(candidate)
+				|| qgraphicsitem_cast<TrackLineItem*>(candidate)
+				|| qgraphicsitem_cast<ConnectionItem*>(candidate)
+				|| qgraphicsitem_cast<SignalItem*>(candidate)
+				|| qgraphicsitem_cast<TrainBodyItem*>(candidate)
+				|| qgraphicsitem_cast<PassengerItem*>(candidate))
+				return candidate;
+		}
+	}
+	return nullptr;
+}
+
 // handles the click on graphical items
 void NetworkScene::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) {
 	// emit signal according to clicked item (mouse left button pressed)
 	if (mouseEvent->button() == Qt::LeftButton) {
-		bool itemClicked = false;
-		QTransform viewTransform;
-		for (QGraphicsView* view : views()) {
-			if (view->viewport() == mouseEvent->widget()) {
-				viewTransform = view->viewportTransform();
-				break;
-			}
-		}
-
-		const QList<QGraphicsItem*> hitItems = items(
-			mouseEvent->scenePos(), Qt::IntersectsItemShape, Qt::DescendingOrder, viewTransform);
-		for (QGraphicsItem* item : hitItems) {
-			for (QGraphicsItem* candidate = item; candidate; candidate = candidate->parentItem()) {
-				if (NodeItem* node = qgraphicsitem_cast<NodeItem*>(candidate)) {
-					emit MousePressedOnNode(node);
-					itemClicked = true;
-				} else if (StationNodeItem* stationNode = qgraphicsitem_cast<StationNodeItem*>(candidate)) {
-					emit MousePressedOnStationNode(stationNode);
-					itemClicked = true;
-				} else if (TrackLineItem* arc = qgraphicsitem_cast<TrackLineItem*>(candidate)) {
-					emit MousePressedOnArc(arc);
-					itemClicked = true;
-				} else if (ConnectionItem* connection = qgraphicsitem_cast<ConnectionItem*>(candidate)) {
-					emit MousePressedOnConnection(connection);
-					itemClicked = true;
-				} else if (SignalItem* signal = qgraphicsitem_cast<SignalItem*>(candidate)) {
-					emit MousePressedOnSignal(signal);
-					itemClicked = true;
-				} else if (TrainBodyItem* train = qgraphicsitem_cast<TrainBodyItem*>(candidate)) {
-					emit MousePressedOnTrain(train);
-					itemClicked = true;
-				} else if (PassengerItem* passenger = qgraphicsitem_cast<PassengerItem*>(candidate)) {
-					emit MousePressedOnPassenger(passenger);
-					itemClicked = true;
-				}
-
-				if (itemClicked)
-					break;
-			}
-			if (itemClicked)
-				break;
-		}
+		QGraphicsItem* item = semanticItemAt(mouseEvent->scenePos(), mouseEvent->widget());
+		const bool itemClicked = item != nullptr;
+		if (NodeItem* node = qgraphicsitem_cast<NodeItem*>(item))
+			emit MousePressedOnNode(node);
+		else if (StationNodeItem* stationNode = qgraphicsitem_cast<StationNodeItem*>(item))
+			emit MousePressedOnStationNode(stationNode);
+		else if (TrackLineItem* arc = qgraphicsitem_cast<TrackLineItem*>(item))
+			emit MousePressedOnArc(arc);
+		else if (ConnectionItem* connection = qgraphicsitem_cast<ConnectionItem*>(item))
+			emit MousePressedOnConnection(connection);
+		else if (SignalItem* signal = qgraphicsitem_cast<SignalItem*>(item))
+			emit MousePressedOnSignal(signal);
+		else if (TrainBodyItem* train = qgraphicsitem_cast<TrainBodyItem*>(item))
+			emit MousePressedOnTrain(train);
+		else if (PassengerItem* passenger = qgraphicsitem_cast<PassengerItem*>(item))
+			emit MousePressedOnPassenger(passenger);
 
 		if (!itemClicked)
 			emit DisableHighlight();
@@ -65,4 +65,11 @@ void NetworkScene::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) {
 
 	// default implementation
 	QGraphicsScene::mousePressEvent(mouseEvent);
+}
+
+void NetworkScene::contextMenuEvent(QGraphicsSceneContextMenuEvent* event) {
+	QGraphicsItem* item = semanticItemAt(event->scenePos(), event->widget());
+	emit ContextMenuRequested(item, event->scenePos(), event->screenPos(),
+		event->reason() == QGraphicsSceneContextMenuEvent::Keyboard);
+	event->accept();
 }

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkScene.h
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkScene.h
@@ -2,6 +2,7 @@
 #define NETWORKSCENE_H
 
 #include <QGraphicsScene>
+#include <QGraphicsSceneContextMenuEvent>
 #include <QMouseEvent>
 #include <QGraphicsSceneMouseEvent>
 #include <QEvent>
@@ -34,6 +35,7 @@ public:
 	~NetworkScene();
 
 	void mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent);
+	void contextMenuEvent(QGraphicsSceneContextMenuEvent* event) override;
 
 signals:
 	void MousePressedOnScene();
@@ -45,6 +47,11 @@ signals:
 	void MousePressedOnTrain(TrainBodyItem* train);
 	void MousePressedOnPassenger(PassengerItem* passenger);
 	void DisableHighlight();
+	void ContextMenuRequested(QGraphicsItem* item, const QPointF& scenePos, const QPoint& screenPos, bool keyboard);
+
+private:
+	QTransform viewTransformFor(QWidget* widget) const;
+	QGraphicsItem* semanticItemAt(const QPointF& scenePos, QWidget* widget) const;
 };
 
 #endif // NETWORKSCENE_H

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkScene.h
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkScene.h
@@ -34,7 +34,7 @@ public:
 	NetworkScene(QObject* parent);
 	~NetworkScene();
 
-	void mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent);
+	void mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) override;
 	void contextMenuEvent(QGraphicsSceneContextMenuEvent* event) override;
 
 signals:

--- a/EGTRAIN/QEGTRAIN/tests/test_networkscene_selection.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networkscene_selection.cpp
@@ -1,6 +1,7 @@
 #include "graphics/NetworkScene.h"
 
 #include <QApplication>
+#include <QContextMenuEvent>
 #include <QGraphicsPixmapItem>
 #include <QGraphicsSceneContextMenuEvent>
 #include <QGraphicsTextItem>
@@ -37,6 +38,14 @@ static bool sendContextMenu(NetworkScene& scene, QGraphicsView& view,
 	event.setScreenPos(screenPos);
 	event.setWidget(view.viewport());
 	scene.contextMenuEvent(&event);
+	return event.isAccepted();
+}
+
+static bool sendViewportContextMenu(QGraphicsView& view, QContextMenuEvent::Reason reason,
+	const QPointF& scenePos) {
+	const QPoint viewportPos = view.mapFromScene(scenePos);
+	QContextMenuEvent event(reason, viewportPos, view.viewport()->mapToGlobal(viewportPos));
+	QApplication::sendEvent(view.viewport(), &event);
 	return event.isAccepted();
 }
 
@@ -213,6 +222,28 @@ int main(int argc, char* argv[]) {
 			QGraphicsSceneContextMenuEvent::Mouse, "context request resolves passenger");
 		expectContext(nullptr, QPointF(220.0, 140.0), QPoint(81, 82),
 			QGraphicsSceneContextMenuEvent::Mouse, "context request resolves empty space");
+
+		const int viewportMouseBefore = contextRequests;
+		const bool viewportMouseAccepted = sendViewportContextMenu(view, QContextMenuEvent::Mouse,
+			QPointF(80.0, -80.0));
+		ok &= expect(viewportMouseAccepted, "viewport mouse context event is accepted");
+		ok &= expect(contextRequests == viewportMouseBefore + 1,
+			"viewport mouse context request emits exactly once");
+		ok &= expect(requestedItem == &train,
+			"viewport mouse context request resolves the semantic train target");
+		ok &= expect(!requestedKeyboard,
+			"viewport mouse context request preserves mouse reason");
+
+		const int viewportKeyboardBefore = contextRequests;
+		const bool viewportKeyboardAccepted = sendViewportContextMenu(view, QContextMenuEvent::Keyboard,
+			QPointF(80.0, -80.0));
+		ok &= expect(viewportKeyboardAccepted, "viewport keyboard context event is accepted");
+		ok &= expect(contextRequests == viewportKeyboardBefore + 1,
+			"viewport keyboard context request emits exactly once");
+		ok &= expect(requestedItem == &train,
+			"viewport keyboard context request resolves the semantic train target");
+		ok &= expect(requestedKeyboard,
+			"viewport keyboard context request preserves keyboard reason");
 
 		sendLeftClick(scene, view, QPointF(80.0, -80.0));
 		ok &= expect(sceneMousePresses == 1, "left click emits scene signal once");

--- a/EGTRAIN/QEGTRAIN/tests/test_networkscene_selection.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networkscene_selection.cpp
@@ -2,6 +2,7 @@
 
 #include <QApplication>
 #include <QGraphicsPixmapItem>
+#include <QGraphicsSceneContextMenuEvent>
 #include <QGraphicsTextItem>
 #include <QGraphicsView>
 
@@ -17,9 +18,26 @@ static void sendLeftClick(NetworkScene& scene, QGraphicsView& view, const QPoint
 	QGraphicsSceneMouseEvent event(QEvent::GraphicsSceneMousePress);
 	event.setButton(Qt::LeftButton);
 	event.setButtons(Qt::LeftButton);
+	event.setPos(view.mapFromScene(scenePos));
 	event.setScenePos(scenePos);
+	event.setScreenPos(view.viewport()->mapToGlobal(view.mapFromScene(scenePos)));
+	event.setButtonDownPos(Qt::LeftButton, event.pos());
+	event.setButtonDownScenePos(Qt::LeftButton, scenePos);
+	event.setButtonDownScreenPos(Qt::LeftButton, event.screenPos());
 	event.setWidget(view.viewport());
 	scene.mousePressEvent(&event);
+}
+
+static bool sendContextMenu(NetworkScene& scene, QGraphicsView& view,
+	QGraphicsSceneContextMenuEvent::Reason reason, const QPointF& scenePos,
+	const QPoint& screenPos) {
+	QGraphicsSceneContextMenuEvent event(QEvent::GraphicsSceneContextMenu);
+	event.setReason(reason);
+	event.setScenePos(scenePos);
+	event.setScreenPos(screenPos);
+	event.setWidget(view.viewport());
+	scene.contextMenuEvent(&event);
+	return event.isAccepted();
 }
 
 static void scaleView(QGraphicsView& view) {
@@ -116,6 +134,167 @@ int main(int argc, char* argv[]) {
 		sendLeftClick(scene, view, QPointF(100.0, 100.0));
 		ok &= expect(entitySignals == 0, "empty click emits no entity signal");
 		ok &= expect(disableHighlight == 1, "empty click disables highlight once");
+	}
+
+	{
+		NetworkScene scene(nullptr);
+		QGraphicsView view(&scene);
+		scaleView(view);
+
+		NodeItem node(QRectF(-8.0, -8.0, 16.0, 16.0));
+		node.setPos(-120.0, -80.0);
+		StationNodeItem station(QRectF(-8.0, -8.0, 16.0, 16.0));
+		station.setPos(-80.0, -80.0);
+		TrackLineItem track(QLineF(-12.0, 0.0, 12.0, 0.0));
+		track.setPos(-40.0, -80.0);
+		ConnectionItem connection(QLineF(-12.0, 0.0, 12.0, 0.0));
+		connection.setPos(0.0, -80.0);
+		SignalItem signal(QRectF(-6.0, -8.0, 12.0, 16.0));
+		signal.setPos(40.0, -80.0);
+		TrainBodyItem train(QPolygonF() << QPointF(-10.0, -6.0) << QPointF(10.0, -6.0)
+			<< QPointF(10.0, 6.0) << QPointF(-10.0, 6.0));
+		train.setPos(80.0, -80.0);
+		QPixmap passengerPixmap(14, 14);
+		passengerPixmap.fill(Qt::white);
+		PassengerItem passenger(passengerPixmap);
+		passenger.setPos(120.0, -80.0);
+		scene.addItem(&node);
+		scene.addItem(&station);
+		scene.addItem(&track);
+		scene.addItem(&connection);
+		scene.addItem(&signal);
+		scene.addItem(&train);
+		scene.addItem(&passenger);
+
+		QGraphicsItem* requestedItem = nullptr;
+		QPointF requestedScenePos;
+		QPoint requestedScreenPos;
+		bool requestedKeyboard = false;
+		int contextRequests = 0;
+		QObject::connect(&scene, &NetworkScene::ContextMenuRequested,
+			[&](QGraphicsItem* item, const QPointF& scenePos, const QPoint& screenPos, bool keyboard) {
+				requestedItem = item;
+				requestedScenePos = scenePos;
+				requestedScreenPos = screenPos;
+				requestedKeyboard = keyboard;
+				++contextRequests;
+			});
+		int sceneMousePresses = 0;
+		QObject::connect(&scene, &NetworkScene::MousePressedOnScene, [&]() { ++sceneMousePresses; });
+		train.setFlag(QGraphicsItem::ItemIsSelectable);
+
+		auto expectContext = [&](QGraphicsItem* expectedItem, const QPointF& expectedScenePos,
+			const QPoint& expectedScreenPos, QGraphicsSceneContextMenuEvent::Reason reason,
+			const char* message) {
+			const int before = contextRequests;
+			const bool accepted = sendContextMenu(scene, view, reason, expectedScenePos, expectedScreenPos);
+			ok &= expect(accepted, "context event is accepted");
+			ok &= expect(contextRequests == before + 1, "context request emits exactly once");
+			ok &= expect(requestedItem == expectedItem, message);
+			ok &= expect(requestedScenePos == expectedScenePos, "context request preserves scene position");
+			ok &= expect(requestedScreenPos == expectedScreenPos, "context request preserves screen position");
+			ok &= expect(requestedKeyboard == (reason == QGraphicsSceneContextMenuEvent::Keyboard),
+				"context request preserves keyboard reason");
+		};
+
+		expectContext(&node, QPointF(-120.0, -80.0), QPoint(11, 12),
+			QGraphicsSceneContextMenuEvent::Mouse, "context request resolves node");
+		expectContext(&station, QPointF(-80.0, -80.0), QPoint(21, 22),
+			QGraphicsSceneContextMenuEvent::Mouse, "context request resolves station");
+		expectContext(&track, QPointF(-40.0, -80.0), QPoint(31, 32),
+			QGraphicsSceneContextMenuEvent::Mouse, "context request resolves track");
+		expectContext(&connection, QPointF(0.0, -80.0), QPoint(41, 42),
+			QGraphicsSceneContextMenuEvent::Mouse, "context request resolves connection");
+		expectContext(&signal, QPointF(40.0, -80.0), QPoint(51, 52),
+			QGraphicsSceneContextMenuEvent::Mouse, "context request resolves signal");
+		expectContext(&train, QPointF(80.0, -80.0), QPoint(61, 62),
+			QGraphicsSceneContextMenuEvent::Keyboard, "context request resolves train");
+		expectContext(&passenger, QPointF(120.0, -80.0), QPoint(71, 72),
+			QGraphicsSceneContextMenuEvent::Mouse, "context request resolves passenger");
+		expectContext(nullptr, QPointF(220.0, 140.0), QPoint(81, 82),
+			QGraphicsSceneContextMenuEvent::Mouse, "context request resolves empty space");
+
+		sendLeftClick(scene, view, QPointF(80.0, -80.0));
+		ok &= expect(sceneMousePresses == 1, "left click emits scene signal once");
+		ok &= expect(train.isSelected(), "left click still dispatches to selectable item");
+	}
+
+	{
+		NetworkScene scene(nullptr);
+		QGraphicsView view(&scene);
+		scaleView(view);
+
+		StationNodeItem station(QRectF(-10.0, -10.0, 20.0, 20.0));
+		QPixmap decorationPixmap(24, 24);
+		decorationPixmap.fill(Qt::white);
+		QGraphicsPixmapItem decoration(decorationPixmap);
+		decoration.setPos(-12.0, -12.0);
+		decoration.setFlag(QGraphicsItem::ItemIgnoresTransformations);
+		decoration.setZValue(10.0);
+		scene.addItem(&station);
+		scene.addItem(&decoration);
+
+		QGraphicsItem* requestedItem = nullptr;
+		QPointF requestedScenePos;
+		QPoint requestedScreenPos;
+		bool requestedKeyboard = true;
+		int contextRequests = 0;
+		QObject::connect(&scene, &NetworkScene::ContextMenuRequested,
+			[&](QGraphicsItem* item, const QPointF& scenePos, const QPoint& screenPos, bool keyboard) {
+				requestedItem = item;
+				requestedScenePos = scenePos;
+				requestedScreenPos = screenPos;
+				requestedKeyboard = keyboard;
+				++contextRequests;
+			});
+
+		const QPointF scenePos(0.0, 0.0);
+		const QPoint screenPos(91, 92);
+		const bool accepted = sendContextMenu(scene, view, QGraphicsSceneContextMenuEvent::Mouse,
+			scenePos, screenPos);
+		ok &= expect(accepted, "ignored-transform context event is accepted");
+		ok &= expect(contextRequests == 1, "ignored-transform context request emits once");
+		ok &= expect(requestedItem == &station,
+			"context request passes through higher-z ignored-transform decoration");
+		ok &= expect(requestedScenePos == scenePos, "ignored-transform request preserves scene position");
+		ok &= expect(requestedScreenPos == screenPos, "ignored-transform request preserves screen position");
+		ok &= expect(!requestedKeyboard, "ignored-transform request preserves mouse reason");
+	}
+
+	{
+		NetworkScene scene(nullptr);
+		QGraphicsView view(&scene);
+		scaleView(view);
+
+		StationNodeItem station(QRectF(-10.0, -10.0, 20.0, 20.0));
+		QGraphicsRectItem child(QRectF(-8.0, -8.0, 16.0, 16.0), &station);
+		child.setZValue(10.0);
+		scene.addItem(&station);
+
+		QGraphicsItem* requestedItem = nullptr;
+		QPointF requestedScenePos;
+		QPoint requestedScreenPos;
+		bool requestedKeyboard = true;
+		int contextRequests = 0;
+		QObject::connect(&scene, &NetworkScene::ContextMenuRequested,
+			[&](QGraphicsItem* item, const QPointF& scenePos, const QPoint& screenPos, bool keyboard) {
+				requestedItem = item;
+				requestedScenePos = scenePos;
+				requestedScreenPos = screenPos;
+				requestedKeyboard = keyboard;
+				++contextRequests;
+			});
+
+		const QPointF scenePos(0.0, 0.0);
+		const QPoint screenPos(101, 102);
+		const bool accepted = sendContextMenu(scene, view, QGraphicsSceneContextMenuEvent::Mouse,
+			scenePos, screenPos);
+		ok &= expect(accepted, "unrecognized-child context event is accepted");
+		ok &= expect(contextRequests == 1, "unrecognized-child context request emits once");
+		ok &= expect(requestedItem == &station, "context request resolves through unrecognized child");
+		ok &= expect(requestedScenePos == scenePos, "unrecognized-child request preserves scene position");
+		ok &= expect(requestedScreenPos == screenPos, "unrecognized-child request preserves screen position");
+		ok &= expect(!requestedKeyboard, "unrecognized-child request preserves mouse reason");
 	}
 
 	if (!ok)

--- a/tools/e2e/visual_polish_smoke.sh
+++ b/tools/e2e/visual_polish_smoke.sh
@@ -7,6 +7,7 @@ OUT="${TMPDIR:-/tmp}/qegtrain-visual-polish-e2e.log"
 SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-e2e.png"
 DENSE_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dense-e2e.png"
 FOLLOW_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-follow-e2e.png"
+CONTEXT_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-context-e2e.png"
 
 if [[ ! -x "$APP" ]]; then
 	echo "QEGTRAIN app not found or not executable: $APP" >&2
@@ -14,17 +15,20 @@ if [[ ! -x "$APP" ]]; then
 fi
 
 cd "$ROOT/EGTRAIN/QEGTRAIN"
+rm -f "$CONTEXT_SHOT"
 QEGTRAIN_AUTOSTART=1 \
 QEGTRAIN_E2E_VISUAL_POLISH=1 \
 QEGTRAIN_E2E_SCREENSHOT="$SHOT" \
 QEGTRAIN_E2E_DENSE_SCREENSHOT="$DENSE_SHOT" \
 QEGTRAIN_E2E_FOLLOW_SCREENSHOT="$FOLLOW_SHOT" \
+QEGTRAIN_E2E_CONTEXT_SCREENSHOT="$CONTEXT_SHOT" \
 "$APP" -n 3 -h 8000 -g 1 -pax 1 -TSM 0 -RC 0 >"$OUT" 2>&1
 
 grep -q "E2E_VISUAL_POLISH_OK" "$OUT"
 test -s "$SHOT"
 test -s "$DENSE_SHOT"
 test -s "$FOLLOW_SHOT"
+test -s "$CONTEXT_SHOT"
 for label in "Planned arrival" "Planned departure" "Simulated arrival" "Simulated departure" "Arrival delay" "Departure delay"; do
 	if ! grep -Fqi "$label" "$ROOT/EGTRAIN/QEGTRAIN/app/MainWindow.cpp"; then
 		echo "missing timetable label in MainWindow.cpp: $label" >&2
@@ -35,4 +39,4 @@ if grep -Fq 'name="actionShow_Graph"' "$ROOT/EGTRAIN/QEGTRAIN/app/MainWindow.ui"
 	echo "dead Show Graph action still present in MainWindow.ui" >&2
 	exit 1
 fi
-echo "visual polish e2e passed: $SHOT $DENSE_SHOT $FOLLOW_SHOT"
+echo "visual polish e2e passed: $SHOT $DENSE_SHOT $FOLLOW_SHOT $CONTEXT_SHOT"


### PR DESCRIPTION
Right-clicking the network scene now opens a context menu for the entity under the pointer: train, station, track, signal, passenger, or empty space. The keyboard context-menu key opens the same menu for the entity at the cursor position.

Menus reuse the semantic hit testing from left-click selection, so labels and decorative icons do not steal the target. Actions cover show details, center in view, follow train, and copying entity identifiers. Empty space gets fit whole network, clear selection, and stop following. Actions whose data paths do not exist yet (planned route highlighting, station arrivals, trains on a track, incidents on a track, next train at a signal) are visible but disabled, and their tooltips say what is missing.

Callbacks resolve their target from copied identifiers at trigger time instead of holding graphics-item pointers. The train details action scans live scene items rather than the cached polygon list; the cached lookup segfaulted in testing when a train body was removed under an open menu. An open menu now does nothing if its target is gone.

Tests: right-click routing per entity class (including transformed views, decorations, child items, and the keyboard reason) in test_networkscene_selection, plus menu content, disabled-action tooltips, one working action per menu, stale-target safety, and a menu screenshot in the visual polish smoke.

Verified with a clean build, the full ctest suite (36/36), and tools/e2e/visual_polish_smoke.sh.

Fixes #114
