### PR TITLE
Stabilize sanitizer smoke timeouts

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -119,7 +119,7 @@ jobs:
           ASAN_OPTIONS: abort_on_error=1:halt_on_error=1
           # The instrumented Debug build runs several times slower than Release,
           # so the GUI autostart smoke needs a larger budget to finish the
-          # horizon-1000 run and populate the Run Results dock before emitting
+          # horizon-500 run and populate the Run Results dock before emitting
           # E2E_GUI_RUN_RESULTS. Keep the post-completion liveness hold short so
           # the whole test still finishes under the ctest TIMEOUT (CMakeLists.txt).
           QEGTRAIN_GUI_SMOKE_MARKER_SECONDS: "360"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -119,7 +119,7 @@ jobs:
           ASAN_OPTIONS: abort_on_error=1:halt_on_error=1
           # The instrumented Debug build runs several times slower than Release,
           # so the GUI autostart smoke needs a larger budget to finish the
-          # horizon-300 run and populate the Run Results dock before emitting
+          # horizon-200 run and populate the Run Results dock before emitting
           # E2E_GUI_RUN_RESULTS. Keep the post-completion liveness hold short so
           # the whole test still finishes under the ctest TIMEOUT (CMakeLists.txt).
           QEGTRAIN_GUI_SMOKE_MARKER_SECONDS: "360"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -119,7 +119,7 @@ jobs:
           ASAN_OPTIONS: abort_on_error=1:halt_on_error=1
           # The instrumented Debug build runs several times slower than Release,
           # so the GUI autostart smoke needs a larger budget to finish the
-          # horizon-500 run and populate the Run Results dock before emitting
+          # horizon-300 run and populate the Run Results dock before emitting
           # E2E_GUI_RUN_RESULTS. Keep the post-completion liveness hold short so
           # the whole test still finishes under the ctest TIMEOUT (CMakeLists.txt).
           QEGTRAIN_GUI_SMOKE_MARKER_SECONDS: "360"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,11 +625,11 @@ if(EGTRAIN_BUILD_TESTS)
 	set_tests_properties(test_csv_export_smoke PROPERTIES TIMEOUT 240)
 	add_test(NAME test_lebanon_scene_smoke
 		COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/lebanon_scene_smoke.sh)
-	set_tests_properties(test_lebanon_scene_smoke PROPERTIES TIMEOUT 180)
+	set_tests_properties(test_lebanon_scene_smoke PROPERTIES TIMEOUT 360)
 	if(APPLE)
 		add_test(NAME test_package_contents_smoke
 			COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/package_contents_smoke.sh)
-		set_tests_properties(test_package_contents_smoke PROPERTIES TIMEOUT 240)
+		set_tests_properties(test_package_contents_smoke PROPERTIES TIMEOUT 420)
 	endif()
 	add_test(NAME test_ci_workflow
 		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_ci_workflow.py)

--- a/tools/e2e/gui_autostart_smoke.py
+++ b/tools/e2e/gui_autostart_smoke.py
@@ -16,9 +16,9 @@ DEFAULT_SECONDS = 75
 # Keep the smoke short enough to finish on hosted runners while still checking
 # completed-run results and generated energy output.
 DEFAULT_HORIZON = 200
-# startup takes under 10s on a local Release build; sanitized Debug on a
-# shared CI runner needs a much larger budget before the first sim tick
-DEFAULT_MARKER_SECONDS = 120
+# Startup takes under 10s locally, but hosted runners can spend several
+# minutes loading Copenhagen before the first simulation tick.
+DEFAULT_MARKER_SECONDS = 300
 
 BAD_PATTERNS = (
     "AddressSanitizer",

--- a/tools/e2e/gui_autostart_smoke.py
+++ b/tools/e2e/gui_autostart_smoke.py
@@ -15,7 +15,7 @@ RUN_DIR = ROOT / "EGTRAIN" / "QEGTRAIN"
 DEFAULT_SECONDS = 75
 # Keep the smoke short enough to finish on hosted runners while still checking
 # completed-run results and generated energy output.
-DEFAULT_HORIZON = 300
+DEFAULT_HORIZON = 200
 # startup takes under 10s on a local Release build; sanitized Debug on a
 # shared CI runner needs a much larger budget before the first sim tick
 DEFAULT_MARKER_SECONDS = 120

--- a/tools/e2e/gui_autostart_smoke.py
+++ b/tools/e2e/gui_autostart_smoke.py
@@ -13,8 +13,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 RUN_DIR = ROOT / "EGTRAIN" / "QEGTRAIN"
 DEFAULT_SECONDS = 75
-# Keep the smoke run short enough to reach simulation completion locally.
-DEFAULT_HORIZON = 1000
+# Keep the smoke short enough to finish on hosted runners while still checking
+# completed-run results and generated energy output.
+DEFAULT_HORIZON = 500
 # startup takes under 10s on a local Release build; sanitized Debug on a
 # shared CI runner needs a much larger budget before the first sim tick
 DEFAULT_MARKER_SECONDS = 120

--- a/tools/e2e/gui_autostart_smoke.py
+++ b/tools/e2e/gui_autostart_smoke.py
@@ -15,7 +15,7 @@ RUN_DIR = ROOT / "EGTRAIN" / "QEGTRAIN"
 DEFAULT_SECONDS = 75
 # Keep the smoke short enough to finish on hosted runners while still checking
 # completed-run results and generated energy output.
-DEFAULT_HORIZON = 500
+DEFAULT_HORIZON = 300
 # startup takes under 10s on a local Release build; sanitized Debug on a
 # shared CI runner needs a much larger budget before the first sim tick
 DEFAULT_MARKER_SECONDS = 120

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -56,6 +56,10 @@ def main() -> None:
         missing.append("sanitizer GUI smoke time budgets")
     if "set_tests_properties(test_gui_autostart_smoke PROPERTIES TIMEOUT 420)" not in cmake:
         missing.append("GUI smoke CTest timeout")
+    if "set_tests_properties(test_lebanon_scene_smoke PROPERTIES TIMEOUT 360)" not in cmake:
+        missing.append("Lebanon smoke CTest timeout")
+    if "set_tests_properties(test_package_contents_smoke PROPERTIES TIMEOUT 420)" not in cmake:
+        missing.append("package smoke CTest timeout")
     if "DEFAULT_HORIZON = 300" not in gui_smoke:
         missing.append("bounded GUI smoke horizon")
     if workflow.count('echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"') != 2:

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -62,6 +62,8 @@ def main() -> None:
         missing.append("package smoke CTest timeout")
     if "DEFAULT_HORIZON = 200" not in gui_smoke:
         missing.append("bounded GUI smoke horizon")
+    if "DEFAULT_MARKER_SECONDS = 300" not in gui_smoke:
+        missing.append("hosted-runner GUI startup budget")
     if workflow.count('echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"') != 2:
         missing.append("TMPDIR routing steps for smoke logs")
     uploads = [block for block in blocks if block.startswith("name: Upload failure diagnostics\n")]

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -56,7 +56,7 @@ def main() -> None:
         missing.append("sanitizer GUI smoke time budgets")
     if "set_tests_properties(test_gui_autostart_smoke PROPERTIES TIMEOUT 420)" not in cmake:
         missing.append("GUI smoke CTest timeout")
-    if "DEFAULT_HORIZON = 500" not in gui_smoke:
+    if "DEFAULT_HORIZON = 300" not in gui_smoke:
         missing.append("bounded GUI smoke horizon")
     if workflow.count('echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"') != 2:
         missing.append("TMPDIR routing steps for smoke logs")

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -60,7 +60,7 @@ def main() -> None:
         missing.append("Lebanon smoke CTest timeout")
     if "set_tests_properties(test_package_contents_smoke PROPERTIES TIMEOUT 420)" not in cmake:
         missing.append("package smoke CTest timeout")
-    if "DEFAULT_HORIZON = 300" not in gui_smoke:
+    if "DEFAULT_HORIZON = 200" not in gui_smoke:
         missing.append("bounded GUI smoke horizon")
     if workflow.count('echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"') != 2:
         missing.append("TMPDIR routing steps for smoke logs")

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[2]
 def main() -> None:
     workflow = (ROOT / ".github/workflows/cmake.yml").read_text(encoding="utf-8")
     cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+    gui_smoke = (ROOT / "tools/e2e/gui_autostart_smoke.py").read_text(encoding="utf-8")
     release_workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     blocks = workflow.split("\n      - ")
     required = {
@@ -55,6 +56,8 @@ def main() -> None:
         missing.append("sanitizer GUI smoke time budgets")
     if "set_tests_properties(test_gui_autostart_smoke PROPERTIES TIMEOUT 420)" not in cmake:
         missing.append("GUI smoke CTest timeout")
+    if "DEFAULT_HORIZON = 500" not in gui_smoke:
+        missing.append("bounded GUI smoke horizon")
     if workflow.count('echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"') != 2:
         missing.append("TMPDIR routing steps for smoke logs")
     uploads = [block for block in blocks if block.startswith("name: Upload failure diagnostics\n")]


### PR DESCRIPTION
## Changes

- Reduce the GUI autostart horizon from 1,000 to 200 simulation steps.
- Allow 300 seconds for a hosted runner to report the first simulation tick.
- Keep the sanitizer override at 360 seconds with a 30-second liveness hold.
- Raise the Lebanon smoke ceiling from 180 to 360 seconds.
- Raise the package-contents smoke ceiling from 240 to 420 seconds.
- Keep the progress, completed-results, energy-output, and liveness assertions.

## Reason

Run 29721615580 reached step 285 of 300 before the sanitizer marker expired. Run 29723183779 spent more than 120 seconds loading Copenhagen in Release before the first tick. Neither log contained a sanitizer report. The smaller horizon shortens the completed-run check, and the larger startup budget covers runner contention without weakening its assertions.

## Local checks

- Workflow contract test
- Python compilation for both smoke scripts
- Direct GUI autostart smoke at horizon 200
- Git diff check

Closes #231
Closes #250