### PR TITLE
Show exact values in diagram hover readouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,17 @@ if(EGTRAIN_BUILD_TESTS)
         ${SRC_DIR}/diagrams/BlockingTimeDiagram.cpp)
     add_test(NAME test_blockingtimediagram COMMAND test_blockingtimediagram)
 
+    add_executable(test_diagramwindow
+        ${SRC_DIR}/tests/test_diagramwindow.cpp
+        ${SRC_DIR}/diagrams/DiagramWindow.cpp
+        ${SRC_DIR}/diagrams/TrainFilterButton.cpp
+        ${SRC_DIR}/util/TimeFormat.cpp)
+    target_include_directories(test_diagramwindow PRIVATE ${SRC_DIR})
+    target_link_libraries(test_diagramwindow PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Charts)
+    add_test(NAME test_diagramwindow COMMAND test_diagramwindow)
+    set_tests_properties(test_diagramwindow PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
     add_executable(test_visualpolish
         ${SRC_DIR}/tests/test_visualpolish.cpp
         ${SRC_DIR}/graphics/VisualPolish.cpp)

--- a/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
@@ -251,8 +251,9 @@ void DiagramWindow::rebuildFilterGroups() {
 
 		// Connect identification signals once per series.
 		if (auto* xy = qobject_cast<QXYSeries*>(series)) {
-			connect(xy, &QXYSeries::hovered, this, [this, series](const QPointF&, bool state) {
+			connect(xy, &QXYSeries::hovered, this, [this, series](const QPointF& point, bool state) {
 				m_hoverName = state ? series->name() : QString();
+				updateReadout(point, m_hoverName);
 			});
 			connect(xy, &QXYSeries::clicked, this, [this, trainId](const QPointF&) {
 				pinTrain(trainId);
@@ -320,6 +321,30 @@ void DiagramWindow::refreshEmphasis() {
 	}
 }
 
+void DiagramWindow::updateReadout(const QPointF& value, const QString& seriesName) {
+	if (!m_readout || !m_view || !m_view->chart())
+		return;
+
+	const QChart* chart = m_view->chart();
+	const auto horizontal = chart->axes(Qt::Horizontal);
+	const auto vertical = chart->axes(Qt::Vertical);
+	const QString xLabel = horizontal.isEmpty() || horizontal.first()->titleText().isEmpty()
+		? QString("x") : horizontal.first()->titleText();
+	const QString yLabel = vertical.isEmpty() || vertical.first()->titleText().isEmpty()
+		? QString("y") : vertical.first()->titleText();
+	const QString xText = m_timeAxis
+		? QString::fromStdString(formatSimTime(static_cast<long long>(value.x()), m_startOffset))
+		: QString::number(value.x(), 'f', 2);
+	const QString yText = QString::number(value.y(), 'f', 2);
+	if (seriesName.isEmpty()) {
+		m_readout->setText(QString("%1: %2   %3: %4")
+			.arg(xLabel).arg(xText).arg(yLabel).arg(yText));
+	} else {
+		m_readout->setText(QString("%1   %2: %3   %4: %5")
+			.arg(seriesName).arg(xLabel).arg(xText).arg(yLabel).arg(yText));
+	}
+}
+
 QStringList DiagramWindow::visibleTrainIds() const {
 	if (m_trainsButton)
 		return m_trainsButton->visibleTrainIds();
@@ -381,13 +406,7 @@ bool DiagramWindow::eventFilter(QObject* obj, QEvent* ev) {
 		QPointF scenePos = m_view->mapToScene(me->pos());
 		QPointF chartPos = m_view->chart()->mapFromScene(scenePos);
 		QPointF val = m_view->chart()->mapToValue(chartPos);
-		QString xText = m_timeAxis
-			? QString::fromStdString(formatSimTime(static_cast<long long>(val.x()), m_startOffset))
-			: QString::number(val.x(), 'f', 2);
-		QString text = m_hoverName.isEmpty()
-			? QString("x: %1   y: %2").arg(xText).arg(val.y(), 0, 'f', 2)
-			: QString("%1   x: %2   y: %3").arg(m_hoverName).arg(xText).arg(val.y(), 0, 'f', 2);
-		m_readout->setText(text);
+		updateReadout(val, m_hoverName);
 	}
 	return QDialog::eventFilter(obj, ev);
 }

--- a/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.h
@@ -5,6 +5,7 @@
 #include <QHash>
 #include <QPen>
 #include <QPointer>
+#include <QPointF>
 #include <QString>
 #include <QStringList>
 #include <QVector>
@@ -66,6 +67,7 @@ private:
 	void refreshEmphasis();
 	QStringList visibleTrainIds() const;
 	QString groupIdForSeries(QAbstractSeries* series) const;
+	void updateReadout(const QPointF& value, const QString& seriesName);
 
 	QPointer<QChartView> m_view;
 	QPointer<QLabel> m_readout;

--- a/EGTRAIN/QEGTRAIN/tests/test_diagramwindow.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_diagramwindow.cpp
@@ -1,0 +1,84 @@
+#include "diagrams/DiagramWindow.h"
+
+#include <QApplication>
+#include <QLabel>
+#include <QLineSeries>
+#include <QValueAxis>
+
+#include <iostream>
+
+QT_CHARTS_USE_NAMESPACE
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+static QLabel* readoutFor(DiagramWindow& window) {
+	for (QLabel* label : window.findChildren<QLabel*>()) {
+		if (label->text().startsWith("Hover over the chart") ||
+			label->text().contains("x:") || label->text().contains("Speed (m/s)"))
+			return label;
+	}
+	return nullptr;
+}
+
+static QChart* chartWithAxes(const QString& xTitle, const QString& yTitle, QLineSeries*& series) {
+	auto* chart = new QChart();
+	series = new QLineSeries();
+	series->setName("Train A");
+	series->append(12.345, 678.901);
+	chart->addSeries(series);
+	chart->createDefaultAxes();
+	chart->axes(Qt::Horizontal).first()->setTitleText(xTitle);
+	chart->axes(Qt::Vertical).first()->setTitleText(yTitle);
+	return chart;
+}
+
+int main(int argc, char* argv[]) {
+	qputenv("QT_QPA_PLATFORM", "offscreen");
+	QApplication app(argc, argv);
+	bool ok = true;
+
+	QLineSeries* speedSeries = nullptr;
+	DiagramWindow speedWindow("Speed versus tractive effort");
+	speedWindow.setChart(chartWithAxes("Speed (m/s)", "Tractive effort (N)", speedSeries));
+	QLabel* speedReadout = readoutFor(speedWindow);
+	ok &= expect(speedReadout != nullptr, "speed chart readout label");
+	if (speedReadout) {
+		emit speedSeries->hovered(QPointF(12.345, 678.901), true);
+		ok &= expect(speedReadout->text().contains("Train A"), "hovered series name");
+		ok &= expect(speedReadout->text().contains("Speed (m/s)"), "speed axis label");
+		ok &= expect(speedReadout->text().contains("Tractive effort (N)"), "tractive-effort axis label");
+		ok &= expect(speedReadout->text().contains("12.35"), "exact hovered x value");
+		ok &= expect(speedReadout->text().contains("678.90"), "exact hovered y value");
+		emit speedSeries->hovered(QPointF(12.345, 678.901), false);
+		ok &= expect(!speedReadout->text().contains("Train A"), "hover exit clears series name");
+		ok &= expect(speedReadout->text().contains("Speed (m/s)"), "hover exit keeps speed axis label");
+		ok &= expect(speedReadout->text().contains("Tractive effort (N)"), "hover exit keeps tractive-effort axis label");
+		ok &= expect(speedReadout->text().contains("12.35"), "hover exit keeps exact x value");
+		ok &= expect(speedReadout->text().contains("678.90"), "hover exit keeps exact y value");
+	}
+
+	QLineSeries* timeSeries = nullptr;
+	DiagramWindow timeWindow("Time versus distance");
+	timeWindow.setChart(chartWithAxes("Time", "Distance (km)", timeSeries));
+	timeWindow.setTimeAxisX(true, 8 * 3600);
+	QLabel* timeReadout = readoutFor(timeWindow);
+	ok &= expect(timeReadout != nullptr, "time chart readout label");
+	if (timeReadout) {
+		emit timeSeries->hovered(QPointF(90.25, 12.345), true);
+		ok &= expect(timeReadout->text().contains("Train A"), "time hovered series name");
+		ok &= expect(timeReadout->text().contains("Time"), "time axis label");
+		ok &= expect(timeReadout->text().contains("Distance (km)"), "distance axis label");
+		ok &= expect(timeReadout->text().contains("08:01:30"), "formatted time with offset");
+		ok &= expect(timeReadout->text().contains("12.35"), "exact hovered distance value");
+	}
+
+	if (!ok)
+		return 1;
+
+	std::cout << "all DiagramWindow tests passed\n";
+	return 0;
+}


### PR DESCRIPTION
## Summary

- Show the exact point emitted by a hovered chart series.
- Label values with each chart's existing axis titles and units.
- Format time values as clock times and clear the series name on hover exit.
- Add an offscreen regression for numeric axes, time offsets, and hover exit.

## Verification

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (38/38 passed)
- `tools/e2e/visual_polish_smoke.sh`

Closes #41
