### PR TITLE
Reorganize the playback command bar

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -42,6 +42,7 @@
 #include <QSignalBlocker>
 #include <QSettings>
 #include <QIcon>
+#include <QToolButton>
 #include <QStringList>
 #include <QTemporaryDir>
 #include <QRegularExpression>
@@ -509,9 +510,12 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_speedSlider = new QSlider(Qt::Horizontal);
 	m_speedSlider->setRange(0, kMaxStepDelayMs);
 	m_speedSlider->setValue(kMaxStepDelayMs);
-	m_speedSlider->setMaximumWidth(200);
+	m_speedSlider->setMaximumWidth(108);
 	m_speedSlider->setToolTip("Simulation speed: fastest");
-	m_speedLabel = new QLabel(simulationSpeedLabel(stepDelayForSlider(m_speedSlider->value())));
+	m_speedSlider->setObjectName("speedSlider");
+	m_speedLabel = new QLabel(simulationSpeedLabel(stepDelayForSlider(m_speedSlider->value())), this);
+	m_speedLabel->setObjectName("speedModeLabel");
+	m_speedLabel->hide();
 
 	// setup info dock widget
 	setupInfoDockWidget();
@@ -626,25 +630,27 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 
 	// --- Build toolbar ---
 	m_toolBar = ui->mainToolBar;
+	m_toolBar->clear();
 	m_toolBar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+	m_toolBar->setIconSize(QSize(16, 16));
+	m_toolBar->setFocusPolicy(Qt::NoFocus);
+	m_toolBar->setFixedHeight(36);
 	ui->actionSimulationStart->setText("Run");
-	ui->actionSimulationStart->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
-	ui->actionSimulationPause->setIcon(style()->standardIcon(QStyle::SP_MediaPause));
-	ui->actionSimulationStop->setIcon(style()->standardIcon(QStyle::SP_MediaStop));
+	ui->actionSimulationStart->setObjectName("actionRun");
+	ui->actionSimulationStart->setIcon(QIcon(":/icons/run.svg"));
+	ui->actionSimulationStart->setProperty("iconResource", ":/icons/run.svg");
+	ui->actionSimulationPause->setObjectName("actionPause");
+	ui->actionSimulationPause->setIcon(QIcon(":/icons/pause.svg"));
+	ui->actionSimulationPause->setProperty("iconResource", ":/icons/pause.svg");
+	ui->actionSimulationStop->setObjectName("actionStop");
+	ui->actionSimulationStop->setIcon(QIcon(":/icons/stop.svg"));
+	ui->actionSimulationStop->setProperty("iconResource", ":/icons/stop.svg");
 	ui->actionSimulationPause->setEnabled(false);
 	ui->actionSimulationStop->setEnabled(false);
 	ui->actionSimulationStart->setToolTip("Run simulation (Ctrl+R)");
 	ui->actionSimulationPause->setToolTip("Pause or resume simulation (Ctrl+.)");
 	ui->actionSimulationStop->setToolTip("Stop simulation (Ctrl+Esc)");
 
-	m_toolbarCaseLabel = new QLabel(this);
-	m_toolbarCaseLabel->setObjectName("toolbarCaseLabel");
-	m_toolbarCaseLabel->setToolTip("Current case study");
-	m_simulationClockLabel = new QLabel(this);
-	m_simulationClockLabel->setObjectName("simulationClockLabel");
-	m_simulationClockLabel->setToolTip("Simulation clock");
-	m_toolBar->insertWidget(ui->actionSimulationStart, m_toolbarCaseLabel);
-	m_toolBar->insertWidget(ui->actionSimulationStop, m_simulationClockLabel);
 
 	// Keep the scenario state and the four useful display layers in the primary
 	// left rail. All scene pointers below are non-owning; QGraphicsScene owns the
@@ -752,16 +758,15 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	});
 	updateCaseLayersPanel();
 
-	// Speed slider in toolbar (between sim controls and zoom)
-	m_toolBar->insertSeparator(ui->actionSimulationStop);
-	m_toolBar->insertWidget(ui->actionSimulationStop, m_speedLabel);
-	m_toolBar->insertWidget(ui->actionSimulationStop, m_speedSlider);
-
 	m_followTrainCombo = new QComboBox(this);
+	m_followTrainCombo->setObjectName("followTrainCombo");
 	m_followTrainCombo->setMinimumWidth(180);
-	m_followTrainCombo->setMaximumWidth(260);
+	m_followTrainCombo->setMaximumWidth(200);
+	m_followTrainCombo->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+	m_followTrainCombo->setFocusPolicy(Qt::StrongFocus);
 	m_followTrainCombo->setToolTip("Select a train to keep centered while the simulation runs");
 	m_followAction = new QAction("Follow", this);
+	m_followAction->setObjectName("actionFollow");
 	m_followAction->setCheckable(true);
 	m_followAction->setToolTip("Center the network view on the selected train");
 	connect(m_followTrainCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
@@ -780,15 +785,142 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 		else
 			setFollowTrain(-1);
 	});
-	m_toolBar->insertAction(ui->actionSimulationStop, m_followAction);
-	m_toolBar->insertWidget(ui->actionSimulationStop, m_followTrainCombo);
 	refreshFollowTrainChoices();
 
-	// start time control (clock time the simulation begins at)
-	QAction* startTimeAction = new QAction("Start Time", this);
-	startTimeAction->setToolTip("Set the clock time the simulation starts at (HH:MM)");
-	connect(startTimeAction, &QAction::triggered, this, &MainWindow::setStartTime);
-	m_toolBar->insertAction(ui->actionSimulationStop, startTimeAction);
+	// The one toolbar entry for every way of opening a case goes through the
+	// existing chooser so bundled scenes, recents, folders, and legacy import
+	// keep a single entry point.
+	m_openCaseAction = new QAction("Open Case", this);
+	m_openCaseAction->setObjectName("actionOpenCase");
+	m_openCaseAction->setProperty("chooserEntryPoint", "showStartupChooser");
+	m_openCaseAction->setToolTip("Choose a bundled, recent, scene-folder, or legacy case");
+	connect(m_openCaseAction, &QAction::triggered, this, &MainWindow::showStartupChooser);
+
+	connect(ui->actionStartTime, &QAction::triggered, this, &MainWindow::setStartTime);
+	ui->actionStartTime->setToolTip("Set the clock time the simulation starts at (HH:MM)");
+
+	ui->actionZoomIn->setObjectName("actionZoomIn");
+	ui->actionZoomIn->setIcon(QIcon(":/icons/zoom-in.svg"));
+	ui->actionZoomIn->setToolTip("Zoom in on the network view (Ctrl++)");
+	ui->actionZoomOut->setObjectName("actionZoomOut");
+	ui->actionZoomOut->setIcon(QIcon(":/icons/zoom-out.svg"));
+	ui->actionZoomOut->setToolTip("Zoom out on the network view (Ctrl+-)");
+	ui->actionFitView->setObjectName("actionFit");
+	ui->actionFitView->setText("Fit");
+	ui->actionFitView->setIcon(QIcon());
+
+	const auto addToolbarButton = [this](QAction* action, const char* objectName, Qt::ToolButtonStyle style) {
+		m_toolBar->addAction(action);
+		if (auto* button = qobject_cast<QToolButton*>(m_toolBar->widgetForAction(action))) {
+			button->setObjectName(objectName);
+			button->setToolButtonStyle(style);
+			button->setAccessibleName(action->text());
+			button->setAccessibleDescription(action->toolTip());
+			button->setFocusPolicy(Qt::StrongFocus);
+			button->setAutoRaise(true);
+			button->setFixedHeight(32);
+			const QString name = QString::fromLatin1(objectName);
+			if (name == "openCaseButton")
+				button->setMinimumWidth(110);
+			else if (name == "actionRunButton")
+				button->setMinimumWidth(75);
+			else if (name == "actionPauseButton")
+				button->setMinimumWidth(91);
+			else if (name == "actionStopButton")
+				button->setMinimumWidth(81);
+			else if (name == "actionFollowButton")
+				button->setMinimumWidth(74);
+			else if (name == "actionZoomInButton" || name == "actionZoomOutButton")
+				button->setFixedWidth(34);
+			else if (name == "actionFitButton")
+				button->setMinimumWidth(44);
+		}
+	};
+	const auto addToolbarLabel = [this](const char* text, const char* objectName) {
+		auto* label = new QLabel(QString::fromLatin1(text), m_toolBar);
+		label->setObjectName(objectName);
+		label->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+		label->setFocusPolicy(Qt::NoFocus);
+		label->setFixedHeight(24);
+		label->setAccessibleName(QString::fromLatin1(text));
+		m_toolBar->addWidget(label);
+		return label;
+	};
+	const auto addToolbarGroupSeparator = [this](const char* objectName, const char* description) {
+		QAction* separator = m_toolBar->addSeparator();
+		separator->setObjectName(objectName);
+		separator->setProperty("toolbarGroupBoundary", true);
+		separator->setToolTip(QString::fromLatin1(description));
+		return separator;
+	};
+
+	m_openCaseAction->setProperty("toolbarGroup", "Case");
+	addToolbarButton(m_openCaseAction, "openCaseButton", Qt::ToolButtonTextOnly);
+	addToolbarGroupSeparator("separatorCasePlayback", "Case commands / playback commands");
+	ui->actionSimulationStart->setProperty("toolbarGroup", "Playback");
+	ui->actionSimulationPause->setProperty("toolbarGroup", "Playback");
+	ui->actionSimulationStop->setProperty("toolbarGroup", "Playback");
+	addToolbarButton(ui->actionSimulationStart, "actionRunButton", Qt::ToolButtonTextBesideIcon);
+	addToolbarButton(ui->actionSimulationPause, "actionPauseButton", Qt::ToolButtonTextBesideIcon);
+	addToolbarButton(ui->actionSimulationStop, "actionStopButton", Qt::ToolButtonTextBesideIcon);
+	QLabel* slowerLabel = addToolbarLabel("Slower", "speedSlowerLabel");
+	slowerLabel->setProperty("toolbarGroup", "Playback");
+	m_speedSlider->setFixedWidth(80);
+	m_speedSlider->setFixedHeight(24);
+	m_speedSlider->setProperty("toolbarGroup", "Playback");
+	m_speedSlider->setAccessibleName("Simulation speed");
+	m_speedSlider->setAccessibleDescription("Adjust simulation speed; right is faster");
+	m_speedSlider->setFocusPolicy(Qt::StrongFocus);
+	m_toolBar->addWidget(m_speedSlider);
+	QLabel* fasterLabel = addToolbarLabel("Faster", "speedFasterLabel");
+	fasterLabel->setProperty("toolbarGroup", "Playback");
+	addToolbarGroupSeparator("separatorPlaybackView", "Playback commands / view commands");
+	m_followAction->setProperty("toolbarGroup", "View");
+	ui->actionZoomIn->setProperty("toolbarGroup", "View");
+	ui->actionZoomOut->setProperty("toolbarGroup", "View");
+	ui->actionFitView->setProperty("toolbarGroup", "View");
+	addToolbarButton(m_followAction, "actionFollowButton", Qt::ToolButtonTextOnly);
+	m_followTrainCombo->setFixedWidth(180);
+	m_followTrainCombo->setFixedHeight(32);
+	m_followTrainCombo->setAccessibleName("Train to follow");
+	m_followTrainCombo->setAccessibleDescription("Select the train to center in the network view");
+	m_toolBar->addWidget(m_followTrainCombo);
+	m_followTrainCombo->setFocusPolicy(Qt::StrongFocus);
+	addToolbarButton(ui->actionZoomIn, "actionZoomInButton", Qt::ToolButtonIconOnly);
+	addToolbarButton(ui->actionZoomOut, "actionZoomOutButton", Qt::ToolButtonIconOnly);
+	addToolbarButton(ui->actionFitView, "actionFitButton", Qt::ToolButtonTextOnly);
+
+	const auto setCommandBarTabOrder = [this]() {
+		QWidget* openCaseButton = m_toolBar->widgetForAction(m_openCaseAction);
+		QWidget* runButton = m_toolBar->widgetForAction(ui->actionSimulationStart);
+		QWidget* pauseButton = m_toolBar->widgetForAction(ui->actionSimulationPause);
+		QWidget* stopButton = m_toolBar->widgetForAction(ui->actionSimulationStop);
+		QWidget* followButton = m_toolBar->widgetForAction(m_followAction);
+		QWidget* zoomInButton = m_toolBar->widgetForAction(ui->actionZoomIn);
+		QWidget* zoomOutButton = m_toolBar->widgetForAction(ui->actionZoomOut);
+		QWidget* fitButton = m_toolBar->widgetForAction(ui->actionFitView);
+		const QList<QWidget*> commandButtons{
+			openCaseButton, runButton, pauseButton, stopButton, followButton, zoomInButton, zoomOutButton, fitButton};
+		for (QWidget* widget : commandButtons) {
+			if (widget)
+				widget->setFocusPolicy(Qt::StrongFocus);
+		}
+		if (m_speedSlider)
+			m_speedSlider->setFocusPolicy(Qt::StrongFocus);
+		if (m_followTrainCombo)
+			m_followTrainCombo->setFocusPolicy(Qt::StrongFocus);
+		QWidget::setTabOrder(openCaseButton, runButton);
+		QWidget::setTabOrder(runButton, pauseButton);
+		QWidget::setTabOrder(pauseButton, stopButton);
+		QWidget::setTabOrder(stopButton, m_speedSlider);
+		QWidget::setTabOrder(m_speedSlider, followButton);
+		QWidget::setTabOrder(followButton, m_followTrainCombo);
+		QWidget::setTabOrder(m_followTrainCombo, zoomInButton);
+		QWidget::setTabOrder(zoomInButton, zoomOutButton);
+		QWidget::setTabOrder(zoomOutButton, fitButton);
+	};
+	setCommandBarTabOrder();
+	QTimer::singleShot(0, this, setCommandBarTabOrder);
 
 	// file menu: output folder chooser
 	if (ui->menuFile) {
@@ -1297,6 +1429,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	refreshTrainUnitPanel();
 	refreshServicePanel();
 	refreshIncidentPanel();
+	// Dock/editor construction above can rebuild the top-level focus chain;
+	// restore the command-bar sequence after every child widget exists.
+	setCommandBarTabOrder();
 }
 
 MainWindow::~MainWindow() {
@@ -3622,7 +3757,7 @@ void MainWindow::updateSceneWindowTitle() {
 }
 
 void MainWindow::updateCaseLayersPanel() {
-	if (!m_caseNameLabel && !m_toolbarCaseLabel && !m_simulationClockLabel)
+	if (!m_caseNameLabel)
 		return;
 
 	QString caseName = m_sceneLoaded ? QString::fromStdString(m_sceneModel.name)
@@ -3633,10 +3768,6 @@ void MainWindow::updateCaseLayersPanel() {
 		caseName = QStringLiteral("Default case study");
 	if (m_caseNameLabel)
 		m_caseNameLabel->setText(caseName);
-	if (m_toolbarCaseLabel)
-		m_toolbarCaseLabel->setText(QString("Case: %1").arg(caseName));
-	if (m_simulationClockLabel)
-		m_simulationClockLabel->setText(QString::fromStdString(formatSimTime(0, m_startOffsetSeconds)));
 }
 
 void MainWindow::updateSpeedModeDisplay(int delayMs) {
@@ -4364,6 +4495,190 @@ void MainWindow::runVisualPolishE2E() {
 		failures << "simulation toolbar icons are missing or not standard media icons";
 	}
 
+	// Command-bar contract: names and order are stable so the toolbar remains
+	// testable without relying on translated display text.
+	const auto actionNamed = [this](const char* objectName) {
+		return findChild<QAction*>(objectName);
+	};
+	QAction* openCaseAction = actionNamed("actionOpenCase");
+	QAction* runAction = actionNamed("actionRun");
+	QAction* pauseAction = actionNamed("actionPause");
+	QAction* stopAction = actionNamed("actionStop");
+	QAction* zoomInAction = actionNamed("actionZoomIn");
+	QAction* zoomOutAction = actionNamed("actionZoomOut");
+	QAction* fitAction = actionNamed("actionFit");
+	const QList<QAction*> requiredActions{
+		openCaseAction, runAction, pauseAction, stopAction, zoomInAction, zoomOutAction, fitAction};
+	if (std::any_of(requiredActions.cbegin(), requiredActions.cend(), [](QAction* action) { return !action; })) {
+		ok = false;
+		failures << "command-bar actions do not have the required stable object names";
+	}
+	if (!openCaseAction || openCaseAction->property("chooserEntryPoint").toString() != "showStartupChooser") {
+		ok = false;
+		failures << "Open Case is not marked as the shared startup chooser entry point";
+	}
+	if (m_toolBar) {
+		const QStringList expectedToolbarObjects{
+			"openCaseButton", "separatorCasePlayback", "actionRunButton", "actionPauseButton", "actionStopButton",
+			"speedSlowerLabel", "speedSlider", "speedFasterLabel", "separatorPlaybackView", "actionFollowButton",
+			"followTrainCombo", "actionZoomInButton", "actionZoomOutButton", "actionFitButton"};
+		QStringList toolbarObjects;
+		for (QAction* action : m_toolBar->actions()) {
+			if (!action)
+				continue;
+			if (QWidget* widget = m_toolBar->widgetForAction(action)) {
+				if (!widget->objectName().isEmpty())
+					toolbarObjects << widget->objectName();
+				else if (!action->objectName().isEmpty())
+					toolbarObjects << action->objectName();
+			} else if (!action->objectName().isEmpty()) {
+				toolbarObjects << action->objectName();
+			}
+		}
+		int lastIndex = -1;
+		for (const QString& objectName : expectedToolbarObjects) {
+			const int index = toolbarObjects.indexOf(objectName);
+			if (index <= lastIndex) {
+				ok = false;
+				failures << QString("command-bar order is missing or out of order: %1").arg(objectName);
+				break;
+			}
+			lastIndex = index;
+		}
+		const auto boundaryIndex = [&toolbarObjects](const char* objectName) {
+			return toolbarObjects.indexOf(QString::fromLatin1(objectName));
+		};
+		const int casePlaybackBoundary = boundaryIndex("separatorCasePlayback");
+		const int playbackViewBoundary = boundaryIndex("separatorPlaybackView");
+		const int openCaseIndex = boundaryIndex("openCaseButton");
+		const int runIndex = boundaryIndex("actionRunButton");
+		const int fasterIndex = boundaryIndex("speedFasterLabel");
+		const int followIndex = boundaryIndex("actionFollowButton");
+		if (casePlaybackBoundary <= openCaseIndex || playbackViewBoundary <= casePlaybackBoundary
+			|| runIndex <= casePlaybackBoundary || fasterIndex >= playbackViewBoundary || followIndex <= playbackViewBoundary) {
+			ok = false;
+			failures << "command-bar Case, Playback, and View ranges are not separated in order";
+		}
+		const auto checkBoundary = [this, &ok, &failures](const char* objectName) {
+			QAction* boundary = findChild<QAction*>(objectName);
+			if (!boundary || !boundary->isSeparator() || !boundary->property("toolbarGroupBoundary").toBool()) {
+				ok = false;
+				failures << QString("command-bar group boundary is not named: %1").arg(objectName);
+			}
+		};
+		checkBoundary("separatorCasePlayback");
+		checkBoundary("separatorPlaybackView");
+		if (pauseAction && stopAction) {
+			const int pauseIndex = toolbarObjects.indexOf("actionPauseButton");
+			const int stopIndex = toolbarObjects.indexOf("actionStopButton");
+			if (pauseIndex < 0 || stopIndex != pauseIndex + 1) {
+				ok = false;
+				failures << "Pause is not immediately followed by Stop in the command bar";
+			}
+		}
+	}
+
+	const auto toolbarWidget = [this](QAction* action) -> QWidget* {
+		return m_toolBar && action ? m_toolBar->widgetForAction(action) : nullptr;
+	};
+	if (!toolbarWidget(openCaseAction)) {
+		ok = false;
+		failures << "Open Case has no toolbar button";
+	} else if (toolbarWidget(openCaseAction)->objectName() != "openCaseButton") {
+		ok = false;
+		failures << "Open Case toolbar button has no stable object name";
+	}
+	const auto checkTransportIcon = [&ok, &failures, &actionNamed](const char* actionName, const char* resource) {
+		QAction* action = actionNamed(actionName);
+		QFile iconFile(QString::fromLatin1(resource));
+		if (!action || !iconFile.exists() || action->icon().isNull()
+			|| action->property("iconResource").toString() != QString::fromLatin1(resource)) {
+			ok = false;
+			failures << QString("transport icon is missing or not assigned: %1").arg(resource);
+		}
+	};
+	checkTransportIcon("actionRun", ":/icons/run.svg");
+	checkTransportIcon("actionPause", ":/icons/pause.svg");
+	checkTransportIcon("actionStop", ":/icons/stop.svg");
+
+	if (findChild<QWidget*>("toolbarCaseLabel") || findChild<QWidget*>("simulationClockLabel")) {
+		ok = false;
+		failures << "toolbar still contains the case badge or simulation clock";
+	}
+	QAction* startTimeAction = actionNamed("actionStartTime");
+	if (!startTimeAction || !ui->menuSimulation || !ui->menuSimulation->actions().contains(startTimeAction)
+		|| (m_toolBar && m_toolBar->actions().contains(startTimeAction))) {
+		ok = false;
+		failures << "Start Time is not exclusively in the Simulation menu";
+	}
+	QLabel* slowerLabel = findChild<QLabel*>("speedSlowerLabel");
+	QLabel* fasterLabel = findChild<QLabel*>("speedFasterLabel");
+	if (!m_speedSlider || !slowerLabel || !fasterLabel || slowerLabel->text() != "Slower" || fasterLabel->text() != "Faster") {
+		ok = false;
+		failures << "speed controls do not expose Slower, slider, and Faster";
+	} else {
+		m_speedSlider->setValue(m_speedSlider->minimum());
+		const int slowDelay = stepDelayForSlider(m_speedSlider->value());
+		m_speedSlider->setValue(m_speedSlider->maximum());
+		const int fastDelay = stepDelayForSlider(m_speedSlider->value());
+		if (fastDelay >= slowDelay) {
+			ok = false;
+			failures << "speed slider right-is-faster mapping changed";
+		}
+	}
+	if (!m_followAction || !m_followTrainCombo || m_followTrainCombo->minimumWidth() != 180
+		|| m_followTrainCombo->maximumWidth() > 200) {
+		ok = false;
+		failures << "Follow or train selector width contract is missing";
+	}
+
+	const auto checkTabTraversal = [&ok, &failures, this, &toolbarWidget](QAction* firstAction, const QStringList& expected) {
+		QWidget* first = toolbarWidget(firstAction);
+		if (!first) {
+			ok = false;
+			failures << "cannot start command-bar Tab traversal";
+			return;
+		}
+		first->setFocusPolicy(Qt::StrongFocus);
+		first->setFocus(Qt::TabFocusReason);
+		QStringList actual;
+		QApplication::processEvents();
+		if (QApplication::focusWidget() != first) {
+			ok = false;
+			failures << QString("command-bar focus did not start on %1").arg(first->objectName());
+			return;
+		}
+		actual << first->objectName();
+		const auto namedAncestor = [](QWidget* widget) {
+			for (QWidget* current = widget; current; current = current->parentWidget()) {
+				if (!current->objectName().isEmpty())
+					return current;
+			}
+			return widget;
+		};
+		for (int i = 1; i < expected.size(); ++i) {
+			QKeyEvent press(QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier);
+			QApplication::sendEvent(first, &press);
+			QApplication::processEvents();
+			QWidget* focused = QApplication::focusWidget();
+			QWidget* named = namedAncestor(focused);
+			actual << (named ? named->objectName() : QString());
+			first = focused;
+			if (!first)
+				break;
+		}
+		if (actual != expected) {
+			ok = false;
+			failures << QString("command-bar Tab traversal order mismatch: %1").arg(actual.join(", "));
+		}
+	};
+	showNormal();
+	resize(1024, 720);
+	QApplication::processEvents();
+	checkTabTraversal(openCaseAction, {"openCaseButton", "actionRunButton", "actionPauseButton", "actionStopButton",
+		"speedSlider", "actionFollowButton", "followTrainCombo", "actionZoomInButton",
+		"actionZoomOutButton", "actionFitButton"});
+
 	const auto caseDock = findChild<QDockWidget*>("caseLayersDock");
 	if (!caseDock || !caseDock->isVisible()) {
 		ok = false;
@@ -4374,10 +4689,9 @@ void MainWindow::runVisualPolishE2E() {
 		ok = false;
 		failures << "case state is empty";
 	}
-	const auto clockLabel = findChild<QLabel*>("simulationClockLabel");
-	if (!clockLabel || !QRegularExpression("^\\d{2}:\\d{2}:\\d{2}").match(clockLabel->text()).hasMatch()) {
+	if (findChild<QLabel*>("simulationClockLabel")) {
 		ok = false;
-		failures << "simulation clock is not formatted";
+		failures << "toolbar still owns the simulation clock";
 	}
 
 	const auto secondaryDockHidden = [this](QDockWidget* dock) {
@@ -4391,6 +4705,69 @@ void MainWindow::runVisualPolishE2E() {
 	}
 
 	showNormal();
+	resize(1200, 800);
+	QApplication::processEvents();
+	const auto checkCommandBarAtSize = [this, &ok, &failures](int width, int height, const char* screenshotVariable) {
+		resize(width, height);
+		QApplication::processEvents();
+		if (!m_toolBar) {
+			ok = false;
+			failures << QString("command bar is missing at %1x%2").arg(width).arg(height);
+			return;
+		}
+		const QStringList requiredWidgetNames{
+			"openCaseButton", "actionRunButton", "actionPauseButton", "actionStopButton", "speedSlowerLabel", "speedSlider",
+			"speedFasterLabel", "actionFollowButton", "followTrainCombo",
+			"actionZoomInButton", "actionZoomOutButton", "actionFitButton"};
+		QList<QWidget*> controls;
+		for (const QString& name : requiredWidgetNames) {
+			QWidget* widget = findChild<QWidget*>(name);
+			if (!widget || !widget->isVisibleTo(m_toolBar)) {
+				ok = false;
+				failures << QString("command-bar control %1 is hidden at %2x%3").arg(name).arg(width).arg(height);
+				continue;
+			}
+			const QRect geometry = widget->geometry();
+			const QRect toolbarArea = m_toolBar->rect().adjusted(0, 0, 0, 8);
+			if (!toolbarArea.contains(geometry) || geometry.height() > 36) {
+				ok = false;
+				failures << QString("command-bar control %1 escapes toolbar bounds at %2x%3 (%4x%5+%6+%7)")
+						.arg(name).arg(width).arg(height).arg(geometry.width()).arg(geometry.height())
+						.arg(geometry.x()).arg(geometry.y());
+			}
+			if (name == "followTrainCombo" && geometry.width() != 180) {
+				ok = false;
+				failures << QString("train selector rendered width changed at %1x%2: expected 180px, has %3px")
+					.arg(width).arg(height).arg(geometry.width());
+			}
+			if (auto* button = qobject_cast<QToolButton*>(widget)) {
+				if (button->toolButtonStyle() != Qt::ToolButtonIconOnly
+					&& !button->text().isEmpty() && button->sizeHint().width() > geometry.width()) {
+					ok = false;
+					failures << QString("command-bar text is clipped at %1x%2: %3 needs %4px, has %5px")
+						.arg(width).arg(height).arg(name).arg(button->sizeHint().width()).arg(geometry.width());
+				}
+			}
+			controls << widget;
+		}
+		for (int i = 0; i < controls.size(); ++i) {
+			for (int j = i + 1; j < controls.size(); ++j) {
+				if (controls[i]->geometry().intersects(controls[j]->geometry())) {
+					ok = false;
+					failures << QString("command-bar controls overlap at %1x%2: %3/%4")
+						.arg(width).arg(height).arg(controls[i]->objectName()).arg(controls[j]->objectName());
+				}
+			}
+		}
+		const QString screenshotPath = qEnvironmentVariable(screenshotVariable);
+		if (!screenshotPath.isEmpty() && !grab().save(screenshotPath)) {
+			ok = false;
+			failures << QString("command-bar screenshot save failed at %1x%2").arg(width).arg(height);
+		}
+	};
+	checkCommandBarAtSize(1024, 720, "QEGTRAIN_E2E_COMMAND_BAR_1024_SCREENSHOT");
+	checkCommandBarAtSize(1200, 800, "QEGTRAIN_E2E_COMMAND_BAR_1200_SCREENSHOT");
+	checkCommandBarAtSize(1440, 900, "QEGTRAIN_E2E_COMMAND_BAR_1440_SCREENSHOT");
 	resize(1200, 800);
 	QApplication::processEvents();
 	const int defaultNetworkWidth = networkView ? networkView->width() : 0;
@@ -8953,8 +9330,6 @@ void MainWindow::egtrainPoint2Screen(Connections* connections, int track1, int t
 // slot to update GUI at each timestep (no longer blocks; simulation runs on worker thread)
 
 void MainWindow::updateTimeline(int timestep, int totalTimesteps) {
-	if (m_simulationClockLabel)
-		m_simulationClockLabel->setText(QString::fromStdString(formatSimTime(timestep, m_startOffsetSeconds)));
 	if (progressBar)
 		progressBar->setProgress(timestep, totalTimesteps, m_startOffsetSeconds);
 }

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -376,6 +376,7 @@ private:
 
 	// toolbar
 	QToolBar* m_toolBar;
+	QAction* m_openCaseAction = nullptr;
 
 	bool m_promptedLoad = false; // ensures the load prompt only fires once
 
@@ -478,8 +479,6 @@ private:
 	// taking ownership; teardownGUI clears them after scene->clear().
 	QDockWidget* m_caseLayersDock = nullptr;
 	QLabel* m_caseNameLabel = nullptr;
-	QLabel* m_toolbarCaseLabel = nullptr;
-	QLabel* m_simulationClockLabel = nullptr;
 	QLabel* m_zoomStatusLabel = nullptr;
 	QCheckBox* m_stationLayerCheck = nullptr;
 	QCheckBox* m_trainLayerCheck = nullptr;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.ui
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.ui
@@ -59,6 +59,7 @@
     <addaction name="actionSimulationStart"/>
     <addaction name="actionSimulationPause"/>
     <addaction name="actionSimulationStop"/>
+    <addaction name="actionStartTime"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -91,13 +92,6 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="actionSimulationStart"/>
-   <addaction name="actionSimulationPause"/>
-   <addaction name="actionSimulationStop"/>
-   <addaction name="separator"/>
-   <addaction name="actionZoomIn"/>
-   <addaction name="actionZoomOut"/>
-   <addaction name="actionFitView"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionAbout">
@@ -138,6 +132,14 @@
     <string>Ctrl+Esc</string>
    </property>
   </action>
+  <action name="actionStartTime">
+   <property name="text">
+    <string>Start Time</string>
+   </property>
+   <property name="toolTip">
+    <string>Set the clock time the simulation starts at (HH:MM)</string>
+   </property>
+  </action>
   <action name="actionLoad_Network">
    <property name="text">
     <string>Load Network...</string>
@@ -175,7 +177,7 @@
   </action>
   <action name="actionFitView">
    <property name="text">
-    <string>Fit View</string>
+    <string>Fit</string>
    </property>
    <property name="toolTip">
     <string>Fit the network view to the window</string>

--- a/EGTRAIN/QEGTRAIN/app/resources.qrc
+++ b/EGTRAIN/QEGTRAIN/app/resources.qrc
@@ -13,6 +13,11 @@
         <file alias="icons/signal-stop.svg">../resources/icons/signal-stop.svg</file>
         <file alias="icons/signal-caution.svg">../resources/icons/signal-caution.svg</file>
         <file alias="icons/signal-proceed.svg">../resources/icons/signal-proceed.svg</file>
+        <file alias="icons/run.svg">../resources/icons/run.svg</file>
+        <file alias="icons/pause.svg">../resources/icons/pause.svg</file>
+        <file alias="icons/stop.svg">../resources/icons/stop.svg</file>
+        <file alias="icons/zoom-in.svg">../resources/icons/zoom-in.svg</file>
+        <file alias="icons/zoom-out.svg">../resources/icons/zoom-out.svg</file>
         <file alias="app/egtrain-16.png">../resources/app/egtrain-16.png</file>
         <file alias="app/egtrain-32.png">../resources/app/egtrain-32.png</file>
         <file alias="app/egtrain-48.png">../resources/app/egtrain-48.png</file>

--- a/EGTRAIN/QEGTRAIN/resources/icons/pause.svg
+++ b/EGTRAIN/QEGTRAIN/resources/icons/pause.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="#27333d" d="M3 2h3v12H3V2zm7 0h3v12h-3V2z"/>
+</svg>

--- a/EGTRAIN/QEGTRAIN/resources/icons/run.svg
+++ b/EGTRAIN/QEGTRAIN/resources/icons/run.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="#27333d" d="M4 2.25v11.5L13 8 4 2.25z"/>
+</svg>

--- a/EGTRAIN/QEGTRAIN/resources/icons/stop.svg
+++ b/EGTRAIN/QEGTRAIN/resources/icons/stop.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="#27333d" d="M3 3h10v10H3V3z"/>
+</svg>

--- a/EGTRAIN/QEGTRAIN/resources/icons/zoom-in.svg
+++ b/EGTRAIN/QEGTRAIN/resources/icons/zoom-in.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <circle cx="6.75" cy="6.75" r="4.25" fill="none" stroke="#27333d" stroke-width="1.5"/>
+  <path d="M10 10l3.5 3.5M6.75 4.5v4.5M4.5 6.75H9" fill="none" stroke="#27333d" stroke-width="1.5"/>
+</svg>

--- a/EGTRAIN/QEGTRAIN/resources/icons/zoom-out.svg
+++ b/EGTRAIN/QEGTRAIN/resources/icons/zoom-out.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <circle cx="6.75" cy="6.75" r="4.25" fill="none" stroke="#27333d" stroke-width="1.5"/>
+  <path d="M10 10l3.5 3.5M4.5 6.75H9" fill="none" stroke="#27333d" stroke-width="1.5"/>
+</svg>

--- a/EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss
+++ b/EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss
@@ -8,7 +8,19 @@ QToolBar {
     border: 0;
     border-bottom: 1px solid #c9d3db;
     spacing: 4px;
-    padding: 4px 8px;
+    padding: 1px 8px;
+}
+
+QToolBar::separator {
+    background: #c9d3db;
+    width: 1px;
+    margin: 0 4px;
+}
+
+QLabel#speedSlowerLabel, QLabel#speedFasterLabel {
+    color: #637584;
+    font-size: 11px;
+    padding: 0;
 }
 
 QToolButton {
@@ -16,7 +28,15 @@ QToolButton {
     border: 1px solid transparent;
     border-radius: 2px;
     color: #27333d;
-    padding: 5px 8px;
+    padding: 4px 6px;
+    min-height: 24px;
+    max-height: 32px;
+}
+
+QToolButton#actionZoomInButton, QToolButton#actionZoomOutButton {
+    min-width: 24px;
+    max-width: 28px;
+    padding: 4px;
 }
 
 QToolButton:hover, QToolButton:focus {
@@ -27,21 +47,6 @@ QToolButton:hover, QToolButton:focus {
 QToolButton:checked {
     background: #0f7c73;
     color: #ffffff;
-}
-
-QLabel#toolbarCaseLabel {
-    color: #344654;
-    font-weight: 600;
-    padding: 0 8px;
-}
-
-QLabel#simulationClockLabel {
-    background: #e8eef2;
-    border: 1px solid #c9d3db;
-    border-radius: 2px;
-    color: #27333d;
-    font-weight: 600;
-    padding: 4px 8px;
 }
 
 QDockWidget {

--- a/EGTRAIN/QEGTRAIN/tests/test_qt_resource_images.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_qt_resource_images.cpp
@@ -42,5 +42,17 @@ int main(int argc, char** argv) {
         if (image.isNull() || image.size() != QSize(24, 24) || !image.hasAlphaChannel())
             return 1;
     }
+    const std::array<const char*, 5> command_icons{
+        ":/icons/run.svg",
+        ":/icons/pause.svg",
+        ":/icons/stop.svg",
+        ":/icons/zoom-in.svg",
+        ":/icons/zoom-out.svg",
+    };
+    for (const char* path : command_icons) {
+        const QImage image(path);
+        if (image.isNull() || image.size() != QSize(16, 16) || !image.hasAlphaChannel())
+            return 1;
+    }
     return 0;
 }

--- a/tools/e2e/visual_polish_smoke.sh
+++ b/tools/e2e/visual_polish_smoke.sh
@@ -8,8 +8,14 @@ SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-e2e.png"
 DENSE_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dense-e2e.png"
 FOLLOW_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-follow-e2e.png"
 CONTEXT_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-context-e2e.png"
+COMMAND_BAR_1024_SHOT="${TMPDIR:-/tmp}/qegtrain-command-bar-1024-e2e.png"
+COMMAND_BAR_1200_SHOT="${TMPDIR:-/tmp}/qegtrain-command-bar-1200-e2e.png"
+COMMAND_BAR_1440_SHOT="${TMPDIR:-/tmp}/qegtrain-command-bar-1440-e2e.png"
 DPR2_OUT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dpr2-e2e.log"
 DPR2_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dpr2-e2e.png"
+DPR2_COMMAND_BAR_1024_SHOT="${TMPDIR:-/tmp}/qegtrain-command-bar-dpr2-1024-e2e.png"
+DPR2_COMMAND_BAR_1200_SHOT="${TMPDIR:-/tmp}/qegtrain-command-bar-dpr2-1200-e2e.png"
+DPR2_COMMAND_BAR_1440_SHOT="${TMPDIR:-/tmp}/qegtrain-command-bar-dpr2-1440-e2e.png"
 STATION_OUT_BASE="${TMPDIR:-/tmp}/qegtrain-station-overlay-e2e"
 STATION_SHOT_BASE="${TMPDIR:-/tmp}/qegtrain-station-overlay-copenhagen"
 STATION_DPR2_OUT="${TMPDIR:-/tmp}/qegtrain-station-overlay-e2e-dpr2.log"
@@ -29,6 +35,9 @@ QEGTRAIN_E2E_SCREENSHOT="$SHOT" \
 QEGTRAIN_E2E_DENSE_SCREENSHOT="$DENSE_SHOT" \
 QEGTRAIN_E2E_FOLLOW_SCREENSHOT="$FOLLOW_SHOT" \
 QEGTRAIN_E2E_CONTEXT_SCREENSHOT="$CONTEXT_SHOT" \
+QEGTRAIN_E2E_COMMAND_BAR_1024_SCREENSHOT="$COMMAND_BAR_1024_SHOT" \
+QEGTRAIN_E2E_COMMAND_BAR_1200_SCREENSHOT="$COMMAND_BAR_1200_SHOT" \
+QEGTRAIN_E2E_COMMAND_BAR_1440_SCREENSHOT="$COMMAND_BAR_1440_SHOT" \
 "$APP" -n 3 -h 8000 -g 1 -pax 1 -TSM 0 -RC 0 >"$OUT" 2>&1
 
 grep -q "E2E_VISUAL_POLISH_OK" "$OUT"
@@ -37,6 +46,9 @@ test -s "$SHOT"
 test -s "$DENSE_SHOT"
 test -s "$FOLLOW_SHOT"
 test -s "$CONTEXT_SHOT"
+test -s "$COMMAND_BAR_1024_SHOT"
+test -s "$COMMAND_BAR_1200_SHOT"
+test -s "$COMMAND_BAR_1440_SHOT"
 for label in "Planned arrival" "Planned departure" "Simulated arrival" "Simulated departure" "Arrival delay" "Departure delay"; do
 	if ! grep -Fqi "$label" "$ROOT/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp"; then
 		echo "missing timetable label in TimetableTableWindow.cpp: $label" >&2
@@ -47,7 +59,7 @@ if grep -Fq 'name="actionShow_Graph"' "$ROOT/EGTRAIN/QEGTRAIN/app/MainWindow.ui"
 	echo "dead Show Graph action still present in MainWindow.ui" >&2
 	exit 1
 fi
-echo "visual polish e2e passed: $SHOT $DENSE_SHOT $FOLLOW_SHOT $CONTEXT_SHOT"
+echo "visual polish e2e passed: $SHOT $DENSE_SHOT $FOLLOW_SHOT $CONTEXT_SHOT $COMMAND_BAR_1024_SHOT $COMMAND_BAR_1200_SHOT $COMMAND_BAR_1440_SHOT"
 
 QT_QPA_PLATFORM=offscreen \
 QT_SCALE_FACTOR=2 \
@@ -57,10 +69,16 @@ QEGTRAIN_E2E_SCREENSHOT="$DPR2_SHOT" \
 QEGTRAIN_E2E_DENSE_SCREENSHOT="${DPR2_SHOT%.png}-dense.png" \
 QEGTRAIN_E2E_FOLLOW_SCREENSHOT="${DPR2_SHOT%.png}-follow.png" \
 QEGTRAIN_E2E_CONTEXT_SCREENSHOT="${DPR2_SHOT%.png}-context.png" \
+QEGTRAIN_E2E_COMMAND_BAR_1024_SCREENSHOT="$DPR2_COMMAND_BAR_1024_SHOT" \
+QEGTRAIN_E2E_COMMAND_BAR_1200_SCREENSHOT="$DPR2_COMMAND_BAR_1200_SHOT" \
+QEGTRAIN_E2E_COMMAND_BAR_1440_SCREENSHOT="$DPR2_COMMAND_BAR_1440_SHOT" \
 "$APP" -n 3 -h 8000 -g 1 -pax 1 -TSM 0 -RC 0 >"$DPR2_OUT" 2>&1
 grep -q "E2E_VISUAL_POLISH_DPR_2.0" "$DPR2_OUT"
 grep -q "E2E_VISUAL_POLISH_OK" "$DPR2_OUT"
 test -s "$DPR2_SHOT"
+test -s "$DPR2_COMMAND_BAR_1024_SHOT"
+test -s "$DPR2_COMMAND_BAR_1200_SHOT"
+test -s "$DPR2_COMMAND_BAR_1440_SHOT"
 echo "visual polish 2x dpr e2e passed: $DPR2_SHOT"
 
 for case in 1 2 3 4; do
@@ -106,3 +124,6 @@ test -s "${STATION_SHOT_BASE}-dpr2-fit.png"
 test -s "${STATION_SHOT_BASE}-dpr2-3x.png"
 test -s "${STATION_SHOT_BASE}-dpr2-12x.png"
 echo "station overlay Copenhagen DPR2 passed: ${STATION_DPR2_OUT}"
+
+"$ROOT/tools/e2e/scene_render_smoke.sh"
+"$ROOT/tools/e2e/legacy_import_smoke.sh"


### PR DESCRIPTION
## Summary

- Group the toolbar into Case, Playback, and View commands.
- Move Start Time to the Simulation menu and remove the duplicate case badge and clock.
- Add a 16-pixel monochrome icon set and checks for order, keyboard focus, sizing, resources, scene loading, and legacy import.

## Checks

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (41 passed)
- `tools/e2e/visual_polish_smoke.sh`

Closes #238