### PR TITLE
Document the main application UI revamp

### DIFF
--- a/docs/planning/2026-07-19-main-application-ui-revamp-plan.md
+++ b/docs/planning/2026-07-19-main-application-ui-revamp-plan.md
@@ -15,6 +15,7 @@ The work is split into small pull requests. Each pull request leaves the applica
 - Use color as a secondary cue. Track and train states need a stroke, pattern, icon, or shape cue as well.
 - Keep public UI text short, literal, and consistent.
 - Verify every pull request at 1024 by 720, 1200 by 800, and 1440 by 900 logical pixels.
+- Treat all documented pixel dimensions as logical pixels. Verify captures at 1x and 2x device-pixel ratios. Do not add explicit high-DPI attributes where the platform already provides the correct scaling.
 - Each Qt widget test must create `QApplication`, link `Qt5::Core`, `Qt5::Gui`, and `Qt5::Widgets`, and run under CTest with `QT_QPA_PLATFORM=offscreen`.
 
 ## Pull request 1: lock down viewport and timeline behavior
@@ -23,28 +24,28 @@ The work is split into small pull requests. Each pull request leaves the applica
 
 - Modify `EGTRAIN/QEGTRAIN/graphics/NetworkView.h` and `NetworkView.cpp`.
 - Modify `EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.h` and `TimeProgressBar.cpp`.
-- Modify `EGTRAIN/QEGTRAIN/app/MainWindow.cpp` only where it routes zoom and timestep updates.
+- Modify `EGTRAIN/QEGTRAIN/app/MainWindow.h` and `MainWindow.cpp` only where they route zoom and timestep updates.
 - Add `EGTRAIN/QEGTRAIN/tests/test_networkview.cpp`.
 - Add `EGTRAIN/QEGTRAIN/tests/test_timeprogressbar.cpp`.
 - Modify `CMakeLists.txt` to register both tests.
 
 ### Work
 
-1. Add a fitted-scale baseline to `NetworkView`. Define Fit as the final transform after topology bounds, device-pixel padding, and the existing track-legibility minimum have all been applied.
-2. Route wheel, toolbar, and mouse-anchored zoom through one `zoomBy(qreal factor)` path.
+1. Add a fitted-scale baseline to `NetworkView`. Define Fit as the transform that shows all rendered track and connection geometry inside logical-pixel padding. Do not reapply the track-separation minimum when it would crop the topology. Hide both scrollbars at Fit.
+2. Keep one `NetworkView::wheelEvent()` handler and route it, toolbar actions, and mouse-anchored zoom through one `zoomBy(qreal factor)` path. Remove the parallel wheel branch from `MainWindow::eventFilter()` and the direct `QGraphicsView::scale()` call.
 3. Clamp the scale from Fit through 12x. Ignore further input at either bound while still emitting one viewport update for the applied change. Expose map-style labels such as `Fit`, `2x`, and `12x` rather than percentages.
 4. Recompute the fitted baseline when a case loads, when Fit runs, and when a fitted view resizes. A resize must preserve the current zoom ratio when the user has zoomed away from fit instead of snapping back unexpectedly.
 5. Keep Ctrl+0 as Fit and make its tooltip state that it restores the full network view.
-6. Give `TimeProgressBar` the real range `0` through `totalSteps - 1`; set its value directly to the zero-based timestep. Remove the integer percentage calculation. Display steps as one-based values and calculate the end clock from `totalSteps - 1`.
-7. Increase the timeline height to 28 pixels and format it as `06:28:29 | Step 10 of 8,000 | End 08:41:40`. Keep it read-only and unfocusable, with no pointing cursor or click handling.
+6. Pass `snapshot->totalTimesteps` into `TimeProgressBar` instead of reading `initial_variables.times`. Give it the range `0` through `totalSteps - 1`, and set its value directly to the zero-based timestep. Display steps as one-based values. Calculate the final interval horizon from `totalSteps`.
+7. Increase the timeline height to 28 pixels and format it as `06:28:29 | Step 10 of 8,000 | Ends 08:41:40`. Keep it read-only and unfocusable, with no pointing cursor or click handling.
 8. Write `Simulation running` to the status bar only when the run enters that state. Timestep updates must not touch the status bar, so errors and transient guidance remain visible for their requested duration.
 
 ### Regression checks
 
-- `test_networkview` records the final fitted scale, applies 100 zoom-in and zoom-out operations, and asserts clamping at 12x and Fit with a floating-point epsilon.
-- The test covers wheel-equivalent and toolbar-equivalent factors through the same public method.
+- `test_networkview` records the final fitted scale, applies 100 zoom-in and zoom-out operations, and asserts clamping at 12x and Fit with a floating-point epsilon. It also asserts that both scrollbars are hidden at Fit.
+- Dispatch real `QWheelEvent` instances to the viewport and trigger the toolbar actions. Prove that both routes use the same clamp and that one wheel step applies once.
 - At each viewport size, the test records Fit, zooms to 3x, resizes to the next supported size, and asserts that the transform remains 3x relative to the recomputed fitted baseline. It then verifies that the new baseline still clamps from Fit through 12x.
-- `test_timeprogressbar` checks the first, middle, and last steps. It asserts the zero-based progress value, one-based displayed step, last-step end clock, and formatted text. It also proves that mouse input does not change the value.
+- `test_timeprogressbar` checks the first, middle, and last steps. It asserts the zero-based progress value, one-based displayed step, final-interval end clock, and formatted text. It also proves that mouse input does not change the value.
 - An in-app hook posts a timed status message, advances the snapshot, and proves that the progress update does not overwrite the message.
 - Run `cmake --build build`, `ctest --test-dir build --output-on-failure`, and `tools/e2e/visual_polish_smoke.sh`.
 
@@ -60,21 +61,22 @@ The work is split into small pull requests. Each pull request leaves the applica
 
 ### Work
 
-1. Replace the separate station icon and rich-text label with one fixed-screen overlay item. Paint the symbol and plain label in one bounding rectangle with an 8-pixel gap.
+1. Replace the separate station icon and rich-text label with one fixed-screen overlay item. Paint the symbol and plain label in one bounding rectangle with an 8-pixel gap. Accept hover events, set accepted mouse buttons to `Qt::NoButton`, and do not handle context-menu events.
 2. Keep existing station classification and icons. Do not change scene or simulation data.
-3. Exclude fixed-screen overlays, train badges, and the map key from the topology bounds used by `fitView()`.
-4. Add 24 device pixels of fit padding around topology.
+3. Compute topology bounds by direct typed iteration over `TrackLineItem`, including `VirtualArcItem`, and `ConnectionItem`. Union painted line geometry, not the wider selection polygons returned for hit testing. Do not use a bounds cache or subtract overlays from an all-items union.
+4. Add 24 logical pixels of fit padding around topology.
 5. Remove scene-space icon-to-label offsets. Preserve case-specific station anchors only until a later scene-format issue can replace them with view metadata.
-6. In the viewport pass, evaluate label rectangles with 4 pixels of collision padding. Below 2x, consider selected, followed-train, interchange, and network-endpoint labels. Define a network endpoint as a station whose rendered infrastructure node has one connection. Do not infer service termini. From 2x up to but excluding 4x, add ordinary labels that fit. At 4x and above, consider every label.
-7. Resolve a remaining collision by selection first, station class second, and distance from the viewport center third. Do not depend on source order.
+6. In the viewport pass, evaluate label rectangles with 4 logical pixels of collision padding. Below 2x, consider selected, followed-train, interchange, and network-endpoint labels. The followed-train station is the station anchor nearest the followed train's current scene position. Define a network endpoint as a station whose rendered infrastructure node has one connection. Do not infer service termini. From 2x up to but excluding 4x, add ordinary labels that fit. At 4x and above, consider every label.
+7. Resolve a remaining collision in this order: selected station, followed-train station, interchange, degree-1 network endpoint, remaining station class, then distance from the viewport center. Do not depend on source order.
 8. Keep a stable preferred label anchor and shift the label within the 12-pixel viewport inset. Use a deterministic alternate side only when the preferred side cannot fit.
-9. Show the full name for a culled label when its station symbol is hovered or selected.
+9. Show the full name for a culled label when its station symbol is hovered or selected. Keep using the existing viewport update pass; do not add a scheduler or cache.
 
 ### Regression checks
 
 - `test_stationoverlay` checks the combined bounding rectangle, the fixed 8-pixel symbol gap, edge placement, and priority ordering with a degree-1 network endpoint and a degree-3 interchange fixture.
+- Dispatch hover and selection events to a station whose label was culled. Assert that the full name appears, then disappears when neither state applies. Assert that a click and context-menu request still resolve through the existing semantic item path.
 - The visual smoke adds assertions that no visible station label intersects its own symbol and that each visible label remains inside the viewport inset.
-- Run label-in-bounds and symbol-intersection checks for Netherlands, Paimpol, Copenhagen, and Brescia at Fit, 3x, and 12x. Capture the three states for Copenhagen.
+- Run label-in-bounds and symbol-intersection checks for Netherlands, Paimpol, Copenhagen, and Brescia at Fit, 3x, and 12x. Capture the three states for Copenhagen at 1x and 2x device-pixel ratios.
 - Run the full UI verification gate.
 
 ## Pull request 3: simplify the command bar and simulation timeline
@@ -84,7 +86,7 @@ The work is split into small pull requests. Each pull request leaves the applica
 - Modify `EGTRAIN/QEGTRAIN/app/MainWindow.ui`.
 - Modify the command-bar construction in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp` and declarations in `MainWindow.h`.
 - Modify `EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss`.
-- Add or update small SVG action icons under `EGTRAIN/QEGTRAIN/resources/icons/` and register them in `resources.qrc`.
+- Add or update small SVG action icons under `EGTRAIN/QEGTRAIN/resources/icons/` and register them in `EGTRAIN/QEGTRAIN/app/resources.qrc`.
 - Extend the visual smoke control assertions.
 
 ### Work
@@ -98,7 +100,7 @@ The work is split into small pull requests. Each pull request leaves the applica
 7. Keep the existing right-is-faster mapping, label the ends `Slower` and `Faster`, and add a regression check for the direction.
 8. Keep Follow as a checkable action followed by the train selector. Give the selector a 140-pixel preferred width and a 200-pixel maximum.
 9. Use icon-only Zoom In and Zoom Out controls. Keep Fit visible with the text `Fit` because it is the recovery action.
-10. Set the toolbar icon size to 16 pixels and target a 32-pixel control height. Primary text buttons can reach 36 pixels; no toolbar control should create a taller row.
+10. Replace the platform Run, Pause, and Stop media icons with one custom monochrome icon family. Set the toolbar icon size to 16 pixels and target a 32-pixel control height. Primary text buttons can reach 36 pixels; no toolbar control should create a taller row.
 11. Use the native toolbar overflow menu only for secondary actions. Open Case, Run, Pause, Stop, and Fit must remain visible at 1024 by 720.
 
 ### Regression checks
@@ -121,18 +123,19 @@ The work is split into small pull requests. Each pull request leaves the applica
 ### Work
 
 1. Remove the always-visible scene legend.
-2. Add a collapsible `Map key` section below the layer controls in the Case and Layers dock. Keep each row within 160 pixels, start expanded for a new profile, and remember the user's choice with `QSettings`. Keep the Map key header visible while collapsed.
+2. Add a collapsible `Map key` section below the layer controls in the Case and Layers dock. Keep each row within 160 pixels, start expanded on every launch, and keep the Map key header visible while collapsed. Do not persist this state with `QSettings`.
 3. Add `Map key` to the View menu so a user can restore it.
 4. Rename the primary toggles to `Stations and platforms`, `Trains`, `Signals`, and `Passengers`.
 5. Add separate secondary toggles for `Station names` and `Train speed labels`. Do not hide an object just because its label is hidden.
-6. Replace the solid checked square with a visible check mark and a keyboard focus border.
+6. Remove the custom solid-square indicator styling and use the native platform check mark. Keep a visible keyboard focus border.
 7. Keep the case name once, followed by run-readiness text such as `Ready to run` or the first blocking validation error.
-8. Include compact key entries for track states, train categories, station roles, signal cue shapes, and passenger-load indicators. Omit a category only when that category is not visible in the loaded case.
+8. Include compact key entries for track states, train categories, station roles, signal cue shapes, and passenger-load indicators. Determine the entries when the case loads. Layer toggles must not make the key content jump or disappear.
 
 ### Regression checks
 
 - `test_networklegend` checks every visible track, train, station, signal, and passenger entry against the same classification functions or constants used by the renderer.
 - The visual smoke asserts that the map key is outside the `QGraphicsView`, can collapse, and can be restored from View.
+- The map key starts expanded after every application restart and keeps the same entries while layers are toggled.
 - Layer tests prove that object and label toggles act independently without changing scene ownership.
 - Run the full UI verification gate.
 
@@ -149,13 +152,14 @@ The work is split into small pull requests. Each pull request leaves the applica
 ### Work
 
 1. Apply the neutral shell and canvas colors from the audit, including the 1-pixel inset border that separates the surfaces.
-2. Draw free track as a 2-pixel `#A0ACB4` solid line. Use Qt pen styles for state underlays: prepared is a medium dash-dot rail-blue line, occupied is a heavy solid red-orange line, and blocked is a heavy dashed amber line with the existing block marker.
+2. Draw free track as a 2-pixel `#A0ACB4` solid line. Remove the undocumented 2, 3, and 4-pixel speed-tier encoding from the overview and delete `classifyTrackSpeed()` if no other consumer remains. Use Qt pen styles for state underlays: prepared is a medium dash-dot rail-blue line, occupied is a heavy solid red-orange line, and blocked is a heavy dashed amber line with the existing block marker.
 3. Do not add custom chevrons, ties, animation, or track textures. Color, width, and Qt pen style provide the redundant cues.
-4. Keep signal aspect colors, but lower housing contrast at overview and show full housings progressively as zoom increases. Their icon or silhouette must remain distinguishable in grayscale at minimum zoom.
+4. Keep signal aspect colors. At overview, retain full emphasis for stop and caution cues while reducing repeated proceed signals to subdued ticks. Show full housings progressively as zoom increases. Their icon or silhouette must remain distinguishable in grayscale at minimum zoom.
 5. Reduce train fill saturation. Preserve category shape differences and use text or icons for delay state.
 6. Keep the followed or selected train identifiable on the canvas without relying on a tooltip. Use a wider selected badge or middle elision that preserves the distinguishing service suffix. Keep the full identifier in the selector and tooltip. Add a smoke assertion that two identifiers with the same prefix remain distinguishable.
 7. Use the system fixed-width font for clock and timestep text. Keep the system UI font everywhere else.
-8. Document exact color, width, dash, marker, and shape assignments in the renderer style map.
+8. Remove the adaptive background grid from the operational view because it has no distance or coordinate meaning.
+9. Document exact color, width, dash, marker, and shape assignments in the renderer style map. Record the measured canvas contrast ratios: free 7.64:1, prepared 4.84:1, occupied 4.42:1, and blocked 7.61:1.
 
 ### Regression checks
 
@@ -164,29 +168,29 @@ The work is split into small pull requests. Each pull request leaves the applica
 - Inspect the captures with common red-green deficiency simulation and record the result in the pull request.
 - Run the full UI verification gate.
 
-## Pull request 6: add persistent guidance and narrow-window coverage
+## Pull request 6: make startup state honest and add navigation coverage
 
 ### Files
 
-- Modify the startup chooser and empty-state handling in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp`.
+- Modify the startup chooser and status handling in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp`.
 - Modify `tools/e2e/visual_polish_smoke.sh` and the in-app smoke hooks.
 - Update `docs/guides/scenes-and-application.md` after the controls settle.
 
 ### Work
 
-1. Rename `Skip` in the startup chooser to `Not now`.
-2. When no case is open, show a quiet canvas empty state with `Open a case to inspect or run it` and a normal button bound to the existing `Open Case` action. Do not add custom scene hit testing.
-3. Add a compact navigation hint below the empty state and a persistent `Network controls` entry under Help: `Drag to pan | Wheel to zoom | Ctrl+0 to fit | Right-click for actions`.
-4. Remove the in-canvas hint after a case opens. Keep Network controls available from Help and from the network view context menu.
-5. Remove the disabled `Planned route and related infrastructure` placeholder from the train context menu until that command works.
-6. Add narrow and wide visual captures at 1024 by 720 and 1440 by 900.
-7. Add a maximum-zoom capture and a fit-after-maximum-zoom assertion.
+1. Replace `Skip` with a button that names the case already loaded from the command line, such as `Continue with Netherlands`. Derive the name from the active case instead of hardcoding it.
+2. Closing or dismissing the chooser keeps the loaded case. The case label, readiness text, and status bar must agree about that state. Do not add an empty-state canvas over a prepared case.
+3. Add a persistent `Network controls` entry under Help and to the network view context menu: `Drag to pan | Wheel to zoom | Ctrl+0 to fit | Right-click for actions`.
+4. Remove the disabled `Planned route and related infrastructure` placeholder from the train context menu until that command works.
+5. Add narrow and wide visual captures at 1024 by 720 and 1440 by 900.
+6. Add a maximum-zoom capture and a fit-after-maximum-zoom assertion.
+7. Record the 1200 by 800 captures at 1x and 2x device-pixel ratios.
 8. Update the user guide with the final names and screenshots.
 
 ### Regression checks
 
-- The startup smoke covers bundled case selection, Not now, persistent empty-state recovery, and Open Case.
-- The loaded-case smoke proves that Network controls remains reachable after the empty state disappears.
+- The startup smoke covers bundled case selection, continuing with the loaded command-line case, and Open Case. It proves that chooser dismissal does not produce false empty-state text.
+- The loaded-case smoke proves that Network controls remains reachable from Help and the network context menu.
 - The visual smoke proves that primary controls do not overflow and station labels remain in bounds at all supported sizes.
 - Run `cmake --build build`, `ctest --test-dir build --output-on-failure`, and `tools/e2e/visual_polish_smoke.sh`.
 
@@ -197,6 +201,6 @@ After all six pull requests:
 1. Run the full build and CTest suite.
 2. Run `tools/e2e/visual_polish_smoke.sh` and `tools/e2e/editor_smoke.sh`.
 3. Run `tools/e2e/headless_smoke.py` to confirm the UI work did not change simulation output.
-4. Compare the five required visual states at all three window sizes.
+4. Compare default, dense, follow, narrow-window, and maximum-zoom states at all three window sizes. Compare the default state at 1x and 2x device-pixel ratios.
 5. Run `graphify update .`.
 6. Close the focused UI issues only after their acceptance checks pass. Close the student-workflow epic only when its remaining non-visual workflow issues are complete.

--- a/docs/planning/2026-07-19-main-application-ui-revamp-plan.md
+++ b/docs/planning/2026-07-19-main-application-ui-revamp-plan.md
@@ -1,0 +1,202 @@
+# Main application UI revamp plan
+
+## Goal
+
+Make the main EGTRAIN workspace readable and predictable without replacing Qt Widgets, the scene model, or the simulation rendering flow.
+
+The work is split into small pull requests. Each pull request leaves the application usable and has its own regression gate. The order fixes correctness and navigation before changing the palette.
+
+## Constraints
+
+- Keep Qt 5 and C++17.
+- Preserve legacy case loading and all four committed case studies.
+- Keep `QMainWindow`, `QToolBar`, `QDockWidget`, `QGraphicsView`, and the existing scene ownership model.
+- Do not add a UI framework, font package, or runtime dependency.
+- Use color as a secondary cue. Track and train states need a stroke, pattern, icon, or shape cue as well.
+- Keep public UI text short, literal, and consistent.
+- Verify every pull request at 1024 by 720, 1200 by 800, and 1440 by 900 logical pixels.
+- Each Qt widget test must create `QApplication`, link `Qt5::Core`, `Qt5::Gui`, and `Qt5::Widgets`, and run under CTest with `QT_QPA_PLATFORM=offscreen`.
+
+## Pull request 1: lock down viewport and timeline behavior
+
+### Files
+
+- Modify `EGTRAIN/QEGTRAIN/graphics/NetworkView.h` and `NetworkView.cpp`.
+- Modify `EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.h` and `TimeProgressBar.cpp`.
+- Modify `EGTRAIN/QEGTRAIN/app/MainWindow.cpp` only where it routes zoom and timestep updates.
+- Add `EGTRAIN/QEGTRAIN/tests/test_networkview.cpp`.
+- Add `EGTRAIN/QEGTRAIN/tests/test_timeprogressbar.cpp`.
+- Modify `CMakeLists.txt` to register both tests.
+
+### Work
+
+1. Add a fitted-scale baseline to `NetworkView`. Define Fit as the final transform after topology bounds, device-pixel padding, and the existing track-legibility minimum have all been applied.
+2. Route wheel, toolbar, and mouse-anchored zoom through one `zoomBy(qreal factor)` path.
+3. Clamp the scale from Fit through 12x. Ignore further input at either bound while still emitting one viewport update for the applied change. Expose map-style labels such as `Fit`, `2x`, and `12x` rather than percentages.
+4. Recompute the fitted baseline when a case loads, when Fit runs, and when a fitted view resizes. A resize must preserve the current zoom ratio when the user has zoomed away from fit instead of snapping back unexpectedly.
+5. Keep Ctrl+0 as Fit and make its tooltip state that it restores the full network view.
+6. Give `TimeProgressBar` the real range `0` through `totalSteps - 1`; set its value directly to the zero-based timestep. Remove the integer percentage calculation. Display steps as one-based values and calculate the end clock from `totalSteps - 1`.
+7. Increase the timeline height to 28 pixels and format it as `06:28:29 | Step 10 of 8,000 | End 08:41:40`. Keep it read-only and unfocusable, with no pointing cursor or click handling.
+8. Write `Simulation running` to the status bar only when the run enters that state. Timestep updates must not touch the status bar, so errors and transient guidance remain visible for their requested duration.
+
+### Regression checks
+
+- `test_networkview` records the final fitted scale, applies 100 zoom-in and zoom-out operations, and asserts clamping at 12x and Fit with a floating-point epsilon.
+- The test covers wheel-equivalent and toolbar-equivalent factors through the same public method.
+- At each viewport size, the test records Fit, zooms to 3x, resizes to the next supported size, and asserts that the transform remains 3x relative to the recomputed fitted baseline. It then verifies that the new baseline still clamps from Fit through 12x.
+- `test_timeprogressbar` checks the first, middle, and last steps. It asserts the zero-based progress value, one-based displayed step, last-step end clock, and formatted text. It also proves that mouse input does not change the value.
+- An in-app hook posts a timed status message, advances the snapshot, and proves that the progress update does not overwrite the message.
+- Run `cmake --build build`, `ctest --test-dir build --output-on-failure`, and `tools/e2e/visual_polish_smoke.sh`.
+
+## Pull request 2: make station overlays fit-safe and collision-aware
+
+### Files
+
+- Add `EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.h` and `StationOverlayItem.cpp`.
+- Modify `EGTRAIN/QEGTRAIN/app/MainWindow.h` and `MainWindow.cpp`.
+- Modify `EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp` only if viewport padding needs a shared helper.
+- Add `EGTRAIN/QEGTRAIN/tests/test_stationoverlay.cpp`.
+- Extend `tools/e2e/visual_polish_smoke.sh` and its in-app capture assertions.
+
+### Work
+
+1. Replace the separate station icon and rich-text label with one fixed-screen overlay item. Paint the symbol and plain label in one bounding rectangle with an 8-pixel gap.
+2. Keep existing station classification and icons. Do not change scene or simulation data.
+3. Exclude fixed-screen overlays, train badges, and the map key from the topology bounds used by `fitView()`.
+4. Add 24 device pixels of fit padding around topology.
+5. Remove scene-space icon-to-label offsets. Preserve case-specific station anchors only until a later scene-format issue can replace them with view metadata.
+6. In the viewport pass, evaluate label rectangles with 4 pixels of collision padding. Below 2x, consider selected, followed-train, interchange, and network-endpoint labels. Define a network endpoint as a station whose rendered infrastructure node has one connection. Do not infer service termini. From 2x up to but excluding 4x, add ordinary labels that fit. At 4x and above, consider every label.
+7. Resolve a remaining collision by selection first, station class second, and distance from the viewport center third. Do not depend on source order.
+8. Keep a stable preferred label anchor and shift the label within the 12-pixel viewport inset. Use a deterministic alternate side only when the preferred side cannot fit.
+9. Show the full name for a culled label when its station symbol is hovered or selected.
+
+### Regression checks
+
+- `test_stationoverlay` checks the combined bounding rectangle, the fixed 8-pixel symbol gap, edge placement, and priority ordering with a degree-1 network endpoint and a degree-3 interchange fixture.
+- The visual smoke adds assertions that no visible station label intersects its own symbol and that each visible label remains inside the viewport inset.
+- Run label-in-bounds and symbol-intersection checks for Netherlands, Paimpol, Copenhagen, and Brescia at Fit, 3x, and 12x. Capture the three states for Copenhagen.
+- Run the full UI verification gate.
+
+## Pull request 3: simplify the command bar and simulation timeline
+
+### Files
+
+- Modify `EGTRAIN/QEGTRAIN/app/MainWindow.ui`.
+- Modify the command-bar construction in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp` and declarations in `MainWindow.h`.
+- Modify `EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss`.
+- Add or update small SVG action icons under `EGTRAIN/QEGTRAIN/resources/icons/` and register them in `resources.qrc`.
+- Extend the visual smoke control assertions.
+
+### Work
+
+1. Divide the toolbar into Case, Playback, and View groups with subtle 1-pixel separators and 8-pixel spacing. Do not add group cards or background fills.
+2. Put Open Case in Case. It launches the existing startup chooser, where bundled and recent scenes, a scene folder, and legacy import remain available.
+3. Put Run, Pause, Stop, and speed in Playback. Keep Run, Pause, and Stop adjacent.
+4. Put Follow, the train selector, Zoom In, Zoom Out, and Fit in View.
+5. Remove the toolbar case badge and toolbar clock. The left dock owns case identity; the timeline owns time.
+6. Move Start Time into the Simulation menu and the scene-run setup path.
+7. Keep the existing right-is-faster mapping, label the ends `Slower` and `Faster`, and add a regression check for the direction.
+8. Keep Follow as a checkable action followed by the train selector. Give the selector a 140-pixel preferred width and a 200-pixel maximum.
+9. Use icon-only Zoom In and Zoom Out controls. Keep Fit visible with the text `Fit` because it is the recovery action.
+10. Set the toolbar icon size to 16 pixels and target a 32-pixel control height. Primary text buttons can reach 36 pixels; no toolbar control should create a taller row.
+11. Use the native toolbar overflow menu only for secondary actions. Open Case, Run, Pause, Stop, and Fit must remain visible at 1024 by 720.
+
+### Regression checks
+
+- The visual smoke locates Open Case, Run, Pause, Stop, and Fit by object name at all three window sizes.
+- It asserts that Stop follows Pause with no unrelated action between them.
+- Keyboard traversal reaches Open Case, Run, Pause, Stop, speed, Follow, train selection, Zoom In, Zoom Out, and Fit in that order.
+- Scene-render and legacy-import smoke hooks prove that both input paths remain reachable from Open Case.
+- Run the full UI verification gate.
+
+## Pull request 4: move the map key into the left rail and clarify layers
+
+### Files
+
+- Replace `EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.h` and `NetworkLegendItem.cpp` with `EGTRAIN/QEGTRAIN/widgets/NetworkLegendWidget.h` and `NetworkLegendWidget.cpp`.
+- Modify `EGTRAIN/QEGTRAIN/app/MainWindow.h` and `MainWindow.cpp`.
+- Modify `CMakeLists.txt` and `EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss`.
+- Add `EGTRAIN/QEGTRAIN/tests/test_networklegend.cpp`.
+
+### Work
+
+1. Remove the always-visible scene legend.
+2. Add a collapsible `Map key` section below the layer controls in the Case and Layers dock. Keep each row within 160 pixels, start expanded for a new profile, and remember the user's choice with `QSettings`. Keep the Map key header visible while collapsed.
+3. Add `Map key` to the View menu so a user can restore it.
+4. Rename the primary toggles to `Stations and platforms`, `Trains`, `Signals`, and `Passengers`.
+5. Add separate secondary toggles for `Station names` and `Train speed labels`. Do not hide an object just because its label is hidden.
+6. Replace the solid checked square with a visible check mark and a keyboard focus border.
+7. Keep the case name once, followed by run-readiness text such as `Ready to run` or the first blocking validation error.
+8. Include compact key entries for track states, train categories, station roles, signal cue shapes, and passenger-load indicators. Omit a category only when that category is not visible in the loaded case.
+
+### Regression checks
+
+- `test_networklegend` checks every visible track, train, station, signal, and passenger entry against the same classification functions or constants used by the renderer.
+- The visual smoke asserts that the map key is outside the `QGraphicsView`, can collapse, and can be restored from View.
+- Layer tests prove that object and label toggles act independently without changing scene ownership.
+- Run the full UI verification gate.
+
+## Pull request 5: revise the renderer palette and visual hierarchy
+
+### Files
+
+- Modify `EGTRAIN/QEGTRAIN/graphics/VisualPolish.h` and `VisualPolish.cpp`.
+- Modify `TrackLineItem`, `SignalItem`, `TrainBadgeItem`, and the new station overlay item.
+- Modify `EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp` and `EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss`.
+- Update `docs/ui/renderer-style-map.md`.
+- Extend `EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp`.
+
+### Work
+
+1. Apply the neutral shell and canvas colors from the audit, including the 1-pixel inset border that separates the surfaces.
+2. Draw free track as a 2-pixel `#A0ACB4` solid line. Use Qt pen styles for state underlays: prepared is a medium dash-dot rail-blue line, occupied is a heavy solid red-orange line, and blocked is a heavy dashed amber line with the existing block marker.
+3. Do not add custom chevrons, ties, animation, or track textures. Color, width, and Qt pen style provide the redundant cues.
+4. Keep signal aspect colors, but lower housing contrast at overview and show full housings progressively as zoom increases. Their icon or silhouette must remain distinguishable in grayscale at minimum zoom.
+5. Reduce train fill saturation. Preserve category shape differences and use text or icons for delay state.
+6. Keep the followed or selected train identifiable on the canvas without relying on a tooltip. Use a wider selected badge or middle elision that preserves the distinguishing service suffix. Keep the full identifier in the selector and tooltip. Add a smoke assertion that two identifiers with the same prefix remain distinguishable.
+7. Use the system fixed-width font for clock and timestep text. Keep the system UI font everywhere else.
+8. Document exact color, width, dash, marker, and shape assignments in the renderer style map.
+
+### Regression checks
+
+- Unit tests assert the exact renderer mapping for every state.
+- Add a grayscale image check that prepared, occupied, and blocked samples differ by stroke structure, not only luminance.
+- Inspect the captures with common red-green deficiency simulation and record the result in the pull request.
+- Run the full UI verification gate.
+
+## Pull request 6: add persistent guidance and narrow-window coverage
+
+### Files
+
+- Modify the startup chooser and empty-state handling in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp`.
+- Modify `tools/e2e/visual_polish_smoke.sh` and the in-app smoke hooks.
+- Update `docs/guides/scenes-and-application.md` after the controls settle.
+
+### Work
+
+1. Rename `Skip` in the startup chooser to `Not now`.
+2. When no case is open, show a quiet canvas empty state with `Open a case to inspect or run it` and a normal button bound to the existing `Open Case` action. Do not add custom scene hit testing.
+3. Add a compact navigation hint below the empty state and a persistent `Network controls` entry under Help: `Drag to pan | Wheel to zoom | Ctrl+0 to fit | Right-click for actions`.
+4. Remove the in-canvas hint after a case opens. Keep Network controls available from Help and from the network view context menu.
+5. Remove the disabled `Planned route and related infrastructure` placeholder from the train context menu until that command works.
+6. Add narrow and wide visual captures at 1024 by 720 and 1440 by 900.
+7. Add a maximum-zoom capture and a fit-after-maximum-zoom assertion.
+8. Update the user guide with the final names and screenshots.
+
+### Regression checks
+
+- The startup smoke covers bundled case selection, Not now, persistent empty-state recovery, and Open Case.
+- The loaded-case smoke proves that Network controls remains reachable after the empty state disappears.
+- The visual smoke proves that primary controls do not overflow and station labels remain in bounds at all supported sizes.
+- Run `cmake --build build`, `ctest --test-dir build --output-on-failure`, and `tools/e2e/visual_polish_smoke.sh`.
+
+## Completion gate
+
+After all six pull requests:
+
+1. Run the full build and CTest suite.
+2. Run `tools/e2e/visual_polish_smoke.sh` and `tools/e2e/editor_smoke.sh`.
+3. Run `tools/e2e/headless_smoke.py` to confirm the UI work did not change simulation output.
+4. Compare the five required visual states at all three window sizes.
+5. Run `graphify update .`.
+6. Close the focused UI issues only after their acceptance checks pass. Close the student-workflow epic only when its remaining non-visual workflow issues are complete.

--- a/docs/planning/2026-07-19-main-application-ux-audit.md
+++ b/docs/planning/2026-07-19-main-application-ux-audit.md
@@ -4,7 +4,7 @@ Date: 2026-07-19
 
 ## Scope and evidence
 
-This audit covers the main playback workspace, the startup chooser, and the controls that remain visible during a simulation. It uses the Copenhagen case at the 1200 by 800 logical window size exercised by `tools/e2e/visual_polish_smoke.sh`. The default, dense, follow-train, and context-menu captures all passed the smoke test on commit `8abde7e`.
+This audit covers the main playback workspace, the startup chooser, and the controls that remain visible during a simulation. It uses the Copenhagen case at the 1200 by 800 logical window size exercised by `tools/e2e/visual_polish_smoke.sh`. The default, dense, follow-train, and context-menu captures all passed the smoke test on commit `8abde7e`. The macOS captures are 2400 by 1600 physical pixels, which confirms the 2x Retina path. The current smoke does not cover a 1x display.
 
 The smoke test proves that the controls and scene items exist. It does not prove that they are readable. The captures reproduce label collisions, clipped text, toolbar crowding, a map-obscuring legend, weak zoom control, and an unreadable timestep bar.
 
@@ -23,6 +23,12 @@ Students cannot reliably identify stations in the view where they are expected t
 The Copenhagen renderer contains station-name lists with Y offsets of 900, 920, 2200, 2800, and 3500 scene units in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:6278`. `MainWindow::fitView()` includes those decorations when it calculates the scene bounds in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:8506`. The resulting default view leaves large empty regions above and below the useful track geometry while rendering the tracks thin and compressed.
 
 The map spends screen area on historical positioning corrections instead of the railway topology.
+
+### P1: Fit does not restore a full-network view
+
+`MainWindow::fitView()` first calls `fitInView()`, then raises the scale to an 8-pixel track-separation minimum in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:8506`. That second transform can crop the topology again. The default and follow captures both show scrollbars after the fitted view has been established.
+
+Fit is the recovery action for a lost or over-zoomed map. It should show the full rendered infrastructure inside viewport padding, with both scrollbars hidden.
 
 ### P1: network zoom has no lower or upper bound
 
@@ -46,6 +52,12 @@ The clock, case badge, and Follow state use large filled rectangles, so secondar
 
 The primary sequence of open, run, pause, and stop is harder to scan. Actions fall into the toolbar overflow at the supported default size.
 
+### P2: playback icons use oversized platform defaults
+
+Run, Pause, and Stop use `QStyle::SP_MediaPlay`, `SP_MediaPause`, and `SP_MediaStop` in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:631`. Their filled platform glyphs are much larger than the nearby text actions and change appearance between Qt platform styles.
+
+The playback group needs one 16-pixel monochrome icon family with matching stroke weight. The action text and tooltips should continue to carry the meaning.
+
 ### P2: the permanent legend covers the network
 
 `NetworkLegendItem` is a fixed 190 by 154 pixel overlay in `EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.cpp:7`. `updateViewportOverlays()` pins it to the lower-right corner in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:10259`. It has no close, collapse, or View-menu action. In both default and dense captures it occupies useful map area and can sit over tracks.
@@ -64,11 +76,23 @@ The dense capture renders a signal housing at nearly every block boundary. Their
 
 Zooming in increases detail but reduces the visual hierarchy of the operational map.
 
+### P2: the background grid has no scale or unit
+
+`NetworkView::drawBackground()` changes the grid spacing to keep cells between 24 and 96 screen pixels in `EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp:47`. It does not show a distance, coordinate, or infrastructure unit. In the default capture it emphasizes the large unused region above the tracks.
+
+The operational view should not imply a measurement that the schematic cannot support. Remove the grid there. A future editor-specific grid should return only with a defined coordinate meaning.
+
 ### P2: track state relies too heavily on color
 
 Prepared and occupied sections are both solid lines. They differ mainly by green versus red and by line width. Blocked sections add a dash pattern. See `EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp:33` and the matching legend in `EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.cpp:9`.
 
 Red and green are also reserved for signal aspects. Reusing them for route state makes the scene harder to teach and gives users with red-green color-vision deficiency too little redundant information.
+
+### P2: free-track speed styling is an unexplained encoding
+
+`classifyTrackSpeed()` assigns blue, dark gray, or light gray and widths of 4, 3, or 2 pixels from the speed limit in `EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp:24`. The map key does not explain those tiers, and the dark mainline color has weak contrast against the canvas.
+
+An overview should not make students infer an undocumented scale. Use one neutral free-track style. Keep speed limits in the infrastructure details until the UI has a labeled speed layer.
 
 ### P2: train identity truncates at the point of use
 
@@ -106,11 +130,11 @@ The network view supports drag-to-pan, wheel zoom, Ctrl-modified scrolling, tool
 
 First-time users have to experiment or read source-level documentation to learn basic navigation.
 
-### P2: leaving the startup chooser creates an unexplained blank state
+### P1: the startup chooser reports a false empty state
 
-The startup chooser offers Open, Open Scene Folder, Import Legacy Case, and Skip in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:6577`. Skip closes the dialog and leaves the main canvas without an in-canvas next step. The only guidance is a temporary status-bar message.
+`main.cpp` selects and prepares the command-line case before it constructs `MainWindow`. A normal launch therefore has Netherlands loaded before the chooser appears. The chooser's Skip path in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:6697` leaves that case active but writes `No case chosen` to the status bar.
 
-A student who dismisses the chooser can land in an empty workspace with no persistent call to action.
+The visible case and status message disagree. The chooser must name the loaded fallback case instead of presenting Skip as an empty-workspace action.
 
 ## Design direction
 
@@ -128,18 +152,22 @@ The target is a railway operations teaching desk. It should be compact, calm, an
 - Remove the duplicate case badge and clock from the command bar.
 - Keep speed and follow controls compact. Move Start Time into simulation setup or the Simulation menu.
 - Use icon-only Zoom In and Zoom Out actions with tooltips. Keep Fit visible as the recovery action.
+- Replace the platform media icons with one custom 16-pixel monochrome set registered in `EGTRAIN/QEGTRAIN/app/resources.qrc`.
 - Replace the 10-pixel progress bar with one 28-pixel read-only simulation timeline below the canvas. It shows current clock time, `Step n of total`, and end time in one line. Keep the progress fill, but do not give it focus, a pointing cursor, click handling, or any other scrubbing cue.
-- Move the map key into the unused lower part of the left dock. Use compact 160-pixel rows, start expanded for a new profile, and keep the Map key header visible when collapsed.
+- Move the map key into the unused lower part of the left dock. Use compact 160-pixel rows, start expanded on every launch, and keep the Map key header visible when collapsed.
 - Use the left dock for case name, run readiness, layers, and the map key. Do not add decorative cards to fill space.
 
 ### Network view
 
-- Calculate fit-to-view from topology, not fixed-size labels, icons, badges, or the legend.
+- Calculate fit-to-view from rendered track and connection geometry, not fixed-size labels, icons, badges, selection hit areas, or the legend.
+- Define Fit as the full topology inside logical-pixel padding. Do not reapply the track-separation minimum when it would crop the network. Hide both scrollbars at Fit.
 - Anchor each station symbol and label as one screen-space overlay with a fixed gap.
-- Keep labels inside viewport padding. Below 2x, show selected, followed-train, interchange, and network-endpoint labels. Define a network endpoint from the rendered infrastructure node degree, not from service assumptions. From 2x up to but excluding 4x, add ordinary station labels when they do not collide. At 4x and above, try every label and resolve remaining ties by selection first, station class second, and distance from the viewport center third.
+- Keep labels inside viewport padding. Below 2x, show the selected station, the station nearest the followed train, interchanges, and network endpoints. Define a network endpoint from the rendered infrastructure node degree, not from service assumptions. From 2x up to but excluding 4x, add ordinary station labels when they do not collide. At 4x and above, try every label. Resolve ties by selection, followed-train proximity, interchange, degree-1 endpoint, remaining station class, then distance from the viewport center.
 - Reveal a culled station name on hover or selection.
+- Let station overlays accept hover but no mouse buttons. Track, station, and train selection and context menus must continue through the existing semantic hit-test path.
 - Treat fitted view as the map baseline. Clamp zoom from Fit to 12x and show map-style labels such as `Fit`, `2x`, and `12x`, not document percentages.
-- Use progressive signal detail rather than switching every signal housing at one threshold.
+- Remove the non-semantic grid from the operational view.
+- Use progressive signal detail rather than switching every signal housing at one threshold. Keep stop and caution cues prominent at Fit. Subdue repeated proceed cues so they do not overpower tracks and stations.
 
 ### Color and type
 
@@ -167,6 +195,8 @@ Track state uses both color and stroke:
 
 These use Qt pen styles rather than custom track textures. State remains legible through color, width, and dash pattern without adding visual noise to dense junctions.
 
+Against the `#12191F` canvas, the proposed contrast ratios are 7.64:1 for free, 4.84:1 for prepared, 4.42:1 for occupied, and 7.61:1 for blocked. Each exceeds the 3:1 non-text graphical-object target. The palette therefore stays less saturated while the stroke structure carries the state distinction.
+
 Signals keep standard red, amber, and green aspects because those colors have railway meaning. Their housing shape and aspect icon remain visible without color. Train categories keep their existing shape differences and move to less saturated fills.
 
 Use the platform system font for controls and labels. Use the platform fixed-width font for the simulation clock and timestep only. This avoids a font dependency and keeps numerical changes from shifting the layout.
@@ -175,12 +205,14 @@ Use the platform system font for controls and labels. Use the platform fixed-wid
 
 - No station name intersects its own station symbol at Fit, 3x, or 12x zoom.
 - Important station labels stay within 12 pixels of the viewport edge and remain discoverable when collision culling hides them.
-- Wheel and toolbar zoom cannot exceed the documented range.
-- The simulation timeline advances on every reported timestep and explains clock time, current step, total steps, and end time.
+- Fit shows the full topology with no horizontal or vertical scrollbar.
+- Real wheel events and toolbar actions cannot exceed the documented zoom range.
+- The simulation timeline advances on every reported timestep. It shows one-based steps while retaining zero-based internal values, and labels the horizon as the end of the final interval.
 - Open, Run, Pause, and Stop remain visible and adjacent at 1024 by 720, 1200 by 800, and 1440 by 900.
 - The speed control visibly identifies its slower and faster ends, with faster on the right.
 - The map key never covers track geometry.
 - Context menus contain working commands only and do not widen for unavailable placeholders.
 - Prepared, occupied, and blocked track states remain distinguishable in grayscale and with common red-green color-vision deficiencies. Signal icons remain distinguishable without aspect color at minimum zoom.
 - Keyboard focus is visible on every command-bar and layer control.
-- Visual smoke coverage records default, dense, follow, narrow-window, and maximum-zoom states.
+- Dismissing the startup chooser leaves the loaded fallback case and its status text in agreement.
+- Visual smoke coverage records default, dense, follow, narrow-window, and maximum-zoom states at 1x and 2x device-pixel ratios.

--- a/docs/planning/2026-07-19-main-application-ux-audit.md
+++ b/docs/planning/2026-07-19-main-application-ux-audit.md
@@ -152,7 +152,7 @@ The shell uses neutral railway-instrument colors rather than the current teal ac
 | Main text | `#24313A` |
 | Divider | `#C8CED2` |
 | Primary action and focus | `#315A70` |
-| Secondary focus or warning | `#A66A2C` |
+| Secondary focus or warning | `#965C22` |
 | Network canvas | `#12191F` |
 | Network text | `#E6EAEC` |
 

--- a/docs/planning/2026-07-19-main-application-ux-audit.md
+++ b/docs/planning/2026-07-19-main-application-ux-audit.md
@@ -1,0 +1,186 @@
+# Main application UX audit
+
+Date: 2026-07-19
+
+## Scope and evidence
+
+This audit covers the main playback workspace, the startup chooser, and the controls that remain visible during a simulation. It uses the Copenhagen case at the 1200 by 800 logical window size exercised by `tools/e2e/visual_polish_smoke.sh`. The default, dense, follow-train, and context-menu captures all passed the smoke test on commit `8abde7e`.
+
+The smoke test proves that the controls and scene items exist. It does not prove that they are readable. The captures reproduce label collisions, clipped text, toolbar crowding, a map-obscuring legend, weak zoom control, and an unreadable timestep bar.
+
+## Findings
+
+### P1: station labels collide with symbols and clip at the viewport edge
+
+At the default fit, station symbols cover parts of labels such as Taastrup and Ballerup. Labels near the right edge are cut to a few characters. The dense capture separates some labels, but the result changes with zoom rather than following a stable label rule.
+
+`MainWindow::paintStationName()` creates fixed-pixel text with `ItemIgnoresTransformations`, while `paintStationIcon()` creates a separate fixed-pixel icon. Their scene-space anchors are calculated independently in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:6262` and rendered in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:7097` and `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:7112`. The icon-to-label gap therefore shrinks or grows with the scene transform even though both items keep a fixed screen size.
+
+Students cannot reliably identify stations in the view where they are expected to follow trains and routes.
+
+### P1: legacy label offsets distort fit-to-view and create dead space
+
+The Copenhagen renderer contains station-name lists with Y offsets of 900, 920, 2200, 2800, and 3500 scene units in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:6278`. `MainWindow::fitView()` includes those decorations when it calculates the scene bounds in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:8506`. The resulting default view leaves large empty regions above and below the useful track geometry while rendering the tracks thin and compressed.
+
+The map spends screen area on historical positioning corrections instead of the railway topology.
+
+### P1: network zoom has no lower or upper bound
+
+Wheel zoom, toolbar zoom, and `NetworkView::scale()` multiply the current transform without a limit. The paths are in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:7708`, `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:9780`, and `EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp:24`. Repeated input can make the scene effectively disappear or magnify it until navigation becomes impractical. The UI shows no zoom level and gives no feedback when fit-to-view is restored.
+
+Users can lose the network and have to know that Ctrl+0 restores it.
+
+### P1: the timestep bar is mathematically wrong and too short for its text
+
+`TimeProgressBar::setProgress()` divides two integers before multiplying by 100. The value remains zero for almost the entire run. The widget is fixed at 10 pixels high while it tries to draw `Time: 9 / 7999`. See `EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.cpp:4` and `EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.cpp:15`.
+
+The same moment also appears as a toolbar clock and as `Simulation running HH:MM:SS / HH:MM:SS` in the status bar at `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:8685`. Three displays compete, but none clearly explains the relationship between clock time, timestep, and total progress.
+
+Progress appears stalled. Students have to infer whether the numbers are seconds, steps, or clock time.
+
+### P1: the command bar is crowded and breaks action grouping
+
+The 1200-pixel toolbar contains a case badge, Run, Pause, a large clock, speed text and slider, Follow and a 180 to 260 pixel train selector, Start Time, Stop, Zoom In, and Zoom Out. Fit View is not visible in the smoke capture. Stop is separated from Run and Pause because several widgets are inserted relative to the Stop action in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:628` through `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:785`.
+
+The clock, case badge, and Follow state use large filled rectangles, so secondary state has similar weight to the run controls. Text-beside-icon treatment makes every action wide.
+
+The primary sequence of open, run, pause, and stop is harder to scan. Actions fall into the toolbar overflow at the supported default size.
+
+### P2: the permanent legend covers the network
+
+`NetworkLegendItem` is a fixed 190 by 154 pixel overlay in `EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.cpp:7`. `updateViewportOverlays()` pins it to the lower-right corner in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:10259`. It has no close, collapse, or View-menu action. In both default and dense captures it occupies useful map area and can sit over tracks.
+
+The left Case and Layers dock has enough unused vertical space to hold a compact, collapsible map key without covering the canvas.
+
+### P2: station-name culling is order-dependent and silent
+
+`updateViewportOverlays()` walks `m_stationNames` and keeps the first non-overlapping label in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:10217`. There is no priority for interchanges, network endpoints, the selected station, or the station nearest a followed train. Hidden labels have no hover or selection fallback.
+
+A less useful label can hide a more useful one, and the user cannot tell that another station is present.
+
+### P2: signals dominate the topology at dense zoom
+
+The dense capture renders a signal housing at nearly every block boundary. Their bright green aspects and repeated dark housings draw more attention than tracks, switches, stations, and the selected train. `kDenseDetailScale` switches all signals at one threshold in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:57` and `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:10215`.
+
+Zooming in increases detail but reduces the visual hierarchy of the operational map.
+
+### P2: track state relies too heavily on color
+
+Prepared and occupied sections are both solid lines. They differ mainly by green versus red and by line width. Blocked sections add a dash pattern. See `EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp:33` and the matching legend in `EGTRAIN/QEGTRAIN/graphics/items/NetworkLegendItem.cpp:9`.
+
+Red and green are also reserved for signal aspects. Reusing them for route state makes the scene harder to teach and gives users with red-green color-vision deficiency too little redundant information.
+
+### P2: train identity truncates at the point of use
+
+The default and follow captures show the selected train badge as `H-Bal...`, while the toolbar selector displays the full `H-Ballerup-Osterport-1` identifier. The canvas badge is the object users follow, but it omits the distinguishing part of the name. `paintTrainBadge()` assigns the full description and the badge decides how much to render in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:7680` and `EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.h:13`.
+
+Users must look away from the train to identify it.
+
+### P2: layer names describe implementation details
+
+The left dock uses `Station decorations`, `Trains with speed labels`, `Signal groups / aspects`, and `Passenger load` in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:668`. The first three combine multiple visual layers under one checkbox. The custom checkbox style draws a filled teal square for checked state without a conventional check mark in `EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss:45`.
+
+It is unclear whether a control hides an object, its label, or both.
+
+### P2: playback speed has no visible direction or range
+
+The speed slider reports only the current mode, such as `Speed: fastest`. It does not label either end of the track. The code correctly maps higher slider values to shorter delays in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:65` and creates the unlabeled control at `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:508`.
+
+Users have to move the control to learn which direction is faster. The intended direction should be visible before interaction.
+
+### P2: the train context menu exposes an unavailable future action
+
+The train context menu ends with a disabled `Planned route and related infrastructure` item. It makes the compact menu much wider than the four working commands and looks like a broken feature. The item is added at `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:3827` and is visible in the context-menu smoke capture.
+
+Unavailable future commands should not occupy the working interface. Add the route action when the train-to-route association exists.
+
+### P2: case and simulation state are duplicated
+
+`Case: Copenhagen` appears in the toolbar and `Copenhagen` appears again in the left dock. Current time appears in the toolbar and status bar. The status bar is also used for transient guidance and errors, so continuous simulation text overwrites those messages.
+
+Duplicated state consumes space without adding context, while transient feedback is easy to miss.
+
+### P2: canvas navigation is not discoverable
+
+The network view supports drag-to-pan, wheel zoom, Ctrl-modified scrolling, toolbar zoom, fit-to-view, selection, and context menus. The canvas shows none of these controls or shortcuts. The relevant behavior is split between `EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp:5`, `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:7708`, and `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:9780`.
+
+First-time users have to experiment or read source-level documentation to learn basic navigation.
+
+### P2: leaving the startup chooser creates an unexplained blank state
+
+The startup chooser offers Open, Open Scene Folder, Import Legacy Case, and Skip in `EGTRAIN/QEGTRAIN/app/MainWindow.cpp:6577`. Skip closes the dialog and leaves the main canvas without an in-canvas next step. The only guidance is a temporary status-bar message.
+
+A student who dismisses the chooser can land in an empty workspace with no persistent call to action.
+
+## Design direction
+
+Three approaches were considered.
+
+1. A QSS-only polish would reduce padding and adjust colors quickly. It would not fix station geometry, zoom behavior, progress math, or overlay obstruction.
+2. A staged Qt Widgets revision fixes the shared interaction paths first, then adjusts the shell and renderer. It keeps `QMainWindow`, `QToolBar`, `QDockWidget`, `QGraphicsView`, and the current scene items. This is the recommended approach.
+3. A new custom canvas and workspace shell could produce the cleanest result, but it would replace working Qt patterns and carry more simulation and scene-selection risk than the current problems justify.
+
+The target is a railway operations teaching desk. It should be compact, calm, and readable at 1200 by 800. The railway state carries the visual emphasis. Widget chrome stays neutral.
+
+### Layout
+
+- Divide the command bar into Case, Playback, and View groups with narrow separators. Put Open Case in the first group; keep Run, Pause, Stop, and speed together in Playback; keep Follow, zoom, and Fit in View.
+- Remove the duplicate case badge and clock from the command bar.
+- Keep speed and follow controls compact. Move Start Time into simulation setup or the Simulation menu.
+- Use icon-only Zoom In and Zoom Out actions with tooltips. Keep Fit visible as the recovery action.
+- Replace the 10-pixel progress bar with one 28-pixel read-only simulation timeline below the canvas. It shows current clock time, `Step n of total`, and end time in one line. Keep the progress fill, but do not give it focus, a pointing cursor, click handling, or any other scrubbing cue.
+- Move the map key into the unused lower part of the left dock. Use compact 160-pixel rows, start expanded for a new profile, and keep the Map key header visible when collapsed.
+- Use the left dock for case name, run readiness, layers, and the map key. Do not add decorative cards to fill space.
+
+### Network view
+
+- Calculate fit-to-view from topology, not fixed-size labels, icons, badges, or the legend.
+- Anchor each station symbol and label as one screen-space overlay with a fixed gap.
+- Keep labels inside viewport padding. Below 2x, show selected, followed-train, interchange, and network-endpoint labels. Define a network endpoint from the rendered infrastructure node degree, not from service assumptions. From 2x up to but excluding 4x, add ordinary station labels when they do not collide. At 4x and above, try every label and resolve remaining ties by selection first, station class second, and distance from the viewport center third.
+- Reveal a culled station name on hover or selection.
+- Treat fitted view as the map baseline. Clamp zoom from Fit to 12x and show map-style labels such as `Fit`, `2x`, and `12x`, not document percentages.
+- Use progressive signal detail rather than switching every signal housing at one threshold.
+
+### Color and type
+
+The shell uses neutral railway-instrument colors rather than the current teal accent:
+
+| Role | Color |
+| --- | --- |
+| Shell background | `#F2F3F1` |
+| Panel background | `#FAFAF8` |
+| Main text | `#24313A` |
+| Divider | `#C8CED2` |
+| Primary action and focus | `#315A70` |
+| Secondary focus or warning | `#A66A2C` |
+| Network canvas | `#12191F` |
+| Network text | `#E6EAEC` |
+
+Use a 1-pixel `#3A4A54` inset border around the network view. The border makes the light workbench shell and dark map surface read as one deliberate instrument panel without adding shadows or card styling.
+
+Track state uses both color and stroke:
+
+- Free: `#A0ACB4`, 2-pixel solid line.
+- Prepared route: `#4C8DAE`, medium dash-dot line.
+- Occupied: `#D05A47`, heavy solid line.
+- Blocked: `#D6A13A`, heavy dashed line with a block marker.
+
+These use Qt pen styles rather than custom track textures. State remains legible through color, width, and dash pattern without adding visual noise to dense junctions.
+
+Signals keep standard red, amber, and green aspects because those colors have railway meaning. Their housing shape and aspect icon remain visible without color. Train categories keep their existing shape differences and move to less saturated fills.
+
+Use the platform system font for controls and labels. Use the platform fixed-width font for the simulation clock and timestep only. This avoids a font dependency and keeps numerical changes from shifting the layout.
+
+## Success criteria
+
+- No station name intersects its own station symbol at Fit, 3x, or 12x zoom.
+- Important station labels stay within 12 pixels of the viewport edge and remain discoverable when collision culling hides them.
+- Wheel and toolbar zoom cannot exceed the documented range.
+- The simulation timeline advances on every reported timestep and explains clock time, current step, total steps, and end time.
+- Open, Run, Pause, and Stop remain visible and adjacent at 1024 by 720, 1200 by 800, and 1440 by 900.
+- The speed control visibly identifies its slower and faster ends, with faster on the right.
+- The map key never covers track geometry.
+- Context menus contain working commands only and do not widen for unavailable placeholders.
+- Prepared, occupied, and blocked track states remain distinguishable in grayscale and with common red-green color-vision deficiencies. Signal icons remain distinguishable without aspect color at minimum zoom.
+- Keyboard focus is visible on every command-bar and layer control.
+- Visual smoke coverage records default, dense, follow, narrow-window, and maximum-zoom states.


### PR DESCRIPTION
## Summary

- Records 20 UI and UX defects reproduced in the main playback workspace.
- Defines six ordered implementation slices for viewport and timeline behavior, station labels, command hierarchy, the map key, renderer styling, and honest startup state.
- Adds checks for all four committed cases at 1024 by 720, 1200 by 800, and 1440 by 900 logical pixels.

## Design direction

- Keep a light, neutral application shell around the dark schematic canvas.
- Treat Fit as the per-case zoom baseline, keep both scrollbars hidden at Fit, and clamp zoom through 12x.
- Keep the timeline read-only while showing clock time, one-based step count, and the final interval horizon.
- Group the command bar into Case, Playback, and View, with a custom 16-pixel monochrome playback icon family.
- Move the map key into the left rail and remove the non-semantic canvas grid.
- Use deterministic station-label priorities, a neutral free-track style, and non-color track-state cues.
- Keep stop and caution signals prominent while subduing repeated proceed signals.
- Name the case already loaded when the startup chooser appears.
- Verify default captures at both 1x and 2x device-pixel ratios.

## Follow-up issues

#235, #236, #237, #238, #239, #240, and #241.

## Verification

- `tools/e2e/visual_polish_smoke.sh`
- Source references checked against commit `8abde7e`
- Markdown structure, contrast calculations, and diff checks

Related to #5