### PR TITLE
Restore legacy run results data

### DIFF
--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
@@ -2179,6 +2179,7 @@ void protectStationAreas(int i) {
 
 // set vector sizes with length of simulation from user input
 void Train::setTrainVectorSizesFromInput(int vec_size) {
+	End_Time = vec_size - 1;
 	// define vector sizes with length of simulation from user input
 	instant_train_speed = std::vector<double>(vec_size, 0);
 	instant_spatial_position = std::vector<double>(vec_size, 0);

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -771,6 +771,8 @@ public:
 
 	//! Calculation of Train Resistances due to Track Curvature
 	virtual double curvature_resistances(double R) {
+		if (R == 0.0)
+			return 0.0;
 		double Frlc;
 		Frlc = g * (total_train_mass) * 700 / (R * 1000);
 		return Frlc;

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -84,6 +84,14 @@ int main() {
 		ok &= expect(train.End_Time == 4, "trajectory allocation initializes the active end bound");
 	}
 	{
+		Train train;
+		const double zeroSpeedResistancePower = train.total_train_resistances(0.0, 0.0, 0.0) * 0.0;
+		ok &= expect(train.curvature_resistances(0.0) == 0.0,
+					 "zero curvature has no curvature resistance");
+		ok &= expect(std::isfinite(zeroSpeedResistancePower),
+					 "zero-speed total-resistance power remains finite");
+	}
+	{
 		auto train = makeTimetableTrain("timetable", {"Central"});
 		train->ScheduledArrivals[0] = 100.0;
 		train->ScheduledDepartures[0] = 130.0;

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -78,6 +78,12 @@ static std::unique_ptr<Train> makeTrain(const std::string& id, int first, int la
 int main() {
 	bool ok = true;
 	{
+		Train train;
+		train.End_Time = -1;
+		train.setTrainVectorSizesFromInput(5);
+		ok &= expect(train.End_Time == 4, "trajectory allocation initializes the active end bound");
+	}
+	{
 		auto train = makeTimetableTrain("timetable", {"Central"});
 		train->ScheduledArrivals[0] = 100.0;
 		train->ScheduledDepartures[0] = 130.0;


### PR DESCRIPTION
## Summary

- initialize the active trajectory bound when legacy simulation vectors are allocated
- treat zero curvature as straight track so stopped trains do not record NaN power

## Verification

- built QEGTRAIN and the RunResults test
- passed all 36 CTest cases, with two macOS UI tests rerun serially
- passed headless and roundtrip smoke tests for all four cases
- exported a full 8,000-step Netherlands run with 40 complete train rows and no non-finite values

Closes #215