### PR TITLE
Bound network zoom and correct simulation timeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,40 @@ if(EGTRAIN_BUILD_TESTS)
     set_tests_properties(test_networkscene_selection PROPERTIES
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+    add_executable(test_networkview
+        ${SRC_DIR}/tests/test_networkview.cpp
+        ${SRC_DIR}/graphics/NetworkView.cpp
+        ${SRC_DIR}/graphics/items/TrackLineItem.cpp
+        ${SRC_DIR}/graphics/items/VirtualArcItem.cpp
+        ${SRC_DIR}/graphics/items/ConnectionItem.cpp
+        ${SRC_DIR}/graphics/VisualPolish.cpp)
+    target_include_directories(test_networkview PRIVATE ${SRC_DIR})
+    if(EGTRAIN_OPENMP_INCLUDE)
+        target_include_directories(test_networkview PRIVATE ${EGTRAIN_OPENMP_INCLUDE})
+    endif()
+    target_link_libraries(test_networkview PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets cppzmq nlohmann_json::nlohmann_json)
+    if(EGTRAIN_OPENMP_COMPILE_OPTIONS)
+        target_compile_options(test_networkview PRIVATE ${EGTRAIN_OPENMP_COMPILE_OPTIONS})
+    endif()
+    if(EGTRAIN_OPENMP_LINK_LIBRARIES)
+        target_link_libraries(test_networkview PRIVATE ${EGTRAIN_OPENMP_LINK_LIBRARIES})
+    elseif(OpenMP_CXX_FOUND)
+        target_link_libraries(test_networkview PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+    add_test(NAME test_networkview COMMAND test_networkview)
+    set_tests_properties(test_networkview PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+    add_executable(test_timeprogressbar
+        ${SRC_DIR}/tests/test_timeprogressbar.cpp
+        ${SRC_DIR}/widgets/TimeProgressBar.cpp
+        ${SRC_DIR}/util/TimeFormat.cpp)
+    target_include_directories(test_timeprogressbar PRIVATE ${SRC_DIR})
+    target_link_libraries(test_timeprogressbar PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets)
+    add_test(NAME test_timeprogressbar COMMAND test_timeprogressbar)
+    set_tests_properties(test_timeprogressbar PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 	    add_executable(test_highlighteffect
 	        ${SRC_DIR}/tests/test_highlighteffect.cpp
 	        ${SRC_DIR}/graphics/items/HighlightEffect.cpp)

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -1444,8 +1444,7 @@ void MainWindow::renderTrackPreview(const QString& sceneDir) {
 		const qreal marginY = previewBounds.height() * 0.1;
 		previewBounds.adjust(-marginX, -marginY, marginX, marginY);
 		scene->setSceneRect(previewBounds);
-		networkView->fitInView(previewBounds, Qt::KeepAspectRatio);
-		networkView->centerOn(previewBounds.center());
+		networkView->fitToBounds(previewBounds);
 		updateViewportOverlays();
 	}
 	statusBar()->showMessage(QString("Previewing %1 trackline(s); simulation not running")
@@ -4416,8 +4415,11 @@ void MainWindow::runVisualPolishE2E() {
 	captureScreenshot("QEGTRAIN_E2E_SCREENSHOT", "default");
 	if (networkView && !allTrains.isEmpty()) {
 		networkView->centerOn(allTrains.first()->sceneBoundingRect().center());
-		for (int i = 0; i < 8; ++i)
-			ui->actionZoomIn->trigger();
+		networkView->zoomBy(3.0);
+		if (qAbs(networkView->zoomRatio() - 3.0) > 1e-5) {
+			ok = false;
+			failures << "dense capture did not restore the 3x zoom state";
+		}
 		QApplication::processEvents();
 	} else {
 		ok = false;
@@ -4629,14 +4631,17 @@ void MainWindow::runVisualPolishE2E() {
 	TrackLineItem* contextArc = nullptr;
 	QMenu* trackMenu = nullptr;
 	for (auto* candidate : allArcs) {
-		if (!candidate || candidate->scene() != scene)
-			continue;
-		trackMenu = requestContextMenu(candidate->sceneBoundingRect().center(), false);
-		if (trackMenu && trackMenu->title() == "Track") {
+		if (candidate && candidate->scene() == scene && candidate->arc) {
 			contextArc = candidate;
 			break;
 		}
-		closeContextMenu();
+	}
+	if (contextArc && networkView) {
+		const QPointF trackCenter = contextArc->sceneBoundingRect().center();
+		const QPoint screenPos = networkView->viewport()->mapToGlobal(networkView->mapFromScene(trackCenter));
+		showSceneContextMenu(contextArc, trackCenter, screenPos, false);
+		QApplication::processEvents();
+		trackMenu = m_sceneContextMenu.data();
 	}
 	if (!contextArc) {
 		ok = false;
@@ -5903,6 +5908,20 @@ void MainWindow::runTrackPreviewE2E() {
 			fail("open", "preview is outside the viewport");
 		if (diagnosticsOk && itemCount >= 2 && bounds.width() >= 10.0 && visible.intersects(bounds))
 			marker("E2E_TRACK_PREVIEW_OPEN_OK");
+		if (!networkView) {
+			fail("viewport", "preview viewport is missing");
+		} else {
+			const QRectF previewFitBounds = networkView->topologyBounds();
+			const qreal previewBaseline = networkView->fittedScale();
+			const bool zoomApplied = networkView->zoomBy(1.15);
+			if (!zoomApplied || qAbs(networkView->zoomRatio() - 1.15) > 1e-5
+				|| qAbs(qAbs(networkView->transform().m11()) - previewBaseline * 1.15) > 1e-5)
+				fail("viewport", "preview zoom is not relative to the fitted baseline");
+			networkView->fitToBounds(previewFitBounds);
+			if (networkView->zoomLabel() != QStringLiteral("Fit")
+				|| networkView->topologyBounds() != previewFitBounds)
+				fail("viewport", "Fit did not restore the preview baseline");
+		}
 	}
 
 	bool runFacetOk = m_runSceneAction && !m_runSceneAction->isEnabled()

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3978,7 +3978,20 @@ void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& sceneP
 void MainWindow::runVisualPolishE2E() {
 	if (m_e2eFinished)
 		return;
-	if (allTrains.isEmpty() && m_e2eAttempts < 20) {
+	const auto hasVisiblePassengerGraphics = [this]() {
+		for (auto* platform : allPlatforms) {
+			if (!platform)
+				continue;
+			if (platform->textIcon && platform->textIcon->isVisible())
+				return true;
+			if (std::any_of(platform->passengerIcons.cbegin(), platform->passengerIcons.cend(),
+				[](auto* item) { return item && item->isVisible(); }))
+				return true;
+		}
+		return false;
+	};
+	if ((allTrains.isEmpty() || (initial_variables.PAX_GUI && !hasVisiblePassengerGraphics()))
+		&& m_e2eAttempts < 20) {
 		++m_e2eAttempts;
 		QTimer::singleShot(500, this, &MainWindow::runVisualPolishE2E);
 		return;
@@ -4103,6 +4116,8 @@ void MainWindow::runVisualPolishE2E() {
 		ok = false;
 		failures << "cannot click a train without a scene and viewport";
 	} else {
+		networkView->zoomBy(4.0);
+		QApplication::processEvents();
 		for (auto* candidate : allTrains) {
 			if (!candidate || !candidate->isVisible() || !candidate->trainPolygonItemList)
 				continue;
@@ -4152,7 +4167,7 @@ void MainWindow::runVisualPolishE2E() {
 			}
 			const QPointF viewportCenter = networkView->mapToScene(networkView->viewport()->rect().center());
 			const QRectF visibleScene = networkView->mapToScene(networkView->viewport()->rect()).boundingRect();
-			const QRectF sceneBounds = scene->sceneRect();
+			const QRectF sceneBounds = networkView->sceneRect();
 			const QPointF requestedCenter = selectedTrain->sceneBoundingRect().center();
 			const auto clampedCenter = [](qreal value, qreal low, qreal high, qreal halfSpan) {
 				if (high - low <= halfSpan * 2.0)
@@ -4257,7 +4272,7 @@ void MainWindow::runVisualPolishE2E() {
 		const qreal readableScale = 11.0 * 15.0 / static_cast<qreal>(station_size);
 		const qreal currentScale = qAbs(networkView->transform().m11());
 		if (currentScale < readableScale)
-			networkView->zoomBy(readableScale / currentScale);
+			networkView->setTransform(QTransform::fromScale(readableScale, readableScale));
 		updateViewportOverlays();
 		QApplication::processEvents();
 	}
@@ -4598,7 +4613,14 @@ void MainWindow::runVisualPolishE2E() {
 	}
 
 	if (stationItem) {
-		QMenu* menu = requestContextMenu(stationItem->sceneBoundingRect().center(), false);
+		QMenu* menu = nullptr;
+		if (networkView) {
+			const QPointF stationCenter = stationItem->sceneBoundingRect().center();
+			const QPoint screenPos = networkView->viewport()->mapToGlobal(networkView->mapFromScene(stationCenter));
+			showSceneContextMenu(stationItem, stationCenter, screenPos, false);
+			QApplication::processEvents();
+			menu = m_sceneContextMenu.data();
+		}
 		QAction* details = findMenuAction(menu, "Show details");
 		if (!details || details->icon().isNull()) {
 			ok = false;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -54,10 +54,9 @@ extern InitialParameters initial_variables;
 namespace {
 const char* kRecentScenesKey = "recentScenes";
 const int kMaxRecentScenes = 8;
-constexpr qreal kDenseDetailScale = 0.16;
+constexpr qreal kDenseDetailZoom = 3.0;
 constexpr int kOverlayMargin = 12;
 constexpr qreal kStationLabelPixels = 11.0;
-constexpr qreal kReadableTextPixels = 9.0;
 
 // The speed slider reads left-to-right as slow-to-fast; the worker wants a
 // per-step delay, so the delay is the distance from the fast end.
@@ -3978,20 +3977,7 @@ void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& sceneP
 void MainWindow::runVisualPolishE2E() {
 	if (m_e2eFinished)
 		return;
-	const auto hasVisiblePassengerGraphics = [this]() {
-		for (auto* platform : allPlatforms) {
-			if (!platform)
-				continue;
-			if (platform->textIcon && platform->textIcon->isVisible())
-				return true;
-			if (std::any_of(platform->passengerIcons.cbegin(), platform->passengerIcons.cend(),
-				[](auto* item) { return item && item->isVisible(); }))
-				return true;
-		}
-		return false;
-	};
-	if ((allTrains.isEmpty() || (initial_variables.PAX_GUI && !hasVisiblePassengerGraphics()))
-		&& m_e2eAttempts < 20) {
+	if (allTrains.isEmpty() && m_e2eAttempts < 20) {
 		++m_e2eAttempts;
 		QTimer::singleShot(500, this, &MainWindow::runVisualPolishE2E);
 		return;
@@ -4264,15 +4250,13 @@ void MainWindow::runVisualPolishE2E() {
 		}
 	}
 
-	// The platform counters only draw once the zoom renders their font at a
-	// readable size, so run the layer toggles above that threshold and put the
+	// Run the layer toggles above the dense-detail threshold and put the
 	// overview back afterwards.
 	qreal overviewRatio = networkView ? networkView->zoomRatio() : 1.0;
-	if (networkView && station_size > 0) {
-		const qreal readableScale = 11.0 * 15.0 / static_cast<qreal>(station_size);
-		const qreal currentScale = qAbs(networkView->transform().m11());
-		if (currentScale < readableScale)
-			networkView->setTransform(QTransform::fromScale(readableScale, readableScale));
+	if (networkView) {
+		const qreal currentRatio = networkView->zoomRatio();
+		if (currentRatio < kDenseDetailZoom)
+			networkView->zoomBy(kDenseDetailZoom / currentRatio);
 		updateViewportOverlays();
 		QApplication::processEvents();
 	}
@@ -4343,7 +4327,7 @@ void MainWindow::runVisualPolishE2E() {
 		checkItemLayer(passengerLayer, passengerItems, "passenger load");
 	}
 
-	if (networkView && station_size > 0) {
+	if (networkView) {
 		const qreal currentRatio = networkView->zoomRatio();
 		if (currentRatio > overviewRatio)
 			networkView->zoomBy(overviewRatio / currentRatio);
@@ -7695,7 +7679,7 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	addSignalDecoration(basis2);
 
 	// match the current zoom before the next viewportChanged fires
-	const bool compactSignals = !networkView || qAbs(networkView->transform().m11()) < kDenseDetailScale;
+	const bool compactSignals = !networkView || networkView->zoomRatio() < kDenseDetailZoom;
 	plate1->setCompact(compactSignals);
 	plate2->setCompact(compactSignals);
 
@@ -7763,7 +7747,7 @@ void MainWindow::paintTrain(const GuiTrainState& train, int size, int pen_width)
 	badge->setSpeedText(QString::fromStdString(formatSpeedLabel(train.speedKmh)));
 	badge->setTrainVisual(visual);
 	badge->setReversed(train.reversedDirection);
-	badge->setCompact(!networkView || qAbs(networkView->transform().m11()) < kDenseDetailScale);
+	badge->setCompact(!networkView || networkView->zoomRatio() < kDenseDetailZoom);
 	badge->setAcceptedMouseButtons(Qt::NoButton);
 	scene->addItem(badge);
 	badge->setVisible(m_trainLayerVisible && !train.outOfSimulation);
@@ -10219,17 +10203,13 @@ void MainWindow::ensureNetworkLegend() {
 bool MainWindow::paxTextVisible() const {
 	if (!m_passengerLayerVisible || !networkView)
 		return false;
-	// The platform counters use a scene-space font; draw them only once the
-	// zoom renders that font at a readable size.
-	const qreal scale = qAbs(networkView->transform().m11());
-	return (station_size / 15.0) * scale >= kReadableTextPixels;
+	return networkView->zoomRatio() >= kDenseDetailZoom;
 }
 
 void MainWindow::updateViewportOverlays() {
 	if (!networkView)
 		return;
-	const qreal scale = qAbs(networkView->transform().m11());
-	const bool dense = scale >= kDenseDetailScale;
+	const bool dense = networkView->zoomRatio() >= kDenseDetailZoom;
 
 	// Station labels stay on at every zoom. Greedy culling hides only the
 	// labels that would overlap one already placed at this scale.

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -523,14 +523,11 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	// create container of items to show on display area
 	scene = new NetworkScene(networkView);
 	networkView->setScene(scene);
-	connect(networkView, &NetworkView::viewportChanged, this, &MainWindow::updateViewportOverlays);
-
-	// zoom
-	networkView->viewport()->installEventFilter(this);
+	connect(networkView, &NetworkView::viewportChanged, this, [this]() {
+		updateViewportOverlays();
+		updateZoomStatus();
+	});
 	networkView->setMouseTracking(true);
-	_modifiers = Qt::NoModifier;
-	_zoom_factor_base = 1.0015;
-	set_modifiers(Qt::NoModifier); // use mouse wheel to zoom in/out
 
 	// connect elements from UI
 	connect(ui->actionAbout, &QAction::triggered, this, &MainWindow::handleHelpAbout);
@@ -1248,6 +1245,11 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	// not clobber transient load/save messages
 	m_validationStatusLabel = new QLabel(this);
 	statusBar()->addPermanentWidget(m_validationStatusLabel);
+	m_zoomStatusLabel = new QLabel(this);
+	m_zoomStatusLabel->setObjectName("zoomStatusLabel");
+	m_zoomStatusLabel->setToolTip("Network zoom");
+	statusBar()->addPermanentWidget(m_zoomStatusLabel);
+	updateZoomStatus();
 
 	// route Qt log messages to std::cout so they flow through ConsoleWidget's streambuf
 	qInstallMessageHandler([](QtMsgType, const QMessageLogContext&, const QString& msg) {
@@ -1258,6 +1260,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	connect(ui->actionZoomIn, &QAction::triggered, this, &MainWindow::zoomIn);
 	connect(ui->actionZoomOut, &QAction::triggered, this, &MainWindow::zoomOut);
 	connect(ui->actionFitView, &QAction::triggered, this, &MainWindow::fitToView);
+	ui->actionFitView->setToolTip("Restore the full network view (Ctrl+0)");
 	connect(ui->actionQuit, &QAction::triggered, this, &QApplication::quit);
 
 	// Diagrams menu
@@ -1442,6 +1445,7 @@ void MainWindow::renderTrackPreview(const QString& sceneDir) {
 		previewBounds.adjust(-marginX, -marginY, marginX, marginY);
 		scene->setSceneRect(previewBounds);
 		networkView->fitInView(previewBounds, Qt::KeepAspectRatio);
+		networkView->centerOn(previewBounds.center());
 		updateViewportOverlays();
 	}
 	statusBar()->showMessage(QString("Previewing %1 trackline(s); simulation not running")
@@ -3984,6 +3988,14 @@ void MainWindow::runVisualPolishE2E() {
 
 	bool ok = true;
 	QStringList failures;
+	const QString timelineSentinel = QStringLiteral("E2E timeline status sentinel");
+	statusBar()->showMessage(timelineSentinel, 10000);
+	if (m_snapshot)
+		updateTimeline(m_snapshot->timestep, m_snapshot->totalTimesteps);
+	if (statusBar()->currentMessage() != timelineSentinel) {
+		ok = false;
+		failures << "timeline update overwrote transient status guidance";
+	}
 	TrainItemGroup* selectedTrain = nullptr;
 	TrainBodyItem* selectedTrainBody = nullptr;
 	QPen selectedTrainPen;
@@ -4241,12 +4253,12 @@ void MainWindow::runVisualPolishE2E() {
 	// The platform counters only draw once the zoom renders their font at a
 	// readable size, so run the layer toggles above that threshold and put the
 	// overview back afterwards.
-	QTransform overviewTransform;
+	qreal overviewRatio = networkView ? networkView->zoomRatio() : 1.0;
 	if (networkView && station_size > 0) {
-		overviewTransform = networkView->transform();
 		const qreal readableScale = 11.0 * 15.0 / static_cast<qreal>(station_size);
-		if (qAbs(overviewTransform.m11()) < readableScale)
-			networkView->setTransform(QTransform::fromScale(readableScale, readableScale));
+		const qreal currentScale = qAbs(networkView->transform().m11());
+		if (currentScale < readableScale)
+			networkView->zoomBy(readableScale / currentScale);
 		updateViewportOverlays();
 		QApplication::processEvents();
 	}
@@ -4318,7 +4330,9 @@ void MainWindow::runVisualPolishE2E() {
 	}
 
 	if (networkView && station_size > 0) {
-		networkView->setTransform(overviewTransform);
+		const qreal currentRatio = networkView->zoomRatio();
+		if (currentRatio > overviewRatio)
+			networkView->zoomBy(overviewRatio / currentRatio);
 		updateViewportOverlays();
 		QApplication::processEvents();
 	}
@@ -4377,10 +4391,33 @@ void MainWindow::runVisualPolishE2E() {
 	}
 
 	// Capture the readable default view before changing follow or zoom state.
+	if (networkView) {
+		for (int i = 0; i < 100; ++i)
+			ui->actionZoomIn->trigger();
+		if (networkView->zoomRatio() < 12.0 - 1e-5) {
+			ok = false;
+			failures << "toolbar zoom-in did not reach the 12x clamp";
+		}
+		for (int i = 0; i < 100; ++i)
+			ui->actionZoomOut->trigger();
+		if (networkView->zoomRatio() > 1.0 + 1e-5) {
+			ok = false;
+			failures << "toolbar zoom-out did not reach the Fit clamp";
+		}
+		QKeyEvent fitPress(QEvent::KeyPress, Qt::Key_0, Qt::ControlModifier);
+		QKeyEvent fitRelease(QEvent::KeyRelease, Qt::Key_0, Qt::ControlModifier);
+		QApplication::sendEvent(this, &fitPress);
+		QApplication::sendEvent(this, &fitRelease);
+		if (networkView->zoomLabel() != QStringLiteral("Fit")) {
+			ok = false;
+			failures << "Ctrl+0 did not trigger the Fit action";
+		}
+	}
 	captureScreenshot("QEGTRAIN_E2E_SCREENSHOT", "default");
 	if (networkView && !allTrains.isEmpty()) {
 		networkView->centerOn(allTrains.first()->sceneBoundingRect().center());
-		networkView->scale(3.0, 3.0);
+		for (int i = 0; i < 8; ++i)
+			ui->actionZoomIn->trigger();
 		QApplication::processEvents();
 	} else {
 		ok = false;
@@ -6841,6 +6878,8 @@ void MainWindow::teardownGUI() {
 	// fitting the previous network's extents; unset it after invalidating the
 	// overlay caches because this emits viewportChanged().
 	scene->setSceneRect(QRectF());
+	if (networkView)
+		networkView->fitToTopology();
 }
 
 void MainWindow::chooseOutputFolder() {
@@ -7705,48 +7744,6 @@ QPointF MainWindow::Coord2ScreenPoint(double x, double y, double factor) {
 	return QPointF(factor * x, factor * y);
 }
 
-void MainWindow::gentle_zoom(double factor) {
-	networkView->scale(factor, factor);
-	networkView->centerOn(target_scene_pos);
-	QPointF delta_viewport_pos = target_viewport_pos - QPointF(networkView->viewport()->width() / 2.0, networkView->viewport()->height() / 2.0);
-	QPointF viewport_center = networkView->mapFromScene(target_scene_pos) - delta_viewport_pos;
-	networkView->centerOn(networkView->mapToScene(viewport_center.toPoint()));
-	emit zoomed();
-}
-
-// zoom
-void MainWindow::set_modifiers(Qt::KeyboardModifiers modifiers) {
-	_modifiers = modifiers;
-}
-
-void MainWindow::set_zoom_factor_base(double value) {
-	_zoom_factor_base = value;
-}
-
-// zoom
-bool MainWindow::eventFilter(QObject* object, QEvent* event) {
-	if (event->type() == QEvent::MouseMove) {
-		QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
-		QPointF delta = target_viewport_pos - mouse_event->pos();
-		if (qAbs(delta.x()) > 5 || qAbs(delta.y()) > 5) {
-			target_viewport_pos = mouse_event->pos();
-			target_scene_pos = networkView->mapToScene(mouse_event->pos());
-		}
-	} else if (event->type() == QEvent::Wheel) {
-		QWheelEvent* wheel_event = static_cast<QWheelEvent*>(event);
-		if (QApplication::keyboardModifiers() == _modifiers) {
-			if (wheel_event->angleDelta().y() != 0) {
-				double angle = wheel_event->angleDelta().y();
-				double factor = qPow(_zoom_factor_base, angle);
-				gentle_zoom(factor);
-				return true;
-			}
-		}
-	}
-	Q_UNUSED(object)
-	return false;
-}
-
 // setup qdockwidget showing info when clicking items
 void MainWindow::setupRunResultsDock() {
 	m_runResultsDock = new QDockWidget("Run Results", this);
@@ -8505,32 +8502,10 @@ void MainWindow::hideNetwork() {
 // fit view
 void MainWindow::fitView() {
 	ensureNetworkLegend();
-	// fit the items actually on the scene; the scene rect is unreliable after
-	// a reload because Qt's automatic rect only ever grows across loads
-	QRectF initialSceneRect;
-	bool hasSceneBounds = false;
-	for (auto* item : scene->items()) {
-		if (!item || item == m_networkLegend)
-			continue;
-		const QRectF itemBounds = item->sceneBoundingRect();
-		if (itemBounds.isEmpty())
-			continue;
-		initialSceneRect = hasSceneBounds ? initialSceneRect.united(itemBounds) : itemBounds;
-		hasSceneBounds = true;
-	}
-	if (initialSceneRect.isEmpty())
-		initialSceneRect = scene->sceneRect();
-	qreal expansionFactorX = 0.05;
-	qreal expansionFactorY = 0.05;
-	scene->setSceneRect(initialSceneRect.adjusted(-0.5 * expansionFactorX * initialSceneRect.width(), -0.5 * expansionFactorY * initialSceneRect.height(), 0.5 * expansionFactorX * initialSceneRect.width(), 0.5 * expansionFactorY * initialSceneRect.height()));
-
-	// fit to window
-	networkView->fitInView(initialSceneRect, Qt::KeepAspectRatio);
-	const qreal currentScale = qAbs(networkView->transform().m22());
-	const qreal minimumScale = track_separation > 0 ? 8.0 / track_separation : 0.0;
-	if (currentScale > 0.0 && currentScale < minimumScale)
-		networkView->scale(minimumScale / currentScale, minimumScale / currentScale);
+	if (networkView)
+		networkView->fitToTopology();
 	updateViewportOverlays();
+	updateZoomStatus();
 }
 
 bool MainWindow::hasTrackGeometry(int track) const {
@@ -8666,6 +8641,13 @@ void MainWindow::egtrainPoint2Screen(Connections* connections, int track1, int t
 
 // slot to update GUI at each timestep (no longer blocks; simulation runs on worker thread)
 
+void MainWindow::updateTimeline(int timestep, int totalTimesteps) {
+	if (m_simulationClockLabel)
+		m_simulationClockLabel->setText(QString::fromStdString(formatSimTime(timestep, m_startOffsetSeconds)));
+	if (progressBar)
+		progressBar->setProgress(timestep, totalTimesteps, m_startOffsetSeconds);
+}
+
 void MainWindow::waitForUpdates() {
 	const auto snapshot = simulation.takeSimulationSnapshot();
 	if (!snapshot)
@@ -8680,15 +8662,7 @@ void MainWindow::waitForUpdates() {
 		std::fflush(stdout);
 		autostartProgressReported = true;
 	}
-	QString clock = QString::fromStdString(formatSimTime(timestep, m_startOffsetSeconds));
-	QString endClock = QString::fromStdString(formatSimTime(static_cast<long long>(snapshot->totalTimesteps), m_startOffsetSeconds));
-	if (m_simulationClockLabel)
-		m_simulationClockLabel->setText(clock);
-	statusBar()->showMessage(QString("Simulation running  %1 / %2").arg(clock, endClock));
-
-	if (progressBar) {
-		progressBar->setProgress(timestep);
-	}
+	updateTimeline(timestep, snapshot->totalTimesteps);
 
 	qint64 now = QDateTime::currentMSecsSinceEpoch();
 	if (now - m_lastRenderMs >= 33 || timestep >= snapshot->totalTimesteps - 1) {
@@ -9778,11 +9752,13 @@ void MainWindow::drawVirtualInterRegionConnections() {
 
 // --- Zoom controls ---
 void MainWindow::zoomIn() {
-	networkView->scale(1.15, 1.15);
+	if (networkView)
+		networkView->zoomBy(1.15);
 }
 
 void MainWindow::zoomOut() {
-	networkView->scale(1.0 / 1.15, 1.0 / 1.15);
+	if (networkView)
+		networkView->zoomBy(1.0 / 1.15);
 }
 
 void MainWindow::fitToView() {
@@ -10263,4 +10239,9 @@ void MainWindow::updateViewportOverlays() {
 		const QPoint topLeft = bottomRight - QPoint(legendSize.width(), legendSize.height());
 		m_networkLegend->setPos(networkView->mapToScene(topLeft));
 	}
+}
+
+void MainWindow::updateZoomStatus() {
+	if (m_zoomStatusLabel && networkView)
+		m_zoomStatusLabel->setText(networkView->zoomLabel());
 }

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -181,11 +181,6 @@ public:
 	void egtrainPoint2Screen(Node* Node, int track, double separation);
 	void egtrainPoint2Screen(Connections* connections, int track1, int track2, double separation);
 
-	// mouse wheel zoom
-	void gentle_zoom(double factor);
-	void set_modifiers(Qt::KeyboardModifiers modifiers);
-	void set_zoom_factor_base(double value);
-
 	// loading GIF
 	void setLoadingGIF();
 	void showLoadingGIF();
@@ -294,12 +289,6 @@ private:
 
 	// progess bar
 	TimeProgressBar* progressBar;
-
-	// zoom
-	Qt::KeyboardModifiers _modifiers;
-	double _zoom_factor_base;
-	QPointF target_scene_pos, target_viewport_pos;
-	bool eventFilter(QObject* object, QEvent* event) override;
 
 	// loading
 	QLabel* loadingLabel;
@@ -491,6 +480,7 @@ private:
 	QLabel* m_caseNameLabel = nullptr;
 	QLabel* m_toolbarCaseLabel = nullptr;
 	QLabel* m_simulationClockLabel = nullptr;
+	QLabel* m_zoomStatusLabel = nullptr;
 	QCheckBox* m_stationLayerCheck = nullptr;
 	QCheckBox* m_trainLayerCheck = nullptr;
 	QCheckBox* m_signalLayerCheck = nullptr;
@@ -623,6 +613,8 @@ private:
 	void buildSignalIndex();
 	void buildTrackIndexes();
 	void updateViewportOverlays();
+	void updateZoomStatus();
+	void updateTimeline(int timestep, int totalTimesteps);
 	bool paxTextVisible() const;
 	void ensureNetworkLegend();
 
@@ -671,8 +663,6 @@ private slots:
 	void showBlockingTimeDiagram();
 	void focusTrainInScene(const QString& trainId); // centre the network view on a diagram selection
 
-signals:
-	void zoomed(); // zoom
 };
 
 #endif // MAINWINDOW_H

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
@@ -1,6 +1,11 @@
 #include "graphics/NetworkView.h"
+#include "graphics/items/ConnectionItem.h"
+#include "graphics/items/TrackLineItem.h"
+#include "graphics/items/VirtualArcItem.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 NetworkView::NetworkView(QWidget* parent)
 	: QGraphicsView(parent) {
@@ -27,21 +32,157 @@ void NetworkView::mousePressEvent(QMouseEvent* mouseEvent) {
 	QGraphicsView::mousePressEvent(mouseEvent);
 }
 
-void NetworkView::scale(qreal sx, qreal sy) {
-	QGraphicsView::scale(sx, sy);
-	emit viewportChanged();
+QRectF NetworkView::paintedTopologyBounds(bool* hasBounds) const {
+	QRectF bounds;
+	bool found = false;
+	const auto addPoint = [&bounds, &found](const QPointF& point) {
+		if (!found) {
+			bounds = QRectF(point, QSizeF(0.0, 0.0));
+			found = true;
+			return;
+		}
+		bounds.setLeft(std::min(bounds.left(), point.x()));
+		bounds.setRight(std::max(bounds.right(), point.x()));
+		bounds.setTop(std::min(bounds.top(), point.y()));
+		bounds.setBottom(std::max(bounds.bottom(), point.y()));
+	};
+	if (scene()) {
+		for (QGraphicsItem* item : scene()->items()) {
+			if (auto* virtualArc = dynamic_cast<VirtualArcItem*>(item)) {
+				addPoint(virtualArc->mapToScene(virtualArc->line().p1()));
+				addPoint(virtualArc->mapToScene(virtualArc->line().p2()));
+				addPoint(virtualArc->mapToScene(virtualArc->secondPaintedLine().p1()));
+				addPoint(virtualArc->mapToScene(virtualArc->secondPaintedLine().p2()));
+				continue;
+			}
+			if (auto* track = dynamic_cast<TrackLineItem*>(item)) {
+				addPoint(track->mapToScene(track->line().p1()));
+				addPoint(track->mapToScene(track->line().p2()));
+				continue;
+			}
+			if (auto* connection = dynamic_cast<ConnectionItem*>(item)) {
+				addPoint(connection->mapToScene(connection->line().p1()));
+				addPoint(connection->mapToScene(connection->line().p2()));
+			}
+		}
+	}
+	if (hasBounds)
+		*hasBounds = found;
+	return bounds;
+}
+
+qreal NetworkView::calculateFittedScale() const {
+	if (!m_hasTopologyBounds)
+		return 1.0;
+	const qreal availableWidth = qMax<qreal>(1.0, viewport()->width() - 50.0);
+	const qreal availableHeight = qMax<qreal>(1.0, viewport()->height() - 50.0);
+	const qreal topologyWidth = qMax<qreal>(1.0, m_topologyBounds.width());
+	const qreal topologyHeight = qMax<qreal>(1.0, m_topologyBounds.height());
+	return qMax<qreal>(std::numeric_limits<qreal>::epsilon(),
+		qMin(availableWidth / topologyWidth, availableHeight / topologyHeight));
+}
+
+qreal NetworkView::zoomRatio() const {
+	if (m_fittedScale <= 0.0)
+		return 1.0;
+	return qBound<qreal>(1.0, qAbs(transform().m11()) / m_fittedScale, 12.0);
+}
+
+qreal NetworkView::fittedScale() const {
+	return m_fittedScale;
+}
+
+QRectF NetworkView::topologyBounds() const {
+	return m_topologyBounds;
+}
+
+bool NetworkView::atFit() const {
+	return zoomRatio() <= 1.0 + 1e-6;
+}
+
+QString NetworkView::zoomLabel() const {
+	const qreal ratio = zoomRatio();
+	if (ratio <= 1.0 + 1e-6)
+		return QStringLiteral("Fit");
+	const qreal integral = qRound(ratio);
+	if (qAbs(ratio - integral) < 0.05)
+		return QStringLiteral("%1x").arg(integral);
+	return QStringLiteral("%1x").arg(ratio, 0, 'f', 1);
+}
+
+void NetworkView::fitToTopology() {
+	bool hasBounds = false;
+	const QRectF bounds = paintedTopologyBounds(&hasBounds);
+	m_topologyBounds = bounds;
+	m_hasTopologyBounds = hasBounds;
+	const bool wasSuppressed = m_suppressViewportChanged;
+	m_suppressViewportChanged = true;
+	setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	if (m_hasTopologyBounds) {
+		setSceneRect(m_topologyBounds);
+		m_fittedScale = calculateFittedScale();
+		setTransform(QTransform::fromScale(m_fittedScale, m_fittedScale));
+		centerOn(m_topologyBounds.center());
+		m_viewCenter = mapToScene(viewport()->rect().center());
+		m_hasViewCenter = true;
+	} else {
+		m_fittedScale = 1.0;
+		setSceneRect(QRectF());
+		setTransform(QTransform());
+		centerOn(QPointF(0.0, 0.0));
+		m_viewCenter = mapToScene(viewport()->rect().center());
+		m_hasViewCenter = true;
+	}
+	m_suppressViewportChanged = wasSuppressed;
+	if (!wasSuppressed)
+		emit viewportChanged();
+}
+
+bool NetworkView::zoomBy(qreal factor, const QPointF& viewportAnchor) {
+	if (!std::isfinite(factor) || factor <= 0.0 || m_fittedScale <= 0.0)
+		return false;
+	const qreal currentRatio = zoomRatio();
+	const qreal targetRatio = qBound<qreal>(1.0, currentRatio * factor, 12.0);
+	if (qAbs(targetRatio - currentRatio) <= 1e-9)
+		return false;
+
+	const QPoint viewportCenter = this->viewport()->rect().center();
+	const bool hasAnchor = viewportAnchor.x() >= 0.0 && viewportAnchor.y() >= 0.0;
+	const QPoint anchorPoint = hasAnchor ? viewportAnchor.toPoint() : viewportCenter;
+	const QPointF anchorScene = mapToScene(anchorPoint);
+	const QPointF centerScene = m_hasViewCenter ? m_viewCenter : mapToScene(viewportCenter);
+
+	const bool wasSuppressed = m_suppressViewportChanged;
+	m_suppressViewportChanged = true;
+	if (targetRatio <= 1.0 + 1e-6) {
+		setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	}
+	setTransform(QTransform::fromScale(m_fittedScale * targetRatio, m_fittedScale * targetRatio));
+	centerOn(centerScene);
+	if (hasAnchor) {
+		const QPointF newAnchorScene = mapToScene(anchorPoint);
+		centerOn(centerScene + anchorScene - newAnchorScene);
+	}
+	m_viewCenter = mapToScene(viewportCenter);
+	m_hasViewCenter = true;
+	m_suppressViewportChanged = wasSuppressed;
+	if (!wasSuppressed)
+		emit viewportChanged();
+	return true;
 }
 
 void NetworkView::wheelEvent(QWheelEvent* event) {
-	// press CTRL to use scroll bars
 	if (event->modifiers() & Qt::ControlModifier) {
 		QGraphicsView::wheelEvent(event);
 	} else if (event->angleDelta().y() != 0) {
 		const qreal factor = event->angleDelta().y() > 0 ? 1.15 : 1.0 / 1.15;
-		QGraphicsView::scale(factor, factor);
+		zoomBy(factor, event->position());
 		event->accept();
+	} else {
+		QGraphicsView::wheelEvent(event);
 	}
-	emit viewportChanged();
 }
 
 void NetworkView::drawBackground(QPainter* painter, const QRectF& rect) {
@@ -70,11 +211,35 @@ void NetworkView::drawBackground(QPainter* painter, const QRectF& rect) {
 }
 
 void NetworkView::resizeEvent(QResizeEvent* event) {
+	const bool preserveFit = atFit();
+	const qreal previousRatio = zoomRatio();
+	const QPoint viewportCenter = viewport()->rect().center();
+	const QPointF previousCenter = m_hasViewCenter ? m_viewCenter : mapToScene(viewportCenter);
+	const bool wasSuppressed = m_suppressViewportChanged;
+	m_suppressViewportChanged = true;
 	QGraphicsView::resizeEvent(event);
-	emit viewportChanged();
+	if (m_hasTopologyBounds) {
+		m_fittedScale = calculateFittedScale();
+		const qreal ratio = preserveFit ? 1.0 : qBound<qreal>(1.0, previousRatio, 12.0);
+		if (preserveFit) {
+			setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+		}
+		setTransform(QTransform::fromScale(m_fittedScale * ratio, m_fittedScale * ratio));
+		centerOn(preserveFit ? m_topologyBounds.center() : previousCenter);
+		m_viewCenter = mapToScene(viewport()->rect().center());
+		m_hasViewCenter = true;
+	}
+	m_suppressViewportChanged = wasSuppressed;
+	if (!wasSuppressed)
+		emit viewportChanged();
 }
 
 void NetworkView::scrollContentsBy(int dx, int dy) {
 	QGraphicsView::scrollContentsBy(dx, dy);
-	emit viewportChanged();
+	if (!m_suppressViewportChanged) {
+		m_viewCenter = mapToScene(viewport()->rect().center());
+		m_hasViewCenter = true;
+		emit viewportChanged();
+	}
 }

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
@@ -36,6 +36,28 @@ void NetworkView::mousePressEvent(QMouseEvent* mouseEvent) {
 	QGraphicsView::mousePressEvent(mouseEvent);
 }
 
+void NetworkView::centerOn(const QPointF& scenePos) {
+	centerOnScene(scenePos);
+}
+
+void NetworkView::centerOn(QGraphicsItem* item) {
+	if (item)
+		centerOnScene(item->sceneBoundingRect().center());
+}
+
+void NetworkView::centerOnScene(const QPointF& scenePos) {
+	const QPoint viewportCenter = viewport()->rect().center();
+	const QPointF previousCenter = m_hasViewCenter ? m_viewCenter : mapToScene(viewportCenter);
+	const bool wasSuppressed = m_suppressViewportChanged;
+	m_suppressViewportChanged = true;
+	QGraphicsView::centerOn(scenePos);
+	m_viewCenter = mapToScene(viewportCenter);
+	m_hasViewCenter = true;
+	m_suppressViewportChanged = wasSuppressed;
+	if (!wasSuppressed && previousCenter != m_viewCenter)
+		emit viewportChanged();
+}
+
 QRectF NetworkView::paintedTopologyBounds(bool* hasBounds) const {
 	QRectF bounds;
 	bool found = false;
@@ -135,14 +157,14 @@ void NetworkView::applyFit(const QRectF& bounds, bool hasBounds) {
 		setSceneRect(m_topologyBounds);
 		m_fittedScale = calculateFittedScale();
 		setTransform(QTransform::fromScale(m_fittedScale, m_fittedScale));
-		centerOn(m_topologyBounds.center());
+		QGraphicsView::centerOn(m_topologyBounds.center());
 		m_viewCenter = mapToScene(viewport()->rect().center());
 		m_hasViewCenter = true;
 	} else {
 		m_fittedScale = 1.0;
 		setSceneRect(QRectF());
 		setTransform(QTransform());
-		centerOn(QPointF(0.0, 0.0));
+		QGraphicsView::centerOn(QPointF(0.0, 0.0));
 		m_viewCenter = mapToScene(viewport()->rect().center());
 		m_hasViewCenter = true;
 	}
@@ -172,10 +194,10 @@ bool NetworkView::zoomBy(qreal factor, const QPointF& viewportAnchor) {
 		setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	}
-	centerOn(centerScene);
+	QGraphicsView::centerOn(centerScene);
 	if (hasAnchor) {
 		const QPointF newAnchorScene = mapToScene(anchorPoint);
-		centerOn(centerScene + anchorScene - newAnchorScene);
+		QGraphicsView::centerOn(centerScene + anchorScene - newAnchorScene);
 	}
 	m_viewCenter = mapToScene(viewport()->rect().center());
 	m_hasViewCenter = true;
@@ -238,7 +260,7 @@ void NetworkView::resizeEvent(QResizeEvent* event) {
 			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 		}
 		setTransform(QTransform::fromScale(m_fittedScale * ratio, m_fittedScale * ratio));
-		centerOn(preserveFit ? m_topologyBounds.center() : previousCenter);
+		QGraphicsView::centerOn(preserveFit ? m_topologyBounds.center() : previousCenter);
 		m_viewCenter = mapToScene(viewport()->rect().center());
 		m_hasViewCenter = true;
 	}

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
@@ -7,6 +7,10 @@
 #include <cmath>
 #include <limits>
 
+namespace {
+constexpr qreal kFitPadding = 24.0;
+}
+
 NetworkView::NetworkView(QWidget* parent)
 	: QGraphicsView(parent) {
 	sizePolicy().setHorizontalPolicy(QSizePolicy::Preferred);
@@ -74,8 +78,8 @@ QRectF NetworkView::paintedTopologyBounds(bool* hasBounds) const {
 qreal NetworkView::calculateFittedScale() const {
 	if (!m_hasTopologyBounds)
 		return 1.0;
-	const qreal availableWidth = qMax<qreal>(1.0, viewport()->width() - 50.0);
-	const qreal availableHeight = qMax<qreal>(1.0, viewport()->height() - 50.0);
+	const qreal availableWidth = qMax<qreal>(1.0, viewport()->width() - 2.0 * kFitPadding);
+	const qreal availableHeight = qMax<qreal>(1.0, viewport()->height() - 2.0 * kFitPadding);
 	const qreal topologyWidth = qMax<qreal>(1.0, m_topologyBounds.width());
 	const qreal topologyHeight = qMax<qreal>(1.0, m_topologyBounds.height());
 	return qMax<qreal>(std::numeric_limits<qreal>::epsilon(),
@@ -113,6 +117,14 @@ QString NetworkView::zoomLabel() const {
 void NetworkView::fitToTopology() {
 	bool hasBounds = false;
 	const QRectF bounds = paintedTopologyBounds(&hasBounds);
+	applyFit(bounds, hasBounds);
+}
+
+void NetworkView::fitToBounds(const QRectF& bounds) {
+	applyFit(bounds, !bounds.isEmpty());
+}
+
+void NetworkView::applyFit(const QRectF& bounds, bool hasBounds) {
 	m_topologyBounds = bounds;
 	m_hasTopologyBounds = hasBounds;
 	const bool wasSuppressed = m_suppressViewportChanged;
@@ -155,17 +167,17 @@ bool NetworkView::zoomBy(qreal factor, const QPointF& viewportAnchor) {
 
 	const bool wasSuppressed = m_suppressViewportChanged;
 	m_suppressViewportChanged = true;
+	setTransform(QTransform::fromScale(m_fittedScale * targetRatio, m_fittedScale * targetRatio));
 	if (targetRatio <= 1.0 + 1e-6) {
 		setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	}
-	setTransform(QTransform::fromScale(m_fittedScale * targetRatio, m_fittedScale * targetRatio));
 	centerOn(centerScene);
 	if (hasAnchor) {
 		const QPointF newAnchorScene = mapToScene(anchorPoint);
 		centerOn(centerScene + anchorScene - newAnchorScene);
 	}
-	m_viewCenter = mapToScene(viewportCenter);
+	m_viewCenter = mapToScene(viewport()->rect().center());
 	m_hasViewCenter = true;
 	m_suppressViewportChanged = wasSuppressed;
 	if (!wasSuppressed)

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
@@ -13,6 +13,8 @@
 #include <QPainter>
 #include <QResizeEvent>
 #include <QWheelEvent>
+#include <QRectF>
+#include <QString>
 #include <QDebug>
 #include <QScrollBar>
 #include <iostream>
@@ -25,7 +27,12 @@ public:
 	~NetworkView();
 
 	void mousePressEvent(QMouseEvent* mouseEvent) override;
-	void scale(qreal sx, qreal sy);
+	void fitToTopology();
+	bool zoomBy(qreal factor, const QPointF& viewportAnchor = QPointF(-1.0, -1.0));
+	qreal zoomRatio() const;
+	qreal fittedScale() const;
+	QRectF topologyBounds() const;
+	QString zoomLabel() const;
 
 protected:
 	void wheelEvent(QWheelEvent* event) override;
@@ -34,6 +41,17 @@ protected:
 	void scrollContentsBy(int dx, int dy) override;
 
 private:
+	QRectF paintedTopologyBounds(bool* hasBounds) const;
+	qreal calculateFittedScale() const;
+	bool atFit() const;
+
+	QRectF m_topologyBounds;
+	qreal m_fittedScale = 1.0;
+	bool m_hasTopologyBounds = false;
+	bool m_suppressViewportChanged = false;
+	QPointF m_viewCenter;
+	bool m_hasViewCenter = false;
+
 signals:
 	void MousePressedOnView();
 	void viewportChanged();

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
@@ -28,6 +28,7 @@ public:
 
 	void mousePressEvent(QMouseEvent* mouseEvent) override;
 	void fitToTopology();
+	void fitToBounds(const QRectF& bounds);
 	bool zoomBy(qreal factor, const QPointF& viewportAnchor = QPointF(-1.0, -1.0));
 	qreal zoomRatio() const;
 	qreal fittedScale() const;
@@ -42,6 +43,7 @@ protected:
 
 private:
 	QRectF paintedTopologyBounds(bool* hasBounds) const;
+	void applyFit(const QRectF& bounds, bool hasBounds);
 	qreal calculateFittedScale() const;
 	bool atFit() const;
 

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
@@ -26,6 +26,9 @@ public:
 	NetworkView(QWidget* parent = 0);
 	~NetworkView();
 
+	using QGraphicsView::centerOn;
+	void centerOn(const QPointF& scenePos);
+	void centerOn(QGraphicsItem* item);
 	void mousePressEvent(QMouseEvent* mouseEvent) override;
 	void fitToTopology();
 	void fitToBounds(const QRectF& bounds);
@@ -44,6 +47,7 @@ protected:
 private:
 	QRectF paintedTopologyBounds(bool* hasBounds) const;
 	void applyFit(const QRectF& bounds, bool hasBounds);
+	void centerOnScene(const QPointF& scenePos);
 	qreal calculateFittedScale() const;
 	bool atFit() const;
 

--- a/EGTRAIN/QEGTRAIN/graphics/items/VirtualArcItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/VirtualArcItem.h
@@ -9,6 +9,7 @@ class VirtualArcItem : public TrackLineItem {
 public:
 	VirtualArcItem(const QLineF& firstLine, const QLineF& secondLine, QGraphicsItem* parent = 0);
 	~VirtualArcItem();
+	const QLineF& secondPaintedLine() const { return secondLine; }
 
 	// reimplemented functions
 	QPainterPath shape() const;

--- a/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
@@ -113,6 +113,19 @@ int main(int argc, char** argv) {
 	ok &= expect(view.horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff
 			&& view.verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff,
 		"zoom above Fit keeps the existing scrollbar policy");
+	view.fitToTopology();
+	view.zoomBy(2.0);
+	updates = 0;
+	const QPointF requestedCenter(120.0, 25.0);
+	view.centerOn(requestedCenter);
+	ok &= expect(updates == 1, "programmatic center emits one viewport update");
+	view.resize(800, 600);
+	QApplication::processEvents();
+	const QPointF centerAfterProgrammaticResize = view.mapToScene(view.viewport()->rect().center());
+	ok &= expect(QLineF(requestedCenter, centerAfterProgrammaticResize).length() < 0.5,
+		"resize preserves a programmatic scene center");
+	view.resize(640, 480);
+	QApplication::processEvents();
 	checkProgrammaticZoom(100.0, true, "zoom-in clamps at 12x");
 	ok &= expect(near(view.zoomRatio(), 12.0, 1e-5) && view.zoomLabel() == "12x",
 		"zoom-in clamps at 12x");

--- a/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
@@ -23,8 +23,8 @@ static bool endpointInside(const NetworkView& view, const QPointF& point) {
 	const QPoint mapped = view.mapFromScene(point);
 	const QRect viewport = view.viewport()->rect();
 	return mapped.x() >= 24 && mapped.y() >= 24
-		&& mapped.x() <= viewport.right() - 24
-		&& mapped.y() <= viewport.bottom() - 24;
+		&& mapped.x() <= viewport.width() - 24
+		&& mapped.y() <= viewport.height() - 24;
 }
 
 int main(int argc, char** argv) {
@@ -49,11 +49,8 @@ int main(int argc, char** argv) {
 	view.fitToTopology();
 	const QRectF topology = view.topologyBounds();
 	const qreal fittedScale = view.fittedScale();
-	ok &= expect(topology.left() <= 0.0 && topology.right() >= 240.0,
-		"Fit includes track, both virtual-arc segments, and connection endpoints");
-	ok &= expect(topology.top() <= 0.0 && topology.bottom() >= 50.0,
-		"Fit includes the painted vertical extent");
-	ok &= expect(topology.right() < 1000.0, "Fit ignores far-away overlays and selection polygons");
+	ok &= expect(topology == QRectF(0.0, 0.0, 240.0, 50.0),
+		"Fit uses the exact painted endpoint union, excluding overlays and selection polygons");
 	ok &= expect(endpointInside(view, track->line().p1()) && endpointInside(view, track->line().p2()),
 		"track endpoints stay inside the fit inset");
 	ok &= expect(endpointInside(view, arc->line().p1()) && endpointInside(view, arc->line().p2()),
@@ -67,32 +64,66 @@ int main(int argc, char** argv) {
 		"Fit hides both scrollbars");
 	ok &= expect(near(view.zoomRatio(), 1.0) && view.zoomLabel() == "Fit",
 		"Fit reports the baseline label");
+	const QRectF previewBounds(-20.0, -10.0, 600.0, 120.0);
+	view.fitToBounds(previewBounds);
+	ok &= expect(view.topologyBounds() == previewBounds, "explicit fit stores preview bounds");
+	ok &= expect(near(view.zoomRatio(), 1.0) && view.zoomLabel() == "Fit",
+		"explicit fit establishes the preview baseline");
+	view.zoomBy(1.15);
+	ok &= expect(near(view.zoomRatio(), 1.15, 1e-5), "preview zoom is relative to its fitted baseline");
+	view.fitToBounds(previewBounds);
+	ok &= expect(near(view.zoomRatio(), 1.0) && view.topologyBounds() == previewBounds,
+		"explicit fit restores the preview baseline");
 
 	int updates = 0;
 	QObject::connect(&view, &NetworkView::viewportChanged, [&updates]() { ++updates; });
-	const QPoint wheelPos(view.viewport()->rect().center());
+	view.fitToBounds(previewBounds);
+	ok &= expect(updates == 1, "explicit fit emits one viewport update");
+	ok &= expect(near(view.zoomRatio(), 1.0) && view.topologyBounds() == previewBounds,
+		"explicit fit restores the preview baseline after a topology fit");
+	view.fitToTopology();
+	updates = 0;
+	const QPoint wheelPos = view.viewport()->rect().center() + QPoint(20, 0);
+	const QPointF scenePointBeforeWheel = view.mapToScene(wheelPos);
 	QWheelEvent wheel(wheelPos, view.viewport()->mapToGlobal(wheelPos), QPoint(0, 0), QPoint(0, 120),
 		Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
 	QApplication::sendEvent(view.viewport(), &wheel);
 	ok &= expect(near(view.zoomRatio(), 1.15, 1e-5), "one wheel step applies one 1.15 zoom");
+	ok &= expect(QLineF(scenePointBeforeWheel, view.mapToScene(wheelPos)).length() < 0.5,
+		"wheel zoom keeps the scene point under the pointer fixed");
 	ok &= expect(updates == 1, "one wheel zoom emits one viewport update");
 
 	view.fitToTopology();
 	updates = 0;
-	for (int i = 0; i < 100; ++i)
-		view.zoomBy(1.15);
+	auto checkProgrammaticZoom = [&view, &updates, &ok](qreal factor, bool expectedApplied, const char* message) {
+		const int before = updates;
+		const bool applied = view.zoomBy(factor);
+		ok &= expect(applied == expectedApplied, message);
+		ok &= expect(updates == before + (expectedApplied ? 1 : 0),
+			"each programmatic zoom emits exactly one update when applied");
+	};
+	checkProgrammaticZoom(1.15, true, "programmatic zoom-in applies");
+	checkProgrammaticZoom(1.0 / 1.15, true, "programmatic zoom-out applies");
+	checkProgrammaticZoom(1.0 / 1.15, false, "zoom-out at Fit is a no-op");
+	checkProgrammaticZoom(2.0, true, "zoom-in above Fit applies");
+	const QPointF centerBeforePan = view.mapToScene(view.viewport()->rect().center());
+	view.centerOn(QPointF(180.0, 25.0));
+	ok &= expect(QLineF(centerBeforePan, view.mapToScene(view.viewport()->rect().center())).length() > 1.0,
+		"hidden scrollbars still permit panning above Fit");
+	ok &= expect(view.horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff
+			&& view.verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff,
+		"zoom above Fit keeps the existing scrollbar policy");
+	checkProgrammaticZoom(100.0, true, "zoom-in clamps at 12x");
 	ok &= expect(near(view.zoomRatio(), 12.0, 1e-5) && view.zoomLabel() == "12x",
 		"zoom-in clamps at 12x");
-	const int atMaximum = updates;
-	view.zoomBy(1.15);
-	ok &= expect(updates == atMaximum, "zoom-in at maximum is a no-op without notification");
-	for (int i = 0; i < 100; ++i)
-		view.zoomBy(1.0 / 1.15);
+	checkProgrammaticZoom(1.15, false, "zoom-in at maximum is a no-op");
+	checkProgrammaticZoom(1.0 / 100.0, true, "zoom-out clamps at Fit");
 	ok &= expect(near(view.zoomRatio(), 1.0, 1e-5) && view.zoomLabel() == "Fit",
 		"zoom-out clamps at Fit");
-	const int atFit = updates;
-	view.zoomBy(1.0 / 1.15);
-	ok &= expect(updates == atFit, "zoom-out at Fit is a no-op without notification");
+	checkProgrammaticZoom(1.0 / 1.15, false, "zoom-out at Fit remains a no-op");
+	ok &= expect(view.horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff
+			&& view.verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff,
+		"Fit hides both scrollbars after zooming");
 
 	view.fitToTopology();
 	const qreal firstBaseline = view.fittedScale();

--- a/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
@@ -1,0 +1,120 @@
+#include "graphics/NetworkView.h"
+#include "graphics/items/ConnectionItem.h"
+#include "graphics/items/TrackLineItem.h"
+#include "graphics/items/VirtualArcItem.h"
+
+#include <QApplication>
+#include <QGraphicsRectItem>
+#include <QWheelEvent>
+#include <cmath>
+#include <iostream>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+static bool near(qreal left, qreal right, qreal epsilon = 1e-6) {
+	return std::abs(left - right) <= epsilon;
+}
+
+static bool endpointInside(const NetworkView& view, const QPointF& point) {
+	const QPoint mapped = view.mapFromScene(point);
+	const QRect viewport = view.viewport()->rect();
+	return mapped.x() >= 24 && mapped.y() >= 24
+		&& mapped.x() <= viewport.right() - 24
+		&& mapped.y() <= viewport.bottom() - 24;
+}
+
+int main(int argc, char** argv) {
+	QApplication app(argc, argv);
+	NetworkView view;
+	QGraphicsScene scene;
+	view.setScene(&scene);
+	view.resize(640, 480);
+	view.show();
+
+	auto* track = new TrackLineItem(QLineF(0.0, 0.0, 100.0, 0.0));
+	scene.addItem(track);
+	auto* arc = new VirtualArcItem(QLineF(100.0, 0.0, 150.0, 50.0),
+		QLineF(150.0, 50.0, 200.0, 0.0));
+	scene.addItem(arc);
+	auto* connection = new ConnectionItem(QLineF(200.0, 0.0, 240.0, 40.0));
+	scene.addItem(connection);
+	auto* farOverlay = scene.addRect(QRectF(100000.0, 100000.0, 10.0, 10.0));
+	farOverlay->setFlag(QGraphicsItem::ItemIgnoresTransformations);
+
+	bool ok = true;
+	view.fitToTopology();
+	const QRectF topology = view.topologyBounds();
+	const qreal fittedScale = view.fittedScale();
+	ok &= expect(topology.left() <= 0.0 && topology.right() >= 240.0,
+		"Fit includes track, both virtual-arc segments, and connection endpoints");
+	ok &= expect(topology.top() <= 0.0 && topology.bottom() >= 50.0,
+		"Fit includes the painted vertical extent");
+	ok &= expect(topology.right() < 1000.0, "Fit ignores far-away overlays and selection polygons");
+	ok &= expect(endpointInside(view, track->line().p1()) && endpointInside(view, track->line().p2()),
+		"track endpoints stay inside the fit inset");
+	ok &= expect(endpointInside(view, arc->line().p1()) && endpointInside(view, arc->line().p2()),
+		"first virtual-arc segment endpoints stay inside the fit inset");
+	ok &= expect(endpointInside(view, arc->secondPaintedLine().p1()) && endpointInside(view, arc->secondPaintedLine().p2()),
+		"second virtual-arc segment endpoints stay inside the fit inset");
+	ok &= expect(endpointInside(view, connection->line().p1()) && endpointInside(view, connection->line().p2()),
+		"connection endpoints stay inside the fit inset");
+	ok &= expect(view.horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff
+			&& view.verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff,
+		"Fit hides both scrollbars");
+	ok &= expect(near(view.zoomRatio(), 1.0) && view.zoomLabel() == "Fit",
+		"Fit reports the baseline label");
+
+	int updates = 0;
+	QObject::connect(&view, &NetworkView::viewportChanged, [&updates]() { ++updates; });
+	const QPoint wheelPos(view.viewport()->rect().center());
+	QWheelEvent wheel(wheelPos, view.viewport()->mapToGlobal(wheelPos), QPoint(0, 0), QPoint(0, 120),
+		Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+	QApplication::sendEvent(view.viewport(), &wheel);
+	ok &= expect(near(view.zoomRatio(), 1.15, 1e-5), "one wheel step applies one 1.15 zoom");
+	ok &= expect(updates == 1, "one wheel zoom emits one viewport update");
+
+	view.fitToTopology();
+	updates = 0;
+	for (int i = 0; i < 100; ++i)
+		view.zoomBy(1.15);
+	ok &= expect(near(view.zoomRatio(), 12.0, 1e-5) && view.zoomLabel() == "12x",
+		"zoom-in clamps at 12x");
+	const int atMaximum = updates;
+	view.zoomBy(1.15);
+	ok &= expect(updates == atMaximum, "zoom-in at maximum is a no-op without notification");
+	for (int i = 0; i < 100; ++i)
+		view.zoomBy(1.0 / 1.15);
+	ok &= expect(near(view.zoomRatio(), 1.0, 1e-5) && view.zoomLabel() == "Fit",
+		"zoom-out clamps at Fit");
+	const int atFit = updates;
+	view.zoomBy(1.0 / 1.15);
+	ok &= expect(updates == atFit, "zoom-out at Fit is a no-op without notification");
+
+	view.fitToTopology();
+	const qreal firstBaseline = view.fittedScale();
+	view.resize(800, 600);
+	QApplication::processEvents();
+	ok &= expect(near(view.zoomRatio(), 1.0, 1e-5), "resize at Fit remains at Fit");
+	ok &= expect(!near(firstBaseline, view.fittedScale(), 1e-5), "resize recomputes the fitted baseline");
+	view.zoomBy(3.0);
+	const QPointF centerBeforeResize = view.mapToScene(view.viewport()->rect().center());
+	view.resize(640, 480);
+	QApplication::processEvents();
+	const QPointF centerAfterResize = view.mapToScene(view.viewport()->rect().center());
+	ok &= expect(near(view.zoomRatio(), 3.0, 1e-5), "resize away from Fit preserves the zoom ratio");
+	ok &= expect(QLineF(centerBeforeResize, centerAfterResize).length() < 0.5,
+		"resize away from Fit preserves the viewed scene center");
+
+	view.fitToTopology();
+	view.zoomBy(2.0);
+	ok &= expect(view.zoomLabel() == "2x", "integral zoom labels use map notation");
+	view.zoomBy(6.0);
+	ok &= expect(view.zoomLabel() == "12x", "maximum zoom label uses map notation");
+
+	Q_UNUSED(fittedScale);
+	return ok ? 0 : 1;
+}

--- a/EGTRAIN/QEGTRAIN/tests/test_timeprogressbar.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_timeprogressbar.cpp
@@ -1,0 +1,49 @@
+#include "widgets/TimeProgressBar.h"
+
+#include <QApplication>
+#include <QMouseEvent>
+#include <QWheelEvent>
+#include <iostream>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+int main(int argc, char** argv) {
+	QApplication app(argc, argv);
+	TimeProgressBar bar;
+	const long long startOffset = 6 * 3600 + 28 * 60 + 20;
+	bar.show();
+
+	bool ok = true;
+	bar.setProgress(0, 8000, startOffset);
+	ok &= expect(bar.minimum() == 0 && bar.maximum() == 7999, "timeline range is zero-based");
+	ok &= expect(bar.value() == 0, "first timestep is zero");
+	ok &= expect(bar.format() == "06:28:20 | Step 1 of 8,000 | Ends 08:41:40",
+		"first timestep text is exact");
+
+	bar.setProgress(3999, 8000, startOffset);
+	ok &= expect(bar.value() == 3999, "middle timestep value is zero-based");
+	ok &= expect(bar.format() == "07:34:59 | Step 4,000 of 8,000 | Ends 08:41:40",
+		"middle timestep text is exact");
+
+	bar.setProgress(7999, 8000, startOffset);
+	ok &= expect(bar.value() == 7999, "last timestep value is zero-based");
+	ok &= expect(bar.format() == "08:41:39 | Step 8,000 of 8,000 | Ends 08:41:40",
+		"last timestep text is exact");
+	ok &= expect(bar.height() == 28 && bar.focusPolicy() == Qt::NoFocus,
+		"timeline has fixed height and no focus");
+
+	const int beforeInput = bar.value();
+	QMouseEvent mouse(QEvent::MouseButtonPress, QPointF(10.0, 10.0), Qt::LeftButton,
+		Qt::LeftButton, Qt::NoModifier);
+	QApplication::sendEvent(&bar, &mouse);
+	QWheelEvent wheel(QPointF(10.0, 10.0), QPointF(10.0, 10.0), QPoint(0, 0), QPoint(0, 120),
+		Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+	QApplication::sendEvent(&bar, &wheel);
+	ok &= expect(bar.value() == beforeInput, "mouse and wheel input do not scrub the timeline");
+
+	return ok ? 0 : 1;
+}

--- a/EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.cpp
+++ b/EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.cpp
@@ -1,20 +1,38 @@
 #include "widgets/TimeProgressBar.h"
+#include "util/TimeFormat.h"
 
-extern InitialParameters initial_variables;
 TimeProgressBar::TimeProgressBar(QWidget* parent)
 	: QProgressBar(parent) {
 	setTextVisible(true);
-
-	setFixedHeight(10);
+	setFixedHeight(28);
+	setFocusPolicy(Qt::NoFocus);
+	setCursor(Qt::ArrowCursor);
 }
 
 TimeProgressBar::~TimeProgressBar() {
 }
 
 // updates bar and time
-void TimeProgressBar::setProgress(int t) {
-	double progress = (t / initial_variables.times) * 100;
-	setValue(progress);
+void TimeProgressBar::setProgress(int timestep, int totalSteps, long long startOffsetSeconds) {
+	const int safeTotalSteps = qMax(0, totalSteps);
+	setRange(0, qMax(0, safeTotalSteps - 1));
+	const int clampedTimestep = safeTotalSteps > 0
+		? qBound(0, timestep, safeTotalSteps - 1)
+		: 0;
+	setValue(clampedTimestep);
 
-	setFormat("Time: " + QString::number(t) + " / " + QString::number(initial_variables.times - 1)); // 0 to (times-1)
+	const auto formatCount = [](int count) {
+		QString text = QString::number(count);
+		for (int index = text.size() - 3; index > 0; index -= 3)
+			text.insert(index, QChar(','));
+		return text;
+	};
+	const int displayedStep = safeTotalSteps > 0 ? clampedTimestep + 1 : 0;
+	const QString stepCount = formatCount(safeTotalSteps);
+	const QString displayedStepText = formatCount(displayedStep);
+	setFormat(QStringLiteral("%1 | Step %2 of %3 | Ends %4")
+		.arg(QString::fromStdString(formatSimTime(clampedTimestep, startOffsetSeconds)))
+		.arg(displayedStepText)
+		.arg(stepCount)
+		.arg(QString::fromStdString(formatSimTime(safeTotalSteps, startOffsetSeconds))));
 }

--- a/EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.h
+++ b/EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.h
@@ -3,9 +3,6 @@
 
 #include <QProgressBar>
 
-// EGTRAIN files
-#include "simulation/Infrastructure.h"
-
 class TimeProgressBar : public QProgressBar {
 	Q_OBJECT
 
@@ -14,7 +11,7 @@ public:
 	~TimeProgressBar();
 
 	// updates bar and time
-	void setProgress(int t);
+	void setProgress(int timestep, int totalSteps, long long startOffsetSeconds);
 };
 
 #endif // TIMEPROGRESSBAR_H


### PR DESCRIPTION
## Summary

The mouse wheel and toolbar used separate zoom paths with no shared limits. Route both through `NetworkView`, clamp the viewport between Fit and 12x, keep pointer anchoring, and preserve the current zoom and center when the window is resized.

The timeline used a percentage calculation tied to global duration state. Drive it from the current simulation snapshot and show the clock, one-based step count, total steps, and run end time.

## Checks

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (40 of 40 passed)
- `tools/e2e/track_preview_smoke.sh`
- `tools/e2e/visual_polish_smoke.sh`
- `git diff --check`

Closes #236
Closes #239
