### PR TITLE
Export a network-wide signalling areas file with scenes

### DIFF
--- a/EGTRAIN/QEGTRAIN/scene/SceneExporter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneExporter.cpp
@@ -69,6 +69,66 @@ static std::string formatNumber(double val) {
 	return oss.str();
 }
 
+// The simulation reads signalling levels only from TrackLines/AreasCaseStudy.txt
+// (InitializeAllNetworkAreas); without the file every section keeps the unset
+// default and no signalling handler runs at all. Cover the whole exported
+// extent with ETCS level 3, the moving-block model the default simulation
+// uses, unless the scene's legacy data already provides the file.
+static void synthesizeSignallingAreas(const std::string& outDir, SceneExportResult& result) {
+	auto addDiag = [&](SceneSeverity sev, const std::string& code, const std::string& msg, const std::string& file = "") {
+		SceneDiagnostic d;
+		d.severity = sev;
+		d.code = code;
+		d.message = msg;
+		d.file = file;
+		result.diagnostics.push_back(d);
+	};
+
+	fs::path areasFile = fs::path(outDir) / "TrackLines" / "AreasCaseStudy.txt";
+	std::error_code ec;
+	if (fs::exists(areasFile, ec))
+		return;
+
+	double minX = std::numeric_limits<double>::infinity();
+	double maxX = -std::numeric_limits<double>::infinity();
+	fs::path tracklinesDir = fs::path(outDir) / "TrackLines";
+	if (fs::exists(tracklinesDir, ec) && fs::is_directory(tracklinesDir, ec)) {
+		for (const auto& entry : fs::directory_iterator(tracklinesDir, ec)) {
+			std::error_code dec;
+			if (!entry.is_directory(dec) || dec)
+				continue;
+			std::ifstream nf(entry.path() / "NodiCumPari.txt");
+			if (!nf)
+				continue;
+			std::string nline;
+			while (std::getline(nf, nline)) {
+				size_t tab1 = nline.find('\t');
+				if (tab1 == std::string::npos)
+					continue;
+				size_t tab2 = nline.find('\t', tab1 + 1);
+				if (tab2 == std::string::npos)
+					continue;
+				double x = std::atof(nline.substr(tab1 + 1, tab2 - tab1 - 1).c_str());
+				minX = std::min(minX, x);
+				maxX = std::max(maxX, x);
+			}
+		}
+	}
+	if (!(minX < maxX)) {
+		addDiag(SceneSeverity::Info, "scene.export.info", "no trackline node data so no signalling areas file was generated");
+		return;
+	}
+
+	std::ofstream out(areasFile);
+	if (!out) {
+		addDiag(SceneSeverity::Error, "scene.export.write", "Failed to write TrackLines/AreasCaseStudy.txt");
+		result.wroteAll = false;
+		return;
+	}
+	out << "Network\t" << formatNumber(minX - 1.0) << "\t" << formatNumber(maxX + 1.0) << "\t3\n";
+	addDiag(SceneSeverity::Info, "scene.export.info", "signalling areas file covers the network at ETCS level 3");
+}
+
 static void synthesizeGuiLayout(const std::string& outDir, SceneExportResult& result) {
 	auto addDiag = [&](SceneSeverity sev, const std::string& code, const std::string& msg, const std::string& file = "") {
 		SceneDiagnostic d;
@@ -749,6 +809,7 @@ SceneExportResult exportLegacyScene(const std::string& sceneDir, const std::stri
 	}
 
 	if (result.success()) {
+		synthesizeSignallingAreas(outDir, result);
 		synthesizeGuiLayout(outDir, result);
 	}
 


### PR DESCRIPTION
## Summary

- The simulation assigns signalling levels only from TrackLines/AreasCaseStudy.txt via InitializeAllNetworkAreas; the exporter never wrote one, so every scene-staged section kept the unset default and no signalling handler ran (#218).
- synthesizeSignallingAreas scans the exported NodiCumPari node coordinates across all tracklines, pads the extent by a kilometre on each side, and writes one Network row at ETCS level 3, the moving-block model the default simulation uses. The full extent matters because direction bands sit far apart (the assignment case has B0 at 0 to 64 km and B1 at 100 to 164 km).
- Scenes whose legacy data already provides the file keep it: the writer runs after the legacy passthrough copy and skips when the file exists, so Milano_Brescia retains its committed level 0 areas.

## Verification

- All six committed scenes validate and export with build/scene_tool; Milano_Brescia keeps its own areas file, the other five gain the level 3 row.
- incident_smoke.py passes all five phases on top of the merged #219, with base-run timings identical to before the level change.
- cmake build clean; ctest 36/36 passed; headless_smoke.py and roundtrip_smoke.py pass.

The dead AreasL*.TXT data in the legacy cases is #220 and the missing movement authority producer for moving-block separation is #221; both are follow-ups this change does not attempt.

Fixes #218.