### PR TITLE
Fix remaining Qt list comparisons

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -5144,7 +5144,11 @@ void MainWindow::runVisualPolishE2E() {
 			failures << "PAX enabled but no visible passenger-owned graphics rendered";
 		}
 		checkItemLayer(passengerLayer, passengerItems, "passenger load");
-		if (!m_networkLegendWidget || m_networkLegendWidget->entryLabels() != mapKeyEntries) {
+		const QStringList currentMapKeyEntries = m_networkLegendWidget
+			? m_networkLegendWidget->entryLabels() : QStringList();
+		if (!m_networkLegendWidget
+			|| currentMapKeyEntries.size() != mapKeyEntries.size()
+			|| !std::equal(currentMapKeyEntries.cbegin(), currentMapKeyEntries.cend(), mapKeyEntries.cbegin())) {
 			ok = false;
 			failures << "layer toggles changed or reordered map key entries";
 		}

--- a/EGTRAIN/QEGTRAIN/tests/test_networklegend.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networklegend.cpp
@@ -5,6 +5,7 @@
 #include <QRegularExpression>
 #include <QToolButton>
 
+#include <algorithm>
 #include <iostream>
 
 static bool expect(bool condition, const char* message) {
@@ -99,7 +100,9 @@ int main(int argc, char* argv[]) {
 	ok &= expect(!legend.isExpanded() && body && !body->isVisible(), "map key collapses");
 	ok &= expect(header && header->isVisible(), "map key header remains visible while collapsed");
 	legend.setExpanded(true);
-	ok &= expect(legend.entryLabels() == labelsBeforeCollapse,
+	const QStringList labelsAfterExpand = legend.entryLabels();
+	ok &= expect(labelsAfterExpand.size() == labelsBeforeCollapse.size()
+		&& std::equal(labelsAfterExpand.cbegin(), labelsAfterExpand.cend(), labelsBeforeCollapse.cbegin()),
 		"collapsing does not change map key entries");
 
 	for (QLabel* row : legend.findChildren<QLabel*>(QRegularExpression("^mapKeyEntry")))

--- a/tools/e2e/test_windows_subsystem_config.py
+++ b/tools/e2e/test_windows_subsystem_config.py
@@ -14,6 +14,16 @@ def _has_direct_qlist_equality(text: str) -> bool:
     )
 
 
+def _has_direct_entry_label_equality(text: str) -> bool:
+    normalized = re.sub(r"[\s()]", "", text)
+    entry_labels = r"(?:[A-Za-z_]\w*(?:\.|->))*entryLabels"
+    return any(
+        re.search(rf"(?:{entry_labels}{operator}{other}|{other}{operator}{entry_labels})", normalized)
+        for other in ("mapKeyEntries", "labelsBeforeCollapse")
+        for operator in ("==", "!=")
+    )
+
+
 def test_preview_snapshot_comparator() -> None:
     for sample in (
         "( ( left . items ) ) == ( right.items )",
@@ -22,7 +32,21 @@ def test_preview_snapshot_comparator() -> None:
         if not _has_direct_qlist_equality(sample):
             raise SystemExit("QList equality detector misses reversed or parenthesized operands")
 
+    for sample in (
+        "entryLabels() != (mapKeyEntries)",
+        "labelsBeforeCollapse == ((legend.entryLabels()))",
+    ):
+        if not _has_direct_entry_label_equality(sample):
+            raise SystemExit("entryLabels comparison detector misses reversed or parenthesized operands")
+
     source = (ROOT / "EGTRAIN/QEGTRAIN/app/MainWindow.cpp").read_text(encoding="utf-8")
+    test_source = (ROOT / "EGTRAIN/QEGTRAIN/tests/test_networklegend.cpp").read_text(encoding="utf-8")
+    for path, text in (
+        ("MainWindow.cpp", source),
+        ("test_networklegend.cpp", test_source),
+    ):
+        if _has_direct_entry_label_equality(text):
+            raise SystemExit(f"{path} still compares entryLabels directly")
     if not re.search(
         r"if\s*\(\s*actual\.size\(\)\s*!=\s*expected\.size\(\)\s*"
         r"\|\|\s*!std::equal\(actual\.begin\(\),\s*actual\.end\(\),\s*expected\.begin\(\)\)\s*\)",


### PR DESCRIPTION
## Summary

- remove the remaining direct `QStringList` comparison from the map-key visual smoke
- make the network legend regression test portable to current MSVC
- harden the Windows portability check against qualified, reversed, and parenthesized comparisons

## Context

The first repair removed the comparison reported by earlier runs. Post-merge Release run `30747403020` exposed the remaining production comparison at `MainWindow.cpp:5147`.

## Verification

- full build passed
- full CTest: 41/42 passed before the detector correction; only the detector self-check failed
- corrected `test_windows_subsystem_config` passed
- complete `tools/e2e/visual_polish_smoke.sh` passed
- final review found no issues