### PR TITLE
Deduplicate terminal power sample sanitizing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,8 +352,10 @@ if(EGTRAIN_BUILD_TESTS)
         ${SRC_DIR}/simulation/Infrastructure.cpp
         ${SRC_DIR}/simulation/InitialParameters.cpp
         ${SRC_DIR}/simulation/NumberGenerator.cpp
+        ${SRC_DIR}/simulation/Passengers.cpp
         ${SRC_DIR}/simulation/RollingStock.cpp
         ${SRC_DIR}/simulation/Signalling.cpp
+        ${SRC_DIR}/simulation/Simulation.cpp
         ${SRC_DIR}/util/Logger.cpp
         ${SRC_DIR}/util/TrajectoryUtil.cpp)
     target_include_directories(test_runresults PRIVATE ${SRC_DIR})

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -808,13 +808,17 @@ public:
 		return instant_train_energy_consumption[t];
 	}
 
-	// Function to calculate Total Energy Consumed with and without regenrative braking (the inputs are the Eta of the Substation and the Eta of the regenerative braking)
-	void TotalEnergyConsumptionWithAndWithoutRegBraking(double EtaSubst, double EtaRegBrak) {
-		// A completed trajectory can leave a non-finite power sample at End_Time;
-		// treat that boundary sample as zero, matching train_energy_consumption().
+	// A completed trajectory can leave a non-finite power sample at End_Time;
+	// treat that boundary sample as zero, matching train_energy_consumption().
+	void sanitizeTerminalPowerSample() {
 		if (End_Time >= 0 && End_Time < static_cast<int>(instant_train_power_consumption.size()) &&
 			!std::isfinite(instant_train_power_consumption[static_cast<std::size_t>(End_Time)]))
 			instant_train_power_consumption[static_cast<std::size_t>(End_Time)] = 0.0;
+	}
+
+	// Function to calculate Total Energy Consumed with and without regenrative braking (the inputs are the Eta of the Substation and the Eta of the regenerative braking)
+	void TotalEnergyConsumptionWithAndWithoutRegBraking(double EtaSubst, double EtaRegBrak) {
+		sanitizeTerminalPowerSample();
 		// This is the total Energy consumed by the train to move
 		this->TotalEnergyConsumed = instant_train_energy_consumption[End_Time];
 		this->EnergyForAuxiliaries = 0.10 * TotalEnergyConsumed;

--- a/EGTRAIN/QEGTRAIN/simulation/Simulation.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Simulation.cpp
@@ -37,9 +37,7 @@ bool canComputeTrainEnergy(Train& train) {
 		return false;
 	// Completed runs can leave a non-finite terminal power sample; the shared
 	// energy calculation treats that boundary sample as zero.
-	if (train.End_Time < static_cast<int>(train.instant_train_power_consumption.size()) &&
-		!std::isfinite(train.instant_train_power_consumption[static_cast<std::size_t>(train.End_Time)]))
-		train.instant_train_power_consumption[static_cast<std::size_t>(train.End_Time)] = 0.0;
+	train.sanitizeTerminalPowerSample();
 	const int energyStart = static_cast<int>(train.departure_time);
 	return energyStart >= 0 && energyStart <= train.End_Time &&
 		energySeriesCovers(train.instant_train_power_consumption, energyStart, train.End_Time) &&

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -1,6 +1,7 @@
 #include "diagrams/RunResults.h"
 
 #include "simulation/RollingStock.h"
+#include "simulation/Simulation.h"
 #include "util/Logger.hpp"
 
 #include <cmath>
@@ -289,6 +290,49 @@ int main() {
 	ok &= expect(std::isfinite(terminalPower->TotalEnergyConsWithRegBrak) &&
 					 std::isfinite(terminalPower->TotalEnergySubstRequestWithRegBrak),
 					"terminal nonfinite power does not poison regenerative totals");
+	ok &= expect(terminalPower->instant_train_power_consumption[3] == 0.0,
+					"energy calculation zeroes the terminal nonfinite sample");
+
+	{
+		auto nanSample = makeTrain("sanitize-nan", 1, 3, 0.0, 0.0, 0.0, 0.0);
+		nanSample->instant_train_power_consumption[3] = std::numeric_limits<double>::quiet_NaN();
+		nanSample->sanitizeTerminalPowerSample();
+		ok &= expect(nanSample->instant_train_power_consumption[3] == 0.0,
+					 "sanitize zeroes a nonfinite sample at End_Time");
+		ok &= expect(closeTo(nanSample->instant_train_power_consumption[2], 100.0),
+					 "sanitize leaves samples before End_Time untouched");
+	}
+
+	{
+		auto finiteSample = makeTrain("sanitize-finite", 1, 3, 0.0, 0.0, 0.0, 0.0);
+		finiteSample->sanitizeTerminalPowerSample();
+		ok &= expect(closeTo(finiteSample->instant_train_power_consumption[3], 100.0),
+					 "sanitize keeps an in-range finite sample");
+	}
+
+	{
+		auto outOfRange = makeTrain("sanitize-out-of-range", 1, 3, 0.0, 0.0, 0.0, 0.0);
+		outOfRange->instant_train_power_consumption[3] = std::numeric_limits<double>::quiet_NaN();
+		outOfRange->End_Time = 4;
+		outOfRange->sanitizeTerminalPowerSample();
+		ok &= expect(std::isnan(outOfRange->instant_train_power_consumption[3]),
+					 "sanitize does not write past the series end");
+		outOfRange->End_Time = -1;
+		outOfRange->sanitizeTerminalPowerSample();
+		ok &= expect(std::isnan(outOfRange->instant_train_power_consumption[3]),
+					 "sanitize does not write for a negative End_Time");
+	}
+
+	{
+		auto networkEnergy = makeTrain("network-energy", 1, 3, 0.0, 0.0, 0.0, 0.0);
+		networkEnergy->departure_time = 1;
+		networkEnergy->instant_train_power_consumption[3] = std::numeric_limits<double>::quiet_NaN();
+		ComputeEnergyConsumptionForAllTrains(networkEnergy.get(), 1);
+		ok &= expect(networkEnergy->instant_train_power_consumption[3] == 0.0,
+					 "network energy pass sanitizes the terminal sample");
+		ok &= expect(closeTo(networkEnergy->TotalEnergyConsumed, 220.0),
+					 "network energy pass still computes totals");
+	}
 
 	{
 		auto regionalFirst = makeRegionalTimetableTrain("regional-first", {"A"});


### PR DESCRIPTION
The guarded zeroing of a non-finite terminal power sample existed as two independent copies that both wrote into simulation state: one inline in Train::TotalEnergyConsumptionWithAndWithoutRegBraking, one in canComputeTrainEnergy in Simulation.cpp. The copies could drift, and each caller depended on its own version.

This moves the guard into a single Train::sanitizeTerminalPowerSample() helper and calls it from both sites. The helper is the exact code that was inlined, including the End_Time bounds checks and the comment explaining the boundary sample. The Simulation.cpp copy lacked the End_Time >= 0 check, but the early return above it already guarantees a non-negative End_Time there, so behavior is unchanged at both call sites.

Tests cover the helper directly (NaN at End_Time becomes zero, finite samples stay untouched, out-of-range End_Time writes nothing) and both call paths, including ComputeEnergyConsumptionForAllTrains end to end. Covering the canComputeTrainEnergy path required linking Simulation.cpp and Passengers.cpp into the test_runresults target.

Verified with a clean build, the full ctest suite (36/36), headless_smoke.py, and roundtrip_smoke.py. Removing the Simulation.cpp sanitize call makes the new network-energy assertions fail, so the test really exercises that path.

Fixes #171
