### PR TITLE
Restore moving-block train separation

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -972,7 +972,7 @@ else regional_train[0].max_train_speed = 33.61;*/
 		Apply_Signal_Failures_Mixed_Signalling(t);
 
 		// Only for level>=3
-		// ReportAllTrainPositionsToRBC(t, 50);    //Reporting the positions of the trains to the RBC considering a safety Margin of 50 metres
+		ReportAllTrainPositionsToRBC(t, 50);
 
 		// Predict_And_Check_Decoupling_MA_For_All_Train_in_Following_Mode(t);  // Predict and check the Predict_MA_To_DecoupleAt for all trains which are in following mode
 
@@ -1216,7 +1216,7 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 		Apply_Signal_Failures_Mixed_Signalling(t);
 
 		// Only for level>=3
-		// ReportAllTrainPositionsToRBC(t, 50);    //Reporting the positions of the trains to the RBC considering a safety Margin of 50 metres
+		ReportAllTrainPositionsToRBC(t, 50);
 
 		// Predict_And_Check_Decoupling_MA_For_All_Train_in_Following_Mode(t);  // Predict and check the Predict_MA_To_DecoupleAt for all trains which are in following mode
 

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -4546,20 +4546,28 @@ public:
 
 	// Function to Report Train Position to RBC (the ETCS3 Safety Margin must be given in m)
 	void ReportPositionToRBC(int i, Section* BS, int N_BS, double ETCS3SafetyMargin) {
+		if (BS == nullptr || N_BS <= 0 || timestep <= 0)
+			return;
 		if (OutOfSimulation == 0) {
 			if ((i >= departure_time) && (CanEnter == 1)) {
+				const int delayedIndex = i - static_cast<int>(S_delay / timestep);
+				if (delayedIndex < 0 ||
+					delayedIndex >= static_cast<int>(instant_spatial_position.size()) ||
+					delayedIndex >= static_cast<int>(instant_train_speed.size()))
+					return;
+
 				double LastTrainAcceleration = 0;
-				if ((i - (int)(S_delay / timestep)) >= 1) { // Last Acceleration is computed when i - (int)(S_delay / timestep) is at least >1 so that we can also refer to the previous value of speed instant_train_speed[i - 1 - (int)(S_delay / timestep)]
-					LastTrainAcceleration = (instant_train_speed[i - (int)(S_delay / timestep)] - instant_train_speed[i - 1 - (int)(S_delay / timestep)]) / timestep;
+				if (delayedIndex >= 1) {
+					LastTrainAcceleration = (instant_train_speed[delayedIndex] - instant_train_speed[delayedIndex - 1]) / timestep;
 				}
 
-				for (int h = 0; h < Blocks; h++) {
+				for (int h = 0; h < N_BS; h++) {
 					if ((BS[h].SignallingLevel == 3) || (BS[h].SignallingLevel == 4)) {
 
 						// Report the position of the max safe rear end
 
 						// Case if the train-based detection of the rear is more permissive (i.e the position of the rear & the (rear - ETCS3SafetyMargin) are in the same block)
-						if (((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin) < BS[h].end_node.X * 1000) && ((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin) >= BS[h].start_node.X * 1000) && ((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length) < BS[h].end_node.X * 1000)) {
+						if (((instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin) < BS[h].end_node.X * 1000) && ((instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin) >= BS[h].start_node.X * 1000) && ((instant_spatial_position[delayedIndex] - train_length) < BS[h].end_node.X * 1000)) {
 							// Defining veriables for the ID of the previous, Current and Next Section of the edge of the train
 							string CurrentSectionID, NextSectionID;
 							CurrentSectionID = BS[h].ID;
@@ -4577,16 +4585,16 @@ public:
 							}
 
 							if (BS[h].withSwitchDiv == 0) {
-								elaborateRbcMas((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute], train_route[this->indexOfRoute].reversed_direction, "TrainEnd", "Tale");
-								lockSwitchesOnAllConnectedSections((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin), (instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute].reversed_direction, "None");
+								elaborateRbcMas((instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute], train_route[this->indexOfRoute].reversed_direction, "TrainEnd", "Tale");
+								lockSwitchesOnAllConnectedSections((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin), (instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute].reversed_direction, "None");
 							} else { // if instead the block section has a diverging switch
-								elaborateMaOnBlockSectionsWithSwitchDiv((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Tale");
-								lockSwitchesWhileTrainTraverses((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin), (instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Tale");
+								elaborateMaOnBlockSectionsWithSwitchDiv((instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Tale");
+								lockSwitchesWhileTrainTraverses((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin), (instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Tale");
 							}
 						}
 
 						// Case if the track-based vacancy detection is more permissive than the train-based method
-						else if (((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length) < BS[h].end_node.X * 1000) && ((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length) >= BS[h].start_node.X * 1000) && (instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin) < BS[h].start_node.X * 1000) {
+						else if (((instant_spatial_position[delayedIndex] - train_length) < BS[h].end_node.X * 1000) && ((instant_spatial_position[delayedIndex] - train_length) >= BS[h].start_node.X * 1000) && (instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin) < BS[h].start_node.X * 1000) {
 							// Defining veriables for the ID of the previous, Current and Next Section of the edge of the train
 							string CurrentSectionID, NextSectionID;
 							CurrentSectionID = BS[h].ID;
@@ -4604,22 +4612,22 @@ public:
 							}
 
 							if (BS[h].withSwitchDiv == 0) {
-								elaborateRbcMas((BS[h].start_node.X * 1000), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute], train_route[this->indexOfRoute].reversed_direction, "TrainEnd", "Tale");
-								lockSwitchesOnAllConnectedSections((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin), (BS[h].start_node.X * 1000), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute].reversed_direction, "None");
+								elaborateRbcMas((BS[h].start_node.X * 1000), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute], train_route[this->indexOfRoute].reversed_direction, "TrainEnd", "Tale");
+								lockSwitchesOnAllConnectedSections((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin), (BS[h].start_node.X * 1000), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute].reversed_direction, "None");
 							} else { // if instead the block section has a diverging switch
-								elaborateMaOnBlockSectionsWithSwitchDiv((BS[h].start_node.X * 1000), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Tale");
-								lockSwitchesWhileTrainTraverses((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin), (BS[h].start_node.X * 1000), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Tale");
+								elaborateMaOnBlockSectionsWithSwitchDiv((BS[h].start_node.X * 1000), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Tale");
+								lockSwitchesWhileTrainTraverses((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin), (BS[h].start_node.X * 1000), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Tale");
 							}
 						}
 
 						// if the train is in the simulation but its tale is still outside of the network (so the position of the tale is lower than the beginning of the first block section) then the MA should refer to the beginning Node of the first block section of the route
-						if ((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin) < BS[0].start_node.X) {
+						if ((instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin) < BS[0].start_node.X * 1000) {
 
-							elaborateRbcMas((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[0], BS[0].ID, BS[1].ID, trainDescription, train_route[this->indexOfRoute], train_route[this->indexOfRoute].reversed_direction, "TrainEnd", "Tale");
+							elaborateRbcMas((instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[0], BS[0].ID, N_BS > 1 ? BS[1].ID : "None", trainDescription, train_route[this->indexOfRoute], train_route[this->indexOfRoute].reversed_direction, "TrainEnd", "Tale");
 						}
 
 						// Detecting the MA related to the front of the train
-						if (((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin) < BS[h].end_node.X * 1000) && ((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin) >= BS[h].start_node.X * 1000)) {
+						if (((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin) < BS[h].end_node.X * 1000) && ((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin) >= BS[h].start_node.X * 1000)) {
 							// Defining veriables for the ID of the previous, Current and Next Section of the edge of the train
 							string CurrentSectionID, NextSectionID;
 							CurrentSectionID = BS[h].ID;
@@ -4637,18 +4645,18 @@ public:
 							}
 
 							if (BS[h].withSwitchDiv == 0) {
-								elaborateRbcMas((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute], train_route[this->indexOfRoute].reversed_direction, "TrainEnd", "Front");
-								lockSwitchesOnAllConnectedSections((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin), (instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute].reversed_direction, "None");
+								elaborateRbcMas((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute], train_route[this->indexOfRoute].reversed_direction, "TrainEnd", "Front");
+								lockSwitchesOnAllConnectedSections((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin), (instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], CurrentSectionID, NextSectionID, trainDescription, train_route[this->indexOfRoute].reversed_direction, "None");
 							} else { // if instead the block section has a diverging switch
-								elaborateMaOnBlockSectionsWithSwitchDiv((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Front");
-								lockSwitchesWhileTrainTraverses((instant_spatial_position[i - (int)(S_delay / timestep)] + ETCS3SafetyMargin), (instant_spatial_position[i - (int)(S_delay / timestep)] - train_length - ETCS3SafetyMargin), instant_train_speed[i - (int)(S_delay / timestep)], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Front");
+								elaborateMaOnBlockSectionsWithSwitchDiv((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Front");
+								lockSwitchesWhileTrainTraverses((instant_spatial_position[delayedIndex] + ETCS3SafetyMargin), (instant_spatial_position[delayedIndex] - train_length - ETCS3SafetyMargin), instant_train_speed[delayedIndex], LastTrainAcceleration, BS[h], trainDescription, train_route[indexOfRoute], "Front");
 							}
 							break;
 						}
 					}
 				}
 				// In case the train is stopping at a station to perform a service stop communicate all this information to the corresponding Movement Authorities
-				if ((instant_train_speed[i - (int)(S_delay / timestep)] == 0) && (this->StoppedForServiceStop == 1)) {
+				if ((instant_train_speed[delayedIndex] == 0) && (this->StoppedForServiceStop == 1)) {
 					if (ETCS_MA.size() > 0) {
 						for (list<MovementAuthority>::iterator it = ETCS_MA.begin(); it != ETCS_MA.end(); it++) {
 							if (it->TrainInfo.trainDescription == this->trainDescription) {

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -3857,7 +3857,7 @@ void elaborateRbcMas(double S_i, double V_i, double Acc_i, const Section& BLS, c
 	MovementAuthority MA;
 	if (IsRouteReversed == 0) { // if the train route is not reversed
 		MA.ReversedDirection = false;
-		if (S_i < TrainRoute.sequence_of_block_sections[0].start_node.X) { // With this we ensure that if the tale of the train is still out of the simulation the first Node of the block section is protected
+		if (S_i < TrainRoute.sequence_of_block_sections[0].start_node.X * 1000) { // With this we ensure that if the tale of the train is still out of the simulation the first Node of the block section is protected
 			MA.BSID = TrainRoute.sequence_of_block_sections[0].ID;
 			MA.AbsPosEoA = TrainRoute.sequence_of_block_sections[0].GeoXBegNode;
 			MA.EoA_Dist_From_BSID_Beg = 0;
@@ -3875,7 +3875,7 @@ void elaborateRbcMas(double S_i, double V_i, double Acc_i, const Section& BLS, c
 
 	} else { // if instead the route is reversed
 		MA.ReversedDirection = true;
-		if (S_i < TrainRoute.sequence_of_block_sections[0].start_node.X) { // With this we ensure that if the tale of the train is still out of the simulation the first Node of the block section is protected
+		if (S_i < TrainRoute.sequence_of_block_sections[0].start_node.X * 1000) { // With this we ensure that if the tale of the train is still out of the simulation the first Node of the block section is protected
 			MA.BSID = TrainRoute.sequence_of_block_sections[0].ID;
 			MA.AbsPosEoA = TrainRoute.sequence_of_block_sections[0].GeoXBegNode;
 			MA.EoA_Dist_From_BSID_Beg = 0;

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -102,8 +102,8 @@ int main() {
 		for (int index = 0; index < 2; ++index) {
 			sections[index].ID = index == 0 ? "in-route" : "out-of-route";
 			sections[index].SignallingLevel = 3;
-			sections[index].start_node.X = index;
-			sections[index].end_node.X = index + 1;
+			sections[index].start_node.X = 9.636 + index;
+			sections[index].end_node.X = 10.636 + index;
 			sections[index].start_node.ID = index * 2;
 			sections[index].end_node.ID = index * 2 + 1;
 			sections[index].GeoXBegNode = sections[index].start_node.X * 1000;
@@ -115,14 +115,14 @@ int main() {
 			sections[index].arcs_in_signalling_block_section[0].length = 1000;
 		}
 
-		Route route;
-		route.ID = "moving-block-test";
-		route.N_Block_Sections = 1;
-		route.sequence_of_block_sections[0] = sections[0];
-		route.x_of_start_node = 0;
-		route.x_of_end_node = 1;
+		auto route = std::make_unique<Route>();
+		route->ID = "moving-block-test";
+		route->N_Block_Sections = 1;
+		route->sequence_of_block_sections[0] = sections[0];
+		route->x_of_start_node = sections[0].start_node.X;
+		route->x_of_end_node = sections[0].end_node.X;
 		train_route.clear();
-		train_route.push_back(route);
+		train_route.push_back(*route);
 		Blocks = 2;
 		timestep = 1;
 		S_delay = 0;
@@ -134,7 +134,7 @@ int main() {
 		train.departure_time = 0;
 		train.CanEnter = true;
 		train.train_length = 1000;
-		train.instant_spatial_position = {1500, 1500};
+		train.instant_spatial_position = {10500, 10500};
 		train.instant_train_speed = {10, 10};
 		train.ReportPositionToRBC(1, sections, 1, 50);
 		bool outOfRouteAuthority = false;
@@ -142,6 +142,19 @@ int main() {
 			outOfRouteAuthority |= authority.BSID == sections[1].ID;
 		ok &= expect(!outOfRouteAuthority,
 					 "reporting uses the supplied route section bound");
+		bool foundEntranceAuthority = false;
+		double entrancePosition = std::numeric_limits<double>::quiet_NaN();
+		for (const auto& authority : ETCS_MA) {
+			if (authority.BSID == sections[0].ID && authority.type == "TrainEnd" && authority.typePart == "Tale") {
+				foundEntranceAuthority = true;
+				entrancePosition = authority.AbsPosEoA;
+				break;
+			}
+		}
+		ok &= expect(foundEntranceAuthority,
+					 "reporting creates a TrainEnd/Tale authority for the first section entrance");
+		ok &= expect(foundEntranceAuthority && std::fabs(entrancePosition - sections[0].GeoXBegNode) < 0.001,
+					 "first-section entrance authority uses the geographic start coordinate");
 
 		ETCS_MA.clear();
 		S_delay = 2;

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -134,7 +134,7 @@ int main() {
 		train.departure_time = 0;
 		train.CanEnter = true;
 		train.train_length = 1000;
-		train.instant_spatial_position = {10500, 10500};
+		train.instant_spatial_position = {10600, 10600};
 		train.instant_train_speed = {10, 10};
 		train.ReportPositionToRBC(1, sections, 1, 50);
 		bool outOfRouteAuthority = false;

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -92,6 +92,70 @@ int main() {
 					 "zero-speed total-resistance power remains finite");
 	}
 	{
+		const int savedBlocks = Blocks;
+		const double savedTimestep = timestep;
+		const double savedDelay = S_delay;
+		const auto savedRoutes = train_route;
+		const auto savedAuthorities = ETCS_MA;
+
+		Section sections[2];
+		for (int index = 0; index < 2; ++index) {
+			sections[index].ID = index == 0 ? "in-route" : "out-of-route";
+			sections[index].SignallingLevel = 3;
+			sections[index].start_node.X = index;
+			sections[index].end_node.X = index + 1;
+			sections[index].start_node.ID = index * 2;
+			sections[index].end_node.ID = index * 2 + 1;
+			sections[index].GeoXBegNode = sections[index].start_node.X * 1000;
+			sections[index].GeoXEndNode = sections[index].end_node.X * 1000;
+			sections[index].total_nodes = 2;
+			sections[index].total_arcs = 1;
+			sections[index].arcs_in_signalling_block_section[0].startNode = sections[index].start_node;
+			sections[index].arcs_in_signalling_block_section[0].endNode = sections[index].end_node;
+			sections[index].arcs_in_signalling_block_section[0].length = 1000;
+		}
+
+		Route route;
+		route.ID = "moving-block-test";
+		route.N_Block_Sections = 1;
+		route.sequence_of_block_sections[0] = sections[0];
+		route.x_of_start_node = 0;
+		route.x_of_end_node = 1;
+		train_route.clear();
+		train_route.push_back(route);
+		Blocks = 2;
+		timestep = 1;
+		S_delay = 0;
+		ETCS_MA.clear();
+
+		Train train;
+		train.trainDescription = "moving-block-test";
+		train.indexOfRoute = 0;
+		train.departure_time = 0;
+		train.CanEnter = true;
+		train.train_length = 1000;
+		train.instant_spatial_position = {1500, 1500};
+		train.instant_train_speed = {10, 10};
+		train.ReportPositionToRBC(1, sections, 1, 50);
+		bool outOfRouteAuthority = false;
+		for (const auto& authority : ETCS_MA)
+			outOfRouteAuthority |= authority.BSID == sections[1].ID;
+		ok &= expect(!outOfRouteAuthority,
+					 "reporting uses the supplied route section bound");
+
+		ETCS_MA.clear();
+		S_delay = 2;
+		train.ReportPositionToRBC(1, sections, 1, 50);
+		ok &= expect(ETCS_MA.empty(),
+					 "reporting skips delayed samples before the trajectory");
+
+		Blocks = savedBlocks;
+		timestep = savedTimestep;
+		S_delay = savedDelay;
+		train_route = savedRoutes;
+		ETCS_MA = savedAuthorities;
+	}
+	{
 		auto train = makeTimetableTrain("timetable", {"Central"});
 		train->ScheduledArrivals[0] = 100.0;
 		train->ScheduledDepartures[0] = 130.0;


### PR DESCRIPTION
## Summary

- Publish current train positions to the RBC in both mixed-signalling loops.
- Validate delayed samples and route section bounds before creating train-end authorities.
- Fix entrance coordinate units and cover non-zero route starts.

## Verification

- Full build completed.
- CTest passed 36 of 36 tests.
- Headless smoke passed all four cases.
- Roundtrip smoke passed all four cases.
- Assignment smoke passed. A 10,000-step run kept 22 repeated services ordered with at least 3,633.715 m rear clearance.
- The route-bound regression fails when the loop is mutated back to global `Blocks` and passes with `N_BS`.

Closes #221