### PR TITLE
Fix station label placement and topology fit bounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set(EGTRAIN_SOURCES
     ${SRC_DIR}/graphics/items/NetworkLegendItem.cpp
     ${SRC_DIR}/graphics/items/IconItem.cpp
     ${SRC_DIR}/graphics/items/StationNodeItem.cpp
+    ${SRC_DIR}/graphics/items/StationOverlayItem.cpp
     ${SRC_DIR}/graphics/NetworkScene.cpp
     ${SRC_DIR}/graphics/NetworkView.cpp
     ${SRC_DIR}/simulation/NumberGenerator.cpp
@@ -159,6 +160,7 @@ set(EGTRAIN_HEADERS
     ${SRC_DIR}/graphics/items/NetworkLegendItem.h
     ${SRC_DIR}/graphics/items/IconItem.h
     ${SRC_DIR}/graphics/items/StationNodeItem.h
+    ${SRC_DIR}/graphics/items/StationOverlayItem.h
     ${SRC_DIR}/graphics/NetworkScene.h
     ${SRC_DIR}/graphics/NetworkView.h
     ${SRC_DIR}/simulation/NumberGenerator.h
@@ -398,6 +400,35 @@ if(EGTRAIN_BUILD_TESTS)
         ${SRC_DIR}/graphics/VisualPolish.cpp)
     target_link_libraries(test_visualpolish PRIVATE Qt5::Core Qt5::Gui)
     add_test(NAME test_visualpolish COMMAND test_visualpolish)
+
+    add_executable(test_stationoverlay
+        ${SRC_DIR}/tests/test_stationoverlay.cpp
+        ${SRC_DIR}/graphics/items/StationOverlayItem.cpp
+        ${SRC_DIR}/graphics/VisualPolish.cpp
+        ${SRC_DIR}/graphics/NetworkScene.cpp
+        ${SRC_DIR}/graphics/items/NodeItem.cpp
+        ${SRC_DIR}/graphics/items/StationNodeItem.cpp
+        ${SRC_DIR}/graphics/items/TrackLineItem.cpp
+        ${SRC_DIR}/graphics/items/ConnectionItem.cpp
+        ${SRC_DIR}/graphics/items/SignalItem.cpp
+        ${SRC_DIR}/graphics/items/TrainBodyItem.cpp
+        ${SRC_DIR}/graphics/items/PassengerItem.cpp)
+    target_include_directories(test_stationoverlay PRIVATE ${SRC_DIR})
+    target_link_libraries(test_stationoverlay PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets cppzmq nlohmann_json::nlohmann_json)
+    if(EGTRAIN_OPENMP_INCLUDE)
+        target_include_directories(test_stationoverlay PRIVATE ${EGTRAIN_OPENMP_INCLUDE})
+    endif()
+    if(EGTRAIN_OPENMP_COMPILE_OPTIONS)
+        target_compile_options(test_stationoverlay PRIVATE ${EGTRAIN_OPENMP_COMPILE_OPTIONS})
+    endif()
+    if(EGTRAIN_OPENMP_LINK_LIBRARIES)
+        target_link_libraries(test_stationoverlay PRIVATE ${EGTRAIN_OPENMP_LINK_LIBRARIES})
+    elseif(OpenMP_CXX_FOUND)
+        target_link_libraries(test_stationoverlay PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+    add_test(NAME test_stationoverlay COMMAND test_stationoverlay)
+    set_tests_properties(test_stationoverlay PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
     add_executable(test_networkscene_selection
         ${SRC_DIR}/tests/test_networkscene_selection.cpp

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -4068,6 +4068,31 @@ void MainWindow::runStationOverlayE2E() {
 		};
 
 		checkZoom(1.0, "FIT");
+		const bool hasTopologyPriority = std::any_of(m_stationOverlays.cbegin(), m_stationOverlays.cend(),
+			[](const auto* overlay) { return overlay && (overlay->isInterchange() || overlay->isEndpoint()); });
+		if (!hasTopologyPriority && m_stationOverlays.size() > 1) {
+			const QString previousSelectedStationName = m_selectedStationName;
+			StationOverlayItem* selectedOverlay = nullptr;
+			for (auto* overlay : m_stationOverlays) {
+				if (overlay && overlay->isVisible()) {
+					selectedOverlay = overlay;
+					break;
+				}
+			}
+			if (selectedOverlay) {
+				m_selectedStationName = selectedOverlay->stationName();
+				updateViewportOverlays();
+				const bool ordinaryLabelVisible = std::any_of(m_stationOverlays.cbegin(), m_stationOverlays.cend(),
+					[selectedOverlay](const auto* overlay) {
+						return overlay && overlay != selectedOverlay && overlay->isLabelVisible()
+							&& !overlay->isInterchange() && !overlay->isEndpoint();
+					});
+				if (!ordinaryLabelVisible)
+					fail("FIT selected station suppressed every ordinary fallback label");
+				m_selectedStationName = previousSelectedStationName;
+				updateViewportOverlays();
+			}
+		}
 		StationOverlayItem* hovered = nullptr;
 		for (auto* overlay : m_stationOverlays) {
 			if (overlay && overlay->isVisible()) {
@@ -10579,11 +10604,10 @@ void MainWindow::updateViewportOverlays() {
 		return StationOverlayItem::priorityLess(*left, *right,
 			toDevice.inverted().map(viewport.center()));
 	});
-	const bool hasOverviewPriority = std::any_of(candidates.cbegin(), candidates.cend(), [](const auto* overlay) {
-		return overlay->isSelected() || overlay->isFollowed() || overlay->isHovered()
-			|| overlay->isInterchange() || overlay->isEndpoint();
+	const bool hasTopologyPriority = std::any_of(candidates.cbegin(), candidates.cend(), [](const auto* overlay) {
+		return overlay->isInterchange() || overlay->isEndpoint();
 	});
-	const bool showOrdinaryOverviewLabels = !hasOverviewPriority;
+	const bool showOrdinaryOverviewLabels = !hasTopologyPriority;
 	QList<QRectF> placedLabels;
 	for (auto* overlay : candidates) {
 		const bool forced = overlay->isSelected() || overlay->isFollowed() || overlay->isHovered();

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -29,6 +29,7 @@
 #include <cfloat>
 #include <QThread>
 #include <QCloseEvent>
+#include <QGraphicsSceneHoverEvent>
 #include <QDialog>
 #include <QVBoxLayout>
 #include <QLabel>
@@ -317,6 +318,7 @@ void addLoadedDataTreeItem(QTreeWidget* tree, QTreeWidgetItem* parent, const Sce
 
 bool e2eDialogsSuppressed() {
 	return qEnvironmentVariableIsSet("QEGTRAIN_E2E_VISUAL_POLISH")
+		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_STATION_OVERLAYS")
 		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_SCENE_RUN")
 		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_EDITOR_SMOKE")
 		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_TRACK_PREVIEW")
@@ -3974,6 +3976,223 @@ void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& sceneP
 	openMenu();
 }
 
+void MainWindow::runStationOverlayE2E() {
+	if (m_e2eFinished)
+		return;
+	m_e2eFinished = true;
+
+	bool ok = true;
+	QStringList failures;
+	const auto marker = [](const QString& value) {
+		std::fprintf(stdout, "%s\n", value.toStdString().c_str());
+		std::fflush(stdout);
+	};
+	const auto fail = [&](const QString& value) {
+		ok = false;
+		failures << value;
+	};
+	const QString caseName = QFileInfo(QString::fromStdString(InputMainFolder)).fileName();
+	if (!networkView || m_stationOverlays.isEmpty()) {
+		fail("station overlay scene is empty");
+	} else {
+		const QRectF topologyBounds = networkView->topologyBounds();
+		const auto checkZoom = [&](qreal ratio, const char* label) {
+			networkView->fitToTopology();
+			if (ratio > 1.0)
+				networkView->zoomBy(ratio);
+			updateViewportOverlays();
+			QApplication::processEvents();
+			if (qAbs(networkView->zoomRatio() - ratio) > 1e-5)
+				fail(QString("%1 zoom did not settle").arg(label));
+			if (networkView->topologyBounds() != topologyBounds)
+				fail(QString("%1 changed topology-only fit bounds").arg(label));
+			const QRectF inset = networkView->viewport()->rect().adjusted(kOverlayMargin, kOverlayMargin,
+				-kOverlayMargin, -kOverlayMargin);
+			QList<QRectF> labels;
+			for (auto* overlay : m_stationOverlays) {
+				if (!overlay || !overlay->isVisible() || !overlay->isLabelVisible())
+					continue;
+				const QPointF anchor = networkView->viewportTransform().map(overlay->stableAnchor())
+					+ overlay->viewportOffset();
+				const QRectF symbol = overlay->symbolRect().translated(anchor);
+				const QRectF labelRect = overlay->labelRect().translated(anchor);
+				if (!inset.contains(labelRect))
+					fail(QString("%1 label clipped: %2").arg(label).arg(overlay->stationName()));
+				if (labelRect.intersects(symbol))
+					fail(QString("%1 label intersects symbol: %2").arg(label).arg(overlay->stationName()));
+				for (const QRectF& other : labels)
+					if (labelRect.intersects(other))
+						fail(QString("%1 labels intersect: %2").arg(label).arg(overlay->stationName()));
+				labels.append(labelRect);
+			}
+			marker(QString("E2E_STATION_OVERLAY_%1_%2_OK").arg(caseName, label));
+		};
+
+		checkZoom(1.0, "FIT");
+		StationOverlayItem* hovered = nullptr;
+		for (auto* overlay : m_stationOverlays) {
+			if (overlay && overlay->isVisible()) {
+				hovered = overlay;
+				break;
+			}
+		}
+		if (!hovered) {
+			fail("no overlay available for hover dispatch");
+		} else {
+			hovered->setLayoutVisible(false);
+			QGraphicsSceneHoverEvent enter(QEvent::GraphicsSceneHoverEnter);
+			enter.setPos(QPointF());
+			enter.setScenePos(hovered->stableAnchor());
+			scene->sendEvent(hovered, &enter);
+			if (!hovered->isLabelVisible())
+				fail("hover did not reveal culled station label");
+			QGraphicsSceneHoverEvent leave(QEvent::GraphicsSceneHoverLeave);
+			leave.setPos(QPointF());
+			leave.setScenePos(hovered->stableAnchor());
+			scene->sendEvent(hovered, &leave);
+			if (hovered->isLabelVisible())
+				fail("hover leave did not hide culled station label");
+		}
+
+		StationNodeItem* stationTarget = nullptr;
+		StationOverlayItem* overlappingOverlay = nullptr;
+		bool temporarySemanticOverlay = false;
+		for (auto* item : scene->items()) {
+			auto* station = qgraphicsitem_cast<StationNodeItem*>(item);
+			if (!station || !station->node)
+				continue;
+			for (auto* overlay : m_stationOverlays) {
+				if (overlay && overlay->stationName() == QString::fromStdString(station->node->stationName)
+					&& overlay->sceneBoundingRect().intersects(station->sceneBoundingRect())) {
+					stationTarget = station;
+					overlappingOverlay = overlay;
+					break;
+				}
+			}
+			if (stationTarget)
+				break;
+		}
+		if (!stationTarget) {
+			for (auto* item : scene->items()) {
+				auto* station = qgraphicsitem_cast<StationNodeItem*>(item);
+				if (station && station->node) {
+					stationTarget = station;
+					break;
+				}
+			}
+		}
+		if (stationTarget && !overlappingOverlay) {
+			overlappingOverlay = new StationOverlayItem(
+				QString::fromStdString(stationTarget->node->stationName),
+				stationTarget->sceneBoundingRect().center(),
+				classifyStation(!stationTarget->node->stationPlatformId.empty(), 0));
+			scene->addItem(overlappingOverlay);
+			temporarySemanticOverlay = true;
+		}
+		if (!stationTarget || !overlappingOverlay) {
+			fail("no overlapping station overlay target for semantic dispatch");
+		} else {
+			QList<QPair<QGraphicsItem*, bool>> hiddenSemanticItems;
+			for (auto* item : scene->items()) {
+				if (item == stationTarget || item == overlappingOverlay || !item->isVisible())
+					continue;
+				hiddenSemanticItems.append(qMakePair(item, true));
+				item->setVisible(false);
+			}
+			QPointF semanticPoint = stationTarget->sceneBoundingRect().center();
+			bool foundSemanticPoint = false;
+			const QRectF stationBounds = stationTarget->sceneBoundingRect();
+			for (int y = 0; y <= 4 && !foundSemanticPoint; ++y) {
+				for (int x = 0; x <= 4 && !foundSemanticPoint; ++x) {
+					const QPointF point(stationBounds.left() + stationBounds.width() * x / 4.0,
+						stationBounds.top() + stationBounds.height() * y / 4.0);
+					if (!overlappingOverlay->contains(overlappingOverlay->mapFromScene(point)))
+						continue;
+					QGraphicsItem* semantic = nullptr;
+					for (auto* item : scene->items(point, Qt::IntersectsItemShape, Qt::DescendingOrder,
+						networkView->viewportTransform())) {
+						for (QGraphicsItem* candidate = item; candidate; candidate = candidate->parentItem()) {
+							if (qgraphicsitem_cast<NodeItem*>(candidate)
+								|| qgraphicsitem_cast<StationNodeItem*>(candidate)
+								|| qgraphicsitem_cast<TrackLineItem*>(candidate)
+								|| qgraphicsitem_cast<ConnectionItem*>(candidate)
+								|| qgraphicsitem_cast<SignalItem*>(candidate)
+								|| qgraphicsitem_cast<TrainBodyItem*>(candidate)
+								|| qgraphicsitem_cast<PassengerItem*>(candidate)) {
+								semantic = candidate;
+								break;
+							}
+						}
+						if (semantic)
+							break;
+					}
+					if (semantic == stationTarget) {
+						semanticPoint = point;
+						foundSemanticPoint = true;
+					}
+				}
+			}
+			if (!foundSemanticPoint) {
+				fail("no clear station semantic hit point under overlay");
+				semanticPoint = stationTarget->sceneBoundingRect().center();
+			}
+			displayStationNodeInfo(stationTarget);
+			if (m_selectedStationName != QString::fromStdString(stationTarget->node->stationName))
+				fail("station selection did not track station name");
+			if (!overlappingOverlay->isLabelVisible())
+				fail("selected station label is not revealed");
+
+			const QPointF scenePos = semanticPoint;
+			QGraphicsSceneMouseEvent click(QEvent::GraphicsSceneMousePress);
+			click.setButton(Qt::LeftButton);
+			click.setButtons(Qt::LeftButton);
+			click.setScenePos(scenePos);
+			click.setPos(networkView->mapFromScene(scenePos));
+			click.setScreenPos(networkView->viewport()->mapToGlobal(click.pos().toPoint()));
+			click.setWidget(networkView->viewport());
+			scene->mousePressEvent(&click);
+			QGraphicsItem* contextTarget = nullptr;
+			const QMetaObject::Connection contextConnection = connect(scene, &NetworkScene::ContextMenuRequested,
+				this, [&](QGraphicsItem* item, const QPointF&, const QPoint&, bool) { contextTarget = item; });
+			QGraphicsSceneContextMenuEvent context(QEvent::GraphicsSceneContextMenu);
+			context.setReason(QGraphicsSceneContextMenuEvent::Mouse);
+			context.setScenePos(scenePos);
+			context.setScreenPos(networkView->viewport()->mapToGlobal(networkView->mapFromScene(scenePos)));
+			context.setWidget(networkView->viewport());
+			scene->contextMenuEvent(&context);
+			disconnect(contextConnection);
+			if (contextTarget != stationTarget)
+				fail(QString("context menu did not preserve station semantic target (got=%1 expected=%2 gotType=%3 expectedType=%4)")
+					.arg(reinterpret_cast<quintptr>(contextTarget), 0, 16)
+					.arg(reinterpret_cast<quintptr>(stationTarget), 0, 16)
+					.arg(contextTarget ? contextTarget->type() : -1)
+					.arg(stationTarget ? stationTarget->type() : -1));
+			if (m_sceneContextMenu)
+				m_sceneContextMenu->close();
+			for (const auto& hidden : hiddenSemanticItems)
+				hidden.first->setVisible(hidden.second);
+		}
+		if (temporarySemanticOverlay) {
+			scene->removeItem(overlappingOverlay);
+			delete overlappingOverlay;
+		}
+
+		checkZoom(3.0, "3X");
+		checkZoom(12.0, "12X");
+		const qreal devicePixelRatio = windowHandle() ? windowHandle()->devicePixelRatio() : 1.0;
+		marker(QString("E2E_STATION_OVERLAY_DPR_%1").arg(devicePixelRatio, 0, 'f', 1));
+	}
+
+	if (ok) {
+		marker("E2E_STATION_OVERLAY_OK");
+		QCoreApplication::exit(0);
+		return;
+	}
+	std::fprintf(stderr, "E2E_STATION_OVERLAY_FAIL: %s\n", failures.join(", ").toStdString().c_str());
+	std::fflush(stderr);
+	QCoreApplication::exit(2);
+}
+
 void MainWindow::runVisualPolishE2E() {
 	if (m_e2eFinished)
 		return;
@@ -4949,6 +5168,8 @@ void MainWindow::runVisualPolishE2E() {
 	}
 
 	if (ok) {
+		const qreal devicePixelRatio = windowHandle() ? windowHandle()->devicePixelRatio() : 1.0;
+		std::fprintf(stdout, "E2E_VISUAL_POLISH_DPR_%0.1f\n", devicePixelRatio);
 		std::fprintf(stdout, "E2E_VISUAL_POLISH_OK\n");
 		std::fflush(stdout);
 		if (m_worker && m_workerThread && m_workerThread->isRunning()) {
@@ -6444,16 +6665,9 @@ void MainWindow::setupGUI() {
 			pt.setY(StationArray[i].graphY + avgShiftY * station_name_graphID * track_separation);
 		}
 
-		// print station name
-		paintStationName(pt, StationArray[i].stationName);
-
-		// shifted point to draw icon (draw icon above the text)
-		pt.setY(pt.y() - station_size / 2);
-
-		// draw station icon
-		paintStationIcon(pt,
-			classifyStation(StationArray[i].N_StationPlatforms > 0,
-				StationArray[i].N_StationPlatforms));
+		paintStationOverlay(pt,
+			classifyStation(StationArray[i].N_StationPlatforms > 0, 0),
+			StationArray[i].stationName);
 	}
 
 	// draw connections
@@ -6573,13 +6787,14 @@ void MainWindow::setupGUI() {
 
 	buildSignalIndex();
 	buildTrackIndexes();
-	updateViewportOverlays();
 
 	// hide objects from unused tracklines
 	hideUnusedTracks();
 
 	// draw virtual inter region connections
 	drawVirtualInterRegionConnections();
+	updateStationOverlayDegrees();
+	updateViewportOverlays();
 
 	refreshFollowTrainChoices();
 
@@ -6614,6 +6829,8 @@ void MainWindow::showEvent(QShowEvent* e) {
 		QTimer::singleShot(1500, this, &MainWindow::startSimulation);
 	if (qEnvironmentVariableIsSet("QEGTRAIN_E2E_VISUAL_POLISH"))
 		QTimer::singleShot(2600, this, &MainWindow::runVisualPolishE2E);
+	if (qEnvironmentVariableIsSet("QEGTRAIN_E2E_STATION_OVERLAYS"))
+		QTimer::singleShot(1000, this, &MainWindow::runStationOverlayE2E);
 	if (qEnvironmentVariableIsSet("QEGTRAIN_E2E_EDITOR_SMOKE"))
 		// let the startup case load and the docks settle before the smoke runs
 		QTimer::singleShot(1000, this, &MainWindow::runEditorSmokeE2E);
@@ -6870,7 +7087,8 @@ void MainWindow::teardownGUI() {
 	allTrains.clear();
 	allSignals.clear();
 	m_signalDecorations.clear();
-	m_stationNames.clear();
+	m_stationOverlays.clear();
+	m_selectedStationName.clear();
 	m_vcMessageItems.clear();
 	m_stationDecorations.clear();
 	m_signalsByAheadId.clear();
@@ -7157,60 +7375,15 @@ void MainWindow::paintStationNode(QPointF coord, int size, int pen_width, int tr
 	scene->addItem(el);
 }
 
-// draws a station icon above the track
-void MainWindow::paintStationIcon(QPointF coord, const StationVisual& visual) {
-	const int pinSize = 24;
-	IconItem* item = new IconItem(QPixmap(visual.iconResource).scaled(QSize(pinSize, pinSize), Qt::KeepAspectRatio, Qt::SmoothTransformation));
-	item->setFlag(QGraphicsItem::ItemIgnoresTransformations);
-	scene->addItem(item);
-	m_stationDecorations.push_back(item);
-	item->setVisible(m_stationLayerVisible);
-
-	item->setPos(coord.x() - (pinSize / 2), coord.y() - (pinSize / 2));
-	item->setTransformationMode(Qt::SmoothTransformation);
-
-	// fit to window
-	networkView->fitInView(scene->sceneRect(), Qt::KeepAspectRatio);
-}
-
-// adds the name of each station above the track
-void MainWindow::paintStationName(QPointF coord, string sname) {
-	// add spaces to string
-	int length = sname.length();
-	for (int i = 1; i < length; i++) // ignore possible initial uppercase (start from 1)
-	{
-		int c = sname[i];
-		if (isupper(c)) {
-			sname.insert(i, " ");
-			i++; // go to the next (added space)
-		}
-	}
-
-	// convert string
-	QString name = QString::fromStdString(sname);
-
-	// set text size
-	QFont font = QFont();
-	font.setPixelSize((int)kStationLabelPixels);
-
-	// Fixed-size label anchored to the scene point so the name stays legible
-	// at overview zoom; the transform centres the device-space text block.
-	QGraphicsTextItem* station_name = new QGraphicsTextItem;
-	station_name->setPlainText(name);
-	station_name->setFont(font);
-	station_name->setFlag(QGraphicsItem::ItemIgnoresTransformations);
-	station_name->setPos(coord);
-	station_name->setTransform(QTransform::fromTranslate(
-		-station_name->boundingRect().width() / 2.0,
-		-station_name->boundingRect().height() / 2.0));
-	station_name->setDefaultTextColor(Qt::white);
-	station_name->setZValue(3); // draw on top of every item
-	scene->addItem(station_name);
-	m_stationNames.push_back(station_name);
-	station_name->setVisible(m_stationLayerVisible);
-
-	// fit to window
-	networkView->fitInView(scene->sceneRect(), Qt::KeepAspectRatio);
+// Draw the fixed-size station symbol and label as one scene-owned item.
+void MainWindow::paintStationOverlay(QPointF coord, const StationVisual& visual, const string& sname) {
+	if (!scene)
+		return;
+	auto* overlay = new StationOverlayItem(QString::fromStdString(sname), coord, visual);
+	scene->addItem(overlay);
+	m_stationOverlays.push_back(overlay);
+	m_stationDecorations.push_back(overlay);
+	overlay->setVisible(m_stationLayerVisible);
 }
 
 // paint platform next to station Node (upper side)
@@ -8027,6 +8200,11 @@ void MainWindow::handleHelpAbout() {
 // hides all widgets from the dock widget
 // removes highlight from last clicked item
 void MainWindow::handleCloseInfoDockWidget() {
+	m_selectedStationName.clear();
+	for (auto* overlay : m_stationOverlays)
+		if (overlay)
+			overlay->setSelected(false);
+
 	// hide all widgets
 	arcInfoWidget->hide();
 	nodeInfoWidget->hide();
@@ -8041,6 +8219,7 @@ void MainWindow::handleCloseInfoDockWidget() {
 		delete effect;
 		effect = nullptr;
 	}
+	updateViewportOverlays();
 }
 
 // shows Node info on dock widget
@@ -8084,6 +8263,11 @@ void MainWindow::displayStationNodeInfo(StationNodeItem* re) {
 	if (!re || !re->node)
 		return;
 	handleCloseInfoDockWidget();
+	m_selectedStationName = QString::fromStdString(re->node->stationName);
+	for (auto* overlay : m_stationOverlays)
+		if (overlay)
+			overlay->setSelected(overlay->stationName() == m_selectedStationName);
+	updateViewportOverlays();
 
 	// update Node info displayed on widget
 	nodeIDText->setText(QString::fromStdString(to_string_precision(re->node->ID, 0)));
@@ -10200,6 +10384,43 @@ void MainWindow::ensureNetworkLegend() {
 	m_networkLegend->setVisible(true);
 }
 
+void MainWindow::updateStationOverlayDegrees() {
+	if (!scene)
+		return;
+	const auto atEndpoint = [](const QPointF& point, const QPointF& endpoint) {
+		return QLineF(point, endpoint).length() <= 1e-4;
+	};
+	const auto segmentDegree = [&](QGraphicsItem* item, const QLineF& line, const QPointF& point) {
+		const QPointF first = item->mapToScene(line.p1());
+		const QPointF second = item->mapToScene(line.p2());
+		return (atEndpoint(point, first) || atEndpoint(point, second)) ? 1 : 0;
+	};
+
+	for (auto* overlay : m_stationOverlays) {
+		if (!overlay)
+			continue;
+		int highestDegree = 0;
+		for (auto* item : scene->items()) {
+			auto* station = qgraphicsitem_cast<StationNodeItem*>(item);
+			if (!station || !station->node || QString::fromStdString(station->node->stationName) != overlay->stationName())
+				continue;
+			const QPointF point = station->sceneBoundingRect().center();
+			int degree = 0;
+			for (auto* edge : scene->items()) {
+				if (auto* track = qgraphicsitem_cast<TrackLineItem*>(edge)) {
+					degree += segmentDegree(track, track->line(), point);
+					if (auto* virtualArc = dynamic_cast<VirtualArcItem*>(track))
+						degree += segmentDegree(virtualArc, virtualArc->secondPaintedLine(), point);
+				} else if (auto* connection = qgraphicsitem_cast<ConnectionItem*>(edge)) {
+					degree += segmentDegree(connection, connection->line(), point);
+				}
+			}
+			highestDegree = std::max(highestDegree, degree);
+		}
+		overlay->setDegree(highestDegree);
+	}
+}
+
 bool MainWindow::paxTextVisible() const {
 	if (!m_passengerLayerVisible || !networkView)
 		return false;
@@ -10211,29 +10432,125 @@ void MainWindow::updateViewportOverlays() {
 		return;
 	const bool dense = networkView->zoomRatio() >= kDenseDetailZoom;
 
-	// Station labels stay on at every zoom. Greedy culling hides only the
-	// labels that would overlap one already placed at this scale.
 	const QTransform toDevice = networkView->viewportTransform();
+	const QRectF viewport = networkView->viewport()->rect();
+	const QRectF inset = viewport.adjusted(kOverlayMargin, kOverlayMargin,
+		-kOverlayMargin, -kOverlayMargin);
+	const auto translated = [](const QRectF& rect, const QPointF& point, const QPointF& offset) {
+		return rect.translated(point + offset);
+	};
+	const auto clampOffset = [&](const QRectF& rect) {
+		QPointF offset;
+		if (rect.left() < inset.left())
+			offset.rx() += inset.left() - rect.left();
+		else if (rect.right() > inset.right())
+			offset.rx() += inset.right() - rect.right();
+		if (rect.top() < inset.top())
+			offset.ry() += inset.top() - rect.top();
+		else if (rect.bottom() > inset.bottom())
+			offset.ry() += inset.bottom() - rect.bottom();
+		return offset;
+	};
+	const auto overflow = [&](const QRectF& rect) {
+		return std::max<qreal>(0.0, inset.left() - rect.left())
+			+ std::max<qreal>(0.0, rect.right() - inset.right())
+			+ std::max<qreal>(0.0, inset.top() - rect.top())
+			+ std::max<qreal>(0.0, rect.bottom() - inset.bottom());
+	};
+
+	QList<QRectF> symbolRects;
+	QList<StationOverlayItem*> candidates;
+	for (auto* overlay : m_stationOverlays) {
+		if (!overlay)
+			continue;
+		overlay->setViewportOffset(QPointF());
+		overlay->setSelected(!m_selectedStationName.isEmpty()
+			&& overlay->stationName() == m_selectedStationName);
+		overlay->setVisible(m_stationLayerVisible);
+		if (!m_stationLayerVisible)
+			continue;
+
+		const QPointF anchor = toDevice.map(overlay->stableAnchor());
+		overlay->setLabelSide(StationOverlayItem::LabelSide::Right);
+		const QRectF rightRect = translated(overlay->combinedRect(), anchor, QPointF());
+		overlay->setLabelSide(StationOverlayItem::LabelSide::Left);
+		const QRectF leftRect = translated(overlay->combinedRect(), anchor, QPointF());
+		StationOverlayItem::LabelSide side = StationOverlayItem::LabelSide::Right;
+		QRectF chosen = rightRect;
+		if (!inset.contains(rightRect) && inset.contains(leftRect)) {
+			side = StationOverlayItem::LabelSide::Left;
+			chosen = leftRect;
+		} else if (!inset.contains(rightRect) && !inset.contains(leftRect)
+			&& overflow(leftRect) < overflow(rightRect)) {
+			side = StationOverlayItem::LabelSide::Left;
+			chosen = leftRect;
+		}
+		overlay->setLabelSide(side);
+		const QPointF offset = clampOffset(chosen);
+		overlay->setViewportOffset(offset);
+		const QRectF effectiveSymbol = translated(overlay->symbolRect(), anchor, offset);
+		symbolRects.append(effectiveSymbol);
+		candidates.append(overlay);
+	}
+
+	QPointF followedCenter;
+	bool hasFollowedCenter = false;
+	if (m_followAction && m_followAction->isChecked() && m_followTrainIndex >= 0) {
+		if (auto* train = resolveTrainItem(m_followTrainIndex)) {
+			followedCenter = train->sceneBoundingRect().center();
+			hasFollowedCenter = true;
+		}
+	}
+	StationOverlayItem* nearestFollowed = nullptr;
+	qreal nearestDistance = std::numeric_limits<qreal>::max();
+	for (auto* overlay : candidates) {
+		overlay->setFollowed(false);
+		if (!hasFollowedCenter)
+			continue;
+		const QPointF delta = overlay->stableAnchor() - followedCenter;
+		const qreal distance = delta.x() * delta.x() + delta.y() * delta.y();
+		if (!nearestFollowed || distance < nearestDistance) {
+			nearestFollowed = overlay;
+			nearestDistance = distance;
+		}
+	}
+	if (nearestFollowed)
+		nearestFollowed->setFollowed(true);
+
+	std::sort(candidates.begin(), candidates.end(), [&](const auto* left, const auto* right) {
+		return StationOverlayItem::priorityLess(*left, *right,
+			toDevice.inverted().map(viewport.center()));
+	});
 	QList<QRectF> placedLabels;
-	for (auto* name : m_stationNames) {
-		if (!name)
-			continue;
-		if (!m_stationLayerVisible) {
-			name->setVisible(false);
-			continue;
-		}
-		QRectF deviceRect(QPointF(0.0, 0.0), name->boundingRect().size());
-		deviceRect.moveCenter(toDevice.map(name->pos()));
-		bool overlaps = false;
-		for (const QRectF& other : placedLabels) {
-			if (deviceRect.intersects(other)) {
-				overlaps = true;
-				break;
+	for (auto* overlay : candidates) {
+		const bool forced = overlay->isSelected() || overlay->isFollowed() || overlay->isHovered();
+		const bool eligible = networkView->zoomRatio() >= 2.0
+			|| forced || overlay->isInterchange() || overlay->isEndpoint();
+		bool visible = false;
+		if (eligible) {
+			const QRectF label = translated(overlay->labelRect(), toDevice.map(overlay->stableAnchor()),
+				overlay->viewportOffset());
+			const QRectF inflated = label.adjusted(-4.0, -4.0, 4.0, 4.0);
+			bool collision = false;
+			for (const QRectF& symbol : symbolRects) {
+				if (inflated.intersects(symbol)) {
+					collision = true;
+					break;
+				}
 			}
+			if (!collision) {
+				for (const QRectF& other : placedLabels) {
+					if (inflated.intersects(other)) {
+						collision = true;
+						break;
+					}
+				}
+			}
+			visible = forced || !collision;
+			if (visible)
+				placedLabels.append(inflated);
 		}
-		name->setVisible(!overlaps);
-		if (!overlaps)
-			placedLabels.append(deviceRect);
+		overlay->setLayoutVisible(visible);
 	}
 
 	// Full signal housings only once zoomed past the dense threshold; at

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -767,15 +767,18 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	connect(m_followTrainCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
 		if (m_updatingFollowCombo || index < 0)
 			return;
-		m_followTrainIndex = m_followTrainCombo->itemData(index).toInt();
+		if (m_followAction && m_followAction->isChecked())
+			setFollowTrain(m_followTrainCombo->itemData(index).toInt());
 	});
 	connect(m_followAction, &QAction::toggled, this, [this](bool checked) {
 		if (!checked) {
-			m_followTrainIndex = -1;
+			setFollowTrain(-1);
 			return;
 		}
 		if (m_followTrainCombo && m_followTrainCombo->currentIndex() >= 0)
-			m_followTrainIndex = m_followTrainCombo->currentData().toInt();
+			setFollowTrain(m_followTrainCombo->currentData().toInt());
+		else
+			setFollowTrain(-1);
 	});
 	m_toolBar->insertAction(ui->actionSimulationStop, m_followAction);
 	m_toolBar->insertWidget(ui->actionSimulationStop, m_followTrainCombo);
@@ -3672,6 +3675,7 @@ void MainWindow::refreshFollowTrainChoices() {
 		m_followTrainIndex = -1;
 
 	m_updatingFollowCombo = false;
+	updateViewportOverlays();
 }
 
 TrainItemGroup* MainWindow::resolveTrainItem(int trainIndex) const {
@@ -3757,6 +3761,7 @@ void MainWindow::setFollowTrain(int trainIndex) {
 			m_followAction->setChecked(false);
 		}
 		m_followTrainIndex = -1;
+		updateViewportOverlays();
 		return;
 	}
 	if (!resolveTrainItem(trainIndex))
@@ -3773,6 +3778,7 @@ void MainWindow::setFollowTrain(int trainIndex) {
 		m_followAction->setChecked(true);
 	}
 	m_followTrainIndex = trainIndex;
+	updateViewportOverlays();
 }
 
 void MainWindow::showSceneContextMenu(QGraphicsItem* item, const QPointF& scenePos, const QPoint& screenPos, bool keyboard) {
@@ -5179,7 +5185,20 @@ void MainWindow::runVisualPolishE2E() {
 	}
 
 	if (m_followAction && m_followTrainCombo && m_followTrainCombo->count() > 0) {
+		m_followAction->setChecked(false);
+		if (std::any_of(m_stationOverlays.cbegin(), m_stationOverlays.cend(),
+			[](const auto* overlay) { return overlay && overlay->isFollowed(); })) {
+			ok = false;
+			failures << "follow deactivation left a stale station priority";
+		}
 		m_followAction->setChecked(true);
+		const int followedOverlays = static_cast<int>(std::count_if(m_stationOverlays.cbegin(),
+			m_stationOverlays.cend(), [](const auto* overlay) { return overlay && overlay->isFollowed(); }));
+		if (!m_stationOverlays.isEmpty() && followedOverlays != 1) {
+			ok = false;
+			failures << QString("follow activation updated %1 station priorities instead of one")
+				.arg(followedOverlays);
+		}
 		QApplication::processEvents();
 		if (!m_followAction->isChecked() || m_followTrainIndex < 0) {
 			ok = false;
@@ -5238,6 +5257,11 @@ void MainWindow::runVisualPolishE2E() {
 	}
 	if (m_followAction) {
 		m_followAction->setChecked(false);
+		if (std::any_of(m_stationOverlays.cbegin(), m_stationOverlays.cend(),
+			[](const auto* overlay) { return overlay && overlay->isFollowed(); })) {
+			ok = false;
+			failures << "follow toggle left a stale station priority";
+		}
 		QApplication::processEvents();
 	}
 	if (m_followTrainIndex != -1) {

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -30,6 +30,7 @@
 #include <QThread>
 #include <QCloseEvent>
 #include <QGraphicsSceneHoverEvent>
+#include <QMouseEvent>
 #include <QDialog>
 #include <QVBoxLayout>
 #include <QLabel>
@@ -57,7 +58,6 @@ const char* kRecentScenesKey = "recentScenes";
 const int kMaxRecentScenes = 8;
 constexpr qreal kDenseDetailZoom = 3.0;
 constexpr int kOverlayMargin = 12;
-constexpr qreal kStationLabelPixels = 11.0;
 
 // The speed slider reads left-to-right as slow-to-fast; the worker wants a
 // per-step delay, so the delay is the distance from the fast end.
@@ -528,6 +528,8 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 		updateViewportOverlays();
 		updateZoomStatus();
 	});
+	connect(networkView, &NetworkView::interactionFinished,
+		this, &MainWindow::updateViewportOverlays);
 	networkView->setMouseTracking(true);
 
 	// connect elements from UI
@@ -3992,9 +3994,12 @@ void MainWindow::runStationOverlayE2E() {
 		failures << value;
 	};
 	const QString caseName = QFileInfo(QString::fromStdString(InputMainFolder)).fileName();
+	const QString stationScreenshotBase = qEnvironmentVariable("QEGTRAIN_E2E_STATION_SCREENSHOT_BASE");
 	if (!networkView || m_stationOverlays.isEmpty()) {
 		fail("station overlay scene is empty");
 	} else {
+		resize(1200, 800);
+		QApplication::processEvents();
 		const QRectF topologyBounds = networkView->topologyBounds();
 		const auto checkZoom = [&](qreal ratio, const char* label) {
 			networkView->fitToTopology();
@@ -4008,22 +4013,56 @@ void MainWindow::runStationOverlayE2E() {
 				fail(QString("%1 changed topology-only fit bounds").arg(label));
 			const QRectF inset = networkView->viewport()->rect().adjusted(kOverlayMargin, kOverlayMargin,
 				-kOverlayMargin, -kOverlayMargin);
-			QList<QRectF> labels;
+			QList<QRectF> symbols;
 			for (auto* overlay : m_stationOverlays) {
-				if (!overlay || !overlay->isVisible() || !overlay->isLabelVisible())
+				if (!overlay || !overlay->isVisible())
 					continue;
 				const QPointF anchor = networkView->viewportTransform().map(overlay->stableAnchor())
 					+ overlay->viewportOffset();
-				const QRectF symbol = overlay->symbolRect().translated(anchor);
+				symbols.append(overlay->symbolRect().translated(anchor));
+			}
+			QList<QRectF> labels;
+			int importantLabels = 0;
+			int collisionBlockedLabels = 0;
+			int visibleImportantLabels = 0;
+			for (auto* overlay : m_stationOverlays) {
+				if (!overlay || !overlay->isVisible())
+					continue;
+				if (overlay->isInterchange() || overlay->isEndpoint())
+					++importantLabels;
+				if (overlay->isCollisionBlocked())
+					++collisionBlockedLabels;
+				if (!overlay->isLabelVisible())
+					continue;
+				if (overlay->isInterchange() || overlay->isEndpoint())
+					++visibleImportantLabels;
+				const QPointF anchor = networkView->viewportTransform().map(overlay->stableAnchor())
+					+ overlay->viewportOffset();
 				const QRectF labelRect = overlay->labelRect().translated(anchor);
 				if (!inset.contains(labelRect))
 					fail(QString("%1 label clipped: %2").arg(label).arg(overlay->stationName()));
-				if (labelRect.intersects(symbol))
-					fail(QString("%1 label intersects symbol: %2").arg(label).arg(overlay->stationName()));
+				for (const QRectF& otherSymbol : symbols)
+					if (labelRect.intersects(otherSymbol))
+						fail(QString("%1 label intersects symbol: %2").arg(label).arg(overlay->stationName()));
 				for (const QRectF& other : labels)
 					if (labelRect.intersects(other))
 						fail(QString("%1 labels intersect: %2").arg(label).arg(overlay->stationName()));
 				labels.append(labelRect);
+			}
+			if (labels.isEmpty())
+				fail(QString("%1 has no visible station label (%2 collision-blocked)")
+					.arg(QString::fromLatin1(label)).arg(collisionBlockedLabels));
+			if (QString::fromLatin1(label) == QLatin1String("FIT")
+				&& importantLabels > 0 && visibleImportantLabels == 0)
+				fail(QString("FIT has no visible priority label (%1 important, %2 collision-blocked)")
+					.arg(importantLabels).arg(collisionBlockedLabels));
+			if (!stationScreenshotBase.isEmpty()) {
+				const QString path = QString("%1-%2.png")
+					.arg(stationScreenshotBase, QString::fromLatin1(label).toLower());
+				if (!networkView->grab().save(path))
+					fail(QString("%1 station screenshot save failed").arg(label));
+				else
+					marker(QString("E2E_STATION_OVERLAY_SCREENSHOT_%1").arg(path));
 			}
 			marker(QString("E2E_STATION_OVERLAY_%1_%2_OK").arg(caseName, label));
 		};
@@ -4054,128 +4093,142 @@ void MainWindow::runStationOverlayE2E() {
 				fail("hover leave did not hide culled station label");
 		}
 
-		StationNodeItem* stationTarget = nullptr;
-		StationOverlayItem* overlappingOverlay = nullptr;
-		bool temporarySemanticOverlay = false;
+		const QString previousSelectedStationName = m_selectedStationName;
+		const QList<StationOverlayItem*> previousStationOverlays = m_stationOverlays;
+		const QList<QGraphicsItem*> previousStationDecorations = m_stationDecorations;
+		QList<QGraphicsItem*> previouslyVisibleItems;
 		for (auto* item : scene->items()) {
-			auto* station = qgraphicsitem_cast<StationNodeItem*>(item);
-			if (!station || !station->node)
-				continue;
-			for (auto* overlay : m_stationOverlays) {
-				if (overlay && overlay->stationName() == QString::fromStdString(station->node->stationName)
-					&& overlay->sceneBoundingRect().intersects(station->sceneBoundingRect())) {
-					stationTarget = station;
-					overlappingOverlay = overlay;
-					break;
-				}
-			}
-			if (stationTarget)
-				break;
-		}
-		if (!stationTarget) {
-			for (auto* item : scene->items()) {
-				auto* station = qgraphicsitem_cast<StationNodeItem*>(item);
-				if (station && station->node) {
-					stationTarget = station;
-					break;
-				}
-			}
-		}
-		if (stationTarget && !overlappingOverlay) {
-			overlappingOverlay = new StationOverlayItem(
-				QString::fromStdString(stationTarget->node->stationName),
-				stationTarget->sceneBoundingRect().center(),
-				classifyStation(!stationTarget->node->stationPlatformId.empty(), 0));
-			scene->addItem(overlappingOverlay);
-			temporarySemanticOverlay = true;
-		}
-		if (!stationTarget || !overlappingOverlay) {
-			fail("no overlapping station overlay target for semantic dispatch");
-		} else {
-			QList<QPair<QGraphicsItem*, bool>> hiddenSemanticItems;
-			for (auto* item : scene->items()) {
-				if (item == stationTarget || item == overlappingOverlay || !item->isVisible())
-					continue;
-				hiddenSemanticItems.append(qMakePair(item, true));
+			if (item && item->isVisible()) {
+				previouslyVisibleItems.append(item);
 				item->setVisible(false);
 			}
-			QPointF semanticPoint = stationTarget->sceneBoundingRect().center();
-			bool foundSemanticPoint = false;
-			const QRectF stationBounds = stationTarget->sceneBoundingRect();
-			for (int y = 0; y <= 4 && !foundSemanticPoint; ++y) {
-				for (int x = 0; x <= 4 && !foundSemanticPoint; ++x) {
-					const QPointF point(stationBounds.left() + stationBounds.width() * x / 4.0,
-						stationBounds.top() + stationBounds.height() * y / 4.0);
-					if (!overlappingOverlay->contains(overlappingOverlay->mapFromScene(point)))
-						continue;
-					QGraphicsItem* semantic = nullptr;
-					for (auto* item : scene->items(point, Qt::IntersectsItemShape, Qt::DescendingOrder,
-						networkView->viewportTransform())) {
-						for (QGraphicsItem* candidate = item; candidate; candidate = candidate->parentItem()) {
-							if (qgraphicsitem_cast<NodeItem*>(candidate)
-								|| qgraphicsitem_cast<StationNodeItem*>(candidate)
-								|| qgraphicsitem_cast<TrackLineItem*>(candidate)
-								|| qgraphicsitem_cast<ConnectionItem*>(candidate)
-								|| qgraphicsitem_cast<SignalItem*>(candidate)
-								|| qgraphicsitem_cast<TrainBodyItem*>(candidate)
-								|| qgraphicsitem_cast<PassengerItem*>(candidate)) {
-								semantic = candidate;
-								break;
-							}
-						}
-						if (semantic)
+		}
+
+		Node semanticFixtureNode;
+		semanticFixtureNode.ID = -241.0;
+		semanticFixtureNode.station = true;
+		semanticFixtureNode.stationName = "E2ESemanticStation";
+		semanticFixtureNode.stationPlatformId = "E2EPlatform";
+		const QPointF semanticCenter = networkView->mapToScene(networkView->viewport()->rect().center());
+		const StationVisual semanticVisual = classifyStation(true, 0);
+		auto* stationTarget = new StationNodeItem(QRectF(-12.0, -12.0, 24.0, 24.0));
+		stationTarget->track = -1;
+		stationTarget->node = &semanticFixtureNode;
+		stationTarget->setPos(semanticCenter);
+		QPen stationPen(semanticVisual.outline);
+		stationPen.setWidth(0);
+		stationPen.setCosmetic(true);
+		stationTarget->setPen(stationPen);
+		stationTarget->setBrush(semanticVisual.fill);
+		auto* overlappingOverlay = new StationOverlayItem(
+			QString::fromStdString(semanticFixtureNode.stationName), semanticCenter, semanticVisual);
+		scene->addItem(stationTarget);
+		scene->addItem(overlappingOverlay);
+		m_stationOverlays.clear();
+		m_stationDecorations.clear();
+		m_stationOverlays.append(overlappingOverlay);
+		m_stationDecorations.append(overlappingOverlay);
+		if (stationTarget->sceneBoundingRect().center() != overlappingOverlay->stableAnchor())
+			fail("semantic fixture station and overlay anchors diverged");
+
+		overlappingOverlay->setLayoutVisible(false);
+		overlappingOverlay->setCollisionBlocked(false);
+		if (overlappingOverlay->isLabelVisible())
+			fail("semantic dispatch overlay was not culled before click");
+
+		QPointF semanticPoint = stationTarget->sceneBoundingRect().center();
+		bool foundSemanticPoint = false;
+		const QRectF stationBounds = stationTarget->sceneBoundingRect();
+		for (int y = 0; y <= 4 && !foundSemanticPoint; ++y) {
+			for (int x = 0; x <= 4 && !foundSemanticPoint; ++x) {
+				const QPointF point(stationBounds.left() + stationBounds.width() * x / 4.0,
+					stationBounds.top() + stationBounds.height() * y / 4.0);
+				if (!overlappingOverlay->contains(overlappingOverlay->mapFromScene(point)))
+					continue;
+				QGraphicsItem* semantic = nullptr;
+				for (auto* item : scene->items(point, Qt::IntersectsItemShape, Qt::DescendingOrder,
+					networkView->viewportTransform())) {
+					for (QGraphicsItem* candidate = item; candidate; candidate = candidate->parentItem()) {
+						if (qgraphicsitem_cast<NodeItem*>(candidate)
+							|| qgraphicsitem_cast<StationNodeItem*>(candidate)
+							|| qgraphicsitem_cast<TrackLineItem*>(candidate)
+							|| qgraphicsitem_cast<ConnectionItem*>(candidate)
+							|| qgraphicsitem_cast<SignalItem*>(candidate)
+							|| qgraphicsitem_cast<TrainBodyItem*>(candidate)
+							|| qgraphicsitem_cast<PassengerItem*>(candidate)) {
+							semantic = candidate;
 							break;
+						}
 					}
-					if (semantic == stationTarget) {
-						semanticPoint = point;
-						foundSemanticPoint = true;
-					}
+					if (semantic)
+						break;
+				}
+				if (semantic == stationTarget) {
+					semanticPoint = point;
+					foundSemanticPoint = true;
 				}
 			}
-			if (!foundSemanticPoint) {
-				fail("no clear station semantic hit point under overlay");
-				semanticPoint = stationTarget->sceneBoundingRect().center();
-			}
-			displayStationNodeInfo(stationTarget);
-			if (m_selectedStationName != QString::fromStdString(stationTarget->node->stationName))
-				fail("station selection did not track station name");
-			if (!overlappingOverlay->isLabelVisible())
-				fail("selected station label is not revealed");
+		}
+		if (!foundSemanticPoint)
+			fail("no clear station semantic hit point under overlay");
 
-			const QPointF scenePos = semanticPoint;
-			QGraphicsSceneMouseEvent click(QEvent::GraphicsSceneMousePress);
-			click.setButton(Qt::LeftButton);
-			click.setButtons(Qt::LeftButton);
-			click.setScenePos(scenePos);
-			click.setPos(networkView->mapFromScene(scenePos));
-			click.setScreenPos(networkView->viewport()->mapToGlobal(click.pos().toPoint()));
-			click.setWidget(networkView->viewport());
-			scene->mousePressEvent(&click);
-			QGraphicsItem* contextTarget = nullptr;
-			const QMetaObject::Connection contextConnection = connect(scene, &NetworkScene::ContextMenuRequested,
-				this, [&](QGraphicsItem* item, const QPointF&, const QPoint&, bool) { contextTarget = item; });
-			QGraphicsSceneContextMenuEvent context(QEvent::GraphicsSceneContextMenu);
-			context.setReason(QGraphicsSceneContextMenuEvent::Mouse);
-			context.setScenePos(scenePos);
-			context.setScreenPos(networkView->viewport()->mapToGlobal(networkView->mapFromScene(scenePos)));
-			context.setWidget(networkView->viewport());
-			scene->contextMenuEvent(&context);
-			disconnect(contextConnection);
-			if (contextTarget != stationTarget)
-				fail(QString("context menu did not preserve station semantic target (got=%1 expected=%2 gotType=%3 expectedType=%4)")
-					.arg(reinterpret_cast<quintptr>(contextTarget), 0, 16)
-					.arg(reinterpret_cast<quintptr>(stationTarget), 0, 16)
-					.arg(contextTarget ? contextTarget->type() : -1)
-					.arg(stationTarget ? stationTarget->type() : -1));
-			if (m_sceneContextMenu)
-				m_sceneContextMenu->close();
-			for (const auto& hidden : hiddenSemanticItems)
-				hidden.first->setVisible(hidden.second);
-		}
-		if (temporarySemanticOverlay) {
+		const QPoint clickPos = networkView->mapFromScene(semanticPoint);
+		const QPoint screenPos = networkView->viewport()->mapToGlobal(clickPos);
+		QMouseEvent press(QEvent::MouseButtonPress, QPointF(clickPos), QPointF(screenPos),
+			Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+		QApplication::sendEvent(networkView->viewport(), &press);
+		QMouseEvent release(QEvent::MouseButtonRelease, QPointF(clickPos), QPointF(screenPos),
+			Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+		QApplication::sendEvent(networkView->viewport(), &release);
+		QApplication::processEvents();
+		if (m_selectedStationName != QString::fromStdString(semanticFixtureNode.stationName))
+			fail("station selection did not track station name");
+		if (!overlappingOverlay->isSelected())
+			fail(QString("station click did not select the overlapping overlay (%1/%2/%3)")
+				.arg(overlappingOverlay->stationName(), m_selectedStationName)
+				.arg(m_stationOverlays.contains(overlappingOverlay)));
+		if (!overlappingOverlay->isLabelVisible())
+			fail(QString("selected station click did not reveal its culled label (layout=%1 blocked=%2 selected=%3)")
+				.arg(overlappingOverlay->isLayoutVisible())
+				.arg(overlappingOverlay->isLabelLayoutVisible() && !overlappingOverlay->isLabelVisible())
+				.arg(overlappingOverlay->isSelected()));
+
+		QGraphicsItem* contextTarget = nullptr;
+		const QMetaObject::Connection contextConnection = connect(scene, &NetworkScene::ContextMenuRequested,
+			this, [&](QGraphicsItem* item, const QPointF&, const QPoint&, bool) { contextTarget = item; });
+		QGraphicsSceneContextMenuEvent context(QEvent::GraphicsSceneContextMenu);
+		context.setReason(QGraphicsSceneContextMenuEvent::Mouse);
+		context.setScenePos(semanticPoint);
+		context.setScreenPos(networkView->viewport()->mapToGlobal(
+			networkView->mapFromScene(semanticPoint)));
+		context.setWidget(networkView->viewport());
+		scene->contextMenuEvent(&context);
+		disconnect(contextConnection);
+		if (contextTarget != stationTarget)
+			fail(QString("context menu did not preserve station semantic target (got=%1 expected=%2 gotType=%3 expectedType=%4)")
+				.arg(reinterpret_cast<quintptr>(contextTarget), 0, 16)
+				.arg(reinterpret_cast<quintptr>(stationTarget), 0, 16)
+				.arg(contextTarget ? contextTarget->type() : -1)
+				.arg(stationTarget ? stationTarget->type() : -1));
+
+		if (m_sceneContextMenu)
+			m_sceneContextMenu->close();
+		QApplication::processEvents();
+		if (stationTarget->graphicsEffect() == effect)
+			handleCloseInfoDockWidget();
+		if (overlappingOverlay->scene() == scene)
 			scene->removeItem(overlappingOverlay);
-			delete overlappingOverlay;
-		}
+		delete overlappingOverlay;
+		if (stationTarget->scene() == scene)
+			scene->removeItem(stationTarget);
+		delete stationTarget;
+		m_stationOverlays = previousStationOverlays;
+		m_stationDecorations = previousStationDecorations;
+		m_selectedStationName = previousSelectedStationName;
+		for (auto* item : previouslyVisibleItems)
+			if (item && item->scene() == scene)
+				item->setVisible(true);
+		updateViewportOverlays();
 
 		checkZoom(3.0, "3X");
 		checkZoom(12.0, "12X");
@@ -6705,7 +6758,7 @@ void MainWindow::setupGUI() {
 
 			// draw nodes
 			if (i > 0 && !empty(blockSets[track].member[i - 1].endNode.stationName)) { // station Node (only visible from end nodes [end_node] -> i>1)
-				paintStationNode(pt, station_node_size, line_width, track, &blockSets[track].member[i].startNode);
+				paintStationNode(pt, station_node_size, line_width, track, &blockSets[track].member[i - 1].endNode);
 				if (initial_variables.PAX_GUI) {
 					paintStationPlatform(pt, station_node_size, line_width, &blockSets[track].member[i - 1].endNode);
 				}
@@ -10400,13 +10453,18 @@ void MainWindow::updateStationOverlayDegrees() {
 		if (!overlay)
 			continue;
 		int highestDegree = 0;
+		bool hasInterchange = false;
+		bool hasEndpoint = false;
 		for (auto* item : scene->items()) {
 			auto* station = qgraphicsitem_cast<StationNodeItem*>(item);
-			if (!station || !station->node || QString::fromStdString(station->node->stationName) != overlay->stationName())
+			if (!station || !station->node || !station->isVisible()
+				|| QString::fromStdString(station->node->stationName) != overlay->stationName())
 				continue;
 			const QPointF point = station->sceneBoundingRect().center();
 			int degree = 0;
 			for (auto* edge : scene->items()) {
+				if (!edge || !edge->isVisible())
+					continue;
 				if (auto* track = qgraphicsitem_cast<TrackLineItem*>(edge)) {
 					degree += segmentDegree(track, track->line(), point);
 					if (auto* virtualArc = dynamic_cast<VirtualArcItem*>(track))
@@ -10416,8 +10474,10 @@ void MainWindow::updateStationOverlayDegrees() {
 				}
 			}
 			highestDegree = std::max(highestDegree, degree);
+			hasInterchange = hasInterchange || degree >= 3;
+			hasEndpoint = hasEndpoint || degree == 1;
 		}
-		overlay->setDegree(highestDegree);
+		overlay->setNetworkDegree(highestDegree, hasInterchange, hasEndpoint);
 	}
 }
 
@@ -10436,34 +10496,24 @@ void MainWindow::updateViewportOverlays() {
 	const QRectF viewport = networkView->viewport()->rect();
 	const QRectF inset = viewport.adjusted(kOverlayMargin, kOverlayMargin,
 		-kOverlayMargin, -kOverlayMargin);
-	const auto translated = [](const QRectF& rect, const QPointF& point, const QPointF& offset) {
-		return rect.translated(point + offset);
-	};
-	const auto clampOffset = [&](const QRectF& rect) {
-		QPointF offset;
-		if (rect.left() < inset.left())
-			offset.rx() += inset.left() - rect.left();
-		else if (rect.right() > inset.right())
-			offset.rx() += inset.right() - rect.right();
-		if (rect.top() < inset.top())
-			offset.ry() += inset.top() - rect.top();
-		else if (rect.bottom() > inset.bottom())
-			offset.ry() += inset.bottom() - rect.bottom();
-		return offset;
-	};
-	const auto overflow = [&](const QRectF& rect) {
-		return std::max<qreal>(0.0, inset.left() - rect.left())
-			+ std::max<qreal>(0.0, rect.right() - inset.right())
-			+ std::max<qreal>(0.0, inset.top() - rect.top())
-			+ std::max<qreal>(0.0, rect.bottom() - inset.bottom());
+	struct CandidatePlacement {
+		StationOverlayItem* overlay = nullptr;
+		StationOverlayItem::ViewportPlacement right;
+		StationOverlayItem::ViewportPlacement left;
+		StationOverlayItem::ViewportPlacement above;
+		StationOverlayItem::ViewportPlacement below;
+		StationOverlayItem::ViewportPlacement current;
+		int symbolIndex = -1;
 	};
 
 	QList<QRectF> symbolRects;
 	QList<StationOverlayItem*> candidates;
+	QList<CandidatePlacement> placements;
 	for (auto* overlay : m_stationOverlays) {
 		if (!overlay)
 			continue;
 		overlay->setViewportOffset(QPointF());
+		overlay->setCollisionBlocked(false);
 		overlay->setSelected(!m_selectedStationName.isEmpty()
 			&& overlay->stationName() == m_selectedStationName);
 		overlay->setVisible(m_stationLayerVisible);
@@ -10471,27 +10521,26 @@ void MainWindow::updateViewportOverlays() {
 			continue;
 
 		const QPointF anchor = toDevice.map(overlay->stableAnchor());
-		overlay->setLabelSide(StationOverlayItem::LabelSide::Right);
-		const QRectF rightRect = translated(overlay->combinedRect(), anchor, QPointF());
-		overlay->setLabelSide(StationOverlayItem::LabelSide::Left);
-		const QRectF leftRect = translated(overlay->combinedRect(), anchor, QPointF());
-		StationOverlayItem::LabelSide side = StationOverlayItem::LabelSide::Right;
-		QRectF chosen = rightRect;
-		if (!inset.contains(rightRect) && inset.contains(leftRect)) {
-			side = StationOverlayItem::LabelSide::Left;
-			chosen = leftRect;
-		} else if (!inset.contains(rightRect) && !inset.contains(leftRect)
-			&& overflow(leftRect) < overflow(rightRect)) {
-			side = StationOverlayItem::LabelSide::Left;
-			chosen = leftRect;
-		}
-		overlay->setLabelSide(side);
-		const QPointF offset = clampOffset(chosen);
-		overlay->setViewportOffset(offset);
-		const QRectF effectiveSymbol = translated(overlay->symbolRect(), anchor, offset);
-		symbolRects.append(effectiveSymbol);
+		CandidatePlacement placement;
+		placement.overlay = overlay;
+		placement.right = overlay->placementForSide(StationOverlayItem::LabelSide::Right, anchor, inset);
+		placement.left = overlay->placementForSide(StationOverlayItem::LabelSide::Left, anchor, inset);
+		placement.above = overlay->placementForSide(StationOverlayItem::LabelSide::Above, anchor, inset);
+		placement.below = overlay->placementForSide(StationOverlayItem::LabelSide::Below, anchor, inset);
+		placement.current = overlay->preferredViewportPlacement(anchor, inset);
+		overlay->setLabelSide(placement.current.side);
+		overlay->setViewportOffset(placement.current.offset);
+		placement.symbolIndex = symbolRects.size();
+		symbolRects.append(placement.current.symbolRect);
+		placements.append(placement);
 		candidates.append(overlay);
 	}
+	const auto placementFor = [&placements](StationOverlayItem* overlay) -> CandidatePlacement* {
+		for (auto& placement : placements)
+			if (placement.overlay == overlay)
+				return &placement;
+		return nullptr;
+	};
 
 	QPointF followedCenter;
 	bool hasFollowedCenter = false;
@@ -10509,7 +10558,16 @@ void MainWindow::updateViewportOverlays() {
 			continue;
 		const QPointF delta = overlay->stableAnchor() - followedCenter;
 		const qreal distance = delta.x() * delta.x() + delta.y() * delta.y();
-		if (!nearestFollowed || distance < nearestDistance) {
+		bool nearer = !nearestFollowed || distance < nearestDistance;
+		if (!nearer && distance == nearestDistance) {
+			const int nameOrder = QString::compare(overlay->stationName(), nearestFollowed->stationName(),
+				Qt::CaseSensitive);
+			nearer = nameOrder < 0
+				|| (nameOrder == 0 && (overlay->stableAnchor().x() < nearestFollowed->stableAnchor().x()
+					|| (overlay->stableAnchor().x() == nearestFollowed->stableAnchor().x()
+						&& overlay->stableAnchor().y() < nearestFollowed->stableAnchor().y())));
+		}
+		if (nearer) {
 			nearestFollowed = overlay;
 			nearestDistance = distance;
 		}
@@ -10521,35 +10579,83 @@ void MainWindow::updateViewportOverlays() {
 		return StationOverlayItem::priorityLess(*left, *right,
 			toDevice.inverted().map(viewport.center()));
 	});
+	const bool hasOverviewPriority = std::any_of(candidates.cbegin(), candidates.cend(), [](const auto* overlay) {
+		return overlay->isSelected() || overlay->isFollowed() || overlay->isHovered()
+			|| overlay->isInterchange() || overlay->isEndpoint();
+	});
+	const bool showOrdinaryOverviewLabels = !hasOverviewPriority;
 	QList<QRectF> placedLabels;
 	for (auto* overlay : candidates) {
 		const bool forced = overlay->isSelected() || overlay->isFollowed() || overlay->isHovered();
 		const bool eligible = networkView->zoomRatio() >= 2.0
-			|| forced || overlay->isInterchange() || overlay->isEndpoint();
+			|| forced || overlay->isInterchange() || overlay->isEndpoint()
+			|| showOrdinaryOverviewLabels;
 		bool visible = false;
-		if (eligible) {
-			const QRectF label = translated(overlay->labelRect(), toDevice.map(overlay->stableAnchor()),
-				overlay->viewportOffset());
-			const QRectF inflated = label.adjusted(-4.0, -4.0, 4.0, 4.0);
-			bool collision = false;
-			for (const QRectF& symbol : symbolRects) {
-				if (inflated.intersects(symbol)) {
-					collision = true;
-					break;
-				}
+		bool collisionBlocked = false;
+		CandidatePlacement* placement = placementFor(overlay);
+		if (placement) {
+			const StationOverlayItem::ViewportPlacement* choices[4] = {
+				&placement->right, &placement->left, &placement->above, &placement->below};
+			if (placement->current.side == StationOverlayItem::LabelSide::Left) {
+				choices[0] = &placement->left;
+				choices[1] = &placement->right;
 			}
-			if (!collision) {
-				for (const QRectF& other : placedLabels) {
-					if (inflated.intersects(other)) {
-						collision = true;
+			const StationOverlayItem::ViewportPlacement* chosen = nullptr;
+			const StationOverlayItem::ViewportPlacement* hoverFallback = nullptr;
+			for (const auto* choice : choices) {
+				const QRectF inflated = choice->labelRect.adjusted(-4.0, -4.0, 4.0, 4.0);
+				bool symbolCollision = false;
+				for (const QRectF& symbol : symbolRects) {
+					if (inflated.intersects(symbol)) {
+						symbolCollision = true;
 						break;
 					}
 				}
+				if (symbolCollision)
+					continue;
+				bool symbolMovedIntoLabel = false;
+				for (const QRectF& other : placedLabels) {
+					if (other.intersects(choice->symbolRect)) {
+						symbolMovedIntoLabel = true;
+						break;
+					}
+				}
+				if (symbolMovedIntoLabel)
+					continue;
+				if (!hoverFallback)
+					hoverFallback = choice;
+				if (!eligible)
+					continue;
+				bool labelCollision = false;
+				for (const QRectF& other : placedLabels) {
+					if (inflated.intersects(other)) {
+						labelCollision = true;
+						break;
+					}
+				}
+				if (labelCollision)
+					continue;
+				chosen = choice;
+				break;
 			}
-			visible = forced || !collision;
-			if (visible)
-				placedLabels.append(inflated);
+			if (!chosen && hoverFallback) {
+				placement->current = *hoverFallback;
+				overlay->setLabelSide(hoverFallback->side);
+				overlay->setViewportOffset(hoverFallback->offset);
+				symbolRects[placement->symbolIndex] = hoverFallback->symbolRect;
+			}
+			if (!chosen)
+				collisionBlocked = !hoverFallback;
+			if (chosen) {
+				placement->current = *chosen;
+				overlay->setLabelSide(chosen->side);
+				overlay->setViewportOffset(chosen->offset);
+				symbolRects[placement->symbolIndex] = chosen->symbolRect;
+				visible = true;
+				placedLabels.append(chosen->labelRect.adjusted(-4.0, -4.0, 4.0, 4.0));
+			}
 		}
+		overlay->setCollisionBlocked(collisionBlocked);
 		overlay->setLayoutVisible(visible);
 	}
 

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -102,6 +102,7 @@ class QTemporaryDir; // forward declaration for m_runStagingDir
 #include "graphics/items/VirtualArcItem.h"
 #include "graphics/items/NodeItem.h"
 #include "graphics/items/StationNodeItem.h"
+#include "graphics/items/StationOverlayItem.h"
 #include "graphics/items/PlatformItem.h"
 #include "graphics/items/IconItem.h"
 #include "graphics/items/PassengerItem.h"
@@ -161,8 +162,7 @@ public:
 	// painting
 	void paintNode(QPointF coord, int size, int pen_width, int track, Node* Node);
 	void paintStationNode(QPointF coord, int size, int pen_width, int track, Node* Node);
-	void paintStationIcon(QPointF coord, const StationVisual& visual);
-	void paintStationName(QPointF coord, string sname);
+	void paintStationOverlay(QPointF coord, const StationVisual& visual, const string& sname);
 	void paintStationPlatform(QPointF coord, int size, int pen_width, Node* Node);
 	void paintTrainPassengerInfo(TrainItemGroup* trainItem);
 	void paintPassengerInfoIcon(PassengerItem* paxItem);
@@ -490,7 +490,8 @@ private:
 	bool m_signalLayerVisible = true;
 	bool m_passengerLayerVisible = true;
 	QList<QGraphicsItem*> m_stationDecorations;
-	QList<QGraphicsTextItem*> m_stationNames;
+	QList<StationOverlayItem*> m_stationOverlays;
+	QString m_selectedStationName;
 	QList<QGraphicsItem*> m_signalDecorations;
 	QMap<int, QGraphicsItemGroup*> m_vcMessageItems;
 	NetworkLegendItem* m_networkLegend = nullptr;
@@ -599,6 +600,7 @@ private:
 	std::string uniqueIncidentId(const std::string& baseId) const;
 
 	void runVisualPolishE2E();
+	void runStationOverlayE2E();
 	void runEditorSmokeE2E();
 	void runSceneRenderE2E();
 	void runTrackPreviewE2E();
@@ -612,6 +614,7 @@ private:
 	std::unordered_map<std::string, QList<SignalItem*>> m_signalsByAheadId;
 	void buildSignalIndex();
 	void buildTrackIndexes();
+	void updateStationOverlayDegrees();
 	void updateViewportOverlays();
 	void updateZoomStatus();
 	void updateTimeline(int timestep, int totalTimesteps);

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkScene.cpp
@@ -37,10 +37,15 @@ QGraphicsItem* NetworkScene::semanticItemAt(const QPointF& scenePos, QWidget* wi
 
 // handles the click on graphical items
 void NetworkScene::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) {
-	// emit signal according to clicked item (mouse left button pressed)
+	QGraphicsItem* item = nullptr;
+	if (mouseEvent->button() == Qt::LeftButton)
+		item = semanticItemAt(mouseEvent->scenePos(), mouseEvent->widget());
+
+	// Let Qt finish its built-in selection handling before application selection
+	// highlights are applied by the semantic handlers below.
+	QGraphicsScene::mousePressEvent(mouseEvent);
+
 	if (mouseEvent->button() == Qt::LeftButton) {
-		QGraphicsItem* item = semanticItemAt(mouseEvent->scenePos(), mouseEvent->widget());
-		const bool itemClicked = item != nullptr;
 		if (NodeItem* node = qgraphicsitem_cast<NodeItem*>(item))
 			emit MousePressedOnNode(node);
 		else if (StationNodeItem* stationNode = qgraphicsitem_cast<StationNodeItem*>(item))
@@ -56,15 +61,11 @@ void NetworkScene::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) {
 		else if (PassengerItem* passenger = qgraphicsitem_cast<PassengerItem*>(item))
 			emit MousePressedOnPassenger(passenger);
 
-		if (!itemClicked)
+		if (!item)
 			emit DisableHighlight();
 	}
 
-	// send signal
 	emit MousePressedOnScene();
-
-	// default implementation
-	QGraphicsScene::mousePressEvent(mouseEvent);
 }
 
 void NetworkScene::contextMenuEvent(QGraphicsSceneContextMenuEvent* event) {

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
@@ -32,8 +32,12 @@ NetworkView::~NetworkView() {
 }
 
 void NetworkView::mousePressEvent(QMouseEvent* mouseEvent) {
-	emit MousePressedOnView();
 	QGraphicsView::mousePressEvent(mouseEvent);
+}
+
+void NetworkView::mouseReleaseEvent(QMouseEvent* mouseEvent) {
+	QGraphicsView::mouseReleaseEvent(mouseEvent);
+	emit interactionFinished();
 }
 
 void NetworkView::centerOn(const QPointF& scenePos) {

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
@@ -30,6 +30,7 @@ public:
 	void centerOn(const QPointF& scenePos);
 	void centerOn(QGraphicsItem* item);
 	void mousePressEvent(QMouseEvent* mouseEvent) override;
+	void mouseReleaseEvent(QMouseEvent* mouseEvent) override;
 	void fitToTopology();
 	void fitToBounds(const QRectF& bounds);
 	bool zoomBy(qreal factor, const QPointF& viewportAnchor = QPointF(-1.0, -1.0));
@@ -59,7 +60,7 @@ private:
 	bool m_hasViewCenter = false;
 
 signals:
-	void MousePressedOnView();
+	void interactionFinished();
 	void viewportChanged();
 };
 

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.cpp
@@ -1,0 +1,215 @@
+#include "graphics/items/StationOverlayItem.h"
+
+#include <QGraphicsSceneHoverEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QStyleOptionGraphicsItem>
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+
+namespace {
+constexpr qreal kSymbolPixels = 24.0;
+constexpr qreal kLabelPixels = 11.0;
+constexpr qreal kLabelGap = 8.0;
+
+int classPriority(StationVisualKind kind) {
+	return kind == StationVisualKind::Platform ? 1 : 0;
+}
+}
+
+StationOverlayItem::StationOverlayItem(const QString& stationName, const QPointF& stableAnchor,
+	const StationVisual& visual, int degree, QGraphicsItem* parent)
+	: QGraphicsItem(parent), m_stationName(stationName), m_stableAnchor(stableAnchor),
+	  m_visual(visual), m_degree(std::max(0, degree)) {
+	setFlag(QGraphicsItem::ItemIgnoresTransformations);
+	setFlag(QGraphicsItem::ItemIsSelectable);
+	setAcceptHoverEvents(true);
+	setAcceptedMouseButtons(Qt::NoButton);
+	setZValue(3.0);
+	m_labelFont.setPixelSize(static_cast<int>(kLabelPixels));
+	const QPixmap sourceSymbol(m_visual.iconResource);
+	if (!sourceSymbol.isNull())
+		m_symbol = sourceSymbol.scaled(QSize(static_cast<int>(kSymbolPixels),
+			static_cast<int>(kSymbolPixels)), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+	m_displayName = displayName(m_stationName);
+	m_symbolRect = QRectF(-kSymbolPixels / 2.0, -kSymbolPixels / 2.0, kSymbolPixels, kSymbolPixels);
+	m_labelSide = LabelSide::Right;
+	rebuildGeometry();
+	setPos(m_stableAnchor);
+}
+
+StationOverlayItem::~StationOverlayItem() = default;
+
+QString StationOverlayItem::displayName() const {
+	return m_displayName;
+}
+
+QString StationOverlayItem::displayName(const QString& stationName) {
+	QString spaced = stationName;
+	for (int i = 1; i < spaced.size(); ++i) {
+		const auto character = static_cast<unsigned char>(spaced.at(i).toLatin1());
+		if (std::isupper(character)) {
+			spaced.insert(i, QLatin1Char(' '));
+			++i;
+		}
+	}
+	return spaced;
+}
+
+QString StationOverlayItem::displayName(const std::string& stationName) {
+	return displayName(QString::fromStdString(stationName));
+}
+
+void StationOverlayItem::setStableAnchor(const QPointF& anchor) {
+	m_stableAnchor = anchor;
+	setPos(anchor);
+}
+
+void StationOverlayItem::setViewportOffset(const QPointF& offset) {
+	if (m_viewportOffset == offset)
+		return;
+	prepareGeometryChange();
+	m_viewportOffset = offset;
+	update();
+}
+
+void StationOverlayItem::setLabelSide(LabelSide side) {
+	if (m_labelSide == side)
+		return;
+	prepareGeometryChange();
+	m_labelSide = side;
+	rebuildGeometry();
+	update();
+}
+
+QRectF StationOverlayItem::combinedRect() const {
+	return translated(m_symbolRect).united(translated(m_labelRect));
+}
+
+QRectF StationOverlayItem::translated(const QRectF& rect) const {
+	return rect.translated(m_viewportOffset);
+}
+
+QRectF StationOverlayItem::boundingRect() const {
+	return combinedRect();
+}
+
+QPainterPath StationOverlayItem::shape() const {
+	QPainterPath path;
+	path.addRect(translated(m_symbolRect));
+	if (isLabelVisible())
+		path.addRect(translated(m_labelRect));
+	return path;
+}
+
+void StationOverlayItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
+	Q_UNUSED(option);
+	Q_UNUSED(widget);
+	painter->save();
+	painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+	painter->translate(m_viewportOffset);
+	if (!m_symbol.isNull()) {
+		painter->drawPixmap(m_symbolRect, m_symbol, m_symbol.rect());
+	} else {
+		painter->setPen(QPen(m_visual.outline, 1.0));
+		painter->setBrush(m_visual.fill);
+		painter->drawEllipse(m_symbolRect);
+	}
+	if (isLabelVisible()) {
+		painter->setPen(Qt::white);
+		painter->setFont(m_labelFont);
+		painter->drawText(m_labelRect, Qt::AlignVCenter | Qt::AlignLeft, m_displayName);
+	}
+	painter->restore();
+}
+
+void StationOverlayItem::setLayoutVisible(bool visible) {
+	if (m_layoutVisible == visible)
+		return;
+	m_layoutVisible = visible;
+	update();
+}
+
+bool StationOverlayItem::isLabelVisible() const {
+	return m_layoutVisible || m_hovered || isSelected();
+}
+
+void StationOverlayItem::setFollowed(bool followed) {
+	if (m_followed == followed)
+		return;
+	m_followed = followed;
+	update();
+}
+
+void StationOverlayItem::setDegree(int degree) {
+	degree = std::max(0, degree);
+	if (m_degree == degree)
+		return;
+	m_degree = degree;
+	const bool hasPlatform = m_visual.kind != StationVisualKind::StopMarker;
+	m_visual = classifyStation(hasPlatform, m_degree);
+	const QPixmap sourceSymbol(m_visual.iconResource);
+	m_symbol = sourceSymbol.isNull() ? QPixmap() : sourceSymbol.scaled(QSize(static_cast<int>(kSymbolPixels),
+		static_cast<int>(kSymbolPixels)), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+	update();
+}
+
+bool StationOverlayItem::isInterchange() const {
+	return m_degree >= 3 || m_visual.kind == StationVisualKind::Interchange;
+}
+
+bool StationOverlayItem::isEndpoint() const {
+	return m_degree == 1;
+}
+
+bool StationOverlayItem::priorityLess(const StationOverlayItem& left, const StationOverlayItem& right,
+	const QPointF& viewportCenter) {
+	if (left.isSelected() != right.isSelected())
+		return left.isSelected();
+	if (left.isFollowed() != right.isFollowed())
+		return left.isFollowed();
+	if (left.isInterchange() != right.isInterchange())
+		return left.isInterchange();
+	if (left.isEndpoint() != right.isEndpoint())
+		return left.isEndpoint();
+	const int leftClass = classPriority(left.m_visual.kind);
+	const int rightClass = classPriority(right.m_visual.kind);
+	if (leftClass != rightClass)
+		return leftClass > rightClass;
+	const QPointF leftDelta = left.m_stableAnchor - viewportCenter;
+	const QPointF rightDelta = right.m_stableAnchor - viewportCenter;
+	const qreal leftDistance = leftDelta.x() * leftDelta.x() + leftDelta.y() * leftDelta.y();
+	const qreal rightDistance = rightDelta.x() * rightDelta.x() + rightDelta.y() * rightDelta.y();
+	if (!qFuzzyCompare(leftDistance + 1.0, rightDistance + 1.0))
+		return leftDistance < rightDistance;
+	const int nameOrder = QString::compare(left.m_stationName, right.m_stationName, Qt::CaseSensitive);
+	if (nameOrder != 0)
+		return nameOrder < 0;
+	if (!qFuzzyCompare(left.m_stableAnchor.x() + 1.0, right.m_stableAnchor.x() + 1.0))
+		return left.m_stableAnchor.x() < right.m_stableAnchor.x();
+	return left.m_stableAnchor.y() < right.m_stableAnchor.y();
+}
+
+void StationOverlayItem::hoverEnterEvent(QGraphicsSceneHoverEvent* event) {
+	m_hovered = true;
+	update();
+	QGraphicsItem::hoverEnterEvent(event);
+}
+
+void StationOverlayItem::hoverLeaveEvent(QGraphicsSceneHoverEvent* event) {
+	m_hovered = false;
+	update();
+	QGraphicsItem::hoverLeaveEvent(event);
+}
+
+void StationOverlayItem::rebuildGeometry() {
+	const QFontMetricsF metrics(m_labelFont);
+	const qreal width = metrics.horizontalAdvance(m_displayName);
+	const qreal height = metrics.height();
+	if (m_labelSide == LabelSide::Right)
+		m_labelRect = QRectF(m_symbolRect.right() + kLabelGap, -height / 2.0, width, height);
+	else
+		m_labelRect = QRectF(m_symbolRect.left() - kLabelGap - width, -height / 2.0, width, height);
+}

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.cpp
@@ -22,7 +22,8 @@ int classPriority(StationVisualKind kind) {
 StationOverlayItem::StationOverlayItem(const QString& stationName, const QPointF& stableAnchor,
 	const StationVisual& visual, int degree, QGraphicsItem* parent)
 	: QGraphicsItem(parent), m_stationName(stationName), m_stableAnchor(stableAnchor),
-	  m_visual(visual), m_degree(std::max(0, degree)) {
+	  m_visual(visual), m_degree(std::max(0, degree)), m_originalVisualKind(visual.kind),
+	  m_interchange(visual.kind == StationVisualKind::Interchange), m_endpoint(degree == 1) {
 	setFlag(QGraphicsItem::ItemIgnoresTransformations);
 	setFlag(QGraphicsItem::ItemIsSelectable);
 	setAcceptHoverEvents(true);
@@ -84,6 +85,47 @@ void StationOverlayItem::setLabelSide(LabelSide side) {
 	update();
 }
 
+StationOverlayItem::ViewportPlacement StationOverlayItem::placementForSide(
+	LabelSide side, const QPointF& deviceAnchor, const QRectF& viewportInset) const {
+	const QRectF rawSymbol = m_symbolRect.translated(deviceAnchor);
+	const QRectF rawLabel = labelRectForSide(side).translated(deviceAnchor);
+	const QRectF rawCombined = rawSymbol.united(rawLabel);
+	const auto overflowFor = [&viewportInset](const QRectF& rect) {
+		return std::max<qreal>(0.0, viewportInset.left() - rect.left())
+			+ std::max<qreal>(0.0, rect.right() - viewportInset.right())
+			+ std::max<qreal>(0.0, viewportInset.top() - rect.top())
+			+ std::max<qreal>(0.0, rect.bottom() - viewportInset.bottom());
+	};
+	QPointF offset;
+	if (rawCombined.left() < viewportInset.left())
+		offset.rx() += viewportInset.left() - rawCombined.left();
+	else if (rawCombined.right() > viewportInset.right())
+		offset.rx() += viewportInset.right() - rawCombined.right();
+	if (rawCombined.top() < viewportInset.top())
+		offset.ry() += viewportInset.top() - rawCombined.top();
+	else if (rawCombined.bottom() > viewportInset.bottom())
+		offset.ry() += viewportInset.bottom() - rawCombined.bottom();
+	ViewportPlacement placement;
+	placement.side = side;
+	placement.offset = offset;
+	placement.symbolRect = rawSymbol.translated(offset);
+	placement.labelRect = rawLabel.translated(offset);
+	placement.combinedRect = rawCombined.translated(offset);
+	placement.overflow = overflowFor(rawCombined);
+	placement.fitsBeforeClamp = viewportInset.contains(rawCombined);
+	placement.fits = viewportInset.contains(placement.combinedRect);
+	return placement;
+}
+
+StationOverlayItem::ViewportPlacement StationOverlayItem::preferredViewportPlacement(
+	const QPointF& deviceAnchor, const QRectF& viewportInset) const {
+	const ViewportPlacement right = placementForSide(LabelSide::Right, deviceAnchor, viewportInset);
+	const ViewportPlacement left = placementForSide(LabelSide::Left, deviceAnchor, viewportInset);
+	if (right.fitsBeforeClamp || (!left.fitsBeforeClamp && right.overflow <= left.overflow))
+		return right;
+	return left;
+}
+
 QRectF StationOverlayItem::combinedRect() const {
 	return translated(m_symbolRect).united(translated(m_labelRect));
 }
@@ -133,7 +175,14 @@ void StationOverlayItem::setLayoutVisible(bool visible) {
 }
 
 bool StationOverlayItem::isLabelVisible() const {
-	return m_layoutVisible || m_hovered || isSelected();
+	return (m_layoutVisible && !m_collisionBlocked) || m_hovered || isSelected();
+}
+
+void StationOverlayItem::setCollisionBlocked(bool blocked) {
+	if (m_collisionBlocked == blocked)
+		return;
+	m_collisionBlocked = blocked;
+	update();
 }
 
 void StationOverlayItem::setFollowed(bool followed) {
@@ -144,12 +193,21 @@ void StationOverlayItem::setFollowed(bool followed) {
 }
 
 void StationOverlayItem::setDegree(int degree) {
+	setNetworkDegree(degree, degree >= 3, degree == 1);
+}
+
+void StationOverlayItem::setNetworkDegree(int degree, bool interchange, bool endpoint) {
 	degree = std::max(0, degree);
-	if (m_degree == degree)
+	const bool nextInterchange = interchange || degree >= 3
+		|| m_originalVisualKind == StationVisualKind::Interchange;
+	const bool nextEndpoint = endpoint || degree == 1;
+	if (m_degree == degree && m_interchange == nextInterchange && m_endpoint == nextEndpoint)
 		return;
 	m_degree = degree;
-	const bool hasPlatform = m_visual.kind != StationVisualKind::StopMarker;
-	m_visual = classifyStation(hasPlatform, m_degree);
+	m_interchange = nextInterchange;
+	m_endpoint = nextEndpoint;
+	m_visual = classifyStation(m_originalVisualKind == StationVisualKind::Platform,
+		m_interchange ? 3 : m_degree);
 	const QPixmap sourceSymbol(m_visual.iconResource);
 	m_symbol = sourceSymbol.isNull() ? QPixmap() : sourceSymbol.scaled(QSize(static_cast<int>(kSymbolPixels),
 		static_cast<int>(kSymbolPixels)), Qt::KeepAspectRatio, Qt::SmoothTransformation);
@@ -157,11 +215,11 @@ void StationOverlayItem::setDegree(int degree) {
 }
 
 bool StationOverlayItem::isInterchange() const {
-	return m_degree >= 3 || m_visual.kind == StationVisualKind::Interchange;
+	return m_interchange || m_degree >= 3 || m_originalVisualKind == StationVisualKind::Interchange;
 }
 
 bool StationOverlayItem::isEndpoint() const {
-	return m_degree == 1;
+	return m_endpoint || m_degree == 1;
 }
 
 bool StationOverlayItem::priorityLess(const StationOverlayItem& left, const StationOverlayItem& right,
@@ -174,8 +232,8 @@ bool StationOverlayItem::priorityLess(const StationOverlayItem& left, const Stat
 		return left.isInterchange();
 	if (left.isEndpoint() != right.isEndpoint())
 		return left.isEndpoint();
-	const int leftClass = classPriority(left.m_visual.kind);
-	const int rightClass = classPriority(right.m_visual.kind);
+	const int leftClass = classPriority(left.m_originalVisualKind);
+	const int rightClass = classPriority(right.m_originalVisualKind);
 	if (leftClass != rightClass)
 		return leftClass > rightClass;
 	const QPointF leftDelta = left.m_stableAnchor - viewportCenter;
@@ -205,11 +263,18 @@ void StationOverlayItem::hoverLeaveEvent(QGraphicsSceneHoverEvent* event) {
 }
 
 void StationOverlayItem::rebuildGeometry() {
+	m_labelRect = labelRectForSide(m_labelSide);
+}
+
+QRectF StationOverlayItem::labelRectForSide(LabelSide side) const {
 	const QFontMetricsF metrics(m_labelFont);
 	const qreal width = metrics.horizontalAdvance(m_displayName);
 	const qreal height = metrics.height();
-	if (m_labelSide == LabelSide::Right)
-		m_labelRect = QRectF(m_symbolRect.right() + kLabelGap, -height / 2.0, width, height);
-	else
-		m_labelRect = QRectF(m_symbolRect.left() - kLabelGap - width, -height / 2.0, width, height);
+	if (side == LabelSide::Right)
+		return QRectF(m_symbolRect.right() + kLabelGap, -height / 2.0, width, height);
+	if (side == LabelSide::Left)
+		return QRectF(m_symbolRect.left() - kLabelGap - width, -height / 2.0, width, height);
+	if (side == LabelSide::Above)
+		return QRectF(-width / 2.0, m_symbolRect.top() - kLabelGap - height, width, height);
+	return QRectF(-width / 2.0, m_symbolRect.bottom() + kLabelGap, width, height);
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.h
@@ -12,8 +12,18 @@
 
 class StationOverlayItem : public QGraphicsItem {
 public:
-	enum class LabelSide { Right, Left };
+	enum class LabelSide { Right, Left, Above, Below };
 	enum { Type = UserType + 13 };
+	struct ViewportPlacement {
+		LabelSide side = LabelSide::Right;
+		QPointF offset;
+		QRectF symbolRect;
+		QRectF labelRect;
+		QRectF combinedRect;
+		qreal overflow = 0.0;
+		bool fitsBeforeClamp = false;
+		bool fits = false;
+	};
 
 	StationOverlayItem(const QString& stationName, const QPointF& stableAnchor,
 		const StationVisual& visual, int degree = 0, QGraphicsItem* parent = nullptr);
@@ -36,6 +46,10 @@ public:
 
 	LabelSide labelSide() const { return m_labelSide; }
 	void setLabelSide(LabelSide side);
+	ViewportPlacement placementForSide(LabelSide side, const QPointF& deviceAnchor,
+		const QRectF& viewportInset) const;
+	ViewportPlacement preferredViewportPlacement(const QPointF& deviceAnchor,
+		const QRectF& viewportInset) const;
 	QRectF symbolRect() const { return m_symbolRect; }
 	QRectF labelRect() const { return m_labelRect; }
 	QRectF combinedRect() const;
@@ -44,7 +58,9 @@ public:
 	QRectF deviceCombinedRect() const { return combinedRect(); }
 
 	void setLayoutVisible(bool visible);
+	void setCollisionBlocked(bool blocked);
 	bool isLayoutVisible() const { return m_layoutVisible; }
+	bool isCollisionBlocked() const { return m_collisionBlocked; }
 	bool isLabelLayoutVisible() const { return m_layoutVisible; }
 	bool isLabelVisible() const;
 	bool isHovered() const { return m_hovered; }
@@ -52,6 +68,7 @@ public:
 	bool isFollowed() const { return m_followed; }
 	int degree() const { return m_degree; }
 	void setDegree(int degree);
+	void setNetworkDegree(int degree, bool interchange, bool endpoint);
 	StationVisualKind visualKind() const { return m_visual.kind; }
 	const StationVisual& visual() const { return m_visual; }
 	bool isInterchange() const;
@@ -66,6 +83,7 @@ protected:
 
 private:
 	void rebuildGeometry();
+	QRectF labelRectForSide(LabelSide side) const;
 	QRectF translated(const QRectF& rect) const;
 
 	QString m_stationName;
@@ -79,9 +97,13 @@ private:
 	QRectF m_labelRect;
 	LabelSide m_labelSide = LabelSide::Right;
 	bool m_layoutVisible = true;
+	bool m_collisionBlocked = false;
 	bool m_hovered = false;
 	bool m_followed = false;
 	int m_degree = 0;
+	StationVisualKind m_originalVisualKind = StationVisualKind::StopMarker;
+	bool m_interchange = false;
+	bool m_endpoint = false;
 };
 
 #endif // STATIONOVERLAYITEM_H

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.h
@@ -1,0 +1,87 @@
+#ifndef STATIONOVERLAYITEM_H
+#define STATIONOVERLAYITEM_H
+
+#include <QFont>
+#include <QGraphicsItem>
+#include <QPixmap>
+#include <QPointF>
+#include <QRectF>
+#include <QString>
+
+#include "graphics/VisualPolish.h"
+
+class StationOverlayItem : public QGraphicsItem {
+public:
+	enum class LabelSide { Right, Left };
+	enum { Type = UserType + 13 };
+
+	StationOverlayItem(const QString& stationName, const QPointF& stableAnchor,
+		const StationVisual& visual, int degree = 0, QGraphicsItem* parent = nullptr);
+	~StationOverlayItem() override;
+
+	int type() const override { return Type; }
+	QRectF boundingRect() const override;
+	QPainterPath shape() const override;
+	void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;
+
+	QString stationName() const { return m_stationName; }
+	QString displayName() const;
+	static QString displayName(const QString& stationName);
+	static QString displayName(const std::string& stationName);
+
+	QPointF stableAnchor() const { return m_stableAnchor; }
+	void setStableAnchor(const QPointF& anchor);
+	QPointF viewportOffset() const { return m_viewportOffset; }
+	void setViewportOffset(const QPointF& offset);
+
+	LabelSide labelSide() const { return m_labelSide; }
+	void setLabelSide(LabelSide side);
+	QRectF symbolRect() const { return m_symbolRect; }
+	QRectF labelRect() const { return m_labelRect; }
+	QRectF combinedRect() const;
+	QRectF deviceSymbolRect() const { return symbolRect(); }
+	QRectF deviceLabelRect() const { return labelRect(); }
+	QRectF deviceCombinedRect() const { return combinedRect(); }
+
+	void setLayoutVisible(bool visible);
+	bool isLayoutVisible() const { return m_layoutVisible; }
+	bool isLabelLayoutVisible() const { return m_layoutVisible; }
+	bool isLabelVisible() const;
+	bool isHovered() const { return m_hovered; }
+	void setFollowed(bool followed);
+	bool isFollowed() const { return m_followed; }
+	int degree() const { return m_degree; }
+	void setDegree(int degree);
+	StationVisualKind visualKind() const { return m_visual.kind; }
+	const StationVisual& visual() const { return m_visual; }
+	bool isInterchange() const;
+	bool isEndpoint() const;
+
+	static bool priorityLess(const StationOverlayItem& left, const StationOverlayItem& right,
+		const QPointF& viewportCenter);
+
+protected:
+	void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
+	void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
+
+private:
+	void rebuildGeometry();
+	QRectF translated(const QRectF& rect) const;
+
+	QString m_stationName;
+	QString m_displayName;
+	QPointF m_stableAnchor;
+	QPointF m_viewportOffset;
+	StationVisual m_visual;
+	QPixmap m_symbol;
+	QFont m_labelFont;
+	QRectF m_symbolRect;
+	QRectF m_labelRect;
+	LabelSide m_labelSide = LabelSide::Right;
+	bool m_layoutVisible = true;
+	bool m_hovered = false;
+	bool m_followed = false;
+	int m_degree = 0;
+};
+
+#endif // STATIONOVERLAYITEM_H

--- a/EGTRAIN/QEGTRAIN/tests/test_stationoverlay.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_stationoverlay.cpp
@@ -1,0 +1,131 @@
+#include "graphics/items/StationOverlayItem.h"
+
+#include "graphics/NetworkScene.h"
+#include "graphics/items/StationNodeItem.h"
+
+#include <QApplication>
+#include <QGraphicsSceneContextMenuEvent>
+#include <QGraphicsSceneHoverEvent>
+#include <QGraphicsSceneMouseEvent>
+#include <QGraphicsView>
+#include <QMouseEvent>
+
+#include <cmath>
+#include <iostream>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+static void sendLeftClick(NetworkScene& scene, QGraphicsView& view, const QPointF& scenePos) {
+	QGraphicsSceneMouseEvent event(QEvent::GraphicsSceneMousePress);
+	event.setButton(Qt::LeftButton);
+	event.setButtons(Qt::LeftButton);
+	event.setPos(view.mapFromScene(scenePos));
+	event.setScenePos(scenePos);
+	event.setScreenPos(view.viewport()->mapToGlobal(view.mapFromScene(scenePos)));
+	event.setButtonDownPos(Qt::LeftButton, event.pos());
+	event.setButtonDownScenePos(Qt::LeftButton, scenePos);
+	event.setButtonDownScreenPos(Qt::LeftButton, event.screenPos());
+	event.setWidget(view.viewport());
+	scene.mousePressEvent(&event);
+}
+
+static bool sendContextMenu(NetworkScene& scene, QGraphicsView& view, const QPointF& scenePos) {
+	QGraphicsSceneContextMenuEvent event(QEvent::GraphicsSceneContextMenu);
+	event.setReason(QGraphicsSceneContextMenuEvent::Mouse);
+	event.setScenePos(scenePos);
+	event.setScreenPos(view.viewport()->mapToGlobal(view.mapFromScene(scenePos)));
+	event.setWidget(view.viewport());
+	scene.contextMenuEvent(&event);
+	return event.isAccepted();
+}
+
+int main(int argc, char* argv[]) {
+	qputenv("QT_QPA_PLATFORM", "offscreen");
+	QApplication app(argc, argv);
+	bool ok = true;
+
+	StationVisual platform = classifyStation(true, 1);
+	StationOverlayItem overlay("KogeNord", QPointF(40.0, 50.0), platform);
+	const QRectF symbol = overlay.symbolRect();
+	const QRectF right = overlay.labelRect();
+	ok &= expect(qFuzzyCompare(overlay.combinedRect().left(), symbol.left()), "combined bounds include symbol");
+	ok &= expect(qFuzzyCompare(right.left(), symbol.right() + 8.0), "right label gap is eight logical pixels");
+	overlay.setLabelSide(StationOverlayItem::LabelSide::Left);
+	const QRectF left = overlay.labelRect();
+	ok &= expect(qFuzzyCompare(symbol.left(), left.right() + 8.0), "left label gap is eight logical pixels");
+	ok &= expect(overlay.stableAnchor() == QPointF(40.0, 50.0), "stable anchor is retained");
+	overlay.setViewportOffset(QPointF(-3.0, 7.0));
+	ok &= expect(overlay.viewportOffset() == QPointF(-3.0, 7.0), "viewport clamp offset is separate");
+	ok &= expect(overlay.displayName(QStringLiteral("KogeNord")) == QStringLiteral("Koge Nord"), "camel-case display conversion");
+
+	QList<StationOverlayItem*> candidates;
+	StationOverlayItem selected("Zulu", QPointF(0.0, 0.0), platform);
+	StationOverlayItem followed("Alpha", QPointF(1.0, 1.0), platform);
+	StationOverlayItem interchange("Beta", QPointF(2.0, 2.0), classifyStation(true, 3));
+	StationOverlayItem endpoint("Gamma", QPointF(3.0, 3.0), platform);
+	StationOverlayItem stop("Delta", QPointF(4.0, 4.0), classifyStation(false, 0));
+	selected.setSelected(true);
+	followed.setFollowed(true);
+	interchange.setDegree(3);
+	endpoint.setDegree(1);
+	candidates << &stop << &endpoint << &interchange << &followed << &selected;
+	std::sort(candidates.begin(), candidates.end(), [](const auto* a, const auto* b) {
+		return StationOverlayItem::priorityLess(*a, *b, QPointF(0.0, 0.0));
+	});
+	ok &= expect(candidates.at(0) == &selected, "selected station has first priority");
+	ok &= expect(candidates.at(1) == &followed, "followed station has second priority");
+	ok &= expect(candidates.at(2) == &interchange, "interchange has third priority");
+	ok &= expect(candidates.at(3) == &endpoint, "endpoint has fourth priority");
+	ok &= expect(candidates.at(4) == &stop, "stop marker has remaining priority");
+
+	{
+		QGraphicsScene hoverScene;
+		auto* hovered = new StationOverlayItem("Hovered", QPointF(0.0, 0.0), platform);
+		hovered->setLayoutVisible(false);
+		hoverScene.addItem(hovered);
+		ok &= expect(!hovered->isLabelVisible(), "layout culling hides label");
+		QGraphicsSceneHoverEvent hoverEnter(QEvent::GraphicsSceneHoverEnter);
+		hoverEnter.setPos(QPointF(0.0, 0.0));
+		hoverEnter.setScenePos(hovered->stableAnchor());
+		hoverScene.sendEvent(hovered, &hoverEnter);
+		ok &= expect(hovered->isLabelVisible(), "hover reveals culled label");
+		QGraphicsSceneHoverEvent hoverLeave(QEvent::GraphicsSceneHoverLeave);
+		hoverLeave.setPos(QPointF(0.0, 0.0));
+		hoverLeave.setScenePos(hovered->stableAnchor());
+		hoverScene.sendEvent(hovered, &hoverLeave);
+		ok &= expect(!hovered->isLabelVisible(), "hover leave hides culled label");
+		hovered->setSelected(true);
+		ok &= expect(hovered->isLabelVisible(), "selection reveals culled label");
+	}
+
+	{
+		NetworkScene scene(nullptr);
+		QGraphicsView view(&scene);
+		view.resize(240, 180);
+		StationNodeItem station(QRectF(-10.0, -10.0, 20.0, 20.0));
+		station.setPos(0.0, 0.0);
+		StationOverlayItem decoration("Koge", QPointF(0.0, 0.0), platform);
+		decoration.setZValue(3.0);
+		scene.addItem(&station);
+		scene.addItem(&decoration);
+		int stationClicks = 0;
+		QGraphicsItem* contextTarget = nullptr;
+		QObject::connect(&scene, &NetworkScene::MousePressedOnStationNode,
+			[&](StationNodeItem*) { ++stationClicks; });
+		QObject::connect(&scene, &NetworkScene::ContextMenuRequested,
+			[&](QGraphicsItem* item, const QPointF&, const QPoint&, bool) { contextTarget = item; });
+		sendLeftClick(scene, view, QPointF(0.0, 0.0));
+		ok &= expect(stationClicks == 1, "left click passes through station overlay");
+		ok &= expect(sendContextMenu(scene, view, QPointF(0.0, 0.0)), "context event accepted through station overlay");
+		ok &= expect(contextTarget == &station, "context menu preserves station semantic target");
+	}
+
+	if (!ok)
+		return 1;
+	std::cout << "all StationOverlayItem tests passed\n";
+	return 0;
+}

--- a/EGTRAIN/QEGTRAIN/tests/test_stationoverlay.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_stationoverlay.cpp
@@ -49,7 +49,10 @@ int main(int argc, char* argv[]) {
 	bool ok = true;
 
 	StationVisual platform = classifyStation(true, 1);
+	StationVisual stopVisual = classifyStation(false, 0);
 	StationOverlayItem overlay("KogeNord", QPointF(40.0, 50.0), platform);
+	ok &= expect(overlay.flags().testFlag(QGraphicsItem::ItemIsSelectable),
+		"overlay remains programmatically selectable");
 	const QRectF symbol = overlay.symbolRect();
 	const QRectF right = overlay.labelRect();
 	ok &= expect(qFuzzyCompare(overlay.combinedRect().left(), symbol.left()), "combined bounds include symbol");
@@ -61,13 +64,50 @@ int main(int argc, char* argv[]) {
 	overlay.setViewportOffset(QPointF(-3.0, 7.0));
 	ok &= expect(overlay.viewportOffset() == QPointF(-3.0, 7.0), "viewport clamp offset is separate");
 	ok &= expect(overlay.displayName(QStringLiteral("KogeNord")) == QStringLiteral("Koge Nord"), "camel-case display conversion");
+	const QRectF inset(0.0, 0.0, 220.0, 120.0);
+	const StationOverlayItem::ViewportPlacement rightPlacement =
+		overlay.placementForSide(StationOverlayItem::LabelSide::Right, QPointF(80.0, 60.0), inset);
+	ok &= expect(rightPlacement.side == StationOverlayItem::LabelSide::Right,
+		"viewport placement prefers the right side");
+	ok &= expect(rightPlacement.fits, "right-side placement fits in the viewport");
+	ok &= expect(qFuzzyCompare(rightPlacement.labelRect.left(), rightPlacement.symbolRect.right() + 8.0),
+		"production placement keeps the right eight-pixel gap");
+	const StationOverlayItem::ViewportPlacement leftPlacement =
+		overlay.placementForSide(StationOverlayItem::LabelSide::Left, QPointF(80.0, 60.0), inset);
+	ok &= expect(leftPlacement.side == StationOverlayItem::LabelSide::Left,
+		"viewport placement supports the left side");
+	ok &= expect(qFuzzyCompare(leftPlacement.symbolRect.left(), leftPlacement.labelRect.right() + 8.0),
+		"production placement keeps the left eight-pixel gap");
+	const StationOverlayItem::ViewportPlacement abovePlacement =
+		overlay.placementForSide(StationOverlayItem::LabelSide::Above, QPointF(80.0, 60.0), inset);
+	ok &= expect(qFuzzyCompare(abovePlacement.labelRect.bottom() + 8.0,
+		abovePlacement.symbolRect.top()), "production placement keeps the upper eight-pixel gap");
+	const StationOverlayItem::ViewportPlacement belowPlacement =
+		overlay.placementForSide(StationOverlayItem::LabelSide::Below, QPointF(80.0, 60.0), inset);
+	ok &= expect(qFuzzyCompare(belowPlacement.symbolRect.bottom() + 8.0,
+		belowPlacement.labelRect.top()), "production placement keeps the lower eight-pixel gap");
+	const StationOverlayItem::ViewportPlacement edgePlacement =
+		overlay.preferredViewportPlacement(QPointF(2.0, 2.0), inset);
+	ok &= expect(edgePlacement.fits, "edge placement clamps the complete overlay into the viewport");
+	ok &= expect(inset.contains(edgePlacement.combinedRect), "clamped overlay stays inside the viewport inset");
+
+	StationOverlayItem multiNode("MultiNode", QPointF(8.0, 8.0), platform);
+	multiNode.setNetworkDegree(3, true, true);
+	ok &= expect(multiNode.isInterchange(), "multi-node station keeps interchange flag");
+	ok &= expect(multiNode.isEndpoint(), "multi-node station keeps endpoint flag");
+	StationOverlayItem platformAfterDegree("PlatformAfterDegree", QPointF(12.0, 12.0), platform);
+	platformAfterDegree.setDegree(3);
+	StationOverlayItem stopAfterDegree("StopAfterDegree", QPointF(12.0, 12.0), stopVisual);
+	stopAfterDegree.setDegree(3);
+	ok &= expect(StationOverlayItem::priorityLess(platformAfterDegree, stopAfterDegree, QPointF()),
+		"platform class remains ahead of stop marker after interchange classification");
 
 	QList<StationOverlayItem*> candidates;
 	StationOverlayItem selected("Zulu", QPointF(0.0, 0.0), platform);
 	StationOverlayItem followed("Alpha", QPointF(1.0, 1.0), platform);
 	StationOverlayItem interchange("Beta", QPointF(2.0, 2.0), classifyStation(true, 3));
 	StationOverlayItem endpoint("Gamma", QPointF(3.0, 3.0), platform);
-	StationOverlayItem stop("Delta", QPointF(4.0, 4.0), classifyStation(false, 0));
+	StationOverlayItem stop("Delta", QPointF(4.0, 4.0), stopVisual);
 	selected.setSelected(true);
 	followed.setFollowed(true);
 	interchange.setDegree(3);
@@ -81,11 +121,20 @@ int main(int argc, char* argv[]) {
 	ok &= expect(candidates.at(2) == &interchange, "interchange has third priority");
 	ok &= expect(candidates.at(3) == &endpoint, "endpoint has fourth priority");
 	ok &= expect(candidates.at(4) == &stop, "stop marker has remaining priority");
+	StationOverlayItem platformPriority("ZuluPlatform", QPointF(30.0, 0.0), platform);
+	StationOverlayItem stopPriority("AlphaStop", QPointF(30.0, 0.0), stop.visual());
+	ok &= expect(StationOverlayItem::priorityLess(platformPriority, stopPriority, QPointF()),
+		"platform precedes stop marker at equal distance");
+	StationOverlayItem nameZulu("ZuluTie", QPointF(40.0, 0.0), platform);
+	StationOverlayItem nameAlpha("AlphaTie", QPointF(-40.0, 0.0), platform);
+	ok &= expect(StationOverlayItem::priorityLess(nameAlpha, nameZulu, QPointF()),
+		"station name breaks equal-distance priority ties");
 
 	{
 		QGraphicsScene hoverScene;
 		auto* hovered = new StationOverlayItem("Hovered", QPointF(0.0, 0.0), platform);
 		hovered->setLayoutVisible(false);
+		hovered->setCollisionBlocked(true);
 		hoverScene.addItem(hovered);
 		ok &= expect(!hovered->isLabelVisible(), "layout culling hides label");
 		QGraphicsSceneHoverEvent hoverEnter(QEvent::GraphicsSceneHoverEnter);
@@ -99,7 +148,7 @@ int main(int argc, char* argv[]) {
 		hoverScene.sendEvent(hovered, &hoverLeave);
 		ok &= expect(!hovered->isLabelVisible(), "hover leave hides culled label");
 		hovered->setSelected(true);
-		ok &= expect(hovered->isLabelVisible(), "selection reveals culled label");
+		ok &= expect(hovered->isLabelVisible(), "selection reveals collision-blocked label");
 	}
 
 	{
@@ -115,11 +164,15 @@ int main(int argc, char* argv[]) {
 		int stationClicks = 0;
 		QGraphicsItem* contextTarget = nullptr;
 		QObject::connect(&scene, &NetworkScene::MousePressedOnStationNode,
-			[&](StationNodeItem*) { ++stationClicks; });
+			[&](StationNodeItem*) {
+				++stationClicks;
+				decoration.setSelected(true);
+			});
 		QObject::connect(&scene, &NetworkScene::ContextMenuRequested,
 			[&](QGraphicsItem* item, const QPointF&, const QPoint&, bool) { contextTarget = item; });
 		sendLeftClick(scene, view, QPointF(0.0, 0.0));
 		ok &= expect(stationClicks == 1, "left click passes through station overlay");
+		ok &= expect(decoration.isSelected(), "semantic station selection survives default scene dispatch");
 		ok &= expect(sendContextMenu(scene, view, QPointF(0.0, 0.0)), "context event accepted through station overlay");
 		ok &= expect(contextTarget == &station, "context menu preserves station semantic target");
 	}

--- a/tools/e2e/visual_polish_smoke.sh
+++ b/tools/e2e/visual_polish_smoke.sh
@@ -11,6 +11,8 @@ CONTEXT_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-context-e2e.png"
 DPR2_OUT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dpr2-e2e.log"
 DPR2_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dpr2-e2e.png"
 STATION_OUT_BASE="${TMPDIR:-/tmp}/qegtrain-station-overlay-e2e"
+STATION_SHOT_BASE="${TMPDIR:-/tmp}/qegtrain-station-overlay-copenhagen"
+STATION_DPR2_OUT="${TMPDIR:-/tmp}/qegtrain-station-overlay-e2e-dpr2.log"
 
 if [[ ! -x "$APP" ]]; then
 	echo "QEGTRAIN app not found or not executable: $APP" >&2
@@ -63,13 +65,44 @@ echo "visual polish 2x dpr e2e passed: $DPR2_SHOT"
 
 for case in 1 2 3 4; do
 	station_out="${STATION_OUT_BASE}-${case}.log"
-	QT_QPA_PLATFORM=offscreen \
-	QT_SCALE_FACTOR=1 \
-	QEGTRAIN_E2E_STATION_OVERLAYS=1 \
-	"$APP" -n "$case" -h 8000 -g 1 -pax 0 -TSM 0 -RC 0 >"$station_out" 2>&1
+	if [[ "$case" == "3" ]]; then
+		rm -f "${STATION_SHOT_BASE}-dpr1-fit.png" "${STATION_SHOT_BASE}-dpr1-3x.png" "${STATION_SHOT_BASE}-dpr1-12x.png"
+		QT_QPA_PLATFORM=offscreen \
+		QT_SCALE_FACTOR=1 \
+		QEGTRAIN_E2E_STATION_OVERLAYS=1 \
+		QEGTRAIN_E2E_STATION_SCREENSHOT_BASE="${STATION_SHOT_BASE}-dpr1" \
+		"$APP" -n "$case" -h 8000 -g 1 -pax 0 -TSM 0 -RC 0 >"$station_out" 2>&1
+	else
+		QT_QPA_PLATFORM=offscreen \
+		QT_SCALE_FACTOR=1 \
+		QEGTRAIN_E2E_STATION_OVERLAYS=1 \
+		"$APP" -n "$case" -h 8000 -g 1 -pax 0 -TSM 0 -RC 0 >"$station_out" 2>&1
+	fi
 	grep -q "E2E_STATION_OVERLAY_OK" "$station_out"
 	grep -q "E2E_STATION_OVERLAY_.*_FIT_OK" "$station_out"
 	grep -q "E2E_STATION_OVERLAY_.*_3X_OK" "$station_out"
 	grep -q "E2E_STATION_OVERLAY_.*_12X_OK" "$station_out"
+	if [[ "$case" == "3" ]]; then
+		grep -q "E2E_STATION_OVERLAY_DPR_1.0" "$station_out"
+		test -s "${STATION_SHOT_BASE}-dpr1-fit.png"
+		test -s "${STATION_SHOT_BASE}-dpr1-3x.png"
+		test -s "${STATION_SHOT_BASE}-dpr1-12x.png"
+	fi
 	done
 echo "station overlay e2e passed: ${STATION_OUT_BASE}-{1,2,3,4}.log"
+
+rm -f "${STATION_SHOT_BASE}-dpr2-fit.png" "${STATION_SHOT_BASE}-dpr2-3x.png" "${STATION_SHOT_BASE}-dpr2-12x.png"
+QT_QPA_PLATFORM=offscreen \
+QT_SCALE_FACTOR=2 \
+QEGTRAIN_E2E_STATION_OVERLAYS=1 \
+QEGTRAIN_E2E_STATION_SCREENSHOT_BASE="${STATION_SHOT_BASE}-dpr2" \
+"$APP" -n 3 -h 8000 -g 1 -pax 0 -TSM 0 -RC 0 >"$STATION_DPR2_OUT" 2>&1
+grep -q "E2E_STATION_OVERLAY_OK" "$STATION_DPR2_OUT"
+grep -q "E2E_STATION_OVERLAY_.*_FIT_OK" "$STATION_DPR2_OUT"
+grep -q "E2E_STATION_OVERLAY_.*_3X_OK" "$STATION_DPR2_OUT"
+grep -q "E2E_STATION_OVERLAY_.*_12X_OK" "$STATION_DPR2_OUT"
+grep -q "E2E_STATION_OVERLAY_DPR_2.0" "$STATION_DPR2_OUT"
+test -s "${STATION_SHOT_BASE}-dpr2-fit.png"
+test -s "${STATION_SHOT_BASE}-dpr2-3x.png"
+test -s "${STATION_SHOT_BASE}-dpr2-12x.png"
+echo "station overlay Copenhagen DPR2 passed: ${STATION_DPR2_OUT}"

--- a/tools/e2e/visual_polish_smoke.sh
+++ b/tools/e2e/visual_polish_smoke.sh
@@ -8,6 +8,9 @@ SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-e2e.png"
 DENSE_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dense-e2e.png"
 FOLLOW_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-follow-e2e.png"
 CONTEXT_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-context-e2e.png"
+DPR2_OUT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dpr2-e2e.log"
+DPR2_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dpr2-e2e.png"
+STATION_OUT_BASE="${TMPDIR:-/tmp}/qegtrain-station-overlay-e2e"
 
 if [[ ! -x "$APP" ]]; then
 	echo "QEGTRAIN app not found or not executable: $APP" >&2
@@ -16,6 +19,8 @@ fi
 
 cd "$ROOT/EGTRAIN/QEGTRAIN"
 rm -f "$CONTEXT_SHOT"
+QT_QPA_PLATFORM=offscreen \
+QT_SCALE_FACTOR=1 \
 QEGTRAIN_AUTOSTART=1 \
 QEGTRAIN_E2E_VISUAL_POLISH=1 \
 QEGTRAIN_E2E_SCREENSHOT="$SHOT" \
@@ -25,6 +30,7 @@ QEGTRAIN_E2E_CONTEXT_SCREENSHOT="$CONTEXT_SHOT" \
 "$APP" -n 3 -h 8000 -g 1 -pax 1 -TSM 0 -RC 0 >"$OUT" 2>&1
 
 grep -q "E2E_VISUAL_POLISH_OK" "$OUT"
+grep -q "E2E_VISUAL_POLISH_DPR_1.0" "$OUT"
 test -s "$SHOT"
 test -s "$DENSE_SHOT"
 test -s "$FOLLOW_SHOT"
@@ -40,3 +46,30 @@ if grep -Fq 'name="actionShow_Graph"' "$ROOT/EGTRAIN/QEGTRAIN/app/MainWindow.ui"
 	exit 1
 fi
 echo "visual polish e2e passed: $SHOT $DENSE_SHOT $FOLLOW_SHOT $CONTEXT_SHOT"
+
+QT_QPA_PLATFORM=offscreen \
+QT_SCALE_FACTOR=2 \
+QEGTRAIN_AUTOSTART=1 \
+QEGTRAIN_E2E_VISUAL_POLISH=1 \
+QEGTRAIN_E2E_SCREENSHOT="$DPR2_SHOT" \
+QEGTRAIN_E2E_DENSE_SCREENSHOT="${DPR2_SHOT%.png}-dense.png" \
+QEGTRAIN_E2E_FOLLOW_SCREENSHOT="${DPR2_SHOT%.png}-follow.png" \
+QEGTRAIN_E2E_CONTEXT_SCREENSHOT="${DPR2_SHOT%.png}-context.png" \
+"$APP" -n 3 -h 8000 -g 1 -pax 1 -TSM 0 -RC 0 >"$DPR2_OUT" 2>&1
+grep -q "E2E_VISUAL_POLISH_DPR_2.0" "$DPR2_OUT"
+grep -q "E2E_VISUAL_POLISH_OK" "$DPR2_OUT"
+test -s "$DPR2_SHOT"
+echo "visual polish 2x dpr e2e passed: $DPR2_SHOT"
+
+for case in 1 2 3 4; do
+	station_out="${STATION_OUT_BASE}-${case}.log"
+	QT_QPA_PLATFORM=offscreen \
+	QT_SCALE_FACTOR=1 \
+	QEGTRAIN_E2E_STATION_OVERLAYS=1 \
+	"$APP" -n "$case" -h 8000 -g 1 -pax 0 -TSM 0 -RC 0 >"$station_out" 2>&1
+	grep -q "E2E_STATION_OVERLAY_OK" "$station_out"
+	grep -q "E2E_STATION_OVERLAY_.*_FIT_OK" "$station_out"
+	grep -q "E2E_STATION_OVERLAY_.*_3X_OK" "$station_out"
+	grep -q "E2E_STATION_OVERLAY_.*_12X_OK" "$station_out"
+	done
+echo "station overlay e2e passed: ${STATION_OUT_BASE}-{1,2,3,4}.log"


### PR DESCRIPTION
## Summary

- Replace scene-space station names and symbols with fixed-screen overlays.
- Place labels deterministically on four sides, clamp them to the viewport, and cull collisions.
- Prioritize selected, followed, interchange, endpoint, platform, and stop stations.
- Keep hover, selection, clicks, and context menus working through the overlays.
- Fit the network to rendered topology instead of labels, badges, or hit areas.
- Refresh station priority immediately when Follow changes.

## Verification

- `cmake --build build`
- `ctest --test-dir build --output-on-failure`: 41 of 41 passed
- `tools/e2e/visual_polish_smoke.sh`: passed at device-pixel ratios 1 and 2
- Copenhagen station captures checked at Fit, 3x, and 12x

Closes #241
