### PR TITLE
Clamp served-station counts to the timetable array capacity

### DIFF
--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
@@ -490,6 +490,14 @@ void loadAllOrderListsUpgraded(char* FolderName) {
 }
 
 // Fuction to load data of a train Type. Train Type involve the same category (Intercity, Regional), the same Route, and the same stops on that Route
+int Train::clampStationCount(int requested, const string& trainId) {
+	if (requested <= kMaxTimetableStations)
+		return requested;
+	std::cerr << "Train " << trainId << " serves " << requested << " stations but the timetable arrays hold "
+			  << kMaxTimetableStations << "; dropping the last " << requested - kMaxTimetableStations << " stops\n";
+	return kMaxTimetableStations;
+}
+
 void loadTrainType(char* Train_File, int& numRegions) {
 	int N_Reg_Previous = numRegions; // Number of trains before that this category was added
 	int N_Train_Type = 0;		// Number of Trains of this Type
@@ -674,7 +682,8 @@ void loadTrainType(char* Train_File, int& numRegions) {
 		}
 
 		// Setting Stations and Dwell Times
-		regional_train[i + N_Reg_Previous].numStations = NumbStat;
+		regional_train[i + N_Reg_Previous].numStations =
+			Train::clampStationCount(NumbStat, regional_train[i + N_Reg_Previous].trainDescription);
 		regional_train[i + N_Reg_Previous].Stations = new Node[regional_train[i + N_Reg_Previous].numStations];
 
 		for (int s = 0; s < regional_train[i + N_Reg_Previous].numStations; s++) {
@@ -1658,11 +1667,11 @@ void Train::implementDisp(DispatchDecision decision) {
 			// add to vector
 			stationsVec.push_back(stop);
 
-			// save scheduled arr times
-			ScheduledArrivals[noStations] = arrTime; // noStations can be used as index
-
-			// save scheduled dep times
-			ScheduledDepartures[noStations] = depTime; // noStations can be used as index
+			// save scheduled arr and dep times; stops past the cap have no slot
+			if (noStations < kMaxTimetableStations) {
+				ScheduledArrivals[noStations] = arrTime;
+				ScheduledDepartures[noStations] = depTime;
+			}
 
 			// increase index/counter
 			noStations++;
@@ -1695,7 +1704,7 @@ void Train::implementDisp(DispatchDecision decision) {
 	}
 
 	// change stations
-	numStations = noStations;
+	numStations = clampStationCount(noStations, trainDescription);
 	Stations = stations;
 
 	// route does not change

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -634,6 +634,7 @@ public:
 	Node* Stations = nullptr;
 	int numStations;					   // Station is a dynamic array contating all Station Node for the train and int numStations is the Number of Stations (i.e. the dimension of Stations Array)
 	static constexpr int kMaxTimetableStations = 40; // Capacity of the station-indexed arrays below; stations beyond this cap have no timetable slot
+	static int clampStationCount(int requested, const string& trainId); // Clamps a served-station count to kMaxTimetableStations, warning once per train
 	int stationBlockSection[kMaxTimetableStations];		// Cached block section index for each station (avoids full-route scan every timestep)
 	int stationArc[kMaxTimetableStations];				   // Cached Arc index within block section for each station
 	bool ServiceStopBehindATrain = false; // This variable is true only if the train is stopping at a station behind another train. We admit that in moving block operations maximum two trains can perform a service stop queueing one after each other at the same platform

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -202,6 +202,16 @@ int main() {
 					 "over-cap train yields exactly kMaxTimetableStations rows");
 	}
 
+	ok &= expect(Train::clampStationCount(Train::kMaxTimetableStations - 6, "under") ==
+					 Train::kMaxTimetableStations - 6,
+				 "clampStationCount keeps under-cap counts");
+	ok &= expect(Train::clampStationCount(Train::kMaxTimetableStations, "at") ==
+					 Train::kMaxTimetableStations,
+				 "clampStationCount keeps at-cap counts");
+	ok &= expect(Train::clampStationCount(Train::kMaxTimetableStations + 5, "over") ==
+					 Train::kMaxTimetableStations,
+				 "clampStationCount truncates over-cap counts");
+
 	auto delayed = makeTrain("delayed", 3, 7, 10.0, 20.0, 30.0, 40.0);
 	const std::vector<const Train*> delayedTrains{delayed.get()};
 	const auto delayedResults = buildRunResults(delayedTrains, 0.5);


### PR DESCRIPTION
## Summary

- Train::clampStationCount checks a served-station count against kMaxTimetableStations, warns with the train id and the number of dropped stops, and returns the clamped count.
- The legacy train-type loader clamps numStations before filling the station arrays. The rescheduling timetable reload clamps at assignment and no longer writes ScheduledArrivals and ScheduledDepartures past the cap while counting file lines.
- The station stat writers (cacheStationPositions and the arrival and delay loops) now always see numStations at or below the cap, so scenario data cannot overrun the 40-slot arrays. #172 covered the read side; this covers the writes.

## Verification

- cmake build clean; ctest 36/36 passed, including new clampStationCount checks in test_runresults.
- headless_smoke.py and roundtrip_smoke.py pass.

Fixes #196.