### PR TITLE
Apply a professional renderer palette and non-color cues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,7 @@ if(EGTRAIN_BUILD_TESTS)
     add_executable(test_visualpolish
         ${SRC_DIR}/tests/test_visualpolish.cpp
 		${SRC_DIR}/graphics/items/TrainBadgeItem.cpp
+		${SRC_DIR}/graphics/items/SignalItem.cpp
         ${SRC_DIR}/graphics/VisualPolish.cpp)
     target_link_libraries(test_visualpolish PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets)
     add_test(NAME test_visualpolish COMMAND test_visualpolish)

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -5224,6 +5224,8 @@ void MainWindow::runVisualPolishE2E() {
 			failures << "no non-free track intersects default viewport";
 		}
 	}
+	if (m_worker)
+		m_worker->requestPause();
 
 	// Capture the readable default view before changing follow or zoom state.
 	if (networkView) {
@@ -5343,6 +5345,25 @@ void MainWindow::runVisualPolishE2E() {
 	const QString signalApproachExplanation = QStringLiteral(
 		"Requires the signal route association and an approaching-train query.");
 
+	selectedTrain = nullptr;
+	selectedTrainBody = nullptr;
+	for (auto* candidate : allTrains) {
+		if (!candidate || !candidate->isVisible() || !candidate->trainPolygonItemList)
+			continue;
+		for (auto* body : *candidate->trainPolygonItemList) {
+			if (body && body->isVisible() && !body->polygon().isEmpty()) {
+				selectedTrain = candidate;
+				selectedTrainBody = body;
+				break;
+			}
+		}
+		if (selectedTrainBody)
+			break;
+	}
+	if (!selectedTrainBody) {
+		ok = false;
+		failures << "no visible train body available after pausing visual checks";
+	}
 	if (selectedTrainBody) {
 		setFollowTrain(-1);
 		QMenu* menu = requestContextMenu(selectedTrainBody->sceneBoundingRect().center(), true);

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -59,6 +59,9 @@ const char* kRecentScenesKey = "recentScenes";
 const int kMaxRecentScenes = 8;
 constexpr qreal kDenseDetailZoom = 3.0;
 constexpr int kOverlayMargin = 12;
+constexpr int kSignalDecorationRole = 0;
+constexpr int kSignalTrackRole = 1;
+constexpr int kSignalBaseVisibleRole = 2;
 
 // The speed slider reads left-to-right as slow-to-fast; the worker wants a
 // per-step delay, so the delay is the distance from the fast end.
@@ -778,9 +781,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	});
 	connect(m_signalLayerCheck, &QCheckBox::toggled, this, [this](bool checked) {
 		m_signalLayerVisible = checked;
-		for (auto* item : m_signalDecorations)
-			if (item)
-				item->setVisible(checked);
+		updateViewportOverlays();
 	});
 	connect(m_passengerLayerCheck, &QCheckBox::toggled, this, [this](bool checked) {
 		m_passengerLayerVisible = checked;
@@ -4335,6 +4336,8 @@ void MainWindow::runStationOverlayE2E() {
 		for (auto* item : scene->items()) {
 			if (item && item->isVisible()) {
 				previouslyVisibleItems.append(item);
+				if (item->data(kSignalDecorationRole).toBool())
+					item->setData(kSignalBaseVisibleRole, false);
 				item->setVisible(false);
 			}
 		}
@@ -4461,8 +4464,11 @@ void MainWindow::runStationOverlayE2E() {
 		m_stationDecorations = previousStationDecorations;
 		m_selectedStationName = previousSelectedStationName;
 		for (auto* item : previouslyVisibleItems)
-			if (item && item->scene() == scene)
+			if (item && item->scene() == scene) {
+				if (item->data(kSignalDecorationRole).toBool())
+					item->setData(kSignalBaseVisibleRole, true);
 				item->setVisible(true);
+			}
 		updateViewportOverlays();
 
 		checkZoom(3.0, "3X");
@@ -5013,12 +5019,31 @@ void MainWindow::runVisualPolishE2E() {
 	// Run the layer toggles above the dense-detail threshold and put the
 	// overview back afterwards.
 	qreal overviewRatio = networkView ? networkView->zoomRatio() : 1.0;
+	const auto hasVisibleSignalStructure = [this]() {
+		return std::any_of(m_signalDecorations.cbegin(), m_signalDecorations.cend(),
+			[](QGraphicsItem* item) {
+				return item && !qgraphicsitem_cast<SignalItem*>(item) && item->isVisible();
+			});
+	};
+	if (networkView) {
+		networkView->fitToTopology();
+		updateViewportOverlays();
+		QApplication::processEvents();
+	}
+	if (hasVisibleSignalStructure()) {
+		ok = false;
+		failures << "signal posts or bases remain visible at overview zoom";
+	}
 	if (networkView) {
 		const qreal currentRatio = networkView->zoomRatio();
 		if (currentRatio < kDenseDetailZoom)
 			networkView->zoomBy(kDenseDetailZoom / currentRatio);
 		updateViewportOverlays();
 		QApplication::processEvents();
+		if (!hasVisibleSignalStructure()) {
+			ok = false;
+			failures << "signal posts and bases did not return at detailed zoom";
+		}
 	}
 
 	const auto layerToggle = [this](const char* objectName) {
@@ -5125,9 +5150,9 @@ void MainWindow::runVisualPolishE2E() {
 	}
 
 	if (networkView) {
-		const qreal currentRatio = networkView->zoomRatio();
-		if (currentRatio > overviewRatio)
-			networkView->zoomBy(overviewRatio / currentRatio);
+		networkView->fitToTopology();
+		if (overviewRatio > 1.0)
+			networkView->zoomBy(overviewRatio);
 		updateViewportOverlays();
 		QApplication::processEvents();
 	}
@@ -8213,7 +8238,7 @@ void MainWindow::paintArc(QPointF start, QPointF end, int pen_width, int track, 
 
 // Arc drawing
 void MainWindow::arcDrawing(QPointF start, QPointF end, int pen_width, int track, Arc* Arc) {
-	TrackVisual visual = classifyTrackSpeed(Arc ? Arc->speedLimit : 0.0);
+	TrackVisual visual = freeTrackVisual();
 	QPen pen = QPen(visual.color);
 	pen.setWidth(std::max(pen_width, visual.width));
 	pen.setCosmetic(true);
@@ -8236,11 +8261,11 @@ void MainWindow::arcDrawing(QPointF start, QPointF end, int pen_width, int track
 	networkView->fitInView(scene->sceneRect(), Qt::KeepAspectRatio);
 }
 
-
 // draws a connection
 void MainWindow::paintConnection(QPointF start, QPointF end, int pen_width, Connections* connection) {
-	QPen pen = QPen(Qt::white);
-	pen.setWidth(pen_width);
+	const TrackVisual visual = freeTrackVisual();
+	QPen pen(visual.color);
+	pen.setWidth(std::max(pen_width, visual.width));
 	pen.setCosmetic(true);
 
 	// draws a line from start to end with a given line width
@@ -8397,12 +8422,15 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	QGraphicsLineItem* basis2 = new QGraphicsLineItem(QLineF(basisStartX, basisStartY, basisEndX, basisEndY));
 	basis2->setPen(penPost);
 
-	const auto addSignalDecoration = [this, track](QGraphicsItem* item) {
-		item->setData(0, true);
-		item->setData(1, track);
+	const bool detailedSignals = networkView && networkView->zoomRatio() >= kDenseDetailZoom;
+	const auto addSignalDecoration = [this, track, detailedSignals](QGraphicsItem* item) {
+		item->setData(kSignalDecorationRole, true);
+		item->setData(kSignalTrackRole, track);
+		item->setData(kSignalBaseVisibleRole, true);
 		scene->addItem(item);
 		m_signalDecorations.push_back(item);
-		item->setVisible(m_signalLayerVisible);
+		item->setVisible(m_signalLayerVisible
+			&& (qgraphicsitem_cast<SignalItem*>(item) || detailedSignals));
 	};
 	addSignalDecoration(post1);
 	addSignalDecoration(plate1);
@@ -8412,7 +8440,7 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	addSignalDecoration(basis2);
 
 	// match the current zoom before the next viewportChanged fires
-	const bool compactSignals = !networkView || networkView->zoomRatio() < kDenseDetailZoom;
+	const bool compactSignals = !detailedSignals;
 	plate1->setCompact(compactSignals);
 	plate2->setCompact(compactSignals);
 
@@ -10354,9 +10382,11 @@ void MainWindow::hideUnusedTracks() {
 			}
 		}
 
-		if (item->data(0).toBool()) {
-			if (std::find(unusedTracks.begin(), unusedTracks.end(), item->data(1).toInt()) != unusedTracks.end())
+		if (item->data(kSignalDecorationRole).toBool()) {
+			if (std::find(unusedTracks.begin(), unusedTracks.end(), item->data(kSignalTrackRole).toInt()) != unusedTracks.end()) {
+				item->setData(kSignalBaseVisibleRole, false);
 				item->hide();
+			}
 			continue;
 		}
 
@@ -11148,11 +11178,18 @@ void MainWindow::updateViewportOverlays() {
 		overlay->setLayoutVisible(visible);
 	}
 
-	// Full signal housings only once zoomed past the dense threshold; at
-	// overview they collapse to aspect-coloured ticks.
-	for (auto* signal : allSignals) {
-		if (signal)
+	// Signal plates stay available at overview as aspect cues. Posts and bases
+	// return with the full housings only at detailed zoom.
+	for (auto* item : m_signalDecorations) {
+		if (!item)
+			continue;
+		const bool baseVisible = item->data(kSignalBaseVisibleRole).toBool();
+		if (auto* signal = qgraphicsitem_cast<SignalItem*>(item)) {
 			signal->setCompact(!dense);
+			signal->setVisible(m_signalLayerVisible && baseVisible);
+		} else {
+			item->setVisible(m_signalLayerVisible && baseVisible && dense);
+		}
 	}
 
 	const bool paxText = paxTextVisible();

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
@@ -21,7 +21,7 @@ NetworkView::NetworkView(QWidget* parent)
 
 	setMouseTracking(true);
 	setSceneRect(QRectF(0, 0, 0, 0));
-	setBackgroundBrush(QColor("#101A22"));
+	setBackgroundBrush(QColor("#12191F"));
 	setRenderHints(QPainter::Antialiasing | QPainter::HighQualityAntialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
 	setDragMode(QGraphicsView::ScrollHandDrag);
 	setTransformationAnchor(QGraphicsView::AnchorViewCenter);
@@ -224,28 +224,7 @@ void NetworkView::wheelEvent(QWheelEvent* event) {
 }
 
 void NetworkView::drawBackground(QPainter* painter, const QRectF& rect) {
-	painter->fillRect(rect, QColor("#101A22"));
-
-	const qreal viewScale = qAbs(transform().m11());
-	if (viewScale <= 0.0)
-		return;
-
-	qreal spacing = 80.0;
-	while (spacing * viewScale < 24.0)
-		spacing *= 2.0;
-	while (spacing * viewScale > 96.0)
-		spacing /= 2.0;
-
-	QPen gridPen(QColor("#1B2A35"));
-	gridPen.setCosmetic(true);
-	gridPen.setWidth(0);
-	painter->setPen(gridPen);
-	const qreal left = std::floor(rect.left() / spacing) * spacing;
-	const qreal top = std::floor(rect.top() / spacing) * spacing;
-	for (qreal x = left; x <= rect.right(); x += spacing)
-		painter->drawLine(QLineF(x, rect.top(), x, rect.bottom()));
-	for (qreal y = top; y <= rect.bottom(); y += spacing)
-		painter->drawLine(QLineF(rect.left(), y, rect.right(), y));
+	painter->fillRect(rect, QColor("#12191F"));
 }
 
 void NetworkView::resizeEvent(QResizeEvent* event) {

--- a/EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp
@@ -21,23 +21,18 @@ bool containsAny(const std::string& text, std::initializer_list<const char*> nee
 
 } // namespace
 
-TrackVisual classifyTrackSpeed(double speedLimitMetersPerSecond) {
-	double kmh = speedLimitMetersPerSecond * 3.6;
-	if (kmh >= 200.0)
-		return {TrackVisualKind::HighSpeed, QColor(30, 130, 210), 4};
-	if (kmh >= 120.0)
-		return {TrackVisualKind::Mainline, QColor(80, 80, 80), 3};
-	return {TrackVisualKind::Local, QColor(120, 120, 120), 2};
+TrackVisual freeTrackVisual() {
+	return {QColor("#A0ACB4"), 2};
 }
 
 TrackStateVisual classifyTrackState(TrackOperationalState state) {
 	switch (state) {
 	case TrackOperationalState::Prepared:
-		return {QColor("#2ECC71"), 8, Qt::SolidLine};
+		return {QColor("#4C8DAE"), 6, Qt::DashDotLine};
 	case TrackOperationalState::Occupied:
-		return {QColor("#EF5350"), 10, Qt::SolidLine};
+		return {QColor("#D05A47"), 8, Qt::SolidLine};
 	case TrackOperationalState::Blocked:
-		return {QColor("#F2A516"), 8, Qt::DashLine};
+		return {QColor("#D6A13A"), 8, Qt::DashLine};
 	case TrackOperationalState::Free:
 	default:
 		return {Qt::transparent, 0, Qt::NoPen};
@@ -87,14 +82,14 @@ int trackStatePriority(TrackOperationalState state) {
 TrainVisual classifyTrainType(const std::string& type, const std::string& description) {
 	std::string text = lower(type + " " + description);
 	if (containsAny(text, {"freight", "cargo", "goederen"}))
-		return {TrainVisualKind::Freight, QColor(120, 95, 70), QColor(70, 55, 40), classifyTrainBadgeShape(TrainVisualKind::Freight), ":/icons/train-freight.svg"};
+		return {TrainVisualKind::Freight, QColor("#A99787"), QColor("#5D4C3F"), classifyTrainBadgeShape(TrainVisualKind::Freight), ":/icons/train-freight.svg"};
 	if (containsAny(text, {"ice", "hst", "highspeed", "high speed"}))
-		return {TrainVisualKind::HighSpeed, QColor(40, 130, 210), QColor(15, 70, 120), classifyTrainBadgeShape(TrainVisualKind::HighSpeed), ":/icons/train-high-speed.svg"};
+		return {TrainVisualKind::HighSpeed, QColor("#86A6B9"), QColor("#3E627A"), classifyTrainBadgeShape(TrainVisualKind::HighSpeed), ":/icons/train-high-speed.svg"};
 	if (containsAny(text, {"sprinter", "spr"}))
-		return {TrainVisualKind::Sprinter, QColor(40, 170, 110), QColor(20, 90, 60), classifyTrainBadgeShape(TrainVisualKind::Sprinter), ":/icons/train-sprinter.svg"};
+		return {TrainVisualKind::Sprinter, QColor("#86AA96"), QColor("#3F6A54"), classifyTrainBadgeShape(TrainVisualKind::Sprinter), ":/icons/train-sprinter.svg"};
 	if (containsAny(text, {"intercity", " ic", "ic "}))
-		return {TrainVisualKind::Intercity, QColor(235, 190, 45), QColor(120, 90, 20), classifyTrainBadgeShape(TrainVisualKind::Intercity), ":/icons/train-intercity.svg"};
-	return {TrainVisualKind::Passenger, QColor(235, 210, 55), QColor(110, 90, 20), classifyTrainBadgeShape(TrainVisualKind::Passenger), ":/icons/train-passenger.svg"};
+		return {TrainVisualKind::Intercity, QColor("#C6A86E"), QColor("#765623"), classifyTrainBadgeShape(TrainVisualKind::Intercity), ":/icons/train-intercity.svg"};
+	return {TrainVisualKind::Passenger, QColor("#9BA5AA"), QColor("#4A5960"), classifyTrainBadgeShape(TrainVisualKind::Passenger), ":/icons/train-passenger.svg"};
 }
 
 SignalCueKind classifySignalCue(int code) {

--- a/EGTRAIN/QEGTRAIN/graphics/VisualPolish.h
+++ b/EGTRAIN/QEGTRAIN/graphics/VisualPolish.h
@@ -6,7 +6,6 @@
 #include <QString>
 #include <string>
 
-enum class TrackVisualKind { Local, Mainline, HighSpeed };
 enum class TrainVisualKind { Passenger, Sprinter, Intercity, HighSpeed, Freight };
 enum class TrainBadgeShape { Rounded, Capsule, Square };
 enum class StationVisualKind { StopMarker, Platform, Interchange };
@@ -14,7 +13,6 @@ enum class TrackOperationalState { Free, Prepared, Occupied, Blocked };
 enum class SignalCueKind { Neutral, Stop, Caution, Proceed };
 
 struct TrackVisual {
-	TrackVisualKind kind;
 	QColor color;
 	int width;
 };
@@ -46,7 +44,7 @@ struct SignalVisual {
 	QString iconResource;
 };
 
-TrackVisual classifyTrackSpeed(double speedLimitMetersPerSecond);
+TrackVisual freeTrackVisual();
 TrackStateVisual classifyTrackState(TrackOperationalState state);
 int trackStatePriority(TrackOperationalState state);
 TrainVisual classifyTrainType(const std::string& type, const std::string& description);

--- a/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
@@ -54,15 +54,31 @@ void SignalItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option
 	Q_UNUSED(widget);
 
 	// At overview zoom the fixed-size housings overlap into solid bands, so
-	// collapse to a small tick that keeps the aspect colour visible.
+	// keep stop and caution distinct while repeated proceed signals recede.
 	if (m_compact) {
-		QPen tickPen(QColor("#0d131a"));
-		tickPen.setWidthF(1.0);
-		painter->setPen(tickPen);
-		painter->setBrush(m_lampColor);
-		QRectF tick(0.0, 0.0, 3.0, 8.0);
-		tick.moveCenter(rect().center());
-		painter->drawRect(tick);
+		const SignalCueKind cue = classifySignalCue(m_aspectCode);
+		const QPointF center = rect().center();
+		if (cue == SignalCueKind::Stop) {
+			const QRectF lamp(center.x() - 4.0, center.y() - 4.0, 8.0, 8.0);
+			painter->setPen(QPen(QColor("#0D131A"), 1.0));
+			painter->setBrush(m_lampColor);
+			painter->drawEllipse(lamp);
+			painter->drawLine(QLineF(lamp.left() + 2.0, center.y(), lamp.right() - 2.0, center.y()));
+		} else if (cue == SignalCueKind::Caution) {
+			QPolygonF triangle;
+			triangle << QPointF(center.x(), center.y() - 4.0)
+					 << QPointF(center.x() + 4.0, center.y() + 3.5)
+					 << QPointF(center.x() - 4.0, center.y() + 3.5);
+			painter->setPen(QPen(QColor("#0D131A"), 1.0));
+			painter->setBrush(m_lampColor);
+			painter->drawPolygon(triangle);
+		} else {
+			painter->setPen(Qt::NoPen);
+			painter->setBrush(cue == SignalCueKind::Proceed
+				? QColor("#4F7A65") : QColor("#66747D"));
+			QRectF tick(center.x() - 1.0, center.y() - 3.0, 2.0, 6.0);
+			painter->drawRect(tick);
+		}
 		return;
 	}
 

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.cpp
@@ -28,7 +28,7 @@ StationOverlayItem::StationOverlayItem(const QString& stationName, const QPointF
 	setFlag(QGraphicsItem::ItemIsSelectable);
 	setAcceptHoverEvents(true);
 	setAcceptedMouseButtons(Qt::NoButton);
-	setZValue(3.0);
+	setZValue(3.5);
 	m_labelFont.setPixelSize(static_cast<int>(kLabelPixels));
 	const QPixmap sourceSymbol(m_visual.iconResource);
 	if (!sourceSymbol.isNull())

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.h
@@ -48,7 +48,7 @@ public:
 
 	static QString elidedIdentifier(const QString& identifier, const QFontMetricsF& metrics,
 		const QRectF& region) {
-		return metrics.elidedText(identifier, Qt::ElideRight, qMax(0.0, region.width()));
+		return metrics.elidedText(identifier, Qt::ElideMiddle, qMax(0.0, region.width()));
 	}
 
 	QRectF boundingRect() const override;

--- a/EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss
+++ b/EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss
@@ -1,24 +1,24 @@
 QMainWindow, QWidget {
-    background: #eef2f5;
-    color: #27333d;
+    background: #f2f3f1;
+    color: #24313a;
 }
 
 QToolBar {
-    background: #f8fafb;
+    background: #fafaf8;
     border: 0;
-    border-bottom: 1px solid #c9d3db;
+    border-bottom: 1px solid #c8ced2;
     spacing: 4px;
     padding: 1px 8px;
 }
 
 QToolBar::separator {
-    background: #c9d3db;
+    background: #c8ced2;
     width: 1px;
     margin: 0 4px;
 }
 
 QLabel#speedSlowerLabel, QLabel#speedFasterLabel {
-    color: #637584;
+    color: #5b6871;
     font-size: 11px;
     padding: 0;
 }
@@ -27,7 +27,7 @@ QToolButton {
     background: transparent;
     border: 1px solid transparent;
     border-radius: 2px;
-    color: #27333d;
+    color: #24313a;
     padding: 4px 6px;
     min-height: 24px;
     max-height: 32px;
@@ -40,47 +40,47 @@ QToolButton#actionZoomInButton, QToolButton#actionZoomOutButton {
 }
 
 QToolButton:hover, QToolButton:focus {
-    background: #e4eef0;
-    border-color: #8eb7b5;
+    background: #e6ecee;
+    border-color: #315a70;
 }
 
 QToolButton:checked {
-    background: #0f7c73;
+    background: #315a70;
     color: #ffffff;
 }
 
 QDockWidget {
-    background: #f8fafb;
-    color: #27333d;
+    background: #fafaf8;
+    color: #24313a;
 }
 
 QDockWidget::title {
-    background: #e3eaee;
-    border-bottom: 1px solid #c9d3db;
+    background: #e8ebea;
+    border-bottom: 1px solid #c8ced2;
     font-weight: 600;
     padding: 6px 8px;
     text-align: left;
 }
 
 QLabel#caseNameLabel {
-    color: #0f625e;
+    color: #315a70;
     font-size: 14px;
     font-weight: 600;
     padding: 3px 0 1px;
 }
 
 QLabel#caseReadinessLabel {
-    color: #536775;
+    color: #5b6871;
     font-size: 11px;
     padding: 0 0 8px;
 }
 
 QLabel#caseReadinessLabel[blocking="true"] {
-    color: #9b3e35;
+    color: #965c22;
 }
 
 QLabel#caseStudyTitleLabel, QLabel#layersTitleLabel {
-    color: #637584;
+    color: #5b6871;
     font-size: 11px;
     font-weight: 600;
     letter-spacing: 0.4px;
@@ -93,23 +93,23 @@ QCheckBox {
 }
 
 QCheckBox[secondaryLayerToggle="true"] {
-    color: #536775;
+    color: #5b6871;
     margin-left: 16px;
 }
 
 QCheckBox:focus {
-    background: #e4eef0;
-    border: 1px solid #0f7c73;
+    background: #e6ecee;
+    border: 1px solid #315a70;
     border-radius: 2px;
 }
 
 QPushButton:focus, QComboBox:focus, QSlider:focus, QLineEdit:focus {
-    outline: 1px solid #0f7c73;
+    outline: 1px solid #315a70;
     outline-offset: 1px;
 }
 
 QToolButton#mapKeyToggle {
-    color: #536775;
+    color: #5b6871;
     font-size: 11px;
     font-weight: 600;
     padding: 5px 2px;
@@ -119,97 +119,97 @@ QToolButton#mapKeyToggle {
 QToolButton#mapKeyToggle:checked {
     background: transparent;
     border-color: transparent;
-    color: #536775;
+    color: #5b6871;
 }
 
 QToolButton#mapKeyToggle:hover, QToolButton#mapKeyToggle:focus {
-    background: #e4eef0;
-    border-color: #8eb7b5;
+    background: #e6ecee;
+    border-color: #315a70;
 }
 
 QWidget#mapKeyBody QLabel {
-    color: #40515e;
+    color: #3f4d56;
     font-size: 11px;
 }
 
 QPushButton:focus, QComboBox:focus, QLineEdit:focus {
-    border-color: #0f7c73;
+    border-color: #315a70;
 }
 
 QPushButton, QComboBox, QLineEdit {
     background: #ffffff;
-    border: 1px solid #c0ccd4;
+    border: 1px solid #c8ced2;
     border-radius: 2px;
     padding: 5px 7px;
 }
 
 QPushButton:hover, QComboBox:hover {
-    border-color: #0f7c73;
+    border-color: #315a70;
 }
 
 QPushButton:pressed {
-    background: #d8ebe9;
+    background: #d8e1e5;
 }
 
 QTabWidget::pane {
-    border: 1px solid #c9d3db;
-    background: #f8fafb;
+    border: 1px solid #c8ced2;
+    background: #fafaf8;
 }
 
 QTabBar::tab {
-    background: #e3eaee;
-    border: 1px solid #c9d3db;
+    background: #e8ebea;
+    border: 1px solid #c8ced2;
     padding: 5px 10px;
 }
 
 QTabBar::tab:selected {
-    background: #0f7c73;
+    background: #315a70;
     color: #ffffff;
 }
 
 QLineEdit[readOnly="true"] {
-    background: #e8edf0;
-    color: #61717d;
-    border-color: #c4cdd3;
+    background: #eceeec;
+    color: #5b6871;
+    border-color: #c8ced2;
 }
 
 QSlider::groove:horizontal {
     height: 4px;
-    background: #c9d3db;
+    background: #c8ced2;
 }
 
 QSlider::handle:horizontal {
     width: 12px;
     margin: -5px 0;
-    border: 2px solid #0f7c73;
+    border: 2px solid #315a70;
     border-radius: 7px;
     background: #ffffff;
 }
 
 QProgressBar {
-    border: 1px solid #c0ccd4;
+    border: 1px solid #c8ced2;
     border-radius: 2px;
-    background: #e8edf0;
-    color: #27333d;
+    background: #eceeec;
+    color: #24313a;
     text-align: right;
 }
 
 QProgressBar::chunk {
-    background: #0f7c73;
+    background: #315a70;
 }
 
 QPlainTextEdit {
-    background: #17232b;
-    color: #d9e4e8;
+    background: #12191f;
+    color: #dde3e5;
 }
 
 QGraphicsView#networkView {
-    background: #101a22;
-    border: 1px solid #2e4655;
+    background: #12191f;
+    border: 1px solid #3a4a54;
 }
 
 QScrollBar:vertical, QScrollBar:horizontal {
-    background: #e4eaee;
+    background: #e8ebea;
     border: 0;
 }
 
@@ -224,7 +224,7 @@ QScrollBar:horizontal {
 }
 
 QScrollBar::handle:vertical, QScrollBar::handle:horizontal {
-    background: #9eacb5;
+    background: #9aa5ab;
     border-radius: 2px;
     min-height: 24px;
     min-width: 24px;
@@ -237,14 +237,14 @@ QScrollBar::add-line, QScrollBar::sub-line {
 }
 
 QStatusBar {
-    background: #e3eaee;
-    border-top: 1px solid #c9d3db;
-    color: #536775;
+    background: #e8ebea;
+    border-top: 1px solid #c8ced2;
+    color: #5b6871;
 }
 
 QMenu {
-    background: #f8fafb;
-    border: 1px solid #c0ccd4;
+    background: #fafaf8;
+    border: 1px solid #c8ced2;
 }
 
 QMenu::item {
@@ -252,6 +252,6 @@ QMenu::item {
 }
 
 QMenu::item:selected {
-    background: #d8ebe9;
-    color: #27333d;
+    background: #d8e1e5;
+    color: #24313a;
 }

--- a/EGTRAIN/QEGTRAIN/tests/test_networklegend.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networklegend.cpp
@@ -43,17 +43,23 @@ int main(int argc, char* argv[]) {
 	ok &= expect(body && body->isVisible(), "map key body is visible while expanded");
 
 	const QVector<NetworkLegendEntry> entries = legend.entries();
-	ok &= expect(entries.size() == 11, "case content produces stable deduplicated entries");
-	ok &= expect(entries.at(0).label == "Prepared route"
-		&& entries.at(0).trackState == TrackOperationalState::Prepared
-		&& entries.at(0).color == classifyTrackState(TrackOperationalState::Prepared).color
-		&& entries.at(0).penStyle == classifyTrackState(TrackOperationalState::Prepared).style,
+	ok &= expect(entries.size() == 12, "case content produces stable deduplicated entries");
+	ok &= expect(entries.at(0).label == "Free track"
+		&& entries.at(0).trackState == TrackOperationalState::Free
+		&& entries.at(0).color == freeTrackVisual().color
+		&& entries.at(0).lineWidth == freeTrackVisual().width
+		&& entries.at(0).penStyle == Qt::SolidLine,
+		"free track entry uses the renderer base style");
+	ok &= expect(entries.at(1).label == "Prepared route"
+		&& entries.at(1).trackState == TrackOperationalState::Prepared
+		&& entries.at(1).color == classifyTrackState(TrackOperationalState::Prepared).color
+		&& entries.at(1).penStyle == classifyTrackState(TrackOperationalState::Prepared).style,
 		"prepared track entry uses renderer classification");
-	ok &= expect(entries.at(1).label == "Occupied section"
-		&& entries.at(1).color == classifyTrackState(TrackOperationalState::Occupied).color,
+	ok &= expect(entries.at(2).label == "Occupied section"
+		&& entries.at(2).color == classifyTrackState(TrackOperationalState::Occupied).color,
 		"occupied track entry uses renderer classification");
-	ok &= expect(entries.at(2).label == "Blocked section"
-		&& entries.at(2).penStyle == classifyTrackState(TrackOperationalState::Blocked).style,
+	ok &= expect(entries.at(3).label == "Blocked section"
+		&& entries.at(3).penStyle == classifyTrackState(TrackOperationalState::Blocked).style,
 		"blocked track entry keeps its non-color cue");
 
 	int intercityCount = 0;

--- a/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
@@ -5,6 +5,8 @@
 
 #include <QApplication>
 #include <QGraphicsRectItem>
+#include <QImage>
+#include <QPainter>
 #include <QWheelEvent>
 #include <cmath>
 #include <iostream>
@@ -27,8 +29,29 @@ static bool endpointInside(const NetworkView& view, const QPointF& point) {
 		&& mapped.y() <= viewport.height() - 24;
 }
 
+class TestNetworkView : public NetworkView {
+public:
+	using NetworkView::drawBackground;
+};
+
 int main(int argc, char** argv) {
 	QApplication app(argc, argv);
+	TestNetworkView backgroundView;
+	QImage background(160, 160, QImage::Format_RGB32);
+	background.fill(Qt::magenta);
+	{
+		QPainter painter(&background);
+		backgroundView.drawBackground(&painter, QRectF(0.0, 0.0, 160.0, 160.0));
+	}
+	bool uniformBackground = true;
+	for (int y = 0; y < background.height() && uniformBackground; ++y) {
+		for (int x = 0; x < background.width(); ++x) {
+			if (background.pixelColor(x, y) != QColor("#12191F")) {
+				uniformBackground = false;
+				break;
+			}
+		}
+	}
 	NetworkView view;
 	QGraphicsScene scene;
 	view.setScene(&scene);
@@ -46,6 +69,7 @@ int main(int argc, char** argv) {
 	farOverlay->setFlag(QGraphicsItem::ItemIgnoresTransformations);
 
 	bool ok = true;
+	ok &= expect(uniformBackground, "operational canvas has one semantic background color and no grid");
 	view.fitToTopology();
 	const QRectF topology = view.topologyBounds();
 	const qreal fittedScale = view.fittedScale();

--- a/EGTRAIN/QEGTRAIN/tests/test_stationoverlay.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_stationoverlay.cpp
@@ -51,6 +51,8 @@ int main(int argc, char* argv[]) {
 	StationVisual platform = classifyStation(true, 1);
 	StationVisual stopVisual = classifyStation(false, 0);
 	StationOverlayItem overlay("KogeNord", QPointF(40.0, 50.0), platform);
+	ok &= expect(overlay.zValue() > 3.0 && overlay.zValue() < 5.0,
+		"station text paints above signals and below train badges");
 	ok &= expect(overlay.flags().testFlag(QGraphicsItem::ItemIsSelectable),
 		"overlay remains programmatically selectable");
 	const QRectF symbol = overlay.symbolRect();

--- a/EGTRAIN/QEGTRAIN/tests/test_timeprogressbar.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_timeprogressbar.cpp
@@ -1,6 +1,7 @@
 #include "widgets/TimeProgressBar.h"
 
 #include <QApplication>
+#include <QFontDatabase>
 #include <QMouseEvent>
 #include <QWheelEvent>
 #include <iostream>
@@ -35,6 +36,10 @@ int main(int argc, char** argv) {
 		"last timestep text is exact");
 	ok &= expect(bar.height() == 28 && bar.focusPolicy() == Qt::NoFocus,
 		"timeline has fixed height and no focus");
+	ok &= expect(bar.font().family() == QFontDatabase::systemFont(QFontDatabase::FixedFont).family(),
+		"timeline uses the system fixed-width font for clock and step columns");
+	ok &= expect(bar.font().fixedPitch(),
+		"timeline font has fixed character widths");
 
 	const int beforeInput = bar.value();
 	QMouseEvent mouse(QEvent::MouseButtonPress, QPointF(10.0, 10.0), Qt::LeftButton,

--- a/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
@@ -2,7 +2,10 @@
 
 #include <QGuiApplication>
 #include <QFontMetricsF>
+#include <QImage>
+#include <QPainter>
 
+#include "graphics/items/SignalItem.h"
 #include "graphics/items/TrainBadgeItem.h"
 
 #include <iostream>
@@ -13,25 +16,87 @@ static bool expect(bool condition, const char* message) {
 	return condition;
 }
 
+struct RenderedCue {
+	int paintedPixels = 0;
+	QRect bounds;
+};
+
+static QByteArray renderStrokeMask(int width, Qt::PenStyle style) {
+	QImage image(96, 20, QImage::Format_ARGB32_Premultiplied);
+	image.fill(Qt::transparent);
+	{
+		QPainter painter(&image);
+		painter.setRenderHint(QPainter::Antialiasing, false);
+		QPen pen(Qt::black, width, style);
+		painter.setPen(pen);
+		painter.drawLine(QLineF(4.0, 10.0, 91.0, 10.0));
+	}
+	QByteArray mask;
+	mask.reserve(image.width() * image.height());
+	for (int y = 0; y < image.height(); ++y)
+		for (int x = 0; x < image.width(); ++x)
+			mask.append(image.pixelColor(x, y).alpha() > 0 ? '1' : '0');
+	return mask;
+}
+
+static RenderedCue renderCompactSignal(int aspectCode) {
+	QImage image(32, 32, QImage::Format_ARGB32_Premultiplied);
+	image.fill(Qt::transparent);
+	SignalItem signal(QRectF(-6.0, -8.0, 12.0, 16.0));
+	signal.setAspectCode(aspectCode);
+	signal.setCompact(true);
+	{
+		QPainter painter(&image);
+		painter.translate(16.0, 16.0);
+		signal.paint(&painter, nullptr, nullptr);
+	}
+
+	RenderedCue result;
+	int left = image.width();
+	int top = image.height();
+	int right = -1;
+	int bottom = -1;
+	for (int y = 0; y < image.height(); ++y) {
+		for (int x = 0; x < image.width(); ++x) {
+			if (image.pixelColor(x, y).alpha() == 0)
+				continue;
+			++result.paintedPixels;
+			left = qMin(left, x);
+			top = qMin(top, y);
+			right = qMax(right, x);
+			bottom = qMax(bottom, y);
+		}
+	}
+	if (right >= left && bottom >= top)
+		result.bounds = QRect(QPoint(left, top), QPoint(right, bottom));
+	return result;
+}
+
 int main(int argc, char* argv[]) {
 	qputenv("QT_QPA_PLATFORM", "offscreen");
 	QGuiApplication app(argc, argv);
 	bool ok = true;
-	ok &= expect(classifyTrackSpeed(83.4).kind == TrackVisualKind::HighSpeed, "high-speed track classification");
-	ok &= expect(classifyTrackSpeed(44.5).kind == TrackVisualKind::Mainline, "mainline track classification");
-	ok &= expect(classifyTrackSpeed(19.0).kind == TrackVisualKind::Local, "local track classification");
+	const TrackVisual freeBase = freeTrackVisual();
+	ok &= expect(freeBase.color == QColor("#A0ACB4"), "free track uses the neutral base color");
+	ok &= expect(freeBase.width == 2, "free track uses one documented overview width");
 
 	const TrackStateVisual freeTrack = classifyTrackState(TrackOperationalState::Free);
 	const TrackStateVisual preparedTrack = classifyTrackState(TrackOperationalState::Prepared);
 	const TrackStateVisual occupiedTrack = classifyTrackState(TrackOperationalState::Occupied);
 	const TrackStateVisual blockedTrack = classifyTrackState(TrackOperationalState::Blocked);
 	ok &= expect(freeTrack.style == Qt::NoPen && freeTrack.width == 0, "free track has no underlay");
-	ok &= expect(preparedTrack.style == Qt::SolidLine && preparedTrack.width == 8, "prepared track underlay");
-	ok &= expect(occupiedTrack.style == Qt::SolidLine && occupiedTrack.width == 10, "occupied track underlay");
+	ok &= expect(preparedTrack.style == Qt::DashDotLine && preparedTrack.width == 6, "prepared track underlay");
+	ok &= expect(occupiedTrack.style == Qt::SolidLine && occupiedTrack.width == 8, "occupied track underlay");
 	ok &= expect(blockedTrack.style == Qt::DashLine && blockedTrack.width == 8, "blocked track has non-color cue");
-	ok &= expect(preparedTrack.color == QColor("#2ECC71"), "prepared track color");
-	ok &= expect(occupiedTrack.color == QColor("#EF5350"), "occupied track color");
-	ok &= expect(blockedTrack.color == QColor("#F2A516"), "blocked track color");
+	ok &= expect(preparedTrack.color == QColor("#4C8DAE"), "prepared track color");
+	ok &= expect(occupiedTrack.color == QColor("#D05A47"), "occupied track color");
+	ok &= expect(blockedTrack.color == QColor("#D6A13A"), "blocked track color");
+	const QByteArray preparedMask = renderStrokeMask(preparedTrack.width, preparedTrack.style);
+	const QByteArray occupiedMask = renderStrokeMask(occupiedTrack.width, occupiedTrack.style);
+	const QByteArray blockedMask = renderStrokeMask(blockedTrack.width, blockedTrack.style);
+	ok &= expect(preparedMask != occupiedMask && occupiedMask != blockedMask
+		&& preparedMask != blockedMask,
+		"track states remain distinguishable by stroke structure without color");
 	ok &= expect(trackStatePriority(TrackOperationalState::Free) < trackStatePriority(TrackOperationalState::Prepared), "free track priority");
 	ok &= expect(trackStatePriority(TrackOperationalState::Prepared) < trackStatePriority(TrackOperationalState::Occupied), "prepared track priority");
 	ok &= expect(trackStatePriority(TrackOperationalState::Occupied) < trackStatePriority(TrackOperationalState::Blocked), "occupied track priority");
@@ -48,6 +113,18 @@ int main(int argc, char* argv[]) {
 	ok &= expect(classifySignalAspect(0).iconResource == ":/icons/signal-stop.svg", "stop signal icon");
 	ok &= expect(classifySignalAspect(75).iconResource == ":/icons/signal-caution.svg", "caution signal icon");
 	ok &= expect(classifySignalAspect(180).iconResource == ":/icons/signal-proceed.svg", "proceed signal icon");
+	const RenderedCue compactStop = renderCompactSignal(0);
+	const RenderedCue compactCaution = renderCompactSignal(75);
+	const RenderedCue compactProceed = renderCompactSignal(180);
+	ok &= expect(compactStop.bounds.width() >= 7 && compactStop.bounds.height() >= 7,
+		"compact stop cue stays prominent at overview zoom");
+	ok &= expect(compactCaution.bounds.width() >= 7 && compactCaution.bounds.height() >= 7,
+		"compact caution cue stays prominent at overview zoom");
+	ok &= expect(compactProceed.bounds.width() <= 3 && compactProceed.bounds.height() <= 8,
+		"compact proceed cue collapses to a subdued tick");
+	ok &= expect(compactProceed.paintedPixels < compactStop.paintedPixels
+		&& compactProceed.paintedPixels < compactCaution.paintedPixels,
+		"repeated proceed cues carry less visual weight than stop and caution");
 
 	ok &= expect(classifyTrainType("freight", "F01").kind == TrainVisualKind::Freight, "freight train classification");
 	ok &= expect(classifyTrainType("IC", "IC 2201").kind == TrainVisualKind::Intercity, "intercity train classification");
@@ -61,6 +138,18 @@ int main(int argc, char* argv[]) {
 	const TrainVisual intercity = classifyTrainType("IC", "IC 2201");
 	const TrainVisual sprinter = classifyTrainType("", "sprinter 301");
 	const TrainVisual freight = classifyTrainType("freight", "F01");
+	const TrainVisual highSpeed = classifyTrainType("", "ICE 10");
+	const TrainVisual passenger = classifyTrainType("", "regional");
+	ok &= expect(passenger.fill == QColor("#9BA5AA") && passenger.outline == QColor("#4A5960"),
+		"passenger train uses the neutral instrument palette");
+	ok &= expect(sprinter.fill == QColor("#86AA96") && sprinter.outline == QColor("#3F6A54"),
+		"sprinter train uses the muted green palette");
+	ok &= expect(intercity.fill == QColor("#C6A86E") && intercity.outline == QColor("#765623"),
+		"intercity train uses the muted brass palette");
+	ok &= expect(highSpeed.fill == QColor("#86A6B9") && highSpeed.outline == QColor("#3E627A"),
+		"high-speed train uses the steel blue palette");
+	ok &= expect(freight.fill == QColor("#A99787") && freight.outline == QColor("#5D4C3F"),
+		"freight train uses the muted brown palette");
 	ok &= expect(intercity.fill != sprinter.fill && intercity.fill != freight.fill && sprinter.fill != freight.fill,
 		"train category contrast");
 	ok &= expect(intercity.shape == TrainBadgeShape::Capsule, "intercity badge shape");
@@ -96,6 +185,10 @@ int main(int argc, char* argv[]) {
 	const QRectF categoryIcon = TrainBadgeItem::iconRect(denseBody, false);
 	const QString displayedIdentifier = TrainBadgeItem::elidedIdentifier(
 		longIdentifier, badgeMetrics, identifierRegion);
+	const QString serviceOne = TrainBadgeItem::elidedIdentifier(
+		"H-Ballerup-Osterport-1", badgeMetrics, QRectF(0.0, 0.0, 90.0, 20.0));
+	const QString serviceTwo = TrainBadgeItem::elidedIdentifier(
+		"H-Ballerup-Osterport-2", badgeMetrics, QRectF(0.0, 0.0, 90.0, 20.0));
 	TrainBadgeItem speedBadge;
 	speedBadge.setSpeedText(speedText);
 	speedBadge.setSpeedVisible(false);
@@ -106,6 +199,8 @@ int main(int argc, char* argv[]) {
 		"long identifier needs elision");
 	ok &= expect(badgeMetrics.horizontalAdvance(displayedIdentifier) <= identifierRegion.width(),
 		"elided identifier fits its region");
+	ok &= expect(serviceOne != serviceTwo && serviceOne.endsWith('1') && serviceTwo.endsWith('2'),
+		"middle elision preserves distinguishing service suffixes");
 	ok &= expect(identifierRegion.right() <= speedRegion.left(),
 		"identifier and speed regions do not overlap");
 	ok &= expect(categoryIcon.right() <= identifierRegion.left(),

--- a/EGTRAIN/QEGTRAIN/widgets/NetworkLegendWidget.cpp
+++ b/EGTRAIN/QEGTRAIN/widgets/NetworkLegendWidget.cpp
@@ -85,14 +85,21 @@ QString stationLabel(StationVisualKind kind) {
 }
 
 NetworkLegendEntry trackEntry(const QString& label, TrackOperationalState state) {
-	const TrackStateVisual visual = classifyTrackState(state);
 	NetworkLegendEntry entry;
 	entry.kind = NetworkLegendEntryKind::Track;
 	entry.label = label;
 	entry.trackState = state;
-	entry.color = visual.color;
-	entry.lineWidth = visual.width;
-	entry.penStyle = visual.style;
+	if (state == TrackOperationalState::Free) {
+		const TrackVisual visual = freeTrackVisual();
+		entry.color = visual.color;
+		entry.lineWidth = visual.width;
+		entry.penStyle = Qt::SolidLine;
+	} else {
+		const TrackStateVisual visual = classifyTrackState(state);
+		entry.color = visual.color;
+		entry.lineWidth = visual.width;
+		entry.penStyle = visual.style;
+	}
 	return entry;
 }
 
@@ -164,7 +171,8 @@ NetworkLegendWidget::NetworkLegendWidget(QWidget* parent)
 void NetworkLegendWidget::setCaseContent(const NetworkLegendContent& content) {
 	m_entries.clear();
 	if (content.hasTracks) {
-		m_entries << trackEntry("Prepared route", TrackOperationalState::Prepared)
+		m_entries << trackEntry("Free track", TrackOperationalState::Free)
+				  << trackEntry("Prepared route", TrackOperationalState::Prepared)
 				  << trackEntry("Occupied section", TrackOperationalState::Occupied)
 				  << trackEntry("Blocked section", TrackOperationalState::Blocked);
 	}

--- a/EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.cpp
+++ b/EGTRAIN/QEGTRAIN/widgets/TimeProgressBar.cpp
@@ -1,12 +1,18 @@
 #include "widgets/TimeProgressBar.h"
 #include "util/TimeFormat.h"
 
+#include <QFontDatabase>
+
 TimeProgressBar::TimeProgressBar(QWidget* parent)
 	: QProgressBar(parent) {
 	setTextVisible(true);
 	setFixedHeight(28);
 	setFocusPolicy(Qt::NoFocus);
 	setCursor(Qt::ArrowCursor);
+	QFont timelineFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+	timelineFont.setStyleHint(QFont::TypeWriter);
+	timelineFont.setFixedPitch(true);
+	setFont(timelineFont);
 }
 
 TimeProgressBar::~TimeProgressBar() {

--- a/docs/ui/renderer-style-map.md
+++ b/docs/ui/renderer-style-map.md
@@ -1,6 +1,6 @@
 # Renderer style map
 
-This map is the visual contract for the network playback primitives. State colors stay restrained so topology remains visible below the overlay.
+This map is the visual contract for the network playback primitives. State colors stay restrained so topology remains visible below operational overlays.
 
 ## Track operational state
 
@@ -8,12 +8,14 @@ This map is the visual contract for the network playback primitives. State color
 
 | State | Priority | Color | Pen | Meaning |
 | --- | ---: | --- | --- | --- |
-| Free | 0 | none (`#00000000`) | no underlay | No operational reservation or occupation is reported. |
-| Prepared | 1 | `#2ECC71` | solid, 8 px | A route is prepared for movement. |
-| Occupied | 2 | `#EF5350` | solid, 10 px | A train or other movement occupies the section. |
-| Blocked | 3 | `#F2A516` | dashed, 8 px | The section is unavailable or restricted. The dash pattern remains visible in monochrome output. |
+| Free | 0 | `#A0ACB4` | solid, 2 px | No operational reservation or occupation is reported. |
+| Prepared | 1 | `#4C8DAE` | dash-dot, 6 px | A route is prepared for movement. |
+| Occupied | 2 | `#D05A47` | solid, 8 px | A train or other movement occupies the section. |
+| Blocked | 3 | `#D6A13A` | dashed, 8 px | The section is unavailable or restricted. |
 
-`TrackLineItem` paints the operational underlay first, then its normal track pen. Free sections skip the underlay, so the existing topology pen remains the only stroke.
+`TrackLineItem`, `VirtualArcItem`, and `ConnectionItem` use the free-track style for base topology. `TrackLineItem` paints an operational underlay before that base stroke. Prepared, occupied, and blocked states differ by width and pen style as well as color.
+
+Measured against the `#12191F` canvas, the contrast ratios are 7.64:1 for free, 4.84:1 for prepared, 4.42:1 for occupied, and 7.61:1 for blocked. Each exceeds the 3:1 target for graphical objects.
 
 ## Signal aspect
 
@@ -27,11 +29,21 @@ This map is the visual contract for the network playback primitives. State color
 | 270 | green (`#00ff00`) | proceed chevron |
 | other | neutral gray (`#808080`) | none |
 
-`SignalItem` draws a fixed 12 by 16 housing, a lamp cue, and a direction cue while ignoring view transformations. `setReversedDirection(true)` points the direction cue left; `false` points it right. Existing callers that still set the public `reversedDirection` field are supported.
+`SignalItem` ignores view transformations. Below 3x, stop uses a prominent red circle with a bar, caution uses a prominent yellow triangle, and repeated proceed signals use a small muted-green tick. Signal posts and bases are hidden at this scale. At 3x and above, the full 12 by 16 housing, aspect icon, direction cue, post, and base return. `setReversedDirection(true)` points the direction cue left; `false` points it right.
 
 ## Train categories
 
-Train badges reuse the existing `TrainVisual` palette and a shape classification. Intercity is a capsule, Sprinter is rounded, and Freight is square, so the categories remain distinct without relying on color alone. The badge keeps its identifier and optional speed text in one `QGraphicsItem` with `ItemIgnoresTransformations`, so labels stay readable while the map zooms.
+Train badges use the following fill and outline pairs:
+
+| Category | Fill | Outline | Shape |
+| --- | --- | --- | --- |
+| Passenger | `#9BA5AA` | `#4A5960` | rounded |
+| Sprinter | `#86AA96` | `#3F6A54` | rounded |
+| Intercity | `#C6A86E` | `#765623` | capsule |
+| High speed | `#86A6B9` | `#3E627A` | rounded |
+| Freight | `#A99787` | `#5D4C3F` | square |
+
+Shape remains a second category cue. The badge keeps its identifier and optional speed text in one `QGraphicsItem` with `ItemIgnoresTransformations`. Long identifiers use middle elision so a distinguishing service suffix remains visible.
 
 ## Entity icons
 
@@ -41,8 +53,8 @@ Stations render at 24 by 24 screen pixels. Stop stations use a white roundel, pl
 
 The application loads these assets through the Qt resource aliases under `:/icons/`. `MainWindow`, `TrainBadgeItem`, and `SignalItem` cache the pixmaps and draw them with smooth transformation. Station, passenger, train badge, and signal overlays ignore view transformations so their screen sizes remain stable while the network zooms.
 
-## Surface, grid, and low zoom
+## Application surfaces
 
-`NetworkView` paints a dark neutral surface (`#101A22`) and a grid (`#1B2A35`) in `drawBackground()`. The grid uses no scene items. Its scene spacing doubles or halves around an 80-unit base so grid lines stay between 24 and 96 device pixels apart. At low zoom the grid therefore thins instead of filling the viewport, while badges and the legend remain screen-sized.
+The application shell is `#F2F3F1`, panels are `#FAFAF8`, primary text is `#24313A`, and dividers are `#C8CED2`. Primary actions and keyboard focus use `#315A70`. Warnings use `#965C22`.
 
-`NetworkLegendItem` uses the same track and train colors for prepared, occupied, blocked, Intercity, Sprinter, and Freight entries. It also ignores view transformations.
+`NetworkView` paints one dark neutral surface, `#12191F`, inside a `#3A4A54` border. It has no adaptive grid because the schematic has no displayed distance or coordinate unit. The map key lives in the Case and Layers panel and uses the same renderer classifications as the canvas.


### PR DESCRIPTION
## What changed

- Replaced undocumented speed-tier track widths with one neutral 2 px free-track stroke.
- Gave prepared, occupied, and blocked states distinct widths and pen patterns.
- Reduced overview signal clutter while keeping stop and caution cues prominent. Full signal structures return at 3x.
- Applied the documented shell, canvas, and train palette.
- Added the free-track entry to the map key, middle-elided train identifiers, and fixed-width timeline text.
- Kept case-study signal suppression intact during zoom and layer refreshes.

The renderer now reads as a railway schematic without relying on color alone. The dark canvas stays separate from the light application shell, and operational overlays remain visible against the base topology.

## Verification

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` with 42 of 42 tests passing
- `tools/e2e/visual_polish_smoke.sh`
- DPR1 and DPR2 captures at 1024 by 720, 1200 by 800, and 1440 by 900
- Station-overlay checks for all four bundled cases at Fit, 3x, and 12x
- WCAG contrast ratios against `#12191F`: free 7.64:1, prepared 4.84:1, occupied 4.42:1, blocked 7.61:1

Station-marker crowding at overview zoom is tracked in #252.

Closes #235
