### PR TITLE
Simplify network canvas rendering and startup fitting

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -8108,8 +8108,6 @@ void MainWindow::paintStationPlatform(QPointF coord, int size, int pen_width, No
 	// add item to allPlatforms list
 	allPlatforms.push_back(platformItem);
 
-	// fit to window
-	networkView->fitInView(scene->sceneRect(), Qt::KeepAspectRatio);
 }
 
 // paint train passenger info on top of train
@@ -8283,8 +8281,6 @@ void MainWindow::arcDrawing(QPointF start, QPointF end, int pen_width, int track
 	// add item to scene
 	scene->addItem(line);
 
-	// fit to window
-	networkView->fitInView(scene->sceneRect(), Qt::KeepAspectRatio);
 }
 
 // draws a connection
@@ -8304,8 +8300,6 @@ void MainWindow::paintConnection(QPointF start, QPointF end, int pen_width, Conn
 	// add item to scene
 	scene->addItem(line);
 
-	// fit to window
-	networkView->fitInView(scene->sceneRect(), Qt::KeepAspectRatio);
 }
 
 // draws trackside signals (X is the beginning of the block section - except for the last signal of each trackline)
@@ -8464,14 +8458,6 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	addSignalDecoration(post2);
 	addSignalDecoration(plate2);
 	addSignalDecoration(basis2);
-
-	// match the current zoom before the next viewportChanged fires
-	const bool compactSignals = !detailedSignals;
-	plate1->setCompact(compactSignals);
-	plate2->setCompact(compactSignals);
-
-	// fit to window
-	networkView->fitInView(scene->sceneRect(), Qt::KeepAspectRatio);
 
 	// add signals to allSignals list
 	allSignals.push_back(plate1);
@@ -11204,18 +11190,13 @@ void MainWindow::updateViewportOverlays() {
 		overlay->setLayoutVisible(visible);
 	}
 
-	// Signal plates stay available at overview as aspect cues. Posts and bases
-	// return with the full housings only at detailed zoom.
+	// Markers remain available at overview; trackside posts return at detail zoom.
 	for (auto* item : m_signalDecorations) {
 		if (!item)
 			continue;
 		const bool baseVisible = item->data(kSignalBaseVisibleRole).toBool();
-		if (auto* signal = qgraphicsitem_cast<SignalItem*>(item)) {
-			signal->setCompact(!dense);
-			signal->setVisible(m_signalLayerVisible && baseVisible);
-		} else {
-			item->setVisible(m_signalLayerVisible && baseVisible && dense);
-		}
+		item->setVisible(m_signalLayerVisible && baseVisible
+			&& (qgraphicsitem_cast<SignalItem*>(item) || dense));
 	}
 
 	const bool paxText = paxTextVisible();

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.cpp
@@ -21,7 +21,7 @@ NetworkView::NetworkView(QWidget* parent)
 
 	setMouseTracking(true);
 	setSceneRect(QRectF(0, 0, 0, 0));
-	setBackgroundBrush(QColor("#12191F"));
+	setBackgroundBrush(Qt::black);
 	setRenderHints(QPainter::Antialiasing | QPainter::HighQualityAntialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
 	setDragMode(QGraphicsView::ScrollHandDrag);
 	setTransformationAnchor(QGraphicsView::AnchorViewCenter);
@@ -221,10 +221,6 @@ void NetworkView::wheelEvent(QWheelEvent* event) {
 	} else {
 		QGraphicsView::wheelEvent(event);
 	}
-}
-
-void NetworkView::drawBackground(QPainter* painter, const QRectF& rect) {
-	painter->fillRect(rect, QColor("#12191F"));
 }
 
 void NetworkView::resizeEvent(QResizeEvent* event) {

--- a/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
+++ b/EGTRAIN/QEGTRAIN/graphics/NetworkView.h
@@ -41,7 +41,6 @@ public:
 
 protected:
 	void wheelEvent(QWheelEvent* event) override;
-	void drawBackground(QPainter* painter, const QRectF& rect) override;
 	void resizeEvent(QResizeEvent* event) override;
 	void scrollContentsBy(int dx, int dy) override;
 

--- a/EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/VisualPolish.cpp
@@ -28,11 +28,11 @@ TrackVisual freeTrackVisual() {
 TrackStateVisual classifyTrackState(TrackOperationalState state) {
 	switch (state) {
 	case TrackOperationalState::Prepared:
-		return {QColor("#4C8DAE"), 6, Qt::DashDotLine};
+		return {QColor("#4C8DAE"), 5, Qt::DashDotLine};
 	case TrackOperationalState::Occupied:
-		return {QColor("#D05A47"), 8, Qt::SolidLine};
+		return {QColor("#D05A47"), 6, Qt::SolidLine};
 	case TrackOperationalState::Blocked:
-		return {QColor("#D6A13A"), 8, Qt::DashLine};
+		return {QColor("#D6A13A"), 5, Qt::DashLine};
 	case TrackOperationalState::Free:
 	default:
 		return {Qt::transparent, 0, Qt::NoPen};

--- a/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.cpp
@@ -1,13 +1,10 @@
 #include "graphics/items/SignalItem.h"
 
+#include "graphics/VisualPolish.h"
+
 SignalItem::SignalItem(const QRectF& rect, QGraphicsItem* parent)
-	: QGraphicsEllipseItem(rect, parent), m_aspectCode(-1), m_aspectIcon(":/icons/signal-neutral.svg"), m_compact(false) {
-	setFlag(QGraphicsItem::ItemIgnoresTransformations);
+	: QGraphicsEllipseItem(rect, parent), m_aspectCode(-1), m_lampColor(QColor(128, 128, 128)) {
 	setZValue(2); // draw over arcs and connections (which have z = 0), and nodes (z = 1)
-	QRectF fixedHousing = rect;
-	fixedHousing.setSize(QSizeF(12.0, 16.0));
-	fixedHousing.moveCenter(rect.center());
-	setRect(fixedHousing);
 
 	// initialize parameters
 	trackID = -1;
@@ -25,9 +22,7 @@ void SignalItem::setAspectCode(int code) {
 	if (m_aspectCode == code)
 		return;
 	m_aspectCode = code;
-	const SignalVisual visual = classifySignalAspect(code);
-	m_aspectIcon = QPixmap(visual.iconResource);
-	m_lampColor = visual.lamp;
+	m_lampColor = classifySignalAspect(code).lamp;
 	update();
 }
 
@@ -42,63 +37,36 @@ void SignalItem::setReversedDirection(bool reversed) {
 	update();
 }
 
-void SignalItem::setCompact(bool compact) {
-	if (m_compact == compact)
-		return;
-	m_compact = compact;
-	update();
-}
-
 void SignalItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
 	Q_UNUSED(option);
 	Q_UNUSED(widget);
 
-	// At overview zoom the fixed-size housings overlap into solid bands, so
-	// keep stop and caution distinct while repeated proceed signals recede.
-	if (m_compact) {
-		const SignalCueKind cue = classifySignalCue(m_aspectCode);
-		const QPointF center = rect().center();
-		if (cue == SignalCueKind::Stop) {
-			const QRectF lamp(center.x() - 4.0, center.y() - 4.0, 8.0, 8.0);
-			painter->setPen(QPen(QColor("#0D131A"), 1.0));
-			painter->setBrush(m_lampColor);
-			painter->drawEllipse(lamp);
-			painter->drawLine(QLineF(lamp.left() + 2.0, center.y(), lamp.right() - 2.0, center.y()));
-		} else if (cue == SignalCueKind::Caution) {
-			QPolygonF triangle;
-			triangle << QPointF(center.x(), center.y() - 4.0)
-					 << QPointF(center.x() + 4.0, center.y() + 3.5)
-					 << QPointF(center.x() - 4.0, center.y() + 3.5);
-			painter->setPen(QPen(QColor("#0D131A"), 1.0));
-			painter->setBrush(m_lampColor);
-			painter->drawPolygon(triangle);
-		} else {
-			painter->setPen(Qt::NoPen);
-			painter->setBrush(cue == SignalCueKind::Proceed
-				? QColor("#4F7A65") : QColor("#66747D"));
-			QRectF tick(center.x() - 1.0, center.y() - 3.0, 2.0, 6.0);
-			painter->drawRect(tick);
-		}
-		return;
+	QPen effectPen = pen();
+	effectPen.setColor(Qt::blue);
+
+	// change line color when selected
+	if (graphicsEffect()) {
+		painter->setPen(effectPen);
+		painter->setBrush(effectPen.color());
+	} else {
+		painter->setPen(pen());
+		painter->setBrush(m_lampColor);
 	}
 
-	QPen housingPen(QColor("#0d131a"));
-	housingPen.setWidthF(1.0);
-	painter->setPen(housingPen);
-	painter->setBrush(QColor("#26313b"));
-	painter->drawRoundedRect(rect(), 3.0, 3.0);
+	painter->drawEllipse(rect());
 
-	painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
-	const QRectF iconRect(rect().left(), rect().top(), rect().width(), rect().width());
-	painter->drawPixmap(iconRect, m_aspectIcon, m_aspectIcon.rect());
-
-	const qreal y = rect().bottom() - 3.0;
+	// restrained direction cue, scaled with the marker
+	const QPointF center = rect().center();
 	QPolygonF cue;
 	if (reversedDirection) {
-		cue << QPointF(rect().left() + 3.0, y) << QPointF(rect().left() + 7.0, y - 2.5) << QPointF(rect().left() + 7.0, y + 2.5);
+		cue << center + QPointF(-0.3 * rect().width(), 0.0)
+		    << center + QPointF(0.1 * rect().width(), -0.25 * rect().height())
+		    << center + QPointF(0.1 * rect().width(), 0.25 * rect().height());
 	} else {
-		cue << QPointF(rect().right() - 3.0, y) << QPointF(rect().right() - 7.0, y - 2.5) << QPointF(rect().right() - 7.0, y + 2.5);
+		cue << center + QPointF(0.3 * rect().width(), 0.0)
+		    << center + QPointF(-0.1 * rect().width(), -0.25 * rect().height())
+		    << center + QPointF(-0.1 * rect().width(), 0.25 * rect().height());
 	}
-	painter->setBrush(QColor("#f2f5f7"));
+	painter->setBrush(QColor("#0d131a"));
 	painter->drawPolygon(cue);
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/SignalItem.h
@@ -2,15 +2,12 @@
 #define SIGNALITEM_H
 
 #include <QGraphicsEllipseItem>
-#include <QPixmap>
 #include <string>
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>
 #include <QWidget>
 #include <QPolygonF>
 #include <QtMath>
-
-#include "graphics/VisualPolish.h"
 
 class SignalItem : public QGraphicsEllipseItem {
 	// Q_OBJECT
@@ -22,7 +19,6 @@ public:
 	void setAspectCode(int code);
 	int aspectCode() const;
 	void setReversedDirection(bool reversed);
-	void setCompact(bool compact);
 
 	// reimplemented functions
 	void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget);
@@ -52,9 +48,7 @@ public:
 
 private:
 	int m_aspectCode;
-	QPixmap m_aspectIcon;
 	QColor m_lampColor;
-	bool m_compact;
 };
 
 #endif // SIGNALITEM_H

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.cpp
@@ -10,7 +10,7 @@
 #include <cmath>
 
 namespace {
-constexpr qreal kSymbolPixels = 24.0;
+constexpr qreal kSymbolPixels = 16.0;
 constexpr qreal kLabelPixels = 11.0;
 constexpr qreal kLabelGap = 8.0;
 
@@ -30,10 +30,6 @@ StationOverlayItem::StationOverlayItem(const QString& stationName, const QPointF
 	setAcceptedMouseButtons(Qt::NoButton);
 	setZValue(3.5);
 	m_labelFont.setPixelSize(static_cast<int>(kLabelPixels));
-	const QPixmap sourceSymbol(m_visual.iconResource);
-	if (!sourceSymbol.isNull())
-		m_symbol = sourceSymbol.scaled(QSize(static_cast<int>(kSymbolPixels),
-			static_cast<int>(kSymbolPixels)), Qt::KeepAspectRatio, Qt::SmoothTransformation);
 	m_displayName = displayName(m_stationName);
 	m_symbolRect = QRectF(-kSymbolPixels / 2.0, -kSymbolPixels / 2.0, kSymbolPixels, kSymbolPixels);
 	m_labelSide = LabelSide::Right;
@@ -146,14 +142,18 @@ void StationOverlayItem::paint(QPainter* painter, const QStyleOptionGraphicsItem
 	Q_UNUSED(option);
 	Q_UNUSED(widget);
 	painter->save();
-	painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
 	painter->translate(m_viewportOffset);
-	if (!m_symbol.isNull()) {
-		painter->drawPixmap(m_symbolRect, m_symbol, m_symbol.rect());
+	const QColor markerColor(210, 215, 220);
+	painter->setPen(QPen(markerColor, 1.0));
+	if (m_visual.kind == StationVisualKind::StopMarker) {
+		painter->setBrush(markerColor);
+		painter->drawEllipse(m_symbolRect.adjusted(5.0, 5.0, -5.0, -5.0));
 	} else {
-		painter->setPen(QPen(m_visual.outline, 1.0));
-		painter->setBrush(m_visual.fill);
-		painter->drawEllipse(m_symbolRect);
+		painter->setBrush(Qt::NoBrush);
+		const QRectF platform = m_symbolRect.adjusted(3.0, 5.0, -3.0, -5.0);
+		painter->drawRect(platform);
+		if (m_visual.kind == StationVisualKind::Interchange)
+			painter->drawRect(platform.adjusted(-2.0, -2.0, 2.0, 2.0));
 	}
 	if (isLabelVisible()) {
 		painter->setPen(Qt::white);
@@ -211,9 +211,6 @@ void StationOverlayItem::setNetworkDegree(int degree, bool interchange, bool end
 	m_endpoint = nextEndpoint;
 	m_visual = classifyStation(m_originalVisualKind == StationVisualKind::Platform,
 		m_interchange ? 3 : m_degree);
-	const QPixmap sourceSymbol(m_visual.iconResource);
-	m_symbol = sourceSymbol.isNull() ? QPixmap() : sourceSymbol.scaled(QSize(static_cast<int>(kSymbolPixels),
-		static_cast<int>(kSymbolPixels)), Qt::KeepAspectRatio, Qt::SmoothTransformation);
 	update();
 }
 

--- a/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/StationOverlayItem.h
@@ -3,7 +3,6 @@
 
 #include <QFont>
 #include <QGraphicsItem>
-#include <QPixmap>
 #include <QPointF>
 #include <QRectF>
 #include <QString>
@@ -91,7 +90,6 @@ private:
 	QPointF m_stableAnchor;
 	QPointF m_viewportOffset;
 	StationVisual m_visual;
-	QPixmap m_symbol;
 	QFont m_labelFont;
 	QRectF m_symbolRect;
 	QRectF m_labelRect;

--- a/EGTRAIN/QEGTRAIN/tests/test_networkscene_selection.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networkscene_selection.cpp
@@ -159,6 +159,17 @@ int main(int argc, char* argv[]) {
 		ConnectionItem connection(QLineF(-12.0, 0.0, 12.0, 0.0));
 		connection.setPos(0.0, -80.0);
 		SignalItem signal(QRectF(-6.0, -8.0, 12.0, 16.0));
+		signal.setAspectCode(75);
+		signal.setReversedDirection(true);
+		signal.trackID = 3;
+		signal.sectionAheadId = "protected";
+		signal.sectionAheadLength = 125.0;
+		signal.sectionAheadTrackId = 4;
+		ok &= expect(signal.rect() == QRectF(-6.0, -8.0, 12.0, 16.0)
+			&& signal.aspectCode() == 75 && signal.reversedDirection
+			&& signal.trackID == 3 && signal.sectionAheadId == "protected"
+			&& signal.sectionAheadLength == 125.0 && signal.sectionAheadTrackId == 4,
+			"signal marker keeps scene bounds and inspector metadata");
 		signal.setPos(40.0, -80.0);
 		TrainBodyItem train(QPolygonF() << QPointF(-10.0, -6.0) << QPointF(10.0, -6.0)
 			<< QPointF(10.0, 6.0) << QPointF(-10.0, 6.0));

--- a/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networkview.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
 	bool uniformBackground = true;
 	for (int y = 0; y < background.height() && uniformBackground; ++y) {
 		for (int x = 0; x < background.width(); ++x) {
-			if (background.pixelColor(x, y) != QColor("#12191F")) {
+			if (background.pixelColor(x, y) != QColor(Qt::black)) {
 				uniformBackground = false;
 				break;
 			}

--- a/EGTRAIN/QEGTRAIN/tests/test_stationoverlay.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_stationoverlay.cpp
@@ -57,6 +57,8 @@ int main(int argc, char* argv[]) {
 		"overlay remains programmatically selectable");
 	const QRectF symbol = overlay.symbolRect();
 	const QRectF right = overlay.labelRect();
+	ok &= expect(qFuzzyCompare(symbol.width(), 16.0) && qFuzzyCompare(symbol.height(), 16.0),
+		"station symbol stays compact");
 	ok &= expect(qFuzzyCompare(overlay.combinedRect().left(), symbol.left()), "combined bounds include symbol");
 	ok &= expect(qFuzzyCompare(right.left(), symbol.right() + 8.0), "right label gap is eight logical pixels");
 	overlay.setLabelSide(StationOverlayItem::LabelSide::Left);

--- a/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
@@ -5,7 +5,6 @@
 #include <QImage>
 #include <QPainter>
 
-#include "graphics/items/SignalItem.h"
 #include "graphics/items/TrainBadgeItem.h"
 
 #include <iostream>
@@ -15,11 +14,6 @@ static bool expect(bool condition, const char* message) {
 		std::cerr << "failed: " << message << "\n";
 	return condition;
 }
-
-struct RenderedCue {
-	int paintedPixels = 0;
-	QRect bounds;
-};
 
 static QByteArray renderStrokeMask(int width, Qt::PenStyle style) {
 	QImage image(96, 20, QImage::Format_ARGB32_Premultiplied);
@@ -38,40 +32,6 @@ static QByteArray renderStrokeMask(int width, Qt::PenStyle style) {
 			mask.append(image.pixelColor(x, y).alpha() > 0 ? '1' : '0');
 	return mask;
 }
-
-static RenderedCue renderCompactSignal(int aspectCode) {
-	QImage image(32, 32, QImage::Format_ARGB32_Premultiplied);
-	image.fill(Qt::transparent);
-	SignalItem signal(QRectF(-6.0, -8.0, 12.0, 16.0));
-	signal.setAspectCode(aspectCode);
-	signal.setCompact(true);
-	{
-		QPainter painter(&image);
-		painter.translate(16.0, 16.0);
-		signal.paint(&painter, nullptr, nullptr);
-	}
-
-	RenderedCue result;
-	int left = image.width();
-	int top = image.height();
-	int right = -1;
-	int bottom = -1;
-	for (int y = 0; y < image.height(); ++y) {
-		for (int x = 0; x < image.width(); ++x) {
-			if (image.pixelColor(x, y).alpha() == 0)
-				continue;
-			++result.paintedPixels;
-			left = qMin(left, x);
-			top = qMin(top, y);
-			right = qMax(right, x);
-			bottom = qMax(bottom, y);
-		}
-	}
-	if (right >= left && bottom >= top)
-		result.bounds = QRect(QPoint(left, top), QPoint(right, bottom));
-	return result;
-}
-
 int main(int argc, char* argv[]) {
 	qputenv("QT_QPA_PLATFORM", "offscreen");
 	QGuiApplication app(argc, argv);
@@ -85,9 +45,9 @@ int main(int argc, char* argv[]) {
 	const TrackStateVisual occupiedTrack = classifyTrackState(TrackOperationalState::Occupied);
 	const TrackStateVisual blockedTrack = classifyTrackState(TrackOperationalState::Blocked);
 	ok &= expect(freeTrack.style == Qt::NoPen && freeTrack.width == 0, "free track has no underlay");
-	ok &= expect(preparedTrack.style == Qt::DashDotLine && preparedTrack.width == 6, "prepared track underlay");
-	ok &= expect(occupiedTrack.style == Qt::SolidLine && occupiedTrack.width == 8, "occupied track underlay");
-	ok &= expect(blockedTrack.style == Qt::DashLine && blockedTrack.width == 8, "blocked track has non-color cue");
+	ok &= expect(preparedTrack.style == Qt::DashDotLine && preparedTrack.width == 5, "prepared track underlay");
+	ok &= expect(occupiedTrack.style == Qt::SolidLine && occupiedTrack.width == 6, "occupied track underlay");
+	ok &= expect(blockedTrack.style == Qt::DashLine && blockedTrack.width == 5, "blocked track has non-color cue");
 	ok &= expect(preparedTrack.color == QColor("#4C8DAE"), "prepared track color");
 	ok &= expect(occupiedTrack.color == QColor("#D05A47"), "occupied track color");
 	ok &= expect(blockedTrack.color == QColor("#D6A13A"), "blocked track color");
@@ -113,19 +73,6 @@ int main(int argc, char* argv[]) {
 	ok &= expect(classifySignalAspect(0).iconResource == ":/icons/signal-stop.svg", "stop signal icon");
 	ok &= expect(classifySignalAspect(75).iconResource == ":/icons/signal-caution.svg", "caution signal icon");
 	ok &= expect(classifySignalAspect(180).iconResource == ":/icons/signal-proceed.svg", "proceed signal icon");
-	const RenderedCue compactStop = renderCompactSignal(0);
-	const RenderedCue compactCaution = renderCompactSignal(75);
-	const RenderedCue compactProceed = renderCompactSignal(180);
-	ok &= expect(compactStop.bounds.width() >= 7 && compactStop.bounds.height() >= 7,
-		"compact stop cue stays prominent at overview zoom");
-	ok &= expect(compactCaution.bounds.width() >= 7 && compactCaution.bounds.height() >= 7,
-		"compact caution cue stays prominent at overview zoom");
-	ok &= expect(compactProceed.bounds.width() <= 3 && compactProceed.bounds.height() <= 8,
-		"compact proceed cue collapses to a subdued tick");
-	ok &= expect(compactProceed.paintedPixels < compactStop.paintedPixels
-		&& compactProceed.paintedPixels < compactCaution.paintedPixels,
-		"repeated proceed cues carry less visual weight than stop and caution");
-
 	ok &= expect(classifyTrainType("freight", "F01").kind == TrainVisualKind::Freight, "freight train classification");
 	ok &= expect(classifyTrainType("IC", "IC 2201").kind == TrainVisualKind::Intercity, "intercity train classification");
 	ok &= expect(classifyTrainType("", "sprinter 301").kind == TrainVisualKind::Sprinter, "sprinter train classification");

--- a/tools/e2e/startup_launch_contract.py
+++ b/tools/e2e/startup_launch_contract.py
@@ -88,6 +88,11 @@ def main() -> None:
     if not app.exists():
         raise SystemExit(f"QEGTRAIN executable not found: {app}")
 
+    source = (ROOT / "EGTRAIN/QEGTRAIN/app/MainWindow.cpp").read_text(encoding="utf-8")
+    for name in ("paintStationPlatform", "arcDrawing", "paintConnection", "paintSignal"):
+        start = source.index(f"void MainWindow::{name}(")
+        if "fitInView(" in source[start:source.index("\n}\n", start)]:
+            raise SystemExit(f"{name} refits the growing startup scene instead of deferring one final fit")
     assert_launch_reaches_defaults(app, [], "no-argument launch")
     assert_launch_reaches_defaults(app, ["-n", "1", "-g", "1"], "partial-argument launch")
 


### PR DESCRIPTION
## Summary

- restore restrained, scene-scaled signal markers on a plain black canvas
- keep track states distinguishable with narrower strokes and existing Qt pen styles
- use compact schematic station markers and remove repeated per-item startup fitting
- preserve signal metadata, direction, zoom behavior, selection, and legacy input handling

## Verification

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` (42/42 passed)
- `tools/e2e/visual_polish_smoke.sh`
- Fit and 3x canvas captures reviewed

Addresses #257; cold-cache timing remains to be measured separately.