### PR TITLE
Fix Windows Qt list comparison

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -4753,7 +4753,8 @@ void MainWindow::runVisualPolishE2E() {
 			if (!first)
 				break;
 		}
-		if (actual != expected) {
+		if (actual.size() != expected.size()
+			|| !std::equal(actual.begin(), actual.end(), expected.begin())) {
 			ok = false;
 			failures << QString("command-bar Tab traversal order mismatch: %1").arg(actual.join(", "));
 		}

--- a/tools/e2e/test_windows_subsystem_config.py
+++ b/tools/e2e/test_windows_subsystem_config.py
@@ -23,6 +23,12 @@ def test_preview_snapshot_comparator() -> None:
             raise SystemExit("QList equality detector misses reversed or parenthesized operands")
 
     source = (ROOT / "EGTRAIN/QEGTRAIN/app/MainWindow.cpp").read_text(encoding="utf-8")
+    if not re.search(
+        r"if\s*\(\s*actual\.size\(\)\s*!=\s*expected\.size\(\)\s*"
+        r"\|\|\s*!std::equal\(actual\.begin\(\),\s*actual\.end\(\),\s*expected\.begin\(\)\)\s*\)",
+        source,
+    ):
+        raise SystemExit("Tab traversal comparison must size-check before std::equal")
     match = re.search(
         r"auto samePreviewContent = \[\]\(const PreviewContentSnapshot& left, "
         r"const PreviewContentSnapshot& right\) \{(?P<body>.*?)\n\t\};",


### PR DESCRIPTION
## Summary

- avoid Qt 5 `QStringList::operator!=` instantiation in the command-bar smoke on current MSVC
- preserve ordered comparison semantics with an explicit size guard and `std::equal`
- extend the Windows portability regression check

## Verification

- `cmake -S . -B build -DEGTRAIN_BUILD_TESTS=ON -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt@5`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (42/42 passed)
- `tools/e2e/visual_polish_smoke.sh`