### PR TITLE
Fix command bar spacing

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -867,20 +867,8 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 			button->setAutoRaise(true);
 			button->setFixedHeight(32);
 			const QString name = QString::fromLatin1(objectName);
-			if (name == "openCaseButton")
-				button->setMinimumWidth(110);
-			else if (name == "actionRunButton")
-				button->setMinimumWidth(75);
-			else if (name == "actionPauseButton")
-				button->setMinimumWidth(91);
-			else if (name == "actionStopButton")
-				button->setMinimumWidth(81);
-			else if (name == "actionFollowButton")
-				button->setMinimumWidth(74);
-			else if (name == "actionZoomInButton" || name == "actionZoomOutButton")
+			if (name == "actionZoomInButton" || name == "actionZoomOutButton")
 				button->setFixedWidth(34);
-			else if (name == "actionFitButton")
-				button->setMinimumWidth(44);
 		}
 	};
 	const auto addToolbarLabel = [this](const char* text, const char* objectName) {

--- a/EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss
+++ b/EGTRAIN/QEGTRAIN/resources/styles/egtrain.qss
@@ -28,15 +28,17 @@ QToolButton {
     border: 1px solid transparent;
     border-radius: 2px;
     color: #24313a;
-    padding: 4px 6px;
+    padding: 3px 6px;
     min-height: 24px;
     max-height: 32px;
 }
 
 QToolButton#actionZoomInButton, QToolButton#actionZoomOutButton {
-    min-width: 24px;
-    max-width: 28px;
-    padding: 4px;
+    padding: 3px;
+}
+
+QToolBar QLabel, QToolBar QSlider {
+    background: transparent;
 }
 
 QToolButton:hover, QToolButton:focus {
@@ -240,6 +242,11 @@ QStatusBar {
     background: #e8ebea;
     border-top: 1px solid #c8ced2;
     color: #5b6871;
+}
+
+QStatusBar QLabel {
+    background: transparent;
+    padding: 0 4px;
 }
 
 QMenu {


### PR DESCRIPTION
## Summary
- let text toolbar controls use their natural Qt widths
- align toolbar padding with the fixed control height
- remove boxed backgrounds from toolbar and status labels

## Verification
- full CTest suite: 42/42 passed
- editor smoke: 6/6 passed
- visual polish smoke passed at 1024, 1200, 1440, and DPR2