### PR TITLE
Stabilize sanitizer GUI smoke timeout

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -122,7 +122,7 @@ jobs:
           # horizon-1000 run and populate the Run Results dock before emitting
           # E2E_GUI_RUN_RESULTS. Keep the post-completion liveness hold short so
           # the whole test still finishes under the ctest TIMEOUT (CMakeLists.txt).
-          QEGTRAIN_GUI_SMOKE_MARKER_SECONDS: "330"
+          QEGTRAIN_GUI_SMOKE_MARKER_SECONDS: "360"
           QEGTRAIN_GUI_SMOKE_SECONDS: "30"
         run: ctest --test-dir build --output-on-failure --output-log "$RUNNER_TEMP/ctest-sanitizer.log"
 

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def main() -> None:
     workflow = (ROOT / ".github/workflows/cmake.yml").read_text(encoding="utf-8")
+    cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
     release_workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     blocks = workflow.split("\n      - ")
     required = {
@@ -44,6 +45,16 @@ def main() -> None:
         )
     ):
         missing.append("sanitizer failure options")
+    if any(
+        budget not in sanitizer_test
+        for budget in (
+            'QEGTRAIN_GUI_SMOKE_MARKER_SECONDS: "360"',
+            'QEGTRAIN_GUI_SMOKE_SECONDS: "30"',
+        )
+    ):
+        missing.append("sanitizer GUI smoke time budgets")
+    if "set_tests_properties(test_gui_autostart_smoke PROPERTIES TIMEOUT 420)" not in cmake:
+        missing.append("GUI smoke CTest timeout")
     if workflow.count('echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"') != 2:
         missing.append("TMPDIR routing steps for smoke logs")
     uploads = [block for block in blocks if block.startswith("name: Upload failure diagnostics\n")]


### PR DESCRIPTION
## Summary

- Raise the sanitizer GUI results deadline from 330 to 360 seconds.
- Keep the 30 second liveness hold and 420 second CTest ceiling.
- Pin the three timing values in the existing CI workflow test.

## Root cause

The sanitizer jobs in main run 29661488831 and PR #230 run 29662733184 reached simulation tick 981 while still advancing, then hit the 330 second deadline. Neither log contained a sanitizer report. The fixed deadline was too short for slower macOS runners.

## Verification

- `python tools/e2e/test_ci_workflow.py`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/cmake.yml')"`
- `git diff --check`

Closes #231
