### PR TITLE
Give every diagram and table a train dropdown, exports, and shared styling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,8 @@ set(EGTRAIN_SOURCES
     ${SRC_DIR}/util/SpeedFormat.cpp
     ${SRC_DIR}/util/CsvWriter.cpp
     ${SRC_DIR}/diagrams/DiagramWindow.cpp
+    ${SRC_DIR}/diagrams/TrainFilterButton.cpp
+    ${SRC_DIR}/diagrams/TimetableTableWindow.cpp
     ${SRC_DIR}/diagrams/RunResults.cpp
     ${SRC_DIR}/util/TrajectoryUtil.cpp
     ${SRC_DIR}/diagrams/BlockingTimeDiagram.cpp
@@ -189,6 +191,8 @@ set(EGTRAIN_HEADERS
     ${SRC_DIR}/util/SpeedFormat.h
     ${SRC_DIR}/util/CsvWriter.h
     ${SRC_DIR}/diagrams/DiagramWindow.h
+    ${SRC_DIR}/diagrams/TrainFilterButton.h
+    ${SRC_DIR}/diagrams/TimetableTableWindow.h
     ${SRC_DIR}/diagrams/RunResults.h
     ${SRC_DIR}/util/TrajectoryUtil.h
     ${SRC_DIR}/diagrams/BlockingTimeDiagram.h

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -7,6 +7,7 @@
 #include "widgets/ConsoleWidget.h"
 #include "diagrams/DiagramWindow.h"
 #include "diagrams/RunResults.h"
+#include "diagrams/TimetableTableWindow.h"
 #include "util/TrajectoryUtil.h"
 #include "util/CsvWriter.h"
 #include "diagrams/BlockingTimeDiagram.h"
@@ -7520,20 +7521,34 @@ void MainWindow::setupRunResultsDock() {
 	m_runResultsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_runResultsTable->setColumnCount(8);
 	m_runResultsTable->setHorizontalHeaderLabels({
-		"Train", "Start time (s)", "End time (s)", "Travel time (s)",
-		"Energy consumed (kWh)", "Energy consumed with regenerative braking (kWh)",
-		"Substation request (kWh)", "Substation request with regenerative braking (kWh)"});
+		"Train", "Start", "End", "Travel time",
+		"Energy (kWh)", "Energy with regen (kWh)",
+		"Substation (kWh)", "Substation with regen (kWh)"});
+	m_runResultsTable->setAlternatingRowColors(true);
 	m_runResultsTable->horizontalHeader()->setStretchLastSection(true);
 
 	QWidget* container = new QWidget(m_runResultsDock);
 	QVBoxLayout* containerLayout = new QVBoxLayout(container);
 	containerLayout->setContentsMargins(0, 0, 0, 0);
 	QPushButton* exportCsvBtn = new QPushButton("Export CSV...", container);
+	exportCsvBtn->setToolTip("Write travel time and energy per train to a CSV file");
 	connect(exportCsvBtn, &QPushButton::clicked, this, [this]() {
 		saveCsvInteractive(this, "run_summary.csv", buildRunSummaryCsv());
 	});
+	QPushButton* exportPngBtn = new QPushButton("Export PNG...", container);
+	exportPngBtn->setToolTip("Save the table as an image");
+	connect(exportPngBtn, &QPushButton::clicked, this, [this]() {
+		QString path = QFileDialog::getSaveFileName(this, "Export Table", "run_summary.png", "PNG Image (*.png)");
+		if (path.isEmpty())
+			return;
+		if (QFileInfo(path).suffix().compare("png", Qt::CaseInsensitive) != 0)
+			path += ".png";
+		if (!m_runResultsTable->grab().save(path, "PNG"))
+			QMessageBox::warning(this, "Export failed", QString("Could not write the image to:\n%1").arg(path));
+	});
 	QHBoxLayout* toolRow = new QHBoxLayout();
 	toolRow->addWidget(exportCsvBtn);
+	toolRow->addWidget(exportPngBtn);
 	toolRow->addStretch();
 	containerLayout->addLayout(toolRow);
 	containerLayout->addWidget(m_runResultsTable);
@@ -7557,30 +7572,46 @@ void MainWindow::refreshRunResults() {
 		"Substation request (kWh)", "Substation request with regenerative braking (kWh)"});
 	m_runResultsTable->setRowCount(static_cast<int>(results.trains.size()) + 1);
 
-	const auto valueText = [](const RunResultValue& value) {
-		return value.available ? QString::number(value.value, 'f', 6) : QStringLiteral("Unavailable");
+	// Start and end as clock times, travel time as a duration, energy with one
+	// decimal; a dash marks values the run did not produce.
+	const auto clockText = [this](const RunResultValue& value) {
+		return value.available
+			? QString::fromStdString(formatSimTime(static_cast<long long>(value.value), m_startOffsetSeconds))
+			: QStringLiteral("-");
+	};
+	const auto durationText = [](const RunResultValue& value) {
+		if (!value.available)
+			return QStringLiteral("-");
+		const long long total = static_cast<long long>(value.value);
+		return QString("%1:%2:%3")
+			.arg(total / 3600)
+			.arg((total % 3600) / 60, 2, 10, QChar('0'))
+			.arg(total % 60, 2, 10, QChar('0'));
+	};
+	const auto energyText = [](const RunResultValue& value) {
+		return value.available ? QString::number(value.value, 'f', 1) : QStringLiteral("-");
 	};
 	for (int row = 0; row < static_cast<int>(results.trains.size()); ++row) {
 		const TrainRunResult& result = results.trains[static_cast<std::size_t>(row)];
 		m_runResultsTable->setItem(row, 0, new QTableWidgetItem(QString::fromStdString(result.trainId)));
-		m_runResultsTable->setItem(row, 1, new QTableWidgetItem(valueText(result.startSeconds)));
-		m_runResultsTable->setItem(row, 2, new QTableWidgetItem(valueText(result.endSeconds)));
-		m_runResultsTable->setItem(row, 3, new QTableWidgetItem(valueText(result.travelSeconds)));
-		m_runResultsTable->setItem(row, 4, new QTableWidgetItem(valueText(result.energyConsumedKWh)));
-		m_runResultsTable->setItem(row, 5, new QTableWidgetItem(valueText(result.energyWithRegenKWh)));
-		m_runResultsTable->setItem(row, 6, new QTableWidgetItem(valueText(result.substationKWh)));
-		m_runResultsTable->setItem(row, 7, new QTableWidgetItem(valueText(result.substationWithRegenKWh)));
+		m_runResultsTable->setItem(row, 1, new QTableWidgetItem(clockText(result.startSeconds)));
+		m_runResultsTable->setItem(row, 2, new QTableWidgetItem(clockText(result.endSeconds)));
+		m_runResultsTable->setItem(row, 3, new QTableWidgetItem(durationText(result.travelSeconds)));
+		m_runResultsTable->setItem(row, 4, new QTableWidgetItem(energyText(result.energyConsumedKWh)));
+		m_runResultsTable->setItem(row, 5, new QTableWidgetItem(energyText(result.energyWithRegenKWh)));
+		m_runResultsTable->setItem(row, 6, new QTableWidgetItem(energyText(result.substationKWh)));
+		m_runResultsTable->setItem(row, 7, new QTableWidgetItem(energyText(result.substationWithRegenKWh)));
 	}
 
 	const int totalRow = static_cast<int>(results.trains.size());
 	m_runResultsTable->setItem(totalRow, 0, new QTableWidgetItem(QStringLiteral("Network total")));
-	m_runResultsTable->setItem(totalRow, 1, new QTableWidgetItem(valueText(results.networkStartSeconds)));
-	m_runResultsTable->setItem(totalRow, 2, new QTableWidgetItem(valueText(results.networkEndSeconds)));
-	m_runResultsTable->setItem(totalRow, 3, new QTableWidgetItem(valueText(results.networkTravelSeconds)));
-	m_runResultsTable->setItem(totalRow, 4, new QTableWidgetItem(valueText(results.energyConsumedKWh)));
-	m_runResultsTable->setItem(totalRow, 5, new QTableWidgetItem(valueText(results.energyWithRegenKWh)));
-	m_runResultsTable->setItem(totalRow, 6, new QTableWidgetItem(valueText(results.substationKWh)));
-	m_runResultsTable->setItem(totalRow, 7, new QTableWidgetItem(valueText(results.substationWithRegenKWh)));
+	m_runResultsTable->setItem(totalRow, 1, new QTableWidgetItem(clockText(results.networkStartSeconds)));
+	m_runResultsTable->setItem(totalRow, 2, new QTableWidgetItem(clockText(results.networkEndSeconds)));
+	m_runResultsTable->setItem(totalRow, 3, new QTableWidgetItem(durationText(results.networkTravelSeconds)));
+	m_runResultsTable->setItem(totalRow, 4, new QTableWidgetItem(energyText(results.energyConsumedKWh)));
+	m_runResultsTable->setItem(totalRow, 5, new QTableWidgetItem(energyText(results.energyWithRegenKWh)));
+	m_runResultsTable->setItem(totalRow, 6, new QTableWidgetItem(energyText(results.substationKWh)));
+	m_runResultsTable->setItem(totalRow, 7, new QTableWidgetItem(energyText(results.substationWithRegenKWh)));
 	m_runResultsTable->resizeColumnsToContents();
 	m_runResultsDock->show();
 	m_runResultsDock->raise();
@@ -9124,13 +9155,8 @@ void MainWindow::buildCorridorTrainPathDiagram(std::string corridor) {
 	// create chart
 	QChart* chart = new QChart();
 
-	// custom title
-	QString title = "Train Path Diagram: corridor ";
+	QString title = "Train paths (time vs distance), corridor ";
 	title.append(QString::fromStdString(corridor));
-	QFont font;
-	font.setPixelSize(18);
-	chart->setTitleFont(font);
-	chart->setTitleBrush(QBrush(Qt::black));
 	chart->setTitle(title);
 
 	for (int i = 0; i < numRegions; i++) {
@@ -9575,6 +9601,12 @@ void MainWindow::buildPerTrainDiagram(int mode) {
 		}
 	}
 	chart->createDefaultAxes();
+	const char* xTitles[] = {"Distance (km)", "Time", "Time"};
+	const char* yTitles[] = {"Speed (km/h)", "Speed (km/h)", "Distance (km)"};
+	if (!chart->axes(Qt::Horizontal).isEmpty())
+		chart->axes(Qt::Horizontal).first()->setTitleText(xTitles[mode]);
+	if (!chart->axes(Qt::Vertical).isEmpty())
+		chart->axes(Qt::Vertical).first()->setTitleText(yTitles[mode]);
 
 	DiagramWindow* win = new DiagramWindow(titles[mode], this);
 	win->setChart(chart);
@@ -9605,68 +9637,10 @@ void MainWindow::showTimetableTable() {
 		return;
 	}
 
-	QDialog* dlg = new QDialog(this);
-	dlg->setWindowTitle("Timetable: planned vs simulated");
-	dlg->resize(700, 500);
-	dlg->setAttribute(Qt::WA_DeleteOnClose);
-
-	QVBoxLayout* layout = new QVBoxLayout(dlg);
-	QTableWidget* table = new QTableWidget();
-	table->setColumnCount(8);
-	table->setHorizontalHeaderLabels({
-		"Train", "Station call", "Planned arrival", "Planned departure",
-		"Simulated arrival", "Simulated departure", "Arrival delay", "Departure delay"});
-
-	const auto timeText = [this](const RunResultValue& value) {
-		return value.available
-			? QString::fromStdString(formatSimTime(static_cast<long long>(value.value), m_startOffsetSeconds))
-			: QStringLiteral("Unavailable");
-	};
-	const auto delayText = [](const RunResultValue& value) {
-		if (!value.available)
-			return QStringLiteral("Unavailable");
-		return QString("%1%2 s")
-			.arg(value.value >= 0.0 ? "+" : "")
-			.arg(value.value, 0, 'f', 0);
-	};
-	const auto setDelayColor = [](QTableWidgetItem* item, const RunResultValue& value) {
-		if (!value.available)
-			return;
-		if (value.value > 60.0)
-			item->setForeground(QBrush(Qt::red));
-		else if (value.value > 0.0)
-			item->setForeground(QBrush(Qt::darkYellow));
-		else
-			item->setForeground(QBrush(Qt::darkGreen));
-	};
-
-	const auto rows = buildTimetableResults(runResultTrainPointers());
-	for (int row = 0; row < static_cast<int>(rows.size()); ++row) {
-		const TimetableResultRow& result = rows[static_cast<std::size_t>(row)];
-		table->insertRow(row);
-		table->setItem(row, 0, new QTableWidgetItem(QString::fromStdString(result.trainId)));
-		table->setItem(row, 1, new QTableWidgetItem(
-			QString("%1 (#%2)").arg(QString::fromStdString(result.stationId)).arg(result.callIndex)));
-		table->setItem(row, 2, new QTableWidgetItem(timeText(result.plannedArrivalSeconds)));
-		table->setItem(row, 3, new QTableWidgetItem(timeText(result.plannedDepartureSeconds)));
-		table->setItem(row, 4, new QTableWidgetItem(timeText(result.simulatedArrivalSeconds)));
-		table->setItem(row, 5, new QTableWidgetItem(timeText(result.simulatedDepartureSeconds)));
-		auto* arrivalDelayItem = new QTableWidgetItem(delayText(result.arrivalDelaySeconds));
-		auto* departureDelayItem = new QTableWidgetItem(delayText(result.departureDelaySeconds));
-		setDelayColor(arrivalDelayItem, result.arrivalDelaySeconds);
-		setDelayColor(departureDelayItem, result.departureDelaySeconds);
-		table->setItem(row, 6, arrivalDelayItem);
-		table->setItem(row, 7, departureDelayItem);
-	}
-	table->resizeColumnsToContents();
-	layout->addWidget(table);
-
-	QPushButton* exportCsvBtn = new QPushButton("Export CSV...", dlg);
-	connect(exportCsvBtn, &QPushButton::clicked, dlg, [dlg]() {
-		saveCsvInteractive(dlg, "timetable.csv", buildTimetableCsv(allTrainIds()));
-	});
-	layout->addWidget(exportCsvBtn);
-	dlg->show();
+	auto* window = new TimetableTableWindow(buildTimetableResults(runResultTrainPointers()),
+											m_startOffsetSeconds, &buildTimetableCsv, this);
+	window->setAttribute(Qt::WA_DeleteOnClose);
+	window->show();
 }
 
 void MainWindow::showDelayDiagram() {

--- a/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
@@ -1,15 +1,12 @@
 #include "diagrams/DiagramWindow.h"
+#include "diagrams/TrainFilterButton.h"
 #include "util/TimeFormat.h"
 
-#include <QAbstractItemView>
 #include <QColor>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QHBoxLayout>
-#include <QIcon>
 #include <QLabel>
-#include <QLineEdit>
-#include <QListWidget>
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <QPainter>
@@ -19,8 +16,12 @@
 #include <QVariant>
 #include <QVBoxLayout>
 #include <QtCharts/QAbstractSeries>
+#include <QtCharts/QCategoryAxis>
 #include <QtCharts/QLegend>
+#include <QtCharts/QValueAxis>
 #include <QtCharts/QXYSeries>
+
+#include <cmath>
 
 namespace {
 
@@ -59,76 +60,64 @@ DiagramWindow::DiagramWindow(const QString& title, QWidget* parent)
 	// Drag a rectangle to zoom; filter state is unaffected by zoom or pan.
 	m_view->setRubberBand(QChartView::RectangleRubberBand);
 
-	// Filter panel: search, quick actions, and one row per train.
-	QLabel* filterTitle = new QLabel("Trains", this);
-	m_search = new QLineEdit(this);
-	m_search->setPlaceholderText("Search trains...");
-	m_search->setClearButtonEnabled(true);
-	connect(m_search, &QLineEdit::textChanged, this, &DiagramWindow::applyGroupFilter);
+	// Top bar: train visibility dropdown, pin state, zoom reset, exports.
+	m_trainsButton = new TrainFilterButton(this);
+	connect(m_trainsButton, &TrainFilterButton::selectionChanged,
+			this, &DiagramWindow::applyTrainVisibility);
 
-	QPushButton* allBtn = new QPushButton("All", this);
-	QPushButton* noneBtn = new QPushButton("None", this);
-	connect(allBtn, &QPushButton::clicked, this, &DiagramWindow::selectAllGroups);
-	connect(noneBtn, &QPushButton::clicked, this, &DiagramWindow::selectNoGroups);
-	QHBoxLayout* quickRow = new QHBoxLayout();
-	quickRow->addWidget(allBtn);
-	quickRow->addWidget(noneBtn);
-
-	m_groupList = new QListWidget(this);
-	m_groupList->setSelectionMode(QAbstractItemView::NoSelection);
-	connect(m_groupList, &QListWidget::itemChanged, this, &DiagramWindow::onGroupItemChanged);
-
-	QVBoxLayout* panelLayout = new QVBoxLayout();
-	panelLayout->addWidget(filterTitle);
-	panelLayout->addWidget(m_search);
-	panelLayout->addLayout(quickRow);
-	panelLayout->addWidget(m_groupList, 1);
-	QWidget* panel = new QWidget(this);
-	panel->setLayout(panelLayout);
-	panel->setMinimumWidth(220);
-	panel->setMaximumWidth(320);
-
-	QHBoxLayout* topRow = new QHBoxLayout();
-	topRow->addWidget(m_view, 1);
-	topRow->addWidget(panel);
-
-	// Bottom bar: export buttons, pinned readout, hover readout.
-	QPushButton* exportPngBtn = new QPushButton("Export PNG...", this);
-	connect(exportPngBtn, &QPushButton::clicked, this, &DiagramWindow::exportPng);
-	m_csvButton = new QPushButton("Export CSV...", this);
-	m_csvButton->setEnabled(false);
-	connect(m_csvButton, &QPushButton::clicked, this, &DiagramWindow::exportCsv);
 	QPushButton* clearPinBtn = new QPushButton("Clear selection", this);
 	connect(clearPinBtn, &QPushButton::clicked, this, &DiagramWindow::clearPin);
-
 	m_pinLabel = new QLabel("", this);
-	m_readout = new QLabel("hover over the chart", this);
 
-	QHBoxLayout* bar = new QHBoxLayout();
-	bar->addWidget(exportPngBtn);
-	bar->addWidget(m_csvButton);
-	bar->addWidget(clearPinBtn);
-	bar->addWidget(m_pinLabel);
-	bar->addStretch();
-	bar->addWidget(m_readout);
+	QPushButton* resetZoomBtn = new QPushButton("Reset zoom", this);
+	resetZoomBtn->setToolTip("Undo rubber-band zoom (drag on the chart to zoom in)");
+	connect(resetZoomBtn, &QPushButton::clicked, this, &DiagramWindow::resetZoom);
+
+	m_csvButton = new QPushButton("Export CSV...", this);
+	m_csvButton->setToolTip("Write the raw data of the visible trains to a CSV file");
+	m_csvButton->setEnabled(false);
+	connect(m_csvButton, &QPushButton::clicked, this, &DiagramWindow::exportCsv);
+
+	QPushButton* exportPngBtn = new QPushButton("Export PNG...", this);
+	exportPngBtn->setToolTip("Save the chart as an image");
+	connect(exportPngBtn, &QPushButton::clicked, this, &DiagramWindow::exportPng);
+
+	QHBoxLayout* topBar = new QHBoxLayout();
+	topBar->addWidget(m_trainsButton);
+	topBar->addWidget(clearPinBtn);
+	topBar->addWidget(m_pinLabel);
+	topBar->addStretch();
+	topBar->addWidget(resetZoomBtn);
+	topBar->addWidget(m_csvButton);
+	topBar->addWidget(exportPngBtn);
+
+	m_readout = new QLabel("Hover over the chart to read values; click a line to select its train", this);
 
 	QVBoxLayout* layout = new QVBoxLayout(this);
-	layout->addLayout(topRow, 1);
-	layout->addLayout(bar);
+	layout->addLayout(topBar);
+	layout->addWidget(m_view, 1);
+	layout->addWidget(m_readout);
 }
 
 void DiagramWindow::setChart(QChart* chart) {
+	m_timeAxisApplied = false;
+	if (chart)
+		applyChartStyle(chart);
 	m_view->setChart(chart);  // QChartView takes ownership
-	// The train panel replaces the built-in legend, which collapses to "..."
+	// The train dropdown replaces the built-in legend, which collapses to "..."
 	// once many trains are present.
 	if (chart && chart->legend())
 		chart->legend()->hide();
-	rebuildFilterPanel();
+	rebuildFilterGroups();
+	if (m_timeAxis)
+		applyTimeAxis();
 }
 
 void DiagramWindow::setTimeAxisX(bool on, long long startOffsetSeconds) {
 	m_timeAxis = on;
 	m_startOffset = startOffsetSeconds;
+	if (m_timeAxis)
+		applyTimeAxis();
 }
 
 void DiagramWindow::setCsvProvider(std::function<std::string(const QStringList&)> provider,
@@ -137,6 +126,88 @@ void DiagramWindow::setCsvProvider(std::function<std::string(const QStringList&)
 	m_csvSuggestedName = suggestedFileName;
 	if (m_csvButton)
 		m_csvButton->setEnabled(static_cast<bool>(m_csvProvider));
+}
+
+// Shared look for every diagram: quiet grid, readable title, line weight that
+// survives PNG export.
+void DiagramWindow::applyChartStyle(QChart* chart) {
+	chart->setBackgroundRoundness(0);
+	chart->setBackgroundBrush(palette().brush(QPalette::Base));
+	chart->setMargins(QMargins(12, 8, 12, 8));
+
+	QFont titleFont = chart->titleFont();
+	titleFont.setPointSizeF(titleFont.pointSizeF() + 2.0);
+	titleFont.setBold(true);
+	chart->setTitleFont(titleFont);
+	chart->setTitleBrush(palette().brush(QPalette::WindowText));
+
+	const QPen gridPen(QColor(0, 0, 0, 30));
+	const QBrush labelBrush = palette().brush(QPalette::WindowText);
+	const auto axes = chart->axes();
+	for (QAbstractAxis* axis : axes) {
+		axis->setGridLinePen(gridPen);
+		axis->setLabelsBrush(labelBrush);
+		axis->setTitleBrush(labelBrush);
+		axis->setLinePen(QPen(QColor(0, 0, 0, 90)));
+	}
+
+	const auto seriesList = chart->series();
+	for (QAbstractSeries* series : seriesList) {
+		if (auto* xy = qobject_cast<QXYSeries*>(series)) {
+			QPen pen = xy->pen();
+			if (pen.widthF() < 2.0) {
+				pen.setWidthF(2.0);
+				xy->setPen(pen);
+			}
+		}
+	}
+}
+
+// Swap the raw-seconds X axis for one labelled HH:MM:SS at round intervals.
+void DiagramWindow::applyTimeAxis() {
+	QChart* chart = m_view ? m_view->chart() : nullptr;
+	if (!chart || m_timeAxisApplied)
+		return;
+	const auto horizontal = chart->axes(Qt::Horizontal);
+	if (horizontal.isEmpty())
+		return;
+	auto* seconds = qobject_cast<QValueAxis*>(horizontal.first());
+	if (!seconds)
+		return;
+	const double min = seconds->min();
+	const double max = seconds->max();
+	const double span = max - min;
+	if (!(span > 0.0))
+		return;
+
+	// Aim for four to eight round-interval labels.
+	const double candidates[] = {30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 14400, 21600, 43200};
+	double step = candidates[sizeof(candidates) / sizeof(candidates[0]) - 1];
+	for (double candidate : candidates) {
+		if (span / candidate <= 8.0) {
+			step = candidate;
+			break;
+		}
+	}
+
+	auto* clock = new QCategoryAxis(chart);
+	clock->setLabelsPosition(QCategoryAxis::AxisLabelsPositionOnValue);
+	clock->setMin(min);
+	clock->setMax(max);
+	clock->setTitleText("Time");
+	clock->setGridLinePen(QPen(QColor(0, 0, 0, 30)));
+	clock->setLabelsBrush(palette().brush(QPalette::WindowText));
+	clock->setTitleBrush(palette().brush(QPalette::WindowText));
+	for (double tick = std::ceil(min / step) * step; tick <= max + 1e-9; tick += step)
+		clock->append(QString::fromStdString(formatSimTime(static_cast<long long>(tick), m_startOffset)), tick);
+
+	const auto seriesList = chart->series();
+	chart->removeAxis(seconds);
+	seconds->deleteLater();
+	chart->addAxis(clock, Qt::AlignBottom);
+	for (QAbstractSeries* series : seriesList)
+		series->attachAxis(clock);
+	m_timeAxisApplied = true;
 }
 
 QString DiagramWindow::groupIdForSeries(QAbstractSeries* series) const {
@@ -148,17 +219,19 @@ QString DiagramWindow::groupIdForSeries(QAbstractSeries* series) const {
 	return series->name();
 }
 
-void DiagramWindow::rebuildFilterPanel() {
+void DiagramWindow::rebuildFilterGroups() {
 	m_groups.clear();
 	m_basePens.clear();
-	if (m_groupList)
-		m_groupList->clear();
 	QChart* chart = m_view ? m_view->chart() : nullptr;
-	if (!chart)
+	if (!chart) {
+		if (m_trainsButton)
+			m_trainsButton->setTrains({});
 		return;
+	}
 
 	QHash<QString, int> indexByTrain;
-	for (QAbstractSeries* series : chart->series()) {
+	const auto seriesList = chart->series();
+	for (QAbstractSeries* series : seriesList) {
 		if (auto* xy = qobject_cast<QXYSeries*>(series))
 			m_basePens.insert(series, xy->pen());
 
@@ -187,63 +260,30 @@ void DiagramWindow::rebuildFilterPanel() {
 		}
 	}
 
-	if (!m_groupList)
+	if (!m_trainsButton)
 		return;
-	for (int i = 0; i < m_groups.size(); ++i) {
-		SeriesGroup& group = m_groups[i];
-		auto* item = new QListWidgetItem(group.trainId, m_groupList);
-		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
-		item->setCheckState(Qt::Checked);
-		item->setData(Qt::UserRole, group.trainId);
-		// Show the train's line colour as a swatch so the panel reads as a legend.
-		if (!group.members.isEmpty()) {
-			if (auto* xy = qobject_cast<QXYSeries*>(group.members.first())) {
-				QPixmap swatch(12, 12);
-				swatch.fill(xy->pen().color());
-				item->setIcon(QIcon(swatch));
-			}
-		}
-		group.item = item;
-	}
-}
-
-void DiagramWindow::onGroupItemChanged(QListWidgetItem* item) {
-	if (!item)
-		return;
-	setGroupChecked(item->data(Qt::UserRole).toString(), item->checkState() == Qt::Checked);
-}
-
-void DiagramWindow::setGroupChecked(const QString& trainId, bool checked) {
+	QVector<QPair<QString, QColor>> trains;
+	trains.reserve(m_groups.size());
 	for (const SeriesGroup& group : m_groups) {
-		if (group.trainId != trainId)
-			continue;
+		QColor swatch;
+		if (!group.members.isEmpty()) {
+			if (auto* xy = qobject_cast<QXYSeries*>(group.members.first()))
+				swatch = xy->pen().color();
+		}
+		trains.append({group.trainId, swatch});
+	}
+	m_trainsButton->setTrains(trains);
+}
+
+void DiagramWindow::applyTrainVisibility() {
+	if (!m_trainsButton)
+		return;
+	for (const SeriesGroup& group : m_groups) {
+		const bool visible = m_trainsButton->isTrainVisible(group.trainId);
 		for (QAbstractSeries* series : group.members)
-			series->setVisible(checked);
+			series->setVisible(visible);
 	}
 	refreshEmphasis();
-}
-
-void DiagramWindow::applyGroupFilter() {
-	const QString needle = m_search ? m_search->text().trimmed() : QString();
-	for (const SeriesGroup& group : m_groups) {
-		if (!group.item)
-			continue;
-		const bool match = needle.isEmpty() ||
-			group.trainId.contains(needle, Qt::CaseInsensitive);
-		group.item->setHidden(!match);
-	}
-}
-
-void DiagramWindow::selectAllGroups() {
-	for (const SeriesGroup& group : m_groups)
-		if (group.item && !group.item->isHidden())
-			group.item->setCheckState(Qt::Checked);
-}
-
-void DiagramWindow::selectNoGroups() {
-	for (const SeriesGroup& group : m_groups)
-		if (group.item && !group.item->isHidden())
-			group.item->setCheckState(Qt::Unchecked);
 }
 
 void DiagramWindow::pinTrain(const QString& trainId) {
@@ -281,12 +321,14 @@ void DiagramWindow::refreshEmphasis() {
 }
 
 QStringList DiagramWindow::visibleTrainIds() const {
-	QStringList ids;
-	for (const SeriesGroup& group : m_groups) {
-		if (group.item && group.item->checkState() == Qt::Checked)
-			ids.append(group.trainId);
-	}
-	return ids;
+	if (m_trainsButton)
+		return m_trainsButton->visibleTrainIds();
+	return QStringList();
+}
+
+void DiagramWindow::resetZoom() {
+	if (m_view && m_view->chart())
+		m_view->chart()->zoomReset();
 }
 
 void DiagramWindow::exportPng() {

--- a/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.h
@@ -17,13 +17,12 @@
 QT_CHARTS_USE_NAMESPACE
 
 class QLabel;
-class QLineEdit;
-class QListWidget;
-class QListWidgetItem;
 class QPushButton;
+class TrainFilterButton;
 
-// Reusable non-modal window that shows a chart with a train filter panel,
-// hover and click identification, PNG export, and optional CSV export.
+// Reusable non-modal window that shows a chart with a train visibility
+// dropdown, hover and click identification, rubber-band zoom with reset,
+// PNG export, and optional CSV export.
 //
 // Series are grouped by the dynamic property "trainId" when the caller sets it
 // (the same train can own several series, such as planned and simulated lines);
@@ -33,7 +32,7 @@ class DiagramWindow : public QDialog {
 public:
 	explicit DiagramWindow(const QString& title, QWidget* parent = nullptr);
 	void setChart(QChart* chart);                                  // takes ownership
-	void setTimeAxisX(bool on, long long startOffsetSeconds = 0);  // format X hover as HH:MM:SS
+	void setTimeAxisX(bool on, long long startOffsetSeconds = 0);  // label X axis and hover as HH:MM:SS
 
 	// Supply raw source data for CSV export. The provider receives the ids of the
 	// trains currently visible so it can export only what the user is looking at.
@@ -50,21 +49,19 @@ protected:
 private slots:
 	void exportPng();
 	void exportCsv();
-	void applyGroupFilter();       // apply the search box to the visible group list
-	void selectAllGroups();
-	void selectNoGroups();
+	void resetZoom();
+	void applyTrainVisibility();
 	void clearPin();
 
 private:
 	struct SeriesGroup {
 		QString trainId;
 		QVector<QAbstractSeries*> members;
-		QListWidgetItem* item = nullptr;
 	};
 
-	void rebuildFilterPanel();
-	void setGroupChecked(const QString& trainId, bool checked);
-	void onGroupItemChanged(QListWidgetItem* item);
+	void applyChartStyle(QChart* chart);
+	void applyTimeAxis();
+	void rebuildFilterGroups();
 	void pinTrain(const QString& trainId);
 	void refreshEmphasis();
 	QStringList visibleTrainIds() const;
@@ -73,10 +70,10 @@ private:
 	QPointer<QChartView> m_view;
 	QPointer<QLabel> m_readout;
 	QPointer<QLabel> m_pinLabel;
-	QPointer<QLineEdit> m_search;
-	QPointer<QListWidget> m_groupList;
+	QPointer<TrainFilterButton> m_trainsButton;
 	QPointer<QPushButton> m_csvButton;
 	bool m_timeAxis = false;
+	bool m_timeAxisApplied = false;
 	long long m_startOffset = 0;
 	QVector<SeriesGroup> m_groups;
 	QHash<QAbstractSeries*, QPen> m_basePens;

--- a/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp
@@ -1,0 +1,220 @@
+#include "diagrams/TimetableTableWindow.h"
+#include "diagrams/TrainFilterButton.h"
+#include "util/TimeFormat.h"
+
+#include <QBrush>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QPixmap>
+#include <QPushButton>
+#include <QSaveFile>
+#include <QSet>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QVBoxLayout>
+
+#include <limits>
+
+namespace {
+
+constexpr int kSortRole = Qt::UserRole + 1;
+
+// Table item that sorts by a numeric key instead of its display text, so time
+// and delay columns order correctly.
+class SortableItem : public QTableWidgetItem {
+public:
+	using QTableWidgetItem::QTableWidgetItem;
+	bool operator<(const QTableWidgetItem& other) const override {
+		return data(kSortRole).toDouble() < other.data(kSortRole).toDouble();
+	}
+};
+
+// Missing values sort behind every real value.
+SortableItem* makeItem(const QString& text, bool available, double sortKey) {
+	auto* item = new SortableItem(text);
+	item->setData(kSortRole, available ? sortKey : std::numeric_limits<double>::max());
+	item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+	return item;
+}
+
+} // namespace
+
+TimetableTableWindow::TimetableTableWindow(std::vector<TimetableResultRow> rows,
+										   long long startOffsetSeconds,
+										   std::function<std::string(const QStringList&)> csvProvider,
+										   QWidget* parent)
+	: QDialog(parent),
+	  m_rows(std::move(rows)),
+	  m_startOffset(startOffsetSeconds),
+	  m_csvProvider(std::move(csvProvider)) {
+	setModal(false);
+	setWindowTitle("Timetable: planned vs simulated");
+	resize(1080, 640);
+
+	m_trainsButton = new TrainFilterButton(this);
+	connect(m_trainsButton, &TrainFilterButton::selectionChanged,
+			this, &TimetableTableWindow::applyTrainVisibility);
+
+	QPushButton* csvButton = new QPushButton("Export CSV...", this);
+	csvButton->setToolTip("Write the rows of the visible trains to a CSV file");
+	csvButton->setEnabled(static_cast<bool>(m_csvProvider));
+	connect(csvButton, &QPushButton::clicked, this, &TimetableTableWindow::exportCsv);
+
+	QPushButton* pngButton = new QPushButton("Export PNG...", this);
+	pngButton->setToolTip("Save the table as an image");
+	connect(pngButton, &QPushButton::clicked, this, &TimetableTableWindow::exportPng);
+
+	QHBoxLayout* topBar = new QHBoxLayout();
+	topBar->addWidget(m_trainsButton);
+	topBar->addStretch();
+	topBar->addWidget(csvButton);
+	topBar->addWidget(pngButton);
+
+	m_table = new QTableWidget(this);
+	m_table->setColumnCount(8);
+	m_table->setHorizontalHeaderLabels({
+		"Train", "Station call", "Planned arrival", "Planned departure",
+		"Simulated arrival", "Simulated departure", "Arrival delay", "Departure delay"});
+	m_table->setAlternatingRowColors(true);
+	m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+	m_table->verticalHeader()->setVisible(false);
+
+	QVBoxLayout* layout = new QVBoxLayout(this);
+	layout->addLayout(topBar);
+	layout->addWidget(m_table, 1);
+
+	QStringList trainOrder;
+	QSet<QString> seen;
+	for (const TimetableResultRow& row : m_rows) {
+		const QString id = QString::fromStdString(row.trainId);
+		if (!seen.contains(id)) {
+			seen.insert(id);
+			trainOrder.append(id);
+		}
+	}
+	QVector<QPair<QString, QColor>> trains;
+	for (const QString& id : trainOrder)
+		trains.append({id, QColor()});
+	m_trainsButton->setTrains(trains);
+
+	fillTable();
+}
+
+void TimetableTableWindow::fillTable() {
+	const auto timeText = [this](const RunResultValue& value) {
+		return value.available
+			? QString::fromStdString(formatSimTime(static_cast<long long>(value.value), m_startOffset))
+			: QStringLiteral("-");
+	};
+	const auto delayText = [](const RunResultValue& value) {
+		if (!value.available)
+			return QStringLiteral("-");
+		return QString("%1%2 s")
+			.arg(value.value >= 0.0 ? "+" : "")
+			.arg(value.value, 0, 'f', 0);
+	};
+	const auto setDelayColor = [](QTableWidgetItem* item, const RunResultValue& value) {
+		if (!value.available)
+			return;
+		if (value.value > 60.0)
+			item->setForeground(QBrush(Qt::red));
+		else if (value.value > 0.0)
+			item->setForeground(QBrush(Qt::darkYellow));
+		else
+			item->setForeground(QBrush(Qt::darkGreen));
+	};
+
+	m_table->setSortingEnabled(false);
+	m_table->setRowCount(static_cast<int>(m_rows.size()));
+	for (int row = 0; row < static_cast<int>(m_rows.size()); ++row) {
+		const TimetableResultRow& result = m_rows[static_cast<std::size_t>(row)];
+		const QString trainId = QString::fromStdString(result.trainId);
+		auto* trainItem = makeItem(trainId, true, 0.0);
+		trainItem->setData(Qt::UserRole, trainId);
+		m_table->setItem(row, 0, trainItem);
+		m_table->setItem(row, 1, makeItem(
+			QString("%1 (visit %2)").arg(QString::fromStdString(result.stationId)).arg(result.callIndex),
+			true, static_cast<double>(result.journeyIndex)));
+		m_table->setItem(row, 2, makeItem(timeText(result.plannedArrivalSeconds),
+			result.plannedArrivalSeconds.available, result.plannedArrivalSeconds.value));
+		m_table->setItem(row, 3, makeItem(timeText(result.plannedDepartureSeconds),
+			result.plannedDepartureSeconds.available, result.plannedDepartureSeconds.value));
+		m_table->setItem(row, 4, makeItem(timeText(result.simulatedArrivalSeconds),
+			result.simulatedArrivalSeconds.available, result.simulatedArrivalSeconds.value));
+		m_table->setItem(row, 5, makeItem(timeText(result.simulatedDepartureSeconds),
+			result.simulatedDepartureSeconds.available, result.simulatedDepartureSeconds.value));
+		auto* arrivalDelayItem = makeItem(delayText(result.arrivalDelaySeconds),
+			result.arrivalDelaySeconds.available, result.arrivalDelaySeconds.value);
+		auto* departureDelayItem = makeItem(delayText(result.departureDelaySeconds),
+			result.departureDelaySeconds.available, result.departureDelaySeconds.value);
+		setDelayColor(arrivalDelayItem, result.arrivalDelaySeconds);
+		setDelayColor(departureDelayItem, result.departureDelaySeconds);
+		m_table->setItem(row, 6, arrivalDelayItem);
+		m_table->setItem(row, 7, departureDelayItem);
+	}
+	m_table->resizeColumnsToContents();
+	// Content sizing can undercut the header text; keep every title readable.
+	const QFontMetrics metrics(m_table->horizontalHeader()->font());
+	for (int col = 0; col < m_table->columnCount(); ++col) {
+		const int headerWidth = metrics.horizontalAdvance(m_table->horizontalHeaderItem(col)->text()) + 28;
+		if (m_table->columnWidth(col) < headerWidth)
+			m_table->setColumnWidth(col, headerWidth);
+	}
+	m_table->setSortingEnabled(true);
+	applyTrainVisibility();
+}
+
+void TimetableTableWindow::applyTrainVisibility() {
+	if (!m_table || !m_trainsButton)
+		return;
+	for (int row = 0; row < m_table->rowCount(); ++row) {
+		QTableWidgetItem* trainItem = m_table->item(row, 0);
+		if (!trainItem)
+			continue;
+		const QString trainId = trainItem->data(Qt::UserRole).toString();
+		m_table->setRowHidden(row, !m_trainsButton->isTrainVisible(trainId));
+	}
+}
+
+void TimetableTableWindow::exportCsv() {
+	if (!m_csvProvider)
+		return;
+	const std::string content = m_csvProvider(m_trainsButton->visibleTrainIds());
+	if (content.empty()) {
+		QMessageBox::information(this, "Nothing to export",
+								 "There is no data to export for the visible trains.");
+		return;
+	}
+	QString path = QFileDialog::getSaveFileName(this, "Export Data", "timetable.csv", "CSV File (*.csv)");
+	if (path.isEmpty())
+		return;
+	if (QFileInfo(path).suffix().compare("csv", Qt::CaseInsensitive) != 0)
+		path += ".csv";
+	QSaveFile file(path);
+	if (!file.open(QIODevice::WriteOnly)) {
+		QMessageBox::warning(this, "Export failed",
+							 QString("Could not open the file for writing:\n%1").arg(path));
+		return;
+	}
+	const QByteArray bytes = QByteArray::fromStdString(content);
+	if (file.write(bytes) != bytes.size() || !file.commit()) {
+		QMessageBox::warning(this, "Export failed",
+							 QString("Could not write the data to:\n%1").arg(path));
+	}
+}
+
+void TimetableTableWindow::exportPng() {
+	QString path = QFileDialog::getSaveFileName(this, "Export Table", "timetable.png", "PNG Image (*.png)");
+	if (path.isEmpty())
+		return;
+	if (QFileInfo(path).suffix().compare("png", Qt::CaseInsensitive) != 0)
+		path += ".png";
+	QPixmap pix = m_table->grab();
+	if (!pix.save(path, "PNG")) {
+		QMessageBox::warning(this, "Export failed",
+							 QString("Could not write the image to:\n%1").arg(path));
+	}
+}

--- a/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.h
@@ -1,0 +1,41 @@
+#ifndef TIMETABLETABLEWINDOW_H
+#define TIMETABLETABLEWINDOW_H
+
+#include "diagrams/RunResults.h"
+
+#include <QDialog>
+#include <QPointer>
+#include <QStringList>
+
+#include <functional>
+#include <vector>
+
+class QTableWidget;
+class TrainFilterButton;
+
+// Planned versus simulated timetable as a filterable, sortable table with the
+// same train dropdown and export pair the chart windows use.
+class TimetableTableWindow : public QDialog {
+	Q_OBJECT
+public:
+	TimetableTableWindow(std::vector<TimetableResultRow> rows,
+						 long long startOffsetSeconds,
+						 std::function<std::string(const QStringList&)> csvProvider,
+						 QWidget* parent = nullptr);
+
+private slots:
+	void applyTrainVisibility();
+	void exportCsv();
+	void exportPng();
+
+private:
+	void fillTable();
+
+	std::vector<TimetableResultRow> m_rows;
+	long long m_startOffset = 0;
+	std::function<std::string(const QStringList&)> m_csvProvider;
+	QPointer<QTableWidget> m_table;
+	QPointer<TrainFilterButton> m_trainsButton;
+};
+
+#endif // TIMETABLETABLEWINDOW_H

--- a/EGTRAIN/QEGTRAIN/diagrams/TrainFilterButton.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/TrainFilterButton.cpp
@@ -1,0 +1,125 @@
+#include "diagrams/TrainFilterButton.h"
+
+#include <QAbstractItemView>
+#include <QHBoxLayout>
+#include <QIcon>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QMenu>
+#include <QPixmap>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QWidgetAction>
+
+TrainFilterButton::TrainFilterButton(QWidget* parent)
+	: QToolButton(parent) {
+	setPopupMode(QToolButton::InstantPopup);
+	setToolButtonStyle(Qt::ToolButtonTextOnly);
+	setToolTip("Choose which trains are visible");
+
+	auto* menu = new QMenu(this);
+	auto* panel = new QWidget(menu);
+	auto* layout = new QVBoxLayout(panel);
+	layout->setContentsMargins(8, 8, 8, 8);
+
+	m_search = new QLineEdit(panel);
+	m_search->setPlaceholderText("Search trains...");
+	m_search->setClearButtonEnabled(true);
+	connect(m_search, &QLineEdit::textChanged, this, &TrainFilterButton::applySearchFilter);
+	layout->addWidget(m_search);
+
+	auto* allButton = new QPushButton("All", panel);
+	auto* noneButton = new QPushButton("None", panel);
+	connect(allButton, &QPushButton::clicked, this, [this]() { checkAllVisible(true); });
+	connect(noneButton, &QPushButton::clicked, this, [this]() { checkAllVisible(false); });
+	auto* quickRow = new QHBoxLayout();
+	quickRow->addWidget(allButton);
+	quickRow->addWidget(noneButton);
+	layout->addLayout(quickRow);
+
+	m_list = new QListWidget(panel);
+	m_list->setSelectionMode(QAbstractItemView::NoSelection);
+	m_list->setMinimumSize(240, 320);
+	connect(m_list, &QListWidget::itemChanged, this, [this](QListWidgetItem*) {
+		if (m_updating)
+			return;
+		updateCaption();
+		emit selectionChanged();
+	});
+	layout->addWidget(m_list, 1);
+
+	auto* action = new QWidgetAction(menu);
+	action->setDefaultWidget(panel);
+	menu->addAction(action);
+	setMenu(menu);
+	updateCaption();
+}
+
+void TrainFilterButton::setTrains(const QVector<QPair<QString, QColor>>& trains) {
+	m_updating = true;
+	m_list->clear();
+	for (const auto& train : trains) {
+		auto* item = new QListWidgetItem(train.first, m_list);
+		item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+		item->setCheckState(Qt::Checked);
+		item->setData(Qt::UserRole, train.first);
+		if (train.second.isValid()) {
+			QPixmap swatch(12, 12);
+			swatch.fill(train.second);
+			item->setIcon(QIcon(swatch));
+		}
+	}
+	m_updating = false;
+	updateCaption();
+}
+
+QStringList TrainFilterButton::visibleTrainIds() const {
+	QStringList ids;
+	for (int i = 0; i < m_list->count(); ++i) {
+		QListWidgetItem* item = m_list->item(i);
+		if (item->checkState() == Qt::Checked)
+			ids.append(item->data(Qt::UserRole).toString());
+	}
+	return ids;
+}
+
+bool TrainFilterButton::isTrainVisible(const QString& trainId) const {
+	for (int i = 0; i < m_list->count(); ++i) {
+		QListWidgetItem* item = m_list->item(i);
+		if (item->data(Qt::UserRole).toString() == trainId)
+			return item->checkState() == Qt::Checked;
+	}
+	return true;
+}
+
+void TrainFilterButton::applySearchFilter() {
+	const QString needle = m_search->text().trimmed();
+	for (int i = 0; i < m_list->count(); ++i) {
+		QListWidgetItem* item = m_list->item(i);
+		item->setHidden(!needle.isEmpty()
+						&& !item->text().contains(needle, Qt::CaseInsensitive));
+	}
+}
+
+// All/None act on the rows the search currently shows, so a filtered "None"
+// hides one service group without touching the rest.
+void TrainFilterButton::checkAllVisible(bool checked) {
+	m_updating = true;
+	for (int i = 0; i < m_list->count(); ++i) {
+		QListWidgetItem* item = m_list->item(i);
+		if (!item->isHidden())
+			item->setCheckState(checked ? Qt::Checked : Qt::Unchecked);
+	}
+	m_updating = false;
+	updateCaption();
+	emit selectionChanged();
+}
+
+void TrainFilterButton::updateCaption() {
+	const int total = m_list ? m_list->count() : 0;
+	if (total == 0) {
+		setText("Trains");
+		return;
+	}
+	setText(QString("Trains (%1/%2)").arg(visibleTrainIds().size()).arg(total));
+}

--- a/EGTRAIN/QEGTRAIN/diagrams/TrainFilterButton.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/TrainFilterButton.h
@@ -1,0 +1,45 @@
+#ifndef TRAINFILTERBUTTON_H
+#define TRAINFILTERBUTTON_H
+
+#include <QColor>
+#include <QPair>
+#include <QPointer>
+#include <QStringList>
+#include <QToolButton>
+#include <QVector>
+
+class QLineEdit;
+class QListWidget;
+class QListWidgetItem;
+
+// Toolbar dropdown that lists every train with a checkbox, a search box, and
+// All/None shortcuts. The button caption shows how many trains are visible.
+// Emits selectionChanged() whenever any visibility flips.
+class TrainFilterButton : public QToolButton {
+	Q_OBJECT
+public:
+	explicit TrainFilterButton(QWidget* parent = nullptr);
+
+	// Replaces the listed trains. The colour paints the legend swatch next to
+	// each entry; pass an invalid colour for rows without one.
+	void setTrains(const QVector<QPair<QString, QColor>>& trains);
+
+	QStringList visibleTrainIds() const;
+	bool isTrainVisible(const QString& trainId) const;
+
+signals:
+	void selectionChanged();
+
+private slots:
+	void applySearchFilter();
+	void checkAllVisible(bool checked);
+
+private:
+	void updateCaption();
+
+	QPointer<QLineEdit> m_search;
+	QPointer<QListWidget> m_list;
+	bool m_updating = false;
+};
+
+#endif // TRAINFILTERBUTTON_H

--- a/tools/e2e/visual_polish_smoke.sh
+++ b/tools/e2e/visual_polish_smoke.sh
@@ -30,8 +30,8 @@ test -s "$DENSE_SHOT"
 test -s "$FOLLOW_SHOT"
 test -s "$CONTEXT_SHOT"
 for label in "Planned arrival" "Planned departure" "Simulated arrival" "Simulated departure" "Arrival delay" "Departure delay"; do
-	if ! grep -Fqi "$label" "$ROOT/EGTRAIN/QEGTRAIN/app/MainWindow.cpp"; then
-		echo "missing timetable label in MainWindow.cpp: $label" >&2
+	if ! grep -Fqi "$label" "$ROOT/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp"; then
+		echo "missing timetable label in TimetableTableWindow.cpp: $label" >&2
 		exit 1
 	fi
 done


### PR DESCRIPTION
## Summary

- Adds TrainFilterButton, a toolbar dropdown listing every train with a checkbox, search, and All/None shortcuts. The caption shows how many trains are visible.
- DiagramWindow now uses that dropdown instead of a fixed side panel, moves Export CSV and Export PNG into the toolbar, adds Reset zoom, applies a shared chart style (bold title, quiet grid, two point lines), and replaces the raw-seconds X axis with HH:MM:SS labels at round intervals.
- The per-train speed and distance diagrams gain axis titles; the train path window drops its bespoke title font and jargon title.
- The planned versus simulated timetable moves into TimetableTableWindow: same dropdown and export pair, sortable columns, a dash for missing values instead of the word Unavailable, header-safe column widths.
- The Run Results dock shows clock times, travel durations, and one-decimal energy, gains an Export PNG button, and marks missing values with a dash.

## Verification

- cmake build clean; ctest 36/36 passed.
- visual_polish, scene_render, editor, and csv_export smokes all pass (the visual polish label check now points at TimetableTableWindow.cpp).
- Manual GUI run: after a completed run the train graph opens with the dropdown, HH:MM:SS axis, and both exports; the timetable table shows dashes and colored delays and filters rows by train.

Closes #205.