### PR TITLE
Make signal_failure incidents brake trains in the default simulation

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -967,6 +967,10 @@ else regional_train[0].max_train_speed = 33.61;*/
 
 		Occupy_Block_Sections_Of_Route(t); // Fill in the lists Blocks_Occupied and BlocksConnected
 
+		// Occupy failed sections and give them an End of Authority so both
+		// aspect-driven and moving-block trains react to the incident
+		Apply_Signal_Failures_Mixed_Signalling(t);
+
 		// Only for level>=3
 		// ReportAllTrainPositionsToRBC(t, 50);    //Reporting the positions of the trains to the RBC considering a safety Margin of 50 metres
 
@@ -1206,6 +1210,10 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 		ETCS_MA.clear(); // Clear the list containing all the Movement Authorities given to the trains at the previous instant
 
 		Occupy_Block_Sections_Of_Route(t); // Fill in the lists Blocks_Occupied and BlocksConnected
+
+		// Occupy failed sections and give them an End of Authority so both
+		// aspect-driven and moving-block trains react to the incident
+		Apply_Signal_Failures_Mixed_Signalling(t);
 
 		// Only for level>=3
 		// ReportAllTrainPositionsToRBC(t, 50);    //Reporting the positions of the trains to the RBC considering a safety Margin of 50 metres

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -2150,7 +2150,15 @@ public:
 
 		// Identification of the closest EoA where the train needs to brake at (i.e. the EoA for which the train needs to brake the earliest to meet it)
 		for (int z = 0; z <= Cons_Block; z++) {
-			if ((BS[z + BlockPos].SignallingLevel == 3) || (BS[z + BlockPos].SignallingLevel == 4)) {
+			// A SignalFailure EoA applies at every signalling level, so scan the MA list on any section carrying one
+			bool hasSignalFailureMa = false;
+			for (list<MovementAuthority>::iterator it = ETCS_MA.begin(); it != ETCS_MA.end(); it++) {
+				if ((it->type == "SignalFailure") && (it->BSID == BS[z + BlockPos].ID)) {
+					hasSignalFailureMa = true;
+					break;
+				}
+			}
+			if ((BS[z + BlockPos].SignallingLevel == 3) || (BS[z + BlockPos].SignallingLevel == 4) || hasSignalFailureMa) {
 				// Identifying Braking Points computed by the EVC if the train is virtually coupled to a train ahead
 				if (IsTrainInFollowingMode == 1) { // if the train is in following mode
 					if ((Predicted_MA_To_DecoupleAt.TrainInfo.trainDescription != "None") && (Predicted_MA_To_DecoupleAt.TrainInfo.trainDescription == LeadingTrainInFollowingMode)) {
@@ -2179,7 +2187,10 @@ public:
 								ETCSBrakingPoint.X = it->AbsPosEoA;
 							}
 
-							if (BS[z + BlockPos].SignallingLevel == 3) {
+							if (it->type == "SignalFailure") {
+								// a failed signal is a stop target at every signalling level
+								SpeedForEoA = 0;
+							} else if (BS[z + BlockPos].SignallingLevel == 3) {
 								SpeedForEoA = 0;
 
 							} else if (BS[z + BlockPos].SignallingLevel == 4) {

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -5983,3 +5983,70 @@ bool Incident_Holds_Train(const std::string& trainDesc, int timestepIndex) {
 	}
 	return false;
 }
+
+// Apply active signal_failure incidents to the mixed signalling state. The
+// failed sections join BlocksOccupied so aspect-driven levels turn red, and
+// each one gets an End-of-Authority at its entry so moving-block trains brake
+// for it; occupancy alone never reaches the EVC of ETCS level 3 and 4 trains.
+void Apply_Signal_Failures_Mixed_Signalling(int timestepIndex) {
+	for (const auto& inc : simulationIncidents) {
+		if (inc.type != "signal_failure" || timestepIndex < inc.startSeconds || timestepIndex > inc.endSeconds)
+			continue;
+		for (const auto& secID : inc.resolvedSectionIDs) {
+			bool occupied = false;
+			for (const auto& occ : BlocksOccupied) {
+				if (occ == secID) {
+					occupied = true;
+					break;
+				}
+			}
+			if (!occupied)
+				BlocksOccupied.push_back(secID);
+
+			for (int r = 0; r < N_Routes; r++) {
+				for (int b = 0; b < train_route[r].N_Block_Sections; b++) {
+					const Section& section = train_route[r].sequence_of_block_sections[b];
+					if (section.ID != secID)
+						continue;
+					// Anchor the EoA on the section BEFORE the failed one, at its
+					// end node: a train braking for the failure stops inside that
+					// section, and the stopped-at-EoA release check only fires
+					// when the train's current section matches the MA's BSID.
+					const int anchorIndex = (b > 0) ? b - 1 : b;
+					const Section& anchor = train_route[r].sequence_of_block_sections[anchorIndex];
+					const double anchorDist = (b > 0)
+						? (anchor.end_node.X - anchor.start_node.X) * 1000
+						: 0;
+					MovementAuthority MA;
+					MA.BSID = anchor.ID;
+					MA.type = "SignalFailure";
+					MA.typePart = "Front";
+					MA.ReversedDirection = train_route[r].reversed_direction;
+					MA.EoA_Dist_From_BSID_Beg = anchorDist;
+					// The EVC maps a reversed-route EoA back through GeoXBegNode,
+					// so store the value that resolves to the failed entry.
+					MA.AbsPosEoA = train_route[r].reversed_direction
+						? anchor.GeoXBegNode - anchorDist
+						: anchor.start_node.X * 1000 + anchorDist;
+					MA.TrainInfo.trainDescription = "signal_failure:" + inc.target;
+					MA.TrainInfo.Position = MA.AbsPosEoA;
+					MA.TrainInfo.TrainSpeed = 0;
+					MA.TrainInfo.Acceleration = 0;
+					MA.TrainInfo.CurrentSectionID = anchor.ID;
+					MA.TrainInfo.NextSectionID = section.ID;
+					bool alreadyThere = false;
+					for (const auto& existing : ETCS_MA) {
+						if (existing.BSID == MA.BSID && abs(existing.AbsPosEoA - MA.AbsPosEoA) < 0.001
+							&& existing.TrainInfo.trainDescription == MA.TrainInfo.trainDescription) {
+							alreadyThere = true;
+							break;
+						}
+					}
+					if (!alreadyThere)
+						ETCS_MA.push_back(MA);
+					break;
+				}
+			}
+		}
+	}
+}

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.h
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.h
@@ -21,6 +21,7 @@ struct SimulationIncident {
 extern std::vector<SimulationIncident> simulationIncidents;
 void Load_Incidents(const std::string& MainFolder);
 bool Incident_Holds_Train(const std::string& trainDesc, int timestepIndex);
+void Apply_Signal_Failures_Mixed_Signalling(int timestepIndex);
 
 // --- TrainEvent: ordered train events (departures, arrivals, etc.) ---
 class TrainEvent {

--- a/tools/e2e/incident_smoke.py
+++ b/tools/e2e/incident_smoke.py
@@ -40,6 +40,14 @@ WINDOW_START = 800
 WINDOW_END = 1400
 _TOL = 1.0  # metres; positions within this are treated as unchanged
 
+# signal_failure phase: blocks are 2 km each (TrackLines/B0/BlockCumPari.txt),
+# so 12-B0 starts at 24 km. At the window start the train is near 14.5 km,
+# and the base run crosses 24 km around t=1160.
+FAILED_BLOCK = "12-B0"
+BLOCK_ENTRY_M = 24000.0
+SF_WINDOW_START = 900
+SF_WINDOW_END = 1500
+
 
 def export_and_run(scene_dir: Path, tmp: Path, tag: str) -> list[float | None]:
     exported = tmp / f"exported_{tag}"
@@ -135,6 +143,42 @@ def main() -> None:
         if after <= _TOL:
             sys.exit(f"incident failed: {TARGET_TRAIN} did not resume after the window (span {after:.2f} m)")
         print(f"PASS incident: {TARGET_TRAIN} moves {before:.0f} m before and {after:.0f} m after the window")
+
+        # Control for the signal_failure phase: the base run must cross the
+        # failed block entry inside the window.
+        base_crossing = [p for p in base_positions[SF_WINDOW_START:SF_WINDOW_END] if p is not None]
+        if not base_crossing or max(base_crossing) <= BLOCK_ENTRY_M + _TOL:
+            sys.exit(f"control failed: {TARGET_TRAIN} does not pass the {FAILED_BLOCK} entry at "
+                     f"{BLOCK_ENTRY_M:.0f} m during [{SF_WINDOW_START},{SF_WINDOW_END}] in the base scene")
+        print(f"PASS control: {TARGET_TRAIN} passes {BLOCK_ENTRY_M:.0f} m during the failure window in the base scene")
+
+        # Incident: same scene plus a signal_failure on a block ahead of the train.
+        sf_scene = tmp_dir / "scene_signal_failure"
+        shutil.copytree(SCENE_DIR, sf_scene)
+        sf_incidents = {"incidents": [{
+            "id": "smoke_signal_failure",
+            "type": "signal_failure",
+            "target": FAILED_BLOCK,
+            "start_seconds": SF_WINDOW_START,
+            "end_seconds": SF_WINDOW_END,
+        }]}
+        (sf_scene / "incidents.json").write_text(json.dumps(sf_incidents, indent=2), encoding="utf-8")
+
+        sf_positions = export_and_run(sf_scene, tmp_dir, "signal_failure")
+        sf_window = [p for p in sf_positions[SF_WINDOW_START:SF_WINDOW_END] if p is not None]
+        if not sf_window:
+            sys.exit(f"signal_failure failed: {TARGET_TRAIN} has no positions during the failure window")
+        held_at = max(sf_window)
+        if held_at > BLOCK_ENTRY_M + _TOL:
+            sys.exit(f"signal_failure failed: {TARGET_TRAIN} reached {held_at:.0f} m during the window but "
+                     f"should brake before the {FAILED_BLOCK} entry at {BLOCK_ENTRY_M:.0f} m")
+        if span(sf_positions, 300, SF_WINDOW_START) <= _TOL:
+            sys.exit(f"signal_failure failed: {TARGET_TRAIN} did not move before the window")
+        sf_tail = [p for p in sf_positions[SF_WINDOW_END:] if p is not None]
+        if not sf_tail or max(sf_tail) <= BLOCK_ENTRY_M + _TOL:
+            sys.exit(f"signal_failure failed: {TARGET_TRAIN} did not pass the failed block after the window")
+        print(f"PASS signal_failure: {TARGET_TRAIN} held at {held_at:.0f} m before the {FAILED_BLOCK} entry "
+              f"and passed it after the window")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Apply_Signal_Failures_Mixed_Signalling runs each timestep in both mixed signalling loops. Active signal_failure incidents put their resolved sections into BlocksOccupied, so aspect-driven levels turn red, and inject a SignalFailure movement authority so moving-block trains brake. Occupancy alone never reached the EVC, which is why the earlier BlocksOccupied-only injection measured no effect (#90).
- The EoA anchors on the section before the failed one, at its end node. A train braking for the failure stops inside that section, and checkIfMovementAuthorityStillValid only releases a stopped train when its current section matches the MA's BSID; anchoring on the failed section itself left the train held forever after the window ended.
- The EVC scans the MA list on any section carrying a SignalFailure EoA and treats it as a stop target at every signalling level. Staged scene runs assign no signalling level at all (filed as #218), so a level-3/4-gated scan never saw the MA. Other MA types keep their existing level gating.
- incident_smoke.py gains a signal_failure phase: block 12-B0 (entry at 24 km) fails during [900, 1500] while IC1723-1 approaches from 14.5 km. The smoke asserts the base run crosses the entry inside the window, the incident run holds before it, and the train passes it after the window clears.

## Verification

- incident_smoke.py passes all five phases; the train holds at 24000 m for the window and resumes after.
- cmake build clean; ctest 36/36 passed; headless_smoke.py and roundtrip_smoke.py pass.

Fixes #90.