### PR TITLE
Name the timetable station cap and warn on truncation

### DIFF
--- a/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 #include <limits>
 #include <utility>
 
@@ -66,7 +67,12 @@ std::vector<TimetableResultRow> buildTimetableResults(const std::vector<const Tr
 		const Train& train = *trainPtr;
 		if (!train.Stations || train.numStations <= 0)
 			continue;
-		const int stationCount = std::min(train.numStations, 40);
+		const int stationCount = std::min(train.numStations, static_cast<int>(Train::kMaxTimetableStations));
+		if (train.numStations > Train::kMaxTimetableStations) {
+			std::cerr << "Timetable results for train " << train.trainDescription << " truncated to "
+					  << Train::kMaxTimetableStations << " stations ("
+					  << train.numStations - Train::kMaxTimetableStations << " later stops dropped)\n";
+		}
 		for (int stationIndex = 0; stationIndex < stationCount; ++stationIndex) {
 			TimetableResultRow row;
 			row.trainId = train.trainDescription;

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
@@ -95,7 +95,7 @@ Train::Train() {
 	numOverlaps = 0;
 	MAX_OnBoard_Passengers = 300 + 300 * number_of_wagons; // By default it is considered that a carriage can transport maximum 300 passengers so it is 300 pax for the traction unit and 300 pax for each carriage / wagon
 	Current_OnBoard_Passengers = 0;						   // It is considered that the train starts with no passengers onboard
-	for (int i = 0; i < 40; i++) {
+	for (int i = 0; i < kMaxTimetableStations; i++) {
 		StationArrivals[i] = -1;
 		StationArrivalNames[i] = "None";
 		StationDelay[i] = -1;

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -633,22 +633,23 @@ public:
 	std::vector<double> BX;
 	Node* Stations = nullptr;
 	int numStations;					   // Station is a dynamic array contating all Station Node for the train and int numStations is the Number of Stations (i.e. the dimension of Stations Array)
-	int stationBlockSection[40];		// Cached block section index for each station (avoids full-route scan every timestep)
-	int stationArc[40];				   // Cached Arc index within block section for each station
+	static constexpr int kMaxTimetableStations = 40; // Capacity of the station-indexed arrays below; stations beyond this cap have no timetable slot
+	int stationBlockSection[kMaxTimetableStations];		// Cached block section index for each station (avoids full-route scan every timestep)
+	int stationArc[kMaxTimetableStations];				   // Cached Arc index within block section for each station
 	bool ServiceStopBehindATrain = false; // This variable is true only if the train is stopping at a station behind another train. We admit that in moving block operations maximum two trains can perform a service stop queueing one after each other at the same platform
 	bool StoppedForServiceStop = false;   // This variable is true when the train is stopping at a station to perform a service stop
 	string CurrentServiceStop;		   // This variable indicates the name of the Station the train is currently stopping at when StoppedForServiceStop=true
 	string CurrentServiceStopPlatform; // Id of the platform at which the train has stopped when making a service stop at a scheduled station/stop>
 
 	double XCurrentServiceStop;	   // This is the relative abscissa on the route of the train of a service Stop when the train is stopping behind another train at the same platform
-	double StationArrivals[40];	   // This variable is the time instant in which the train actually enters a station
-	string StationArrivalNames[40]; // Preserves served station names for post-run arrival analysis.
-	double StationDelay[40];	   // This variable represent the arrival delay of a train at a certain station
-	double StationConsecDelay[40]; // This is the Consecutive delay at stations i.e. ArrivalDelay-Entrance Delay-Sum of disturbances at previous stations
-	double StationDisturbance[40]; //  This variable represents the disturbance to dwell times at stations
+	double StationArrivals[kMaxTimetableStations];	   // This variable is the time instant in which the train actually enters a station
+	string StationArrivalNames[kMaxTimetableStations]; // Preserves served station names for post-run arrival analysis.
+	double StationDelay[kMaxTimetableStations];	   // This variable represent the arrival delay of a train at a certain station
+	double StationConsecDelay[kMaxTimetableStations]; // This is the Consecutive delay at stations i.e. ArrivalDelay-Entrance Delay-Sum of disturbances at previous stations
+	double StationDisturbance[kMaxTimetableStations]; //  This variable represents the disturbance to dwell times at stations
 	int N_Station_Stopped;		   // This variable counts the number of stations at which the train has stopped
-	double ScheduledArrivals[40] = {};  // This Array contains scheduled train arrival time at stations (it is necessary to calculate train deviations from timetable and therefore train delays)
-	double ScheduledDepartures[40] = {};
+	double ScheduledArrivals[kMaxTimetableStations] = {};  // This Array contains scheduled train arrival time at stations (it is necessary to calculate train deviations from timetable and therefore train delays)
+	double ScheduledDepartures[kMaxTimetableStations] = {};
 	int delayed;						// This is a boolean parameter: if delayed =1 the train will experience a delay at a determined station, else if delayed=0 the train won't experience any delay
 	double TotalInputDelays = 0.0;		// Sum of the Entrance Delays +stochastic disturbances to dwell times
 	double EntranceDelay;				// This is the entrance delay of the train on the network
@@ -703,7 +704,7 @@ public:
 	// Called after Stations or route changes; eliminates the O(N_BS*total_arcs*numStations)
 	// triple scan from the per-timestep hot path.
 	void cacheStationPositions() {
-		for (int s = 0; s < 40; s++) {
+		for (int s = 0; s < kMaxTimetableStations; s++) {
 			stationBlockSection[s] = -1;
 			stationArc[s] = -1;
 		}

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -189,6 +189,18 @@ int main() {
 					 "early arrival and departure preserve negative delays");
 	}
 
+	{
+		std::vector<std::string> stations;
+		for (int index = 0; index < Train::kMaxTimetableStations; ++index)
+			stations.push_back("S" + std::to_string(index));
+		auto train = makeTimetableTrain("overflow", stations);
+		train->numStations = Train::kMaxTimetableStations + 5;
+		const std::vector<const Train*> trains{train.get()};
+		const auto rows = buildTimetableResults(trains);
+		ok &= expect(static_cast<int>(rows.size()) == Train::kMaxTimetableStations,
+					 "over-cap train yields exactly kMaxTimetableStations rows");
+	}
+
 	auto delayed = makeTrain("delayed", 3, 7, 10.0, 20.0, 30.0, 40.0);
 	const std::vector<const Train*> delayedTrains{delayed.get()};
 	const auto delayedResults = buildRunResults(delayedTrains, 0.5);


### PR DESCRIPTION
buildTimetableResults capped the per-train station loop with a bare literal 40. The number is the capacity of the fixed station arrays on Train, but nothing documented that coupling, and any train serving more stations silently lost its later stops from timetable results and the CSV export.

The cap is now Train::kMaxTimetableStations, declared next to the station-indexed array cluster and used to size all nine arrays plus the two init loops that walk them (the Train constructor and cacheStationPositions). buildTimetableResults uses the constant through a static_cast so std::min never takes the member's address, matching the portability care from #188 and #191. When a train exceeds the cap, a stderr line names the train and how many stops were dropped, so truncation is no longer silent.

The diagrams module had no existing warning mechanism, so stderr is the channel; the message fires once per affected train per results build.

Tests: an over-cap train yields exactly kMaxTimetableStations rows in test_runresults. Verified with a clean build, the full ctest suite (36/36), headless_smoke.py, and roundtrip_smoke.py.

The write-side loops that fill these arrays from numStations still have no guard; that is filed as #196.

Fixes #172
