### PR TITLE
Complete the V1 canonical scene model

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -381,10 +381,10 @@ double computeHorizon(const SceneModel& scene) {
 		if (service.entryTimeSeconds > maxSeconds)
 			maxSeconds = service.entryTimeSeconds;
 		for (const auto& stop : service.stops) {
-			if (stop.hasArrival && stop.arrivalSeconds > maxSeconds)
-				maxSeconds = stop.arrivalSeconds;
-			if (stop.hasDeparture && stop.departureSeconds > maxSeconds)
-				maxSeconds = stop.departureSeconds;
+			if (stop.hasPlannedArrival && stop.plannedArrivalSeconds > maxSeconds)
+				maxSeconds = stop.plannedArrivalSeconds;
+			if (stop.hasPlannedDeparture && stop.plannedDepartureSeconds > maxSeconds)
+				maxSeconds = stop.plannedDepartureSeconds;
 		}
 	}
 	double horizon = maxSeconds + 600.0;
@@ -1336,7 +1336,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	connect(m_stopDepartureSecondsEdit, &QLineEdit::editingFinished, this, &MainWindow::commitStopDepartureSeconds);
 	connect(m_stopDwellSecondsEdit, &QLineEdit::editingFinished, this, &MainWindow::commitStopDwellSeconds);
 
-	// incident editor: dockable panel for the flat list of scene incidents. each
+	// incident editor: dockable panel for the default scenario's incidents. each
 	// incident has a type (signal_failure or train_breakdown) and a target whose
 	// valid choices depend on that type, analogous to a stop's platform choices
 	// depending on the selected station.
@@ -1813,7 +1813,7 @@ void MainWindow::refreshValidationPanel() {
 		return;
 	}
 
-	m_sceneDiagnostics = validateScene(m_sceneModel);
+	m_sceneDiagnostics = validateRunnableScene(m_sceneModel);
 
 	std::vector<SceneDiagnostic> ordered = m_sceneDiagnostics;
 	std::stable_sort(ordered.begin(), ordered.end(), [](const SceneDiagnostic& a, const SceneDiagnostic& b) {
@@ -2943,30 +2943,30 @@ void MainWindow::updateStopDetailPanel() {
 	// station combo from inside its own signal
 	refreshStopPlatformCombo();
 
-	bool hasArrival = hasSelection && stop.hasArrival;
+	bool hasPlannedArrival = hasSelection && stop.hasPlannedArrival;
 	if (m_stopHasArrivalCheck) {
 		const QSignalBlocker blocker(m_stopHasArrivalCheck);
-		m_stopHasArrivalCheck->setChecked(hasArrival);
+		m_stopHasArrivalCheck->setChecked(hasPlannedArrival);
 		m_stopHasArrivalCheck->setEnabled(hasSelection);
 	}
 	if (m_stopArrivalSecondsEdit) {
 		const QSignalBlocker blocker(m_stopArrivalSecondsEdit);
-		int seconds = hasSelection ? static_cast<int>(stop.arrivalSeconds) : 0;
+		int seconds = hasSelection ? static_cast<int>(stop.plannedArrivalSeconds) : 0;
 		m_stopArrivalSecondsEdit->setText(QString::number(seconds));
-		m_stopArrivalSecondsEdit->setEnabled(hasArrival);
+		m_stopArrivalSecondsEdit->setEnabled(hasPlannedArrival);
 	}
 
-	bool hasDeparture = hasSelection && stop.hasDeparture;
+	bool hasPlannedDeparture = hasSelection && stop.hasPlannedDeparture;
 	if (m_stopHasDepartureCheck) {
 		const QSignalBlocker blocker(m_stopHasDepartureCheck);
-		m_stopHasDepartureCheck->setChecked(hasDeparture);
+		m_stopHasDepartureCheck->setChecked(hasPlannedDeparture);
 		m_stopHasDepartureCheck->setEnabled(hasSelection);
 	}
 	if (m_stopDepartureSecondsEdit) {
 		const QSignalBlocker blocker(m_stopDepartureSecondsEdit);
-		int seconds = hasSelection ? static_cast<int>(stop.departureSeconds) : 0;
+		int seconds = hasSelection ? static_cast<int>(stop.plannedDepartureSeconds) : 0;
 		m_stopDepartureSecondsEdit->setText(QString::number(seconds));
-		m_stopDepartureSecondsEdit->setEnabled(hasDeparture);
+		m_stopDepartureSecondsEdit->setEnabled(hasPlannedDeparture);
 	}
 
 	if (m_stopDwellSecondsEdit) {
@@ -3210,10 +3210,10 @@ void MainWindow::commitStopHasArrival(bool checked) {
 	int stopRow = m_stopListWidget->currentRow();
 	if (stopRow < 0 || stopRow >= static_cast<int>(stops.size()))
 		return;
-	if (checked == stops[stopRow].hasArrival)
+	if (checked == stops[stopRow].hasPlannedArrival)
 		return;
 
-	stops[stopRow].hasArrival = checked;
+	stops[stopRow].hasPlannedArrival = checked;
 	if (m_stopArrivalSecondsEdit)
 		m_stopArrivalSecondsEdit->setEnabled(checked);
 
@@ -3233,10 +3233,10 @@ void MainWindow::commitStopHasDeparture(bool checked) {
 	int stopRow = m_stopListWidget->currentRow();
 	if (stopRow < 0 || stopRow >= static_cast<int>(stops.size()))
 		return;
-	if (checked == stops[stopRow].hasDeparture)
+	if (checked == stops[stopRow].hasPlannedDeparture)
 		return;
 
-	stops[stopRow].hasDeparture = checked;
+	stops[stopRow].hasPlannedDeparture = checked;
 	if (m_stopDepartureSecondsEdit)
 		m_stopDepartureSecondsEdit->setEnabled(checked);
 
@@ -3269,10 +3269,10 @@ void MainWindow::commitStopArrivalSeconds() {
 	}
 
 	double newValue = static_cast<double>(seconds);
-	if (newValue == stops[stopRow].arrivalSeconds)
+	if (newValue == stops[stopRow].plannedArrivalSeconds)
 		return;
 
-	stops[stopRow].arrivalSeconds = newValue;
+	stops[stopRow].plannedArrivalSeconds = newValue;
 
 	m_sceneDirty = true;
 	updateSceneWindowTitle();
@@ -3303,10 +3303,10 @@ void MainWindow::commitStopDepartureSeconds() {
 	}
 
 	double newValue = static_cast<double>(seconds);
-	if (newValue == stops[stopRow].departureSeconds)
+	if (newValue == stops[stopRow].plannedDepartureSeconds)
 		return;
 
-	stops[stopRow].departureSeconds = newValue;
+	stops[stopRow].plannedDepartureSeconds = newValue;
 
 	m_sceneDirty = true;
 	updateSceneWindowTitle();
@@ -3350,13 +3350,14 @@ void MainWindow::commitStopDwellSeconds() {
 
 void MainWindow::refreshIncidentPanel() {
 	bool hasScene = m_sceneLoaded;
+	const auto& incidents = defaultScenarioIncidents(static_cast<const SceneModel&>(m_sceneModel));
 
 	if (m_incidentListWidget) {
 		int previousRow = m_incidentListWidget->currentRow();
 		const QSignalBlocker blocker(m_incidentListWidget);
 		m_incidentListWidget->clear();
 		if (hasScene) {
-			for (const auto& incident : m_sceneModel.incidents) {
+			for (const auto& incident : incidents) {
 				QString label = QString::fromStdString(incident.id) + " (" + QString::fromStdString(incident.type) + ")";
 				m_incidentListWidget->addItem(label);
 			}
@@ -3382,19 +3383,20 @@ void MainWindow::refreshIncidentPanel() {
 }
 
 void MainWindow::updateIncidentDetailPanel() {
+	const auto& incidents = defaultScenarioIncidents(static_cast<const SceneModel&>(m_sceneModel));
 	int row = m_incidentListWidget ? m_incidentListWidget->currentRow() : -1;
-	bool hasSelection = m_sceneLoaded && row >= 0 && row < static_cast<int>(m_sceneModel.incidents.size());
+	bool hasSelection = m_sceneLoaded && row >= 0 && row < static_cast<int>(incidents.size());
 
 	if (m_incidentIdEdit) {
 		const QSignalBlocker blocker(m_incidentIdEdit);
-		m_incidentIdEdit->setText(hasSelection ? QString::fromStdString(m_sceneModel.incidents[row].id) : QString());
+		m_incidentIdEdit->setText(hasSelection ? QString::fromStdString(incidents[row].id) : QString());
 		m_incidentIdEdit->setEnabled(hasSelection);
 	}
 
 	if (m_incidentTypeCombo) {
 		const QSignalBlocker blocker(m_incidentTypeCombo);
 		if (hasSelection) {
-			QString currentType = QString::fromStdString(m_sceneModel.incidents[row].type);
+			QString currentType = QString::fromStdString(incidents[row].type);
 			int typeIndex = m_incidentTypeCombo->findText(currentType);
 			// unknown type: default to signal_failure
 			m_incidentTypeCombo->setCurrentIndex(typeIndex >= 0 ? typeIndex : 0);
@@ -3410,14 +3412,14 @@ void MainWindow::updateIncidentDetailPanel() {
 
 	if (m_incidentStartSecondsEdit) {
 		const QSignalBlocker blocker(m_incidentStartSecondsEdit);
-		int seconds = hasSelection ? static_cast<int>(m_sceneModel.incidents[row].startSeconds) : 0;
+		int seconds = hasSelection ? static_cast<int>(incidents[row].startSeconds) : 0;
 		m_incidentStartSecondsEdit->setText(QString::number(seconds));
 		m_incidentStartSecondsEdit->setEnabled(hasSelection);
 	}
 
 	if (m_incidentEndSecondsEdit) {
 		const QSignalBlocker blocker(m_incidentEndSecondsEdit);
-		int seconds = hasSelection ? static_cast<int>(m_sceneModel.incidents[row].endSeconds) : 0;
+		int seconds = hasSelection ? static_cast<int>(incidents[row].endSeconds) : 0;
 		m_incidentEndSecondsEdit->setText(QString::number(seconds));
 		m_incidentEndSecondsEdit->setEnabled(hasSelection);
 	}
@@ -3432,15 +3434,16 @@ void MainWindow::refreshIncidentTargetCombo() {
 	if (!m_incidentTargetCombo)
 		return;
 
+	const auto& incidents = defaultScenarioIncidents(static_cast<const SceneModel&>(m_sceneModel));
 	int row = m_incidentListWidget ? m_incidentListWidget->currentRow() : -1;
-	bool hasSelection = m_sceneLoaded && row >= 0 && row < static_cast<int>(m_sceneModel.incidents.size());
+	bool hasSelection = m_sceneLoaded && row >= 0 && row < static_cast<int>(incidents.size());
 
 	const QSignalBlocker blocker(m_incidentTargetCombo);
 	m_incidentTargetCombo->clear();
 	m_incidentTargetCombo->addItem(QString()); // blank choice: no target
 
 	if (hasSelection) {
-		const SceneIncident& incident = m_sceneModel.incidents[row];
+		const SceneIncident& incident = incidents[row];
 		// which pool of ids to offer depends on the current type
 		QString typeText = m_incidentTypeCombo ? m_incidentTypeCombo->currentText() : QString();
 		if (typeText == "signal_failure") {
@@ -3469,8 +3472,9 @@ void MainWindow::refreshIncidentTargetCombo() {
 }
 
 std::string MainWindow::uniqueIncidentId(const std::string& baseId) const {
-	auto idExists = [this](const std::string& id) {
-		for (const auto& incident : m_sceneModel.incidents) {
+	const auto& incidents = defaultScenarioIncidents(m_sceneModel);
+	auto idExists = [&incidents](const std::string& id) {
+		for (const auto& incident : incidents) {
 			if (incident.id == id)
 				return true;
 		}
@@ -3490,10 +3494,11 @@ void MainWindow::addIncident() {
 	if (!m_sceneLoaded)
 		return;
 
+	auto& incidents = defaultScenarioIncidents(m_sceneModel);
 	SceneIncident incident;
 	incident.id = uniqueIncidentId("new_incident");
 	incident.type = "signal_failure";
-	m_sceneModel.incidents.push_back(incident);
+	incidents.push_back(incident);
 
 	m_sceneDirty = true;
 	updateSceneWindowTitle();
@@ -3502,19 +3507,20 @@ void MainWindow::addIncident() {
 	refreshIncidentPanel();
 
 	if (m_incidentListWidget)
-		m_incidentListWidget->setCurrentRow(static_cast<int>(m_sceneModel.incidents.size()) - 1);
+		m_incidentListWidget->setCurrentRow(static_cast<int>(incidents.size()) - 1);
 }
 
 void MainWindow::duplicateIncident() {
 	if (!m_sceneLoaded || !m_incidentListWidget)
 		return;
+	auto& incidents = defaultScenarioIncidents(m_sceneModel);
 	int row = m_incidentListWidget->currentRow();
-	if (row < 0 || row >= static_cast<int>(m_sceneModel.incidents.size()))
+	if (row < 0 || row >= static_cast<int>(incidents.size()))
 		return;
 
-	SceneIncident duplicate = m_sceneModel.incidents[row];
+	SceneIncident duplicate = incidents[row];
 	duplicate.id = uniqueIncidentId(duplicate.id + "_copy");
-	m_sceneModel.incidents.insert(m_sceneModel.incidents.begin() + row + 1, duplicate);
+	incidents.insert(incidents.begin() + row + 1, duplicate);
 
 	m_sceneDirty = true;
 	updateSceneWindowTitle();
@@ -3529,11 +3535,12 @@ void MainWindow::duplicateIncident() {
 void MainWindow::deleteIncident() {
 	if (!m_sceneLoaded || !m_incidentListWidget)
 		return;
+	auto& incidents = defaultScenarioIncidents(m_sceneModel);
 	int row = m_incidentListWidget->currentRow();
-	if (row < 0 || row >= static_cast<int>(m_sceneModel.incidents.size()))
+	if (row < 0 || row >= static_cast<int>(incidents.size()))
 		return;
 
-	QString id = QString::fromStdString(m_sceneModel.incidents[row].id);
+	QString id = QString::fromStdString(incidents[row].id);
 	auto response = QMessageBox::question(this,
 										  "Delete Incident",
 										  QString("Delete incident '%1'?").arg(id),
@@ -3542,7 +3549,7 @@ void MainWindow::deleteIncident() {
 	if (response != QMessageBox::Yes)
 		return;
 
-	m_sceneModel.incidents.erase(m_sceneModel.incidents.begin() + row);
+	incidents.erase(incidents.begin() + row);
 
 	m_sceneDirty = true;
 	updateSceneWindowTitle();
@@ -3554,21 +3561,22 @@ void MainWindow::deleteIncident() {
 void MainWindow::commitIncidentIdEdit() {
 	if (!m_sceneLoaded || !m_incidentListWidget || !m_incidentIdEdit)
 		return;
+	auto& incidents = defaultScenarioIncidents(m_sceneModel);
 	int row = m_incidentListWidget->currentRow();
-	if (row < 0 || row >= static_cast<int>(m_sceneModel.incidents.size()))
+	if (row < 0 || row >= static_cast<int>(incidents.size()))
 		return;
 
 	std::string newId = m_incidentIdEdit->text().trimmed().toStdString();
-	if (newId == m_sceneModel.incidents[row].id)
+	if (newId == incidents[row].id)
 		return;
 
-	m_sceneModel.incidents[row].id = newId;
+	incidents[row].id = newId;
 
 	// update the list row label in place instead of rebuilding the panel, so a
 	// focus-out that lands on another control keeps that pending click intact
 	if (QListWidgetItem* item = m_incidentListWidget->item(row)) {
 		const QSignalBlocker blocker(m_incidentListWidget);
-		QString label = QString::fromStdString(newId) + " (" + QString::fromStdString(m_sceneModel.incidents[row].type) + ")";
+		QString label = QString::fromStdString(newId) + " (" + QString::fromStdString(incidents[row].type) + ")";
 		item->setText(label);
 	}
 
@@ -3581,19 +3589,20 @@ void MainWindow::commitIncidentIdEdit() {
 void MainWindow::commitIncidentType(const QString& text) {
 	if (!m_sceneLoaded || !m_incidentListWidget)
 		return;
+	auto& incidents = defaultScenarioIncidents(m_sceneModel);
 	int row = m_incidentListWidget->currentRow();
-	if (row < 0 || row >= static_cast<int>(m_sceneModel.incidents.size()))
+	if (row < 0 || row >= static_cast<int>(incidents.size()))
 		return;
 
 	std::string newType = text.toStdString();
-	if (newType == m_sceneModel.incidents[row].type)
+	if (newType == incidents[row].type)
 		return;
 
-	m_sceneModel.incidents[row].type = newType;
+	incidents[row].type = newType;
 
 	// when the type changes the valid target pool also changes; drop a target
 	// that is no longer valid for the new type
-	bool targetValid = m_sceneModel.incidents[row].target.empty();
+	bool targetValid = incidents[row].target.empty();
 	if (!targetValid) {
 		if (newType == "signal_failure") {
 #ifdef signals
@@ -3606,14 +3615,14 @@ void MainWindow::commitIncidentType(const QString& text) {
 #undef EGTRAIN_INCIDENT_RESTORE_SIGNALS
 #endif
 			for (int i = 0; i < static_cast<int>(signalList.size()); ++i) {
-				if (signalList[i].id == m_sceneModel.incidents[row].target) {
+				if (signalList[i].id == incidents[row].target) {
 					targetValid = true;
 					break;
 				}
 			}
 		} else {
 			for (const auto& service : m_sceneModel.services) {
-				if (service.id == m_sceneModel.incidents[row].target) {
+				if (service.id == incidents[row].target) {
 					targetValid = true;
 					break;
 				}
@@ -3621,12 +3630,12 @@ void MainWindow::commitIncidentType(const QString& text) {
 		}
 	}
 	if (!targetValid)
-		m_sceneModel.incidents[row].target.clear();
+		incidents[row].target.clear();
 
 	// update the list row label in place to reflect the new type
 	if (QListWidgetItem* item = m_incidentListWidget->item(row)) {
 		const QSignalBlocker blocker(m_incidentListWidget);
-		QString label = QString::fromStdString(m_sceneModel.incidents[row].id) + " (" + text + ")";
+		QString label = QString::fromStdString(incidents[row].id) + " (" + text + ")";
 		item->setText(label);
 	}
 
@@ -3643,15 +3652,16 @@ void MainWindow::commitIncidentType(const QString& text) {
 void MainWindow::commitIncidentTarget(const QString& text) {
 	if (!m_sceneLoaded || !m_incidentListWidget)
 		return;
+	auto& incidents = defaultScenarioIncidents(m_sceneModel);
 	int row = m_incidentListWidget->currentRow();
-	if (row < 0 || row >= static_cast<int>(m_sceneModel.incidents.size()))
+	if (row < 0 || row >= static_cast<int>(incidents.size()))
 		return;
 
 	std::string newTarget = text.toStdString();
-	if (newTarget == m_sceneModel.incidents[row].target)
+	if (newTarget == incidents[row].target)
 		return;
 
-	m_sceneModel.incidents[row].target = newTarget;
+	incidents[row].target = newTarget;
 
 	// the combo already shows the chosen value; no panel rebuild needed
 	m_sceneDirty = true;
@@ -3663,8 +3673,9 @@ void MainWindow::commitIncidentTarget(const QString& text) {
 void MainWindow::commitIncidentStartSeconds() {
 	if (!m_sceneLoaded || !m_incidentListWidget || !m_incidentStartSecondsEdit)
 		return;
+	auto& incidents = defaultScenarioIncidents(m_sceneModel);
 	int row = m_incidentListWidget->currentRow();
-	if (row < 0 || row >= static_cast<int>(m_sceneModel.incidents.size()))
+	if (row < 0 || row >= static_cast<int>(incidents.size()))
 		return;
 
 	bool ok = false;
@@ -3679,10 +3690,10 @@ void MainWindow::commitIncidentStartSeconds() {
 	}
 
 	double newValue = static_cast<double>(seconds);
-	if (newValue == m_sceneModel.incidents[row].startSeconds)
+	if (newValue == incidents[row].startSeconds)
 		return;
 
-	m_sceneModel.incidents[row].startSeconds = newValue;
+	incidents[row].startSeconds = newValue;
 
 	m_sceneDirty = true;
 	updateSceneWindowTitle();
@@ -3693,8 +3704,9 @@ void MainWindow::commitIncidentStartSeconds() {
 void MainWindow::commitIncidentEndSeconds() {
 	if (!m_sceneLoaded || !m_incidentListWidget || !m_incidentEndSecondsEdit)
 		return;
+	auto& incidents = defaultScenarioIncidents(m_sceneModel);
 	int row = m_incidentListWidget->currentRow();
-	if (row < 0 || row >= static_cast<int>(m_sceneModel.incidents.size()))
+	if (row < 0 || row >= static_cast<int>(incidents.size()))
 		return;
 
 	bool ok = false;
@@ -3709,10 +3721,10 @@ void MainWindow::commitIncidentEndSeconds() {
 	}
 
 	double newValue = static_cast<double>(seconds);
-	if (newValue == m_sceneModel.incidents[row].endSeconds)
+	if (newValue == incidents[row].endSeconds)
 		return;
 
-	m_sceneModel.incidents[row].endSeconds = newValue;
+	incidents[row].endSeconds = newValue;
 
 	m_sceneDirty = true;
 	updateSceneWindowTitle();
@@ -5981,9 +5993,9 @@ void MainWindow::runEditorSmokeE2E() {
 	};
 	auto sameStop = [](const SceneStop& left, const SceneStop& right) {
 		return left.stationId == right.stationId && left.platformId == right.platformId
-			&& left.hasArrival == right.hasArrival && left.hasDeparture == right.hasDeparture
-			&& left.arrivalSeconds == right.arrivalSeconds
-			&& left.departureSeconds == right.departureSeconds
+			&& left.hasPlannedArrival == right.hasPlannedArrival && left.hasPlannedDeparture == right.hasPlannedDeparture
+			&& left.plannedArrivalSeconds == right.plannedArrivalSeconds
+			&& left.plannedDepartureSeconds == right.plannedDepartureSeconds
 			&& left.dwellSeconds == right.dwellSeconds;
 	};
 	auto sameCompositions = [](const std::vector<SceneComposition>& left, const std::vector<SceneComposition>& right) {
@@ -6015,7 +6027,8 @@ void MainWindow::runEditorSmokeE2E() {
 		if (left.size() != right.size())
 			return false;
 		return std::equal(left.begin(), left.end(), right.begin(), [&](const SceneService& a, const SceneService& b) {
-			if (a.id != b.id || a.composition != b.composition || a.route != b.route || a.through != b.through
+			if (a.id != b.id || a.operatingCode != b.operatingCode
+				|| a.composition != b.composition || a.route != b.route || a.through != b.through
 				|| a.hasEntryTime != b.hasEntryTime || a.entryTimeSeconds != b.entryTimeSeconds
 				|| a.hasRepeat != b.hasRepeat || a.headwaySeconds != b.headwaySeconds
 				|| a.stops.size() != b.stops.size())
@@ -6114,7 +6127,7 @@ void MainWindow::runEditorSmokeE2E() {
 		expectedCompositions = m_sceneModel.compositions;
 		expectedTrainUnits = m_sceneModel.trainUnits;
 		expectedServices = m_sceneModel.services;
-		expectedIncidents = m_sceneModel.incidents;
+		expectedIncidents = defaultScenarioIncidents(m_sceneModel);
 	}
 
 	std::string editedTrainUnitId;
@@ -6460,10 +6473,10 @@ void MainWindow::runEditorSmokeE2E() {
 						commitStopPlatform(QString::fromStdString(platformId));
 					double lastTime = 0.0;
 					for (const auto& stop : m_sceneModel.services[serviceRow].stops) {
-						if (stop.hasArrival)
-							lastTime = std::max(lastTime, stop.arrivalSeconds);
-						if (stop.hasDeparture)
-							lastTime = std::max(lastTime, stop.departureSeconds);
+						if (stop.hasPlannedArrival)
+							lastTime = std::max(lastTime, stop.plannedArrivalSeconds);
+						if (stop.hasPlannedDeparture)
+							lastTime = std::max(lastTime, stop.plannedDepartureSeconds);
 					}
 					const int arrivalSeconds = static_cast<int>(lastTime) + 600;
 					const int departureSeconds = arrivalSeconds + 60;
@@ -6483,13 +6496,13 @@ void MainWindow::runEditorSmokeE2E() {
 						facetFailure(facetOk, "timetable", "station edit did not apply the chosen station");
 					if (!platformId.empty() && committedStop.platformId != platformId)
 						facetFailure(facetOk, "timetable", "platform edit did not apply the chosen platform");
-					if (!committedStop.hasArrival)
+					if (!committedStop.hasPlannedArrival)
 						facetFailure(facetOk, "timetable", "arrival flag did not apply");
-					if (committedStop.arrivalSeconds != static_cast<double>(arrivalSeconds))
+					if (committedStop.plannedArrivalSeconds != static_cast<double>(arrivalSeconds))
 						facetFailure(facetOk, "timetable", "arrival seconds did not apply the requested value");
-					if (!committedStop.hasDeparture)
+					if (!committedStop.hasPlannedDeparture)
 						facetFailure(facetOk, "timetable", "departure flag did not apply");
-					if (committedStop.departureSeconds != static_cast<double>(departureSeconds))
+					if (committedStop.plannedDepartureSeconds != static_cast<double>(departureSeconds))
 						facetFailure(facetOk, "timetable", "departure seconds did not apply the requested value");
 					if (committedStop.dwellSeconds != 60.0)
 						facetFailure(facetOk, "timetable", "dwell did not apply the requested 60 seconds");
@@ -6506,7 +6519,7 @@ void MainWindow::runEditorSmokeE2E() {
 				moveStopDown();
 				if (!sameStop(m_sceneModel.services[serviceRow].stops.back(), editedStop))
 					facetFailure(facetOk, "timetable", "move down did not restore edited stop");
-				// The source scene's final stop intentionally omits departure_seconds;
+				// The source scene's final stop intentionally omits a planned departure;
 				// leave the edited stop before it so the model remains valid for save/reload.
 				m_stopListWidget->setCurrentRow(originalStopCount);
 				moveStopUp();
@@ -6560,16 +6573,17 @@ void MainWindow::runEditorSmokeE2E() {
 				facetFailure(facetOk, "incident", "delete did not apply");
 		}
 		int editedRow = -1;
-		for (int row = 0; row < static_cast<int>(m_sceneModel.incidents.size()); ++row) {
-			if (m_sceneModel.incidents[row].id == editedIncidentId) {
+		const auto& incidents = defaultScenarioIncidents(m_sceneModel);
+		for (int row = 0; row < static_cast<int>(incidents.size()); ++row) {
+			if (incidents[row].id == editedIncidentId) {
 				editedRow = row;
 				break;
 			}
 		}
-		if (editedRow < 0 || m_sceneModel.incidents[editedRow].type != "train_breakdown"
-				|| m_sceneModel.incidents[editedRow].target != editedServiceId
-				|| m_sceneModel.incidents[editedRow].startSeconds != 100.0
-				|| m_sceneModel.incidents[editedRow].endSeconds != 200.0)
+		if (editedRow < 0 || incidents[editedRow].type != "train_breakdown"
+				|| incidents[editedRow].target != editedServiceId
+				|| incidents[editedRow].startSeconds != 100.0
+				|| incidents[editedRow].endSeconds != 200.0)
 			facetFailure(facetOk, "incident", "edited incident was not retained");
 		if (facetOk)
 			std::fprintf(stdout, "E2E_EDITOR_INCIDENT_OK\n");
@@ -6602,7 +6616,7 @@ void MainWindow::runEditorSmokeE2E() {
 			expectedTrainUnits = m_sceneModel.trainUnits;
 			expectedCompositions = m_sceneModel.compositions;
 			expectedServices = m_sceneModel.services;
-			expectedIncidents = m_sceneModel.incidents;
+			expectedIncidents = defaultScenarioIncidents(m_sceneModel);
 			auto result = ::saveScene(m_sceneModel, outScenePath.toStdString());
 			if (!result.success()) {
 				facetFailure(facetOk, "save/reload", "save failed");
@@ -6614,7 +6628,7 @@ void MainWindow::runEditorSmokeE2E() {
 				facetFailure(facetOk, "save/reload", "composition facet changed after reload");
 			} else if (!sameServices(expectedServices, m_sceneModel.services)) {
 				facetFailure(facetOk, "save/reload", "service/timetable facet changed after reload");
-			} else if (!sameIncidents(expectedIncidents, m_sceneModel.incidents)) {
+			} else if (!sameIncidents(expectedIncidents, defaultScenarioIncidents(m_sceneModel))) {
 				facetFailure(facetOk, "save/reload", "incident facet changed after reload");
 			} else if (m_sceneDirty || hasErrors(m_sceneDiagnostics)) {
 				facetFailure(facetOk, "save/reload", "reloaded scene is dirty or invalid");
@@ -6662,12 +6676,14 @@ void MainWindow::runTrackPreviewE2E() {
 #undef signals
 #endif
 	auto sameSceneModel = [](const SceneModel& left, const SceneModel& right) {
+		const auto& leftIncidents = defaultScenarioIncidents(left);
+		const auto& rightIncidents = defaultScenarioIncidents(right);
 		if (left.schemaVersion != right.schemaVersion || left.name != right.name
 			|| left.description != right.description || left.baseTime != right.baseTime
 			|| left.stations.size() != right.stations.size() || left.signals.size() != right.signals.size()
 			|| left.routes.size() != right.routes.size() || left.trainUnits.size() != right.trainUnits.size()
 			|| left.compositions.size() != right.compositions.size() || left.services.size() != right.services.size()
-			|| left.incidents.size() != right.incidents.size())
+			|| leftIncidents.size() != rightIncidents.size())
 			return false;
 		if (!std::equal(left.stations.begin(), left.stations.end(), right.stations.begin(), [](const auto& a, const auto& b) {
 			return a.id == b.id && a.name == b.name && a.platforms.size() == b.platforms.size()
@@ -6696,18 +6712,19 @@ void MainWindow::runTrackPreviewE2E() {
 			[](const auto& a, const auto& b) { return a.id == b.id && a.units == b.units; }))
 			return false;
 		if (!std::equal(left.services.begin(), left.services.end(), right.services.begin(), [](const auto& a, const auto& b) {
-			if (a.id != b.id || a.composition != b.composition || a.route != b.route || a.through != b.through
+			if (a.id != b.id || a.operatingCode != b.operatingCode
+				|| a.composition != b.composition || a.route != b.route || a.through != b.through
 				|| a.hasEntryTime != b.hasEntryTime || a.entryTimeSeconds != b.entryTimeSeconds
 				|| a.hasRepeat != b.hasRepeat || a.headwaySeconds != b.headwaySeconds || a.stops.size() != b.stops.size())
 				return false;
 			return std::equal(a.stops.begin(), a.stops.end(), b.stops.begin(), [](const auto& x, const auto& y) {
-				return x.stationId == y.stationId && x.platformId == y.platformId && x.hasArrival == y.hasArrival
-					&& x.hasDeparture == y.hasDeparture && x.arrivalSeconds == y.arrivalSeconds
-					&& x.departureSeconds == y.departureSeconds && x.dwellSeconds == y.dwellSeconds;
+				return x.stationId == y.stationId && x.platformId == y.platformId && x.hasPlannedArrival == y.hasPlannedArrival
+					&& x.hasPlannedDeparture == y.hasPlannedDeparture && x.plannedArrivalSeconds == y.plannedArrivalSeconds
+					&& x.plannedDepartureSeconds == y.plannedDepartureSeconds && x.dwellSeconds == y.dwellSeconds;
 			});
 		}))
 			return false;
-		return std::equal(left.incidents.begin(), left.incidents.end(), right.incidents.begin(),
+		return std::equal(leftIncidents.begin(), leftIncidents.end(), rightIncidents.begin(),
 			[](const auto& a, const auto& b) {
 				return a.id == b.id && a.type == b.type && a.target == b.target
 					&& a.startSeconds == b.startSeconds && a.endSeconds == b.endSeconds;
@@ -6808,9 +6825,27 @@ void MainWindow::runTrackPreviewE2E() {
 	if (m_sceneLoaded) {
 		const SceneModel incomplete = m_sceneModel;
 		SceneModel fixed = incomplete;
+		fixed.baseTime = "08:00:00";
+		fixed.settings.hasDuration = true;
+		fixed.settings.durationSeconds = 3600.0;
+		fixed.tracks = {{"e2e_track"}};
+		fixed.nodes = {
+			{"e2e_node_1", "e2e_track", 0.0, 0.0},
+			{"e2e_node_2", "e2e_track", 1.0, 0.0},
+		};
+		fixed.arcs = {{"e2e_arc", "e2e_track", "e2e_node_1", "e2e_node_2", 0.0, 0.0, 1.0}};
+		fixed.blocks = {{"e2e_block", "e2e_track", 1.0}};
+		fixed.connections.clear();
+		fixed.stations.clear();
+		SceneStation station;
+		station.id = "e2e_station";
+		station.name = "E2E station";
+		station.platforms.push_back({"e2e_platform", {"e2e_node_1"}});
+		fixed.stations.push_back(station);
 		fixed.trainUnits.clear();
 		SceneTrainUnit unit;
 		unit.id = "e2e_unit";
+		unit.hasPhysical = true;
 		unit.tractionCurve.push_back({{0.0, 1.0, 1.0, 0.0, 0.0}});
 		fixed.trainUnits.push_back(unit);
 		fixed.compositions.clear();
@@ -6830,7 +6865,7 @@ void MainWindow::runTrackPreviewE2E() {
 		service.route = route.id;
 		service.through = true;
 		fixed.services.push_back(service);
-		fixed.incidents.clear();
+		defaultScenarioIncidents(fixed).clear();
 		m_sceneModel = fixed;
 		refreshValidationPanel();
 		if (hasErrors(m_sceneDiagnostics) || !m_runSceneAction || !m_runSceneAction->isEnabled()
@@ -7970,7 +8005,7 @@ void MainWindow::actionLoad_Network() {
 		showBlockingError(this, "Cannot Open Imported Scene", diagnosticSummary(diagnostics));
 		return;
 	}
-	const auto semanticDiagnostics = validateScene(loadResult.scene);
+	const auto semanticDiagnostics = validateRunnableScene(loadResult.scene);
 	diagnostics.insert(diagnostics.end(), semanticDiagnostics.begin(), semanticDiagnostics.end());
 	showBlockingError(this, "Legacy Import Diagnostics", diagnosticSummary(diagnostics), true);
 	openSceneDirectory(destinationPath);

--- a/EGTRAIN/QEGTRAIN/scene/SceneExporter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneExporter.cpp
@@ -69,11 +69,9 @@ static std::string formatNumber(double val) {
 	return oss.str();
 }
 
-// The simulation reads signalling levels only from TrackLines/AreasCaseStudy.txt
-// (InitializeAllNetworkAreas); without the file every section keeps the unset
-// default and no signalling handler runs at all. Cover the whole exported
-// extent with ETCS level 3, the moving-block model the default simulation
-// uses, unless the scene's legacy data already provides the file.
+// Older EGTRAIN variants read signalling levels from
+// TrackLines/AreasCaseStudy.txt. Keep exported legacy directories compatible
+// with them unless the scene already provides the file.
 static void synthesizeSignallingAreas(const std::string& outDir, SceneExportResult& result) {
 	auto addDiag = [&](SceneSeverity sev, const std::string& code, const std::string& msg, const std::string& file = "") {
 		SceneDiagnostic d;
@@ -465,7 +463,7 @@ SceneExportResult exportLegacyScene(const std::string& sceneDir, const std::stri
 		if (svc.hasEntryTime) {
 			entryTime = svc.entryTimeSeconds;
 		} else if (!svc.stops.empty()) {
-			entryTime = svc.stops[0].departureSeconds;
+			entryTime = svc.stops[0].plannedDepartureSeconds;
 		}
 
 		double headway = 99999999.0;
@@ -684,8 +682,8 @@ SceneExportResult exportLegacyScene(const std::string& sceneDir, const std::stri
 					result.wroteAll = false;
 				}
 				std::string stId = stop.stationId;
-				std::string arr = stop.hasArrival ? formatNumber(stop.arrivalSeconds) : "-1";
-				std::string dep = stop.hasDeparture ? formatNumber(stop.departureSeconds) : "-1";
+				std::string arr = stop.hasPlannedArrival ? formatNumber(stop.plannedArrivalSeconds) : "-1";
+				std::string dep = stop.hasPlannedDeparture ? formatNumber(stop.plannedDepartureSeconds) : "-1";
 				ttf << stId << "\t" << formatNumber(stop.dwellSeconds) << "\t" << arr << "\t" << dep << "\n";
 			}
 		} else {
@@ -695,7 +693,7 @@ SceneExportResult exportLegacyScene(const std::string& sceneDir, const std::stri
 
 		std::ofstream trf(fs::path(outDir) / "Trains" / fname);
 		if (trf) {
-			trf << svc.id << "\n"
+			trf << (svc.operatingCode.empty() ? svc.id : svc.operatingCode) << "\n"
 				<< formatNumber(entryTime) << "\n"
 				<< formatNumber(headway) << "\n"
 				<< rIndex << "\n"
@@ -718,21 +716,22 @@ SceneExportResult exportLegacyScene(const std::string& sceneDir, const std::stri
 		result.wroteAll = false;
 	}
 
-	if (!scene.incidents.empty()) {
+	const auto& incidents = defaultScenarioIncidents(scene);
+	if (!incidents.empty()) {
 		std::unordered_set<std::string> routeBlockTokens;
 		for (const auto& r : scene.routes) {
 			for (const auto& b : r.blocks) {
 				routeBlockTokens.insert(b);
 			}
 		}
-		std::unordered_set<std::string> serviceIds;
+		std::unordered_map<std::string, std::string> serviceOperatingCodes;
 		for (const auto& svc : scene.services) {
-			serviceIds.insert(svc.id);
+			serviceOperatingCodes[svc.id] = svc.operatingCode.empty() ? svc.id : svc.operatingCode;
 		}
 
 		std::ofstream inf(fs::path(outDir) / "Incidents.txt");
 		if (inf) {
-			for (const auto& inc : scene.incidents) {
+			for (const auto& inc : incidents) {
 				if (inc.type != "signal_failure" && inc.type != "train_breakdown") {
 					addDiag(SceneSeverity::Warning, "scene.export.adjusted",
 							"Incident type " + inc.type + " is not supported and was skipped", inc.id);
@@ -742,11 +741,17 @@ SceneExportResult exportLegacyScene(const std::string& sceneDir, const std::stri
 					addDiag(SceneSeverity::Warning, "scene.export.adjusted",
 							"Signal id " + inc.target + " matches no route block so the failure will have no effect", inc.id);
 				}
-				if (inc.type == "train_breakdown" && serviceIds.find(inc.target) == serviceIds.end()) {
-					addDiag(SceneSeverity::Warning, "scene.export.adjusted",
-							"Service id " + inc.target + " matches no service so the breakdown will have no effect", inc.id);
+				std::string target = inc.target;
+				if (inc.type == "train_breakdown") {
+					const auto service = serviceOperatingCodes.find(inc.target);
+					if (service == serviceOperatingCodes.end()) {
+						addDiag(SceneSeverity::Warning, "scene.export.adjusted",
+								"Service id " + inc.target + " matches no service so the breakdown will have no effect", inc.id);
+					} else {
+						target = service->second;
+					}
 				}
-				inf << inc.type << "\t" << inc.target << "\t" << formatNumber(inc.startSeconds) << "\t" << formatNumber(inc.endSeconds) << "\n";
+				inf << inc.type << "\t" << target << "\t" << formatNumber(inc.startSeconds) << "\t" << formatNumber(inc.endSeconds) << "\n";
 			}
 		} else {
 			addDiag(SceneSeverity::Error, "scene.export.write", "Failed to write Incidents.txt");

--- a/EGTRAIN/QEGTRAIN/scene/SceneImporter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneImporter.cpp
@@ -1,4 +1,5 @@
 #include "scene/SceneImporter.h"
+#include "scene/SceneModel.h"
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -6,6 +7,12 @@
 #include <unordered_map>
 #include <algorithm>
 #include <chrono>
+#include <cctype>
+#include <cmath>
+#include <initializer_list>
+#include <map>
+#include <regex>
+#include <set>
 #include <nlohmann/json.hpp>
 
 namespace fs = std::filesystem;
@@ -185,526 +192,1469 @@ static fs::path uniqueSiblingPath(const fs::path& target, const std::string& tag
 	}
 }
 
+struct ReportBuilder {
+	std::vector<SceneImportReportRow> rows;
+
+	SceneImportReportRow& row(const std::string& category, const std::string& sourceFile) {
+		for (auto& value : rows)
+			if (value.category == category && value.sourceFile == sourceFile)
+				return value;
+		SceneImportReportRow value;
+		value.category = category;
+		value.sourceFile = sourceFile;
+		rows.push_back(value);
+		return rows.back();
+	}
+
+	void source(const std::string& category, const std::string& sourceFile) {
+		++row(category, sourceFile).sourceCount;
+	}
+	void converted(const std::string& category, const std::string& sourceFile) {
+		++row(category, sourceFile).convertedCount;
+	}
+	void skipped(const std::string& category, const std::string& sourceFile) {
+		++row(category, sourceFile).skippedCount;
+	}
+	void unresolved(const std::string& category, const std::string& sourceFile) {
+		++row(category, sourceFile).unresolvedReferences;
+	}
+};
+
+static std::string lowerCopy(std::string value) {
+	std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+		return static_cast<char>(std::tolower(c));
+	});
+	return value;
+}
+
+static fs::path findChild(const fs::path& parent, const std::string& wanted) {
+	std::error_code ec;
+	fs::path exact = parent / wanted;
+	if (fs::exists(exact, ec))
+		return exact;
+	if (!fs::is_directory(parent, ec))
+		return {};
+	const std::string lowerWanted = lowerCopy(wanted);
+	for (const auto& entry : fs::directory_iterator(parent, ec)) {
+		if (lowerCopy(entry.path().filename().string()) == lowerWanted)
+			return entry.path();
+	}
+	return {};
+}
+
+static std::vector<std::string> splitTab(const std::string& line) {
+	std::vector<std::string> values;
+	std::stringstream stream(line);
+	std::string value;
+	while (std::getline(stream, value, '\t'))
+		values.push_back(trim(value));
+	return values;
+}
+
+static std::vector<std::string> splitCsvNaive(const std::string& line) {
+	std::vector<std::string> values;
+	std::stringstream stream(line);
+	std::string value;
+	while (std::getline(stream, value, ','))
+		values.push_back(trim(value));
+	return values;
+}
+
+static bool parseDoubleToken(const std::string& token, double& value) {
+	try {
+		std::size_t used = 0;
+		value = std::stod(token, &used);
+		return used == token.size();
+	} catch (...) {
+		return false;
+	}
+}
+
+static bool parseIntegerToken(const std::string& token, int& value) {
+	try {
+		std::size_t used = 0;
+		value = std::stoi(token, &used);
+		return used == token.size();
+	} catch (...) {
+		return false;
+	}
+}
+
+static std::string stripOuterAt(const std::string& token) {
+	if (token.size() >= 2 && token.front() == '@' && token.back() == '@')
+		return token.substr(1, token.size() - 2);
+	return token;
+}
+
+static std::string normaliseStationName(std::string value) {
+	value = lowerCopy(value);
+	for (char& character : value) {
+		if (character == ' ' || character == '-') character = '_';
+	}
+	return value;
+}
+
+static std::string baseTimeForCase(const std::string& sceneName, const fs::path& legacyPath,
+		double& duration, bool& known) {
+	const std::string name = lowerCopy(sceneName);
+	const std::string folder = lowerCopy(legacyPath.filename().string());
+	known = true;
+	if (name == "netherlands" || folder == "input_egtrain_netherlands") {
+		duration = 8000.0;
+		return "06:28:20";
+	}
+	if (name == "paimpol" || name == "paimpol alternative journeys"
+			|| folder == "input_egtrain_paimpol" || folder == "input_egtrain_paimpol - alternativejourneys") {
+		duration = 9000.0;
+		return "07:10:40";
+	}
+	if (name == "copenhagen" || name == "banedanmark"
+			|| folder == "input_egtrain_copenhagen" || folder == "input_egtrain_banedanmark") {
+		duration = 8000.0;
+		return "06:28:20";
+	}
+	if (name == "brescia" || name == "milano_brescia"
+			|| folder == "input_egtrain_milano_brescia") {
+		duration = 4000.0;
+		return "06:28:20";
+	}
+	if (name == "assignment" || folder == "input_egtrain_assignment") {
+		duration = 10000.0;
+		return "07:00:00";
+	}
+	known = false;
+	duration = 0.0;
+	return {};
+}
+
+static std::pair<double, double> passengerTimeWindow(const std::string& token) {
+	double value = 0.0;
+	if (!parseDoubleToken(token, value) || value < 0.0)
+		return {0.0, 0.0};
+	const int hour = static_cast<int>(value);
+	const double fraction = value - hour;
+	if (std::fabs(fraction - 0.25) < 1e-9)
+		return {hour * 3600.0, hour * 3600.0 + 1799.0};
+	if (std::fabs(fraction - 0.75) < 1e-9)
+		return {hour * 3600.0 + 1800.0, hour * 3600.0 + 3599.0};
+	return {hour * 3600.0, hour * 3600.0};
+}
+
 SceneImportResult importLegacyScene(const std::string& legacyDir,
-									const std::string& sceneDir,
-									const std::string& sceneName) {
+		const std::string& sceneDir, const std::string& sceneName) {
 	SceneImportResult result;
-
-	auto addDiag = [&](SceneSeverity sev, const std::string& code, const std::string& msg, const std::string& file = "") {
-		SceneDiagnostic d;
-		d.severity = sev;
-		d.code = code;
-		d.message = msg;
-		d.file = file;
-		result.diagnostics.push_back(d);
+	ReportBuilder report;
+	auto addDiag = [&](SceneSeverity severity, const std::string& code, const std::string& message,
+			const std::string& file = "", const std::string& category = "", bool unresolved = false) {
+		SceneDiagnostic diagnostic;
+		diagnostic.severity = severity;
+		diagnostic.code = code;
+		diagnostic.message = message;
+		diagnostic.file = file;
+		result.diagnostics.push_back(diagnostic);
+		if (unresolved && !category.empty()) report.unresolved(category, file);
 	};
-
 	fs::path legacyPath(legacyDir);
 	fs::path scenePath(sceneDir);
 	const fs::path comparableLegacyPath = comparablePath(legacyPath);
 	const fs::path comparableScenePath = comparablePath(scenePath);
 	if (containsPath(comparableLegacyPath, comparableScenePath)
-		|| containsPath(comparableScenePath, comparableLegacyPath)) {
+			|| containsPath(comparableScenePath, comparableLegacyPath)) {
 		addDiag(SceneSeverity::Error, "scene.import.path",
 				"Legacy directory and scene destination must be separate, non-overlapping directories", scenePath.string());
 		return result;
 	}
-	if (!fs::exists(legacyPath) || !fs::is_directory(legacyPath)) {
+	if (!fs::is_directory(legacyPath)) {
 		addDiag(SceneSeverity::Error, "scene.import.missing", "Legacy directory missing or invalid", legacyPath.string());
 		return result;
 	}
 
-	std::vector<std::string> trainFiles;
-	fs::path manifestPath = resolvePath(legacyPath, "trainNames.txt");
-	if (fs::exists(manifestPath)) {
-		std::string content;
-		if (readFile(manifestPath, content)) {
-			std::stringstream ss(content);
-			std::string line;
-			while (std::getline(ss, line)) {
-				line = trim(line);
-				if (line.empty())
-					continue;
-				std::string lowerLine = line;
-				std::transform(lowerLine.begin(), lowerLine.end(), lowerLine.begin(), ::tolower);
-				// The legacy loader skips manifest entries without "txt" in the
-				// name; folders and other files are filtered the same way here.
-				if (lowerLine.find("txt") != std::string::npos) {
-					trainFiles.push_back("Trains/" + line);
-				}
-			}
-		}
+	// Keep the source root visible in the report because source provenance is
+	// represented by import_report rather than a SceneModel field.
+	report.row("legacy_root", legacyDir).sourceCount = 1;
+	report.converted("legacy_root", legacyDir);
+
+	json infrastructure = { {"tracks", json::array()}, {"nodes", json::array()},
+		{"arcs", json::array()}, {"blocks", json::array()}, {"connections", json::array()} };
+	json stations = json::array();
+	json routes = json::array();
+	json trainUnits = json::array();
+	json compositions = json::array();
+	json services = json::array();
+	json blockDependencies = json::array();
+	json singleTrackRestrictions = json::array();
+	json stationBoundaries = json::array();
+	json scenarios = json::array();
+	json passengers = json::array();
+
+	// InitialParameters is compiled into the current runtime, not stored in
+	// the legacy case directory. Only these known case/name pairs are safe to
+	// convert; unknown cases remain importable without guessed defaults.
+	double durationSeconds = 0.0;
+	bool knownSettings = false;
+	const std::string baseTime = baseTimeForCase(sceneName, legacyPath, durationSeconds, knownSettings);
+	if (knownSettings) {
+		report.source("simulation_settings", "compiled InitialParameters");
+		report.converted("simulation_settings", "compiled InitialParameters");
 	} else {
-		addDiag(SceneSeverity::Info, "scene.import.info", "trainNames.txt missing, falling back to directory enumeration");
-		fs::path trainsDir = resolvePath(legacyPath, "Trains");
-		std::error_code ec;
-		if (fs::is_directory(trainsDir, ec)) {
-			for (const auto& entry : fs::directory_iterator(trainsDir, ec)) {
-				if (entry.is_regular_file()) {
-					std::string name = entry.path().filename().string();
-					std::string ext = entry.path().extension().string();
-					std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-					if (ext == ".txt" && name != "trainNames.txt") {
-						trainFiles.push_back("Trains/" + name);
-					}
-				}
-			}
-		}
+		report.source("simulation_settings", "compiled InitialParameters");
+		report.skipped("simulation_settings", "compiled InitialParameters");
+		report.unresolved("simulation_settings", "compiled InitialParameters");
+		addDiag(SceneSeverity::Warning, "scene.import.settings",
+				"No concrete InitialParameters mapping for case " + sceneName + "; simulation settings omitted",
+				sceneName, "simulation_settings");
 	}
 
-	json servicesArr = json::array();
-	std::unordered_set<std::string> referencedRoutes;
-	std::unordered_map<std::string, std::pair<std::string, std::string>> trainUnitsMap; // stem -> {data, traction}
+	struct NodeRef {
+		std::string id;
+		double x = 0.0;
+	};
+	std::unordered_map<std::string, std::vector<NodeRef>> nodesByTrack;
+	std::vector<NodeRef> allNodes;
+	std::set<std::string> blockIds;
+	std::unordered_map<std::string, int> arcIdentityCounts;
 
-	for (const auto& tf : trainFiles) {
-		fs::path tfPath = resolvePath(legacyPath, tf);
+	fs::path trackRoot = findChild(legacyPath, "TrackLines");
+	if (trackRoot.empty()) trackRoot = findChild(legacyPath, "Tracklines");
+	std::vector<std::pair<int, fs::path>> trackDirs;
+	auto scanTrackDirs = [&](const fs::path& root) {
+		std::error_code scanEc;
+		if (!fs::is_directory(root, scanEc)) return;
+		for (const auto& entry : fs::directory_iterator(root, scanEc)) {
+			if (!entry.is_directory(scanEc)) continue;
+			const std::string name = entry.path().filename().string();
+			if (name.size() < 2 || lowerCopy(name.substr(0, 1)) != "b") continue;
+			const std::string number = name.substr(1);
+			if (number.empty() || !std::all_of(number.begin(), number.end(), [](unsigned char c) { return std::isdigit(c); })) continue;
+			int index = 0;
+			if (parseIntegerToken(number, index)) trackDirs.push_back({index, entry.path()});
+		}
+	};
+	if (!trackRoot.empty()) scanTrackDirs(trackRoot);
+	if (trackDirs.empty()) {
+		scanTrackDirs(legacyPath);
+		if (trackRoot.empty()) trackRoot = legacyPath;
+	}
+	std::sort(trackDirs.begin(), trackDirs.end(), [](const auto& a, const auto& b) {
+		if (a.first != b.first) return a.first < b.first;
+		return a.second.string() < b.second.string();
+	});
+	trackDirs.erase(std::unique(trackDirs.begin(), trackDirs.end(), [](const auto& a, const auto& b) {
+		return a.first == b.first && comparablePath(a.second) == comparablePath(b.second);
+	}), trackDirs.end());
+
+	const std::string trackSource = trackRoot.filename().empty() ? trackRoot.string() : trackRoot.filename().string();
+	report.row("infrastructure.tracks", trackSource).sourceCount = static_cast<int>(trackDirs.size());
+	for (const auto& track : trackDirs) {
+		const int trackNumber = track.first;
+		const std::string trackId = "B" + std::to_string(trackNumber);
+		infrastructure["tracks"].push_back({{"id", trackId}});
+		report.converted("infrastructure.tracks", trackSource);
+
+		const fs::path nodesPath = findChild(track.second, "NodiCumPari.txt");
+		const fs::path arcsPath = findChild(track.second, "ArchiCumPari.txt");
+		const fs::path blocksPath = findChild(track.second, "BlockCumPari.txt");
+		const std::string nodeSource = (track.second / "NodiCumPari.txt").lexically_normal().string();
+		const std::string arcSource = (track.second / "ArchiCumPari.txt").lexically_normal().string();
+		const std::string blockSource = (track.second / "BlockCumPari.txt").lexically_normal().string();
+
+		if (!nodesPath.empty()) {
+			std::string content;
+			readFile(nodesPath, content);
+			std::stringstream input(content);
+			std::string line;
+			int rowIndex = 0;
+			while (std::getline(input, line)) {
+				if (trim(line).empty()) continue;
+				report.source("infrastructure.nodes", nodeSource);
+				const auto tokens = readTokens(line);
+				if (tokens.size() < 3) {
+					report.skipped("infrastructure.nodes", nodeSource);
+					addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed node row " + std::to_string(rowIndex), nodesPath.string());
+					++rowIndex;
+					continue;
+				}
+				double legacyId = 0.0, x = 0.0, y = 0.0;
+				if (!parseDoubleToken(tokens[0], legacyId) || !parseDoubleToken(tokens[1], x) || !parseDoubleToken(tokens[2], y)) {
+					report.skipped("infrastructure.nodes", nodeSource);
+					addDiag(SceneSeverity::Warning, "scene.import.parse", "Invalid node row " + std::to_string(rowIndex), nodesPath.string());
+					++rowIndex;
+					continue;
+				}
+				const std::string nodeId = trackId + ".node." + tokens[0];
+				infrastructure["nodes"].push_back({{"id", nodeId}, {"track", trackId}, {"x_km", x}, {"y_km", y}});
+				nodesByTrack[trackId].push_back({nodeId, x});
+				allNodes.push_back({nodeId, x});
+				report.converted("infrastructure.nodes", nodeSource);
+				++rowIndex;
+			}
+		} else {
+			report.row("infrastructure.nodes", nodeSource).skippedCount++;
+			addDiag(SceneSeverity::Warning, "scene.import.missing", "Missing NodiCumPari.txt", nodeSource);
+		}
+
+		if (!arcsPath.empty()) {
+			std::string content;
+			readFile(arcsPath, content);
+			std::stringstream input(content);
+			std::string line;
+			int rowIndex = 0;
+			while (std::getline(input, line)) {
+				if (trim(line).empty()) continue;
+				report.source("infrastructure.arcs", arcSource);
+				const auto tokens = readTokens(line);
+				if (tokens.size() < 6) {
+					report.skipped("infrastructure.arcs", arcSource);
+					addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed arc row " + std::to_string(rowIndex), arcsPath.string());
+					++rowIndex;
+					continue;
+				}
+				double legacyId = 0.0, from = 0.0, to = 0.0, radius = 0.0, gradient = 0.0, speed = 0.0;
+				if (!parseDoubleToken(tokens[0], legacyId) || !parseDoubleToken(tokens[1], from) || !parseDoubleToken(tokens[2], to)
+						|| !parseDoubleToken(tokens[3], radius) || !parseDoubleToken(tokens[4], gradient) || !parseDoubleToken(tokens[5], speed)) {
+					report.skipped("infrastructure.arcs", arcSource);
+					addDiag(SceneSeverity::Warning, "scene.import.parse", "Invalid arc row " + std::to_string(rowIndex), arcsPath.string());
+					++rowIndex;
+					continue;
+				}
+				const std::string fromToken = tokens[1];
+				const std::string toToken = tokens[2];
+				const std::string fromId = trackId + ".node." + fromToken;
+				const std::string toId = trackId + ".node." + toToken;
+				bool fromKnown = false, toKnown = false;
+				for (const auto& node : nodesByTrack[trackId]) {
+					if (node.id == fromId) fromKnown = true;
+					if (node.id == toId) toKnown = true;
+				}
+				const std::string arcBaseId = trackId + ".arc." + tokens[0];
+				const int arcOccurrence = arcIdentityCounts[arcBaseId]++;
+				const std::string arcId = arcOccurrence == 0 ? arcBaseId
+						: arcBaseId + "." + std::to_string(arcOccurrence + 1);
+				infrastructure["arcs"].push_back({{"id", arcId}, {"track", trackId}, {"from", fromId}, {"to", toId},
+					{"curvature_radius_m", radius}, {"gradient_percent", gradient}, {"speed_limit_ms", speed}});
+				report.converted("infrastructure.arcs", arcSource);
+				if (!fromKnown || !toKnown) {
+					addDiag(SceneSeverity::Warning, "scene.import.ref", "Arc refers to an unknown node: " + arcId,
+						arcsPath.string(), "infrastructure.arcs", true);
+				}
+				++rowIndex;
+			}
+		} else {
+			report.row("infrastructure.arcs", arcSource).skippedCount++;
+			addDiag(SceneSeverity::Warning, "scene.import.missing", "Missing ArchiCumPari.txt", arcSource);
+		}
+
+		if (!blocksPath.empty()) {
+			std::string content;
+			readFile(blocksPath, content);
+			std::stringstream input(content);
+			std::string line;
+			int rowIndex = 0;
+			while (std::getline(input, line)) {
+				if (trim(line).empty()) continue;
+				report.source("infrastructure.blocks", blockSource);
+				const auto tokens = readTokens(line);
+				double ignoredIdentity = 0.0, length = 0.0;
+				if (tokens.size() < 2 || !parseDoubleToken(tokens[0], ignoredIdentity) || !parseDoubleToken(tokens[1], length)) {
+					report.skipped("infrastructure.blocks", blockSource);
+					addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed block row " + std::to_string(rowIndex), blocksPath.string());
+					++rowIndex;
+					continue;
+				}
+				const std::string blockId = std::to_string(rowIndex) + "-" + trackId;
+				infrastructure["blocks"].push_back({{"id", blockId}, {"track", trackId}, {"length_km", length}});
+				blockIds.insert(blockId);
+				report.converted("infrastructure.blocks", blockSource);
+				++rowIndex;
+			}
+		} else {
+			report.row("infrastructure.blocks", blockSource).skippedCount++;
+			addDiag(SceneSeverity::Warning, "scene.import.missing", "Missing BlockCumPari.txt", blockSource);
+		}
+	}
+	auto blockReferenceComponents = [](const std::string& reference) {
+		std::vector<std::string> components;
+		std::size_t begin = 0;
+		while (begin <= reference.size()) {
+			const std::size_t slash = reference.find('/', begin);
+			const std::string part = reference.substr(begin,
+					slash == std::string::npos ? std::string::npos : slash - begin);
+			if (!part.empty()) {
+				std::string id = part;
+				if (part.front() == '@') {
+					const std::size_t end = part.find('@', 1);
+					if (end != std::string::npos) id = part.substr(1, end - 1);
+				} else {
+					const std::size_t at = part.find('@');
+					if (at != std::string::npos) id = part.substr(0, at);
+				}
+				if (!id.empty()) components.push_back(id);
+			}
+			if (slash == std::string::npos) break;
+			begin = slash + 1;
+		}
+		return components;
+	};
+	auto blockReferenceKnown = [&](const std::string& reference) {
+		const auto components = blockReferenceComponents(reference);
+		return !components.empty() && std::all_of(components.begin(), components.end(),
+				[&](const std::string& component) { return blockIds.count(component) != 0; });
+	};
+
+	const fs::path connectionsPath = findChild(trackRoot, "Connections.txt");
+	const std::string connectionsSource = (trackRoot / "Connections.txt").lexically_normal().string();
+	auto findNodeAt = [&](const std::string& trackId, double x) {
+		std::vector<NodeRef> matches;
+		for (const auto& node : nodesByTrack[trackId])
+			if (node.x == x) matches.push_back(node); // runtime uses exact equality
+		return matches;
+	};
+	if (!connectionsPath.empty()) {
 		std::string content;
-		if (!readFile(tfPath, content)) {
-			addDiag(SceneSeverity::Error, "scene.import.missing", "Missing train file: " + tf, tfPath.string());
-			continue;
+		readFile(connectionsPath, content);
+		std::stringstream input(content);
+		std::string line;
+		int rowIndex = 0;
+		while (std::getline(input, line)) {
+			if (trim(line).empty()) continue;
+			report.source("infrastructure.connections", connectionsSource);
+			const auto tokens = readTokens(line);
+			if (tokens.size() < 4 || tokens.size() > 5) {
+				report.skipped("infrastructure.connections", connectionsSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed connection row " + std::to_string(rowIndex), connectionsPath.string());
+				++rowIndex;
+				continue;
+			}
+			int firstTrack = 0, secondTrack = 0;
+			double firstX = 0.0, secondX = 0.0, speed = 0.0;
+			const bool valid = parseIntegerToken(tokens[0], firstTrack) && parseDoubleToken(tokens[1], firstX)
+					&& parseIntegerToken(tokens[2], secondTrack) && parseDoubleToken(tokens[3], secondX)
+					&& (tokens.size() == 4 || parseDoubleToken(tokens[4], speed));
+			if (!valid) {
+				report.skipped("infrastructure.connections", connectionsSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Invalid connection row " + std::to_string(rowIndex), connectionsPath.string());
+				++rowIndex;
+				continue;
+			}
+			const std::string firstTrackId = "B" + std::to_string(firstTrack);
+			const std::string secondTrackId = "B" + std::to_string(secondTrack);
+			const auto firstMatches = findNodeAt(firstTrackId, firstX);
+			const auto secondMatches = findNodeAt(secondTrackId, secondX);
+			if (firstMatches.size() != 1 || secondMatches.size() != 1) {
+				report.skipped("infrastructure.connections", connectionsSource);
+				addDiag(SceneSeverity::Warning, "scene.import.coordinate",
+						"Connection row " + std::to_string(rowIndex) + " has "
+						+ std::to_string(firstMatches.size()) + "/" + std::to_string(secondMatches.size())
+						+ " exact node matches; no connection guessed", connectionsPath.string(),
+						"infrastructure.connections", true);
+				++rowIndex;
+				continue;
+			}
+			const std::string connectionId = "connection." + std::to_string(rowIndex);
+			json value = {{"id", connectionId}, {"from", firstMatches[0].id}, {"to", secondMatches[0].id}};
+			if (tokens.size() == 5) value["speed_limit_ms"] = speed;
+			infrastructure["connections"].push_back(value);
+			report.converted("infrastructure.connections", connectionsSource);
+			++rowIndex;
 		}
-		std::vector<std::string> tokens = readTokens(content);
-		if (tokens.size() < 7) {
-			addDiag(SceneSeverity::Error, "scene.import.parse", "Malformed Trains file, need 7 tokens", tfPath.string());
-			continue;
-		}
+	} else if (!trackDirs.empty()) {
+		report.row("infrastructure.connections", connectionsSource).skippedCount++;
+		addDiag(SceneSeverity::Warning, "scene.import.missing", "Missing Connections.txt", connectionsSource);
+	}
 
-		std::string sName = tokens[0];
+	// Stations are merged by their legacy name. Runtime station assignment uses
+	// exact X equality; every exact node match becomes a platform, while zero or
+	// multiple matches are reported instead of guessed.
+	fs::path stationsPath = findChild(trackRoot, "Stations.txt");
+	if (stationsPath.empty() && trackRoot != legacyPath) stationsPath = findChild(legacyPath, "Stations.txt");
+	const std::string stationsSource = stationsPath.empty()
+		? (trackRoot / "Stations.txt").lexically_normal().string() : stationsPath.string();
+	std::unordered_map<std::string, std::size_t> stationIndex;
+	auto stationIdFor = [&](const std::string& raw, bool& ambiguous) {
+		ambiguous = false;
+		for (std::size_t i = 0; i < stations.size(); ++i)
+			if (stations[i]["id"] == raw) return raw;
+		const std::string normalized = normaliseStationName(raw);
+		std::vector<std::size_t> matches;
+		for (std::size_t i = 0; i < stations.size(); ++i)
+			if (normaliseStationName(stations[i]["id"].get<std::string>()) == normalized) matches.push_back(i);
+		if (matches.size() == 1) return stations[matches[0]]["id"].get<std::string>();
+		if (matches.size() > 1) ambiguous = true;
+		return raw;
+	};
+	if (!stationsPath.empty()) {
+		std::string content;
+		readFile(stationsPath, content);
+		std::stringstream input(content);
+		std::string line;
+		int rowIndex = 0;
+		while (std::getline(input, line)) {
+			if (trim(line).empty()) continue;
+			report.source("stations", stationsSource);
+			std::string positionToken;
+			std::string stationName;
+			const auto tabTokens = splitTab(line);
+			if (tabTokens.size() >= 2) {
+				positionToken = tabTokens[0];
+				stationName = tabTokens[1];
+			} else {
+				const auto tokens = readTokens(line);
+				if (tokens.size() < 2) {
+					report.skipped("stations", stationsSource);
+					addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed station row " + std::to_string(rowIndex), stationsPath.string());
+					++rowIndex;
+					continue;
+				}
+				positionToken = tokens[0];
+				const std::size_t nameStart = line.find(tokens[1]);
+				stationName = nameStart == std::string::npos ? tokens[1] : trim(line.substr(nameStart));
+			}
+			double position = 0.0;
+			if (stationName.empty() || !parseDoubleToken(positionToken, position)) {
+				report.skipped("stations", stationsSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Invalid station row " + std::to_string(rowIndex), stationsPath.string());
+				++rowIndex;
+				continue;
+			}
+			std::size_t index = 0;
+			const auto found = stationIndex.find(stationName);
+			if (found == stationIndex.end()) {
+				index = stations.size();
+				stationIndex[stationName] = index;
+				stations.push_back({{"id", stationName}, {"name", stationName}, {"position_km", position}, {"platforms", json::array()}});
+			} else {
+				index = found->second;
+			}
+			const auto matches = allNodes;
+			int matched = 0;
+			for (const auto& node : matches) {
+				if (node.x != position) continue;
+				++matched;
+				const std::string platformId = stationName + ".platform." + std::to_string(stations[index]["platforms"].size() + 1);
+				stations[index]["platforms"].push_back({{"id", platformId}, {"nodes", {node.id}}});
+			}
+			if (matched == 0) {
+				addDiag(SceneSeverity::Warning, "scene.import.coordinate",
+						"Station " + stationName + " at " + positionToken + " has no exact node match",
+						stationsPath.string(), "stations", true);
+			}
+			report.converted("stations", stationsSource);
+			++rowIndex;
+		}
+	} else {
+		report.row("stations", stationsSource).skippedCount++;
+		addDiag(SceneSeverity::Error, "scene.import.missing", "Missing TrackLines/Stations.txt", stationsSource);
+	}
+	// Read the explicit train manifest before routes so services can retain
+	// their route references and rolling-stock relationships independently.
+	struct Relation {
+		std::string serviceId;
+		std::string operatingCode;
+		std::string compositionId;
+		std::string timetablePath;
 		double entryTime = 0.0;
 		double headway = 0.0;
+		bool hasRepeat = false;
 		int routeIndex = 0;
-		try {
-			entryTime = std::stod(tokens[1]);
-			headway = std::stod(tokens[2]);
-			routeIndex = std::stoi(tokens[3]);
-		} catch (...) {
-			addDiag(SceneSeverity::Error, "scene.import.parse", "Invalid numbers in Trains file", tfPath.string());
+	};
+	struct UnitRelation {
+		std::string id;
+		std::string dataPath;
+		std::string tractionPath;
+	};
+	std::vector<Relation> relations;
+	std::vector<UnitRelation> unitRelations;
+	std::set<std::string> unitIds;
+	std::set<std::string> serviceIds;
+	std::vector<std::string> trainFiles;
+	const fs::path trainsDir = findChild(legacyPath, "Trains");
+	const fs::path manifestPath = findChild(legacyPath, "trainNames.txt");
+	const std::string manifestSource = manifestPath.empty() ? (legacyPath / "trainNames.txt").string() : manifestPath.string();
+	if (!manifestPath.empty()) {
+		std::string content;
+		readFile(manifestPath, content);
+		std::stringstream input(content);
+		std::string line;
+		while (std::getline(input, line)) {
+			line = trim(line);
+			if (line.empty()) continue;
+			const std::string lowerLine = lowerCopy(line);
+			if (lowerLine.find("txt") != std::string::npos) trainFiles.push_back("Trains/" + line);
+		}
+		report.row("rolling_stock.manifest", manifestSource).sourceCount = static_cast<int>(trainFiles.size());
+	} else {
+		addDiag(SceneSeverity::Info, "scene.import.info", "trainNames.txt missing, falling back to Trains directory enumeration", manifestSource);
+		std::error_code scanEc;
+		if (fs::is_directory(trainsDir, scanEc)) {
+			for (const auto& entry : fs::directory_iterator(trainsDir, scanEc)) {
+				if (!entry.is_regular_file(scanEc)) continue;
+				const std::string name = entry.path().filename().string();
+				if (lowerCopy(entry.path().extension().string()) == ".txt" && lowerCopy(name) != "trainnames.txt")
+					trainFiles.push_back("Trains/" + name);
+			}
+		}
+		std::sort(trainFiles.begin(), trainFiles.end());
+		report.row("rolling_stock.manifest", manifestSource).sourceCount = static_cast<int>(trainFiles.size());
+	}
+
+	std::unordered_set<std::string> referencedRoutes;
+	for (const auto& trainFile : trainFiles) {
+		const fs::path trainPath = resolvePath(legacyPath, trainFile);
+		std::string content;
+		if (!readFile(trainPath, content)) {
+			report.skipped("rolling_stock.manifest", manifestSource);
+			addDiag(SceneSeverity::Error, "scene.import.missing", "Missing train file: " + trainFile, trainPath.string());
 			continue;
 		}
+		const auto tokens = readTokens(content);
+		if (tokens.size() < 7) {
+			report.skipped("rolling_stock.manifest", manifestSource);
+			addDiag(SceneSeverity::Error, "scene.import.parse", "Malformed Trains file, need 7 tokens", trainPath.string());
+			continue;
+		}
+		double entryTime = 0.0, headway = 0.0;
+		int routeIndex = 0;
+		if (!parseDoubleToken(tokens[1], entryTime) || !parseDoubleToken(tokens[2], headway) || !parseIntegerToken(tokens[3], routeIndex)) {
+			report.skipped("rolling_stock.manifest", manifestSource);
+			addDiag(SceneSeverity::Error, "scene.import.parse", "Invalid numbers in Trains file", trainPath.string());
+			continue;
+		}
+		std::string serviceId = tokens[0];
+		const std::string originalServiceId = serviceId;
+		for (int suffix = 2; serviceIds.count(serviceId); ++suffix) serviceId = originalServiceId + "_" + std::to_string(suffix);
+		if (serviceId != originalServiceId)
+			addDiag(SceneSeverity::Warning, "scene.import.adjusted", "Duplicate service name " + originalServiceId + " renamed to " + serviceId, trainPath.string());
+		serviceIds.insert(serviceId);
+		const std::string dataPath = tokens[4];
+		const std::string tractionPath = tokens[5];
+		const fs::path dataFile(dataPath);
+		std::string baseId = dataFile.stem().string();
+		if (baseId.empty()) baseId = "train_unit";
+		std::string unitId = baseId;
+		for (int suffix = 2; unitIds.count(unitId); ++suffix) unitId = baseId + "_" + std::to_string(suffix);
+		const auto existingUnit = std::find_if(unitRelations.begin(), unitRelations.end(), [&](const UnitRelation& value) {
+			return value.dataPath == dataPath && value.tractionPath == tractionPath;
+		});
+		if (existingUnit != unitRelations.end()) unitId = existingUnit->id;
+		else {
+			unitIds.insert(unitId);
+			unitRelations.push_back({unitId, dataPath, tractionPath});
+		}
+		const std::string routeId = "route" + std::to_string(routeIndex);
+		referencedRoutes.insert(routeId);
+		Relation relation;
+		relation.serviceId = serviceId;
+		relation.operatingCode = originalServiceId;
+		relation.compositionId = unitId;
+		relation.timetablePath = tokens[6];
+		relation.entryTime = entryTime;
+		relation.headway = headway;
+		relation.hasRepeat = headway < 99999999.0;
+		relation.routeIndex = routeIndex;
+		relations.push_back(relation);
+		report.converted("rolling_stock.manifest", manifestSource);
+	}
 
-		std::string origName = tokens[0];
-		sName = origName;
-		int suffix = 2;
-		while (true) {
-			bool conflict = false;
-			for (const auto& existing : servicesArr) {
-				if (existing["id"] == sName) {
-					conflict = true;
+	// Base routes are numeric and deterministic. Keep basic block IDs without
+	// their @ delimiters; retain composite switch tokens exactly as runtime input.
+	const fs::path routesDir = findChild(legacyPath, "Routes");
+	std::vector<std::pair<int, fs::path>> routeFiles;
+	std::error_code routeEc;
+	if (!routesDir.empty() && fs::is_directory(routesDir, routeEc)) {
+		for (const auto& entry : fs::directory_iterator(routesDir, routeEc)) {
+			if (!entry.is_regular_file(routeEc)) continue;
+			const std::string stem = entry.path().stem().string();
+			const std::string lowerStem = lowerCopy(stem);
+			if (lowerStem.size() <= 5 || lowerStem.substr(0, 5) != "route") continue;
+			const std::string number = stem.substr(5);
+			if (number.empty() || !std::all_of(number.begin(), number.end(), [](unsigned char c) { return std::isdigit(c); })) continue;
+			int index = 0;
+			if (parseIntegerToken(number, index)) routeFiles.push_back({index, entry.path()});
+		}
+	}
+	std::sort(routeFiles.begin(), routeFiles.end(), [](const auto& a, const auto& b) {
+		if (a.first != b.first) return a.first < b.first;
+		return a.second.string() < b.second.string();
+	});
+	std::set<std::string> loadedRouteIds;
+	for (const auto& routeFile : routeFiles) {
+		const std::string routeId = "route" + std::to_string(routeFile.first);
+		const std::string source = routeFile.second.string();
+		std::string content;
+		if (!readFile(routeFile.second, content)) {
+			report.skipped("signalling.routes", source);
+			addDiag(SceneSeverity::Error, "scene.import.ref", "Missing route file: " + source, source);
+			continue;
+		}
+		json blockList = json::array();
+		std::stringstream input(content);
+		std::string line;
+		int rowIndex = 0;
+		while (std::getline(input, line)) {
+			if (trim(line).empty()) continue;
+			report.source("signalling.routes", source);
+			const auto tokens = readTokens(line);
+			if (tokens.empty()) {
+				report.skipped("signalling.routes", source);
+				++rowIndex;
+				continue;
+			}
+			const std::string token = tokens[0];
+			const bool basic = token.size() >= 2 && token.front() == '@' && token.back() == '@' && token.find('/', 1) == std::string::npos;
+			if (!basic && !isSwitchTransitionRouteToken(token)) {
+				report.skipped("signalling.routes", source);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed route block token at row " + std::to_string(rowIndex), source);
+			}
+			blockList.push_back(basic ? stripOuterAt(token) : token);
+			report.converted("signalling.routes", source);
+			++rowIndex;
+		}
+		routes.push_back({{"id", routeId}, {"blocks", blockList}});
+		loadedRouteIds.insert(routeId);
+	}
+	for (const auto& routeId : referencedRoutes) {
+		if (loadedRouteIds.count(routeId)) continue;
+		const std::string number = routeId.substr(5);
+		const fs::path missing = routesDir.empty() ? legacyPath / "Routes" / ("Route" + number + ".txt")
+				: routesDir / ("Route" + number + ".txt");
+		addDiag(SceneSeverity::Error, "scene.import.ref", "Missing route file: " + missing.string(), missing.string(), "signalling.routes", true);
+	}
+
+	// Route corridor metadata is an active GUI input, unlike generated signal
+	// and TDS caches, so retain it directly on the matching route.
+	const fs::path guiDir = findChild(legacyPath, "GUI");
+	const fs::path corridorPath = guiDir.empty() ? fs::path() : findChild(guiDir, "caseStudyRouteCorridors.txt");
+	const std::string corridorSource = corridorPath.empty() ? (legacyPath / "GUI/caseStudyRouteCorridors.txt").string() : corridorPath.string();
+	if (!corridorPath.empty()) {
+		std::string content;
+		readFile(corridorPath, content);
+		std::stringstream input(content);
+		std::string line;
+		while (std::getline(input, line)) {
+			if (trim(line).empty()) continue;
+			report.source("signalling.corridors", corridorSource);
+			const auto tokens = splitTab(line);
+			int routeIndex = 0;
+			if (tokens.size() < 2 || !parseIntegerToken(tokens[0], routeIndex)) {
+				report.skipped("signalling.corridors", corridorSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed route corridor row", corridorPath.string());
+				continue;
+			}
+			const std::string id = "route" + std::to_string(routeIndex);
+			bool found = false;
+			for (auto& route : routes) {
+				if (route["id"] == id) {
+					route["corridor"] = tokens[1];
+					found = true;
 					break;
 				}
 			}
-			if (!conflict)
-				break;
-			sName = origName + "_" + std::to_string(suffix++);
+			if (!found) {
+				addDiag(SceneSeverity::Warning, "scene.import.ref", "Route corridor refers to unknown route " + id,
+						corridorPath.string(), "signalling.corridors", true);
+			} else report.converted("signalling.corridors", corridorSource);
 		}
-		if (sName != origName) {
-			addDiag(SceneSeverity::Warning, "scene.import.adjusted",
-					"Duplicate service name " + origName + " renamed to " + sName, tf);
-		}
+	}
 
-		std::string routeId = "route" + std::to_string(routeIndex);
-		std::string dataPath = tokens[4];
-		std::string tractionPath = tokens[5];
-		std::string timetablePath = tokens[6];
-
-		referencedRoutes.insert(routeId);
-
-		fs::path dp(dataPath);
-		std::string stem = dp.stem().string();
-		trainUnitsMap[stem] = {dataPath, tractionPath};
-
-		fs::path ttPath = resolvePath(legacyPath, timetablePath);
-		std::string ttContent;
-		if (!readFile(ttPath, ttContent)) {
-			addDiag(SceneSeverity::Error, "scene.import.ref", "Missing timetable file: " + timetablePath, ttPath.string());
-			continue;
-		}
-
-		json stopsArr = json::array();
-		std::stringstream ttSs(ttContent);
-		std::string ttLine;
-		int row = 0;
-		while (std::getline(ttSs, ttLine)) {
-			std::vector<std::string> ttTokens = readTokens(ttLine);
-			if (ttTokens.empty())
-				continue;
-			if (ttTokens.size() < 4) {
-				addDiag(SceneSeverity::Error, "scene.import.parse", "Malformed timetable row " + std::to_string(row), ttPath.string());
-				continue;
-			}
-
-			size_t n = ttTokens.size();
-			double dwell = 0, arrival = 0, departure = 0;
-			try {
-				dwell = std::stod(ttTokens[n - 3]);
-				arrival = std::stod(ttTokens[n - 2]);
-				departure = std::stod(ttTokens[n - 1]);
-			} catch (...) {
-				addDiag(SceneSeverity::Error, "scene.import.parse", "Invalid numbers in timetable row " + std::to_string(row), ttPath.string());
-				continue;
-			}
-
-			// Multi-token station names are joined without a separator: the
-			// legacy data writes e.g. "Morengo Bariano" in timetables for the
-			// station "MorengoBariano" in Stations.txt.
-			std::string stationName = ttTokens[0];
-			for (size_t i = 1; i < n - 3; ++i) {
-				stationName += ttTokens[i];
-			}
-
-			json stopObj = {
-				{"station", stationName},
-				{"dwell_seconds", dwell}};
-			// -1 means "not defined" in legacy timetables: typically the first
-			// stop has no arrival and the last stop has no departure, but some
-			// mid-service stops also carry no scheduled arrival.
-			if (arrival != -1) {
-				stopObj["arrival_seconds"] = arrival;
-			}
-			// Whether this is the last stop is only known after the loop, so the
-			// departure is kept for every stop and removed from the terminus below.
-			double outDeparture = departure;
-			if (departure == -1 && arrival != -1) {
-				outDeparture = arrival;
-			} else if (departure != -1 && arrival != -1 && departure < arrival) {
-				outDeparture = arrival;
-				addDiag(SceneSeverity::Warning, "scene.import.adjusted",
-						"Departure " + ttTokens[n - 1] + " before arrival " + ttTokens[n - 2] + " at " + stationName + " of " + sName + "; departure raised to the arrival", timetablePath);
-			}
-			stopObj["departure_seconds"] = outDeparture;
-			stopObj["_orig_departure"] = departure;
-			stopsArr.push_back(stopObj);
-			row++;
-		}
-
-		if (!stopsArr.empty()) {
-			auto& lastStop = stopsArr.back();
-			if (lastStop["_orig_departure"] == -1.0) {
-				lastStop.erase("departure_seconds");
-			}
-			// A non-terminus stop whose departure was -1 borrowed its arrival above.
-			for (size_t i = 0; i + 1 < stopsArr.size(); ++i) {
-				if (stopsArr[i]["_orig_departure"] == -1.0) {
-					addDiag(SceneSeverity::Warning, "scene.import.adjusted",
-							"Departure -1 on non-last stop of " + sName + "; departure set to the arrival", timetablePath);
+	// Materialise joined routes at the append position, following the runtime
+	// row order and optional Reverse token.
+	int nextJoinedRouteIndex = routeFiles.empty() ? 0 : routeFiles.back().first + 1;
+	const fs::path routesToWrite = findChild(legacyPath, "RoutesToWrite");
+	const fs::path joinsPath = routesToWrite.empty() ? fs::path() : findChild(routesToWrite, "RoutesToJoin.txt");
+	const std::string joinsSource = joinsPath.empty() ? (legacyPath / "RoutesToWrite/RoutesToJoin.txt").string() : joinsPath.string();
+	if (!joinsPath.empty()) {
+		std::string content;
+		readFile(joinsPath, content);
+		std::stringstream input(content);
+		std::string line;
+		while (std::getline(input, line)) {
+			if (trim(line).empty()) continue;
+			report.source("signalling.joined_routes", joinsSource);
+			const auto tokens = readTokens(line);
+			std::vector<int> refs;
+			bool reversed = false;
+			for (const auto& token : tokens) {
+				if (lowerCopy(token) == "reverse") {
+					reversed = true;
+					continue;
 				}
+				std::string number = token;
+				if (number.size() >= 5 && lowerCopy(number.substr(0, 5)) == "route") number = number.substr(5);
+				int ref = -1;
+				if (!parseIntegerToken(number, ref)) refs.clear();
+				else refs.push_back(ref);
+				if (refs.empty() && !number.empty() && !parseIntegerToken(number, ref)) break;
 			}
-			for (auto& s : stopsArr) {
-				s.erase("_orig_departure");
-			}
-		}
-		// A service without stops is a through service (freight and long
-		// distance trains cross the corridor without scheduled stops). Mark
-		// it so the validator does not ask for stops.
-
-		json serviceObj = {
-			{"id", sName},
-			{"composition", stem},
-			{"route", routeId},
-			{"entry_time_seconds", entryTime},
-			{"stops", stopsArr}};
-		if (stopsArr.empty()) {
-			serviceObj["through"] = true;
-		}
-		if (headway < 99999999) {
-			serviceObj["repeat"] = {{"headway_seconds", headway}};
-		}
-		servicesArr.push_back(serviceObj);
-	}
-
-	json trainUnitsArr = json::array();
-	json compositionsArr = json::array();
-	for (const auto& kv : trainUnitsMap) {
-		std::string stem = kv.first;
-		std::string dataPath = kv.second.first;
-		std::string tractionPath = kv.second.second;
-
-		fs::path resolvedData = resolvePath(legacyPath, dataPath);
-		std::string dContent;
-		if (!readFile(resolvedData, dContent)) {
-			addDiag(SceneSeverity::Error, "scene.import.ref", "Missing train data file: " + dataPath, resolvedData.string());
-			continue;
-		}
-		std::vector<std::string> dTokens = readTokens(dContent);
-		if (dTokens.size() < 9) {
-			addDiag(SceneSeverity::Error, "scene.import.parse", "Malformed train data file", resolvedData.string());
-			continue;
-		}
-
-		std::vector<double> phys;
-		try {
-			for (int i = 0; i < 9; ++i)
-				phys.push_back(std::stod(dTokens[i]));
-		} catch (...) {
-			addDiag(SceneSeverity::Error, "scene.import.parse", "Invalid numbers in train data file", resolvedData.string());
-			continue;
-		}
-
-		fs::path resolvedTraction = resolvePath(legacyPath, tractionPath);
-		std::string tContent;
-		json tracArr = json::array();
-		if (!readFile(resolvedTraction, tContent)) {
-			addDiag(SceneSeverity::Error, "scene.import.ref", "Missing traction file: " + tractionPath, resolvedTraction.string());
-			continue;
-		}
-
-		std::stringstream tSs(tContent);
-		std::string tLine;
-		int row = 0;
-		while (std::getline(tSs, tLine)) {
-			std::vector<std::string> tTokens = readTokens(tLine);
-			if (tTokens.empty())
-				continue;
-			if (tTokens.size() < 5) {
-				addDiag(SceneSeverity::Error, "scene.import.parse", "Malformed traction row " + std::to_string(row), resolvedTraction.string());
-				continue;
-			}
-			try {
-				tracArr.push_back({std::stod(tTokens[0]), std::stod(tTokens[1]), std::stod(tTokens[2]), std::stod(tTokens[3]), std::stod(tTokens[4])});
-			} catch (...) {
-				addDiag(SceneSeverity::Error, "scene.import.parse", "Invalid numbers in traction row " + std::to_string(row), resolvedTraction.string());
-				continue;
-			}
-			row++;
-		}
-
-		trainUnitsArr.push_back({{"id", stem},
-								 {"physical", {{"mass_of_traction_unit_kg", phys[0]}, {"mass_of_a_wagon_kg", phys[1]}, {"number_of_wagons", phys[2]}, {"max_speed_ms", phys[3]}, {"max_deceleration_ms2", phys[4]}, {"frontal_area_m2", phys[5]}, {"resistance_coefficient", phys[6]}, {"jerk_ms3", phys[7]}, {"length_m", phys[8]}}},
-								 {"traction_curve", tracArr},
-								 {"source", {{"data_file", dataPath}, {"traction_file", tractionPath}}}});
-
-		compositionsArr.push_back({{"id", stem},
-								   {"units", {stem}}});
-	}
-
-	json routesArr = json::array();
-	fs::path rDirForScan = resolvePath(legacyPath, "Routes");
-	std::vector<std::pair<int, fs::path>> routeFiles;
-	std::error_code scanEc;
-	if (fs::is_directory(rDirForScan, scanEc)) {
-		for (const auto& entry : fs::directory_iterator(rDirForScan, scanEc)) {
-			if (entry.is_regular_file()) {
-				std::string name = entry.path().filename().string();
-				std::string ext = entry.path().extension().string();
-				std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-				if (ext == ".txt") {
-					std::string stem = entry.path().stem().string();
-					if (stem.length() > 5 && stem.substr(0, 5) == "Route") {
-						std::string numPart = stem.substr(5);
-						bool isNum = !numPart.empty() && numPart.length() <= 9 &&
-									 std::all_of(numPart.begin(), numPart.end(), [](char value) {
-										 return std::isdigit(static_cast<unsigned char>(value));
-									 });
-						if (isNum) {
-							routeFiles.push_back({std::stoi(numPart), entry.path()});
-						}
+			bool valid = !refs.empty();
+			json joinedBlocks = json::array();
+			if (valid) {
+				for (const int ref : refs) {
+					const std::string id = "route" + std::to_string(ref);
+					const auto found = std::find_if(routes.begin(), routes.end(), [&](const json& route) { return route["id"] == id; });
+					if (found == routes.end()) {
+						valid = false;
+						addDiag(SceneSeverity::Warning, "scene.import.ref", "Joined route refers to unknown route " + id,
+								joinsPath.string(), "signalling.joined_routes", true);
+						break;
 					}
+					for (const auto& block : (*found)["blocks"]) joinedBlocks.push_back(block);
+				}
+			}
+			if (!valid) {
+				report.skipped("signalling.joined_routes", joinsSource);
+				if (tokens.empty()) addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed joined route row", joinsPath.string());
+				continue;
+			}
+			while (loadedRouteIds.count("route" + std::to_string(nextJoinedRouteIndex)))
+				++nextJoinedRouteIndex;
+			const std::string joinedId = "route" + std::to_string(nextJoinedRouteIndex++);
+			json joined = {{"id", joinedId}, {"blocks", joinedBlocks}};
+			if (reversed) joined["reversed"] = true;
+			routes.push_back(joined);
+			loadedRouteIds.insert(joinedId);
+			report.converted("signalling.joined_routes", joinsSource);
+		}
+	}
+
+	// Only the dependency proven by the current Copenhagen signalling path is
+	// persisted. Other signals, virtual signals and TDS rows remain derived.
+	if (blockIds.count("1-B30") && blockIds.count("5-B6") && blockIds.count("5-B7")) {
+		blockDependencies.push_back({{"block", "5-B6"},
+			{"depends_on", "@1-B30@-4.592000/@5-B7@-4.620000"}});
+		report.source("signalling.dependencies", "Copenhagen hard-coded dependency");
+		report.converted("signalling.dependencies", "Copenhagen hard-coded dependency");
+	}
+
+	const fs::path singleTrackPath = guiDir.empty() ? fs::path() : findChild(guiDir, "singleTrackLimits.txt");
+	const std::string singleTrackSource = singleTrackPath.empty() ? (legacyPath / "GUI/singleTrackLimits.txt").string() : singleTrackPath.string();
+	if (!singleTrackPath.empty()) {
+		std::string content;
+		readFile(singleTrackPath, content);
+		std::stringstream input(content);
+		std::string line;
+		while (std::getline(input, line)) {
+			if (trim(line).empty()) continue;
+			report.source("signalling.single_track_restrictions", singleTrackSource);
+			auto tokens = splitTab(line);
+			if (tokens.size() < 4) tokens = readTokens(line);
+			if (tokens.size() < 4) {
+				report.skipped("signalling.single_track_restrictions", singleTrackSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed single-track restriction row", singleTrackPath.string());
+				continue;
+			}
+			json restriction = {{"start_block", stripOuterAt(tokens[0])}, {"end_block", stripOuterAt(tokens[1])},
+				{"protected_start_block", tokens[2]}, {"protected_end_block", tokens[3]}};
+			singleTrackRestrictions.push_back(restriction);
+			report.converted("signalling.single_track_restrictions", singleTrackSource);
+			for (int i = 0; i < 4; ++i) {
+				const std::string ref = i < 2 ? stripOuterAt(tokens[i]) : tokens[i];
+				if (!ref.empty() && !blockReferenceKnown(ref)) {
+					addDiag(SceneSeverity::Warning, "scene.import.ref", "Single-track restriction refers to unknown block " + ref,
+							singleTrackPath.string(), "signalling.single_track_restrictions", true);
 				}
 			}
 		}
 	}
-	std::sort(routeFiles.begin(), routeFiles.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
-	std::unordered_set<std::string> loadedRoutes;
-	for (const auto& pair : routeFiles) {
-		int routeIdx = pair.first;
-		std::string rId = "route" + std::to_string(routeIdx);
-		std::string rPath = "Routes/" + pair.second.filename().string();
-		std::string rContent;
-		if (!readFile(pair.second, rContent)) {
-			addDiag(SceneSeverity::Error, "scene.import.ref", "Missing route file: " + rPath, pair.second.string());
+	const fs::path boundaryPath = guiDir.empty() ? fs::path() : findChild(guiDir, "stationBoundarySections.txt");
+	const std::string boundarySource = boundaryPath.empty() ? (legacyPath / "GUI/stationBoundarySections.txt").string() : boundaryPath.string();
+	if (!boundaryPath.empty()) {
+		std::string content;
+		readFile(boundaryPath, content);
+		std::stringstream input(content);
+		std::string line;
+		while (std::getline(input, line)) {
+			if (trim(line).empty()) continue;
+			report.source("signalling.station_boundaries", boundarySource);
+			auto tokens = splitTab(line);
+			if (tokens.size() < 3) tokens = readTokens(line);
+			if (tokens.size() < 3) {
+				report.skipped("signalling.station_boundaries", boundarySource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed station-boundary row", boundaryPath.string());
+				continue;
+			}
+			int direction = 0;
+			if (!parseIntegerToken(tokens[2], direction) || (direction != 0 && direction != 1)) {
+				report.skipped("signalling.station_boundaries", boundarySource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Invalid station-boundary direction", boundaryPath.string(), "signalling.station_boundaries", true);
+				continue;
+			}
+			json boundary = {{"entrance_block", stripOuterAt(tokens[0])}, {"direction", direction != 0}};
+			if (!tokens[1].empty()) {
+				boundary["exit_block"] = stripOuterAt(tokens[1]);
+				if (!blockReferenceKnown(tokens[1])) {
+					addDiag(SceneSeverity::Warning, "scene.import.ref", "Station boundary refers to unknown exit block " + tokens[1],
+							boundaryPath.string(), "signalling.station_boundaries", true);
+				}
+			}
+			if (!blockReferenceKnown(tokens[0])) {
+				addDiag(SceneSeverity::Warning, "scene.import.ref", "Station boundary refers to unknown entrance block " + tokens[0],
+						boundaryPath.string(), "signalling.station_boundaries", true);
+			}
+			stationBoundaries.push_back(boundary);
+			report.converted("signalling.station_boundaries", boundarySource);
+		}
+	}
+
+	// Timetables preserve arrival and departure presence independently. The
+	// legacy -1 marker is omitted from its corresponding canonical field.
+	for (const auto& relation : relations) {
+		const fs::path timetablePath = resolvePath(legacyPath, relation.timetablePath);
+		const std::string timetableSource = relation.timetablePath;
+		std::string content;
+		if (!readFile(timetablePath, content)) {
+			report.skipped("timetable", timetableSource);
+			addDiag(SceneSeverity::Error, "scene.import.ref", "Missing timetable file: " + relation.timetablePath, timetablePath.string());
 			continue;
 		}
-
-		json blocksArr = json::array();
-		std::stringstream rSs(rContent);
-		std::string rLine;
-		int row = 0;
-		while (std::getline(rSs, rLine)) {
-			std::vector<std::string> rTokens = readTokens(rLine);
-			if (rTokens.empty())
+		json stops = json::array();
+		std::stringstream input(content);
+		std::string line;
+		int rowIndex = 0;
+		while (std::getline(input, line)) {
+			if (trim(line).empty()) continue;
+			report.source("timetable", timetableSource);
+			const auto tokens = readTokens(line);
+			if (tokens.size() < 4) {
+				report.skipped("timetable", timetableSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed timetable row " + std::to_string(rowIndex), timetablePath.string());
+				++rowIndex;
 				continue;
-			std::string token = rTokens[0];
-			size_t first = token.find('@');
-			size_t last = token.rfind('@');
-			if (first != std::string::npos && last != std::string::npos && first != last && first == 0 && last == token.length() - 1) {
-				blocksArr.push_back(token.substr(1, token.length() - 2));
-			} else if (isSwitchTransitionRouteToken(token)) {
-				// Netherlands route files use switch-transition tokens such
-				// as @a@-x/@b@-y. V1 stores route entries as opaque strings.
-				blocksArr.push_back(token);
+			}
+			double dwell = 0.0, arrival = -1.0, departure = -1.0;
+			if (!parseDoubleToken(tokens[tokens.size() - 3], dwell)
+					|| !parseDoubleToken(tokens[tokens.size() - 2], arrival)
+					|| !parseDoubleToken(tokens[tokens.size() - 1], departure)) {
+				report.skipped("timetable", timetableSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Invalid timetable row " + std::to_string(rowIndex), timetablePath.string());
+				++rowIndex;
+				continue;
+			}
+			std::string stationName = tokens[0];
+			for (std::size_t i = 1; i + 3 < tokens.size(); ++i) stationName += tokens[i];
+			bool ambiguous = false;
+			const std::string stationId = stationIdFor(stationName, ambiguous);
+			if (ambiguous || std::none_of(stations.begin(), stations.end(), [&](const json& station) { return station["id"] == stationId; })) {
+				addDiag(SceneSeverity::Warning, "scene.import.ref", "Timetable refers to unresolved station " + stationName,
+						timetablePath.string(), "timetable", true);
+			}
+			json stop = {{"station", stationId}, {"dwell_seconds", dwell}};
+			if (arrival != -1.0) {
+				stop["planned_arrival_seconds"] = arrival;
+			}
+			if (departure != -1.0) {
+				stop["planned_departure_seconds"] = departure;
+			}
+			if (arrival != -1.0 && departure != -1.0 && departure < arrival)
+				addDiag(SceneSeverity::Warning, "scene.import.timetable", "Legacy departure precedes arrival at " + stationName + "; values preserved", timetablePath.string());
+			stops.push_back(stop);
+			report.converted("timetable", timetableSource);
+			++rowIndex;
+		}
+		json service = {{"id", relation.serviceId}, {"operating_code", relation.operatingCode},
+			{"composition", relation.compositionId},
+			{"route", "route" + std::to_string(relation.routeIndex)}, {"entry_time_seconds", relation.entryTime}, {"stops", stops}};
+		if (stops.empty()) service["through"] = true;
+		if (relation.hasRepeat) service["repeat"] = {{"headway_seconds", relation.headway}};
+		services.push_back(service);
+		report.source("services", relation.serviceId);
+		report.converted("services", relation.serviceId);
+	}
+
+	// Parse each explicitly referenced parameter/tractive-effort pair exactly
+	// once. Pair identity, not filename convention, owns the association.
+	for (const auto& relation : unitRelations) {
+		const fs::path dataPath = resolvePath(legacyPath, relation.dataPath);
+		const fs::path tractionPath = resolvePath(legacyPath, relation.tractionPath);
+		const std::string dataSource = relation.dataPath;
+		const std::string tractionSource = relation.tractionPath;
+		std::string dataContent;
+		if (!readFile(dataPath, dataContent)) {
+			report.skipped("rolling_stock.data", dataSource);
+			addDiag(SceneSeverity::Error, "scene.import.ref", "Missing train data file: " + relation.dataPath, dataPath.string());
+			continue;
+		}
+		const auto dataTokens = readTokens(dataContent);
+		if (dataTokens.size() < 9) {
+			report.skipped("rolling_stock.data", dataSource);
+			addDiag(SceneSeverity::Error, "scene.import.parse", "Malformed train data file", dataPath.string());
+			continue;
+		}
+		json physical = json::array();
+		bool physicalValid = true;
+		for (int i = 0; i < 9; ++i) {
+			double value = 0.0;
+			if (!parseDoubleToken(dataTokens[static_cast<std::size_t>(i)], value)) physicalValid = false;
+			physical.push_back(value);
+		}
+		if (!physicalValid) {
+			report.skipped("rolling_stock.data", dataSource);
+			addDiag(SceneSeverity::Error, "scene.import.parse", "Invalid numbers in train data file", dataPath.string());
+			continue;
+		}
+		report.source("rolling_stock.data", dataSource);
+		report.converted("rolling_stock.data", dataSource);
+
+		std::string tractionContent;
+		if (!readFile(tractionPath, tractionContent)) {
+			report.skipped("rolling_stock.traction", tractionSource);
+			addDiag(SceneSeverity::Error, "scene.import.ref", "Missing traction file: " + relation.tractionPath, tractionPath.string());
+			continue;
+		}
+		json curve = json::array();
+		std::stringstream tractionInput(tractionContent);
+		std::string line;
+		int rowIndex = 0;
+		while (std::getline(tractionInput, line)) {
+			if (trim(line).empty()) continue;
+			report.source("rolling_stock.traction", tractionSource);
+			const auto tokens = readTokens(line);
+			if (tokens.size() < 5) {
+				report.skipped("rolling_stock.traction", tractionSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed traction row " + std::to_string(rowIndex), tractionPath.string());
+				++rowIndex;
+				continue;
+			}
+			json row = json::array();
+			bool valid = true;
+			for (int i = 0; i < 5; ++i) {
+				double value = 0.0;
+				if (!parseDoubleToken(tokens[static_cast<std::size_t>(i)], value)) valid = false;
+				row.push_back(value);
+			}
+			if (!valid) {
+				report.skipped("rolling_stock.traction", tractionSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Invalid traction row " + std::to_string(rowIndex), tractionPath.string());
 			} else {
-				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed route block token at row " + std::to_string(row), rPath);
-				blocksArr.push_back(token);
+				curve.push_back(row);
+				report.converted("rolling_stock.traction", tractionSource);
 			}
-			row++;
+			++rowIndex;
 		}
-
-		routesArr.push_back({{"id", rId},
-							 {"blocks", blocksArr}});
-		loadedRoutes.insert(rId);
+		if (curve.empty()) {
+			addDiag(SceneSeverity::Error, "scene.import.parse", "Train traction file has no valid rows", tractionPath.string());
+			continue;
+		}
+		trainUnits.push_back({{"id", relation.id},
+			{"physical", {{"mass_of_traction_unit_kg", physical[0]}, {"mass_of_a_wagon_kg", physical[1]},
+			{"number_of_wagons", physical[2]}, {"max_speed_ms", physical[3]}, {"max_deceleration_ms2", physical[4]},
+			{"frontal_area_m2", physical[5]}, {"resistance_coefficient", physical[6]}, {"jerk_ms3", physical[7]}, {"length_m", physical[8]}}},
+			{"traction_curve", curve}, {"source", {{"data_file", relation.dataPath}, {"traction_file", relation.tractionPath}}}});
+		compositions.push_back({{"id", relation.id}, {"units", {relation.id}}});
+		report.source("rolling_stock.compositions", relation.id);
+		report.converted("rolling_stock.compositions", relation.id);
 	}
 
-	for (const auto& rId : referencedRoutes) {
-		if (loadedRoutes.find(rId) == loadedRoutes.end()) {
-			std::string idxStr = rId.substr(5);
-			std::string rPath = "Routes/Route" + idxStr + ".txt";
-			addDiag(SceneSeverity::Error, "scene.import.ref", "Missing route file: " + rPath,
-					resolvePath(legacyPath, rPath).string());
+	// Baseline incidents are the only flat legacy scenario input. Rollout files
+	// contain positional delay vectors; map them in manifest order and retain
+	// the same value at the two stations used by the runtime scenario loader.
+	json baseline = {{"id", "baseline"}, {"name", "Baseline"}, {"incidents", json::array()}, {"entrance_delays", json::array()}};
+	const fs::path incidentsPath = findChild(legacyPath, "Incidents.txt");
+	const std::string incidentsSource = incidentsPath.empty() ? (legacyPath / "Incidents.txt").string() : incidentsPath.string();
+	if (!incidentsPath.empty()) {
+		std::string content;
+		readFile(incidentsPath, content);
+		std::stringstream input(content);
+		std::string line;
+		int lineNo = 0;
+		while (std::getline(input, line)) {
+			++lineNo;
+			if (trim(line).empty()) continue;
+			report.source("scenarios.incidents", incidentsSource);
+			auto tokens = splitTab(line);
+			if (tokens.size() < 4) tokens = readTokens(line);
+			double start = 0.0, end = 0.0;
+			if (tokens.size() < 4 || !parseDoubleToken(tokens[2], start) || !parseDoubleToken(tokens[3], end)) {
+				report.skipped("scenarios.incidents", incidentsSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed incident row " + std::to_string(lineNo), incidentsPath.string());
+				continue;
+			}
+			std::vector<std::string> targets = {tokens[1]};
+			if (tokens[0] == "train_breakdown") {
+				targets.clear();
+				for (const auto& relation : relations) {
+					if (relation.operatingCode == tokens[1])
+						targets.push_back(relation.serviceId);
+				}
+				if (targets.empty()) {
+					targets.push_back(tokens[1]);
+					addDiag(SceneSeverity::Warning, "scene.import.ref",
+							"Train-breakdown incident refers to an unknown service code " + tokens[1],
+							incidentsPath.string(), "scenarios.incidents", true);
+				} else if (targets.size() > 1) {
+					addDiag(SceneSeverity::Warning, "scene.import.expanded",
+							"Train-breakdown incident code " + tokens[1] + " matches "
+									+ std::to_string(targets.size())
+									+ " services; expanded to preserve legacy prefix-match semantics",
+							incidentsPath.string());
+				}
+			}
+			for (std::size_t targetIndex = 0; targetIndex < targets.size(); ++targetIndex) {
+				std::string id = "incident." + std::to_string(lineNo);
+				if (targets.size() > 1)
+					id += "." + std::to_string(targetIndex + 1);
+				baseline["incidents"].push_back({{"id", id}, {"type", tokens[0]},
+					{"target", targets[targetIndex]}, {"start_seconds", start}, {"end_seconds", end}});
+			}
+			report.converted("scenarios.incidents", incidentsSource);
 		}
 	}
 
-	json stationsArr = json::array();
-	fs::path stationsPath = resolvePath(legacyPath, "Tracklines/Stations.txt");
-	if (!fs::exists(stationsPath)) {
-		stationsPath = resolvePath(legacyPath, "TrackLines/Stations.txt");
+	const fs::path timetableRoot = findChild(legacyPath, "TimeTable");
+	const fs::path rolloutDir = timetableRoot.empty() ? fs::path() : findChild(timetableRoot, "Scenarios_Entrance_Delays");
+	std::vector<std::pair<int, fs::path>> rolloutFiles;
+	std::error_code rolloutEc;
+	if (!rolloutDir.empty() && fs::is_directory(rolloutDir, rolloutEc)) {
+		const std::regex rolloutPattern("^Rollout_([0-9]+)\\.txt$", std::regex::icase);
+		for (const auto& entry : fs::directory_iterator(rolloutDir, rolloutEc)) {
+			if (!entry.is_regular_file(rolloutEc)) continue;
+			std::smatch match;
+			const std::string filename = entry.path().filename().string();
+			if (!std::regex_match(filename, match, rolloutPattern)) continue;
+			int index = 0;
+			if (parseIntegerToken(match[1].str(), index)) rolloutFiles.push_back({index, entry.path()});
+		}
 	}
-	const bool flatInfrastructure = !fs::exists(stationsPath)
-		&& fs::is_regular_file(resolvePath(legacyPath, "Stations.txt"));
-	if (flatInfrastructure)
-		stationsPath = resolvePath(legacyPath, "Stations.txt");
-	if (fs::exists(stationsPath)) {
-		std::string stContent;
-		if (readFile(stationsPath, stContent)) {
-			std::stringstream stSs(stContent);
-			std::string stLine;
-			int row = 0;
-			while (std::getline(stSs, stLine)) {
-				if (trim(stLine).empty())
-					continue;
-				size_t tabPos = stLine.find('\t');
-				std::string name;
-				double pos = 0;
-				if (tabPos != std::string::npos) {
-					std::string posStr = stLine.substr(0, tabPos);
-					name = stLine.substr(tabPos + 1);
-					try {
-						pos = std::stod(trim(posStr));
-					} catch (...) {
-						addDiag(SceneSeverity::Error, "scene.import.parse", "Invalid pos in station row " + std::to_string(row), stationsPath.string());
-						continue;
-					}
-				} else {
-					std::vector<std::string> stTokens = readTokens(stLine);
-					if (stTokens.size() < 2) {
-						addDiag(SceneSeverity::Error, "scene.import.parse", "Malformed station row " + std::to_string(row), stationsPath.string());
-						continue;
-					}
-					try {
-						pos = std::stod(stTokens[0]);
-					} catch (...) {
-						addDiag(SceneSeverity::Error, "scene.import.parse", "Invalid pos in station row " + std::to_string(row), stationsPath.string());
-						continue;
-					}
-					name = stLine.substr(stLine.find(stTokens[1]));
-				}
-				name = trim(name);
-				if (name.empty()) {
-					addDiag(SceneSeverity::Error, "scene.import.parse", "Empty station name in row " + std::to_string(row), stationsPath.string());
+	std::sort(rolloutFiles.begin(), rolloutFiles.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+	for (const auto& rollout : rolloutFiles) {
+		const std::string source = rollout.second.string();
+		std::string content;
+		readFile(rollout.second, content);
+		const auto values = readTokens(content);
+		const std::string scenarioId = "rollout_" + std::to_string(rollout.first);
+		json rolloutIncidents = baseline["incidents"];
+		for (auto& incident : rolloutIncidents)
+			incident["id"] = scenarioId + "." + incident["id"].get<std::string>();
+		json scenario = {{"id", scenarioId}, {"name", "Rollout " + std::to_string(rollout.first)},
+			{"incidents", rolloutIncidents}, {"entrance_delays", json::array()}};
+		std::size_t valueIndex = 0;
+		if (!knownSettings) {
+			const int valuesCount = static_cast<int>(values.size());
+			auto& row = report.row("scenarios.rollouts", source);
+			row.sourceCount += valuesCount;
+			row.skippedCount += valuesCount;
+			row.unresolvedReferences++;
+			addDiag(SceneSeverity::Warning, "scene.import.scenario", "Cannot map rollout without known duration", source);
+			scenarios.push_back(scenario);
+			continue;
+		}
+		for (const auto& relation : relations) {
+			int occurrences = 1;
+			if (relation.hasRepeat && relation.headway > 0.0)
+				occurrences = std::max(1, static_cast<int>(std::ceil(durationSeconds / relation.headway)));
+			for (int occurrence = 1; occurrence <= occurrences; ++occurrence) {
+				report.source("scenarios.rollouts", source);
+				if (valueIndex >= values.size()) {
+					report.skipped("scenarios.rollouts", source);
+					addDiag(SceneSeverity::Warning, "scene.import.scenario", "Rollout vector is shorter than the service occurrence mapping", source, "scenarios.rollouts", true);
+					++valueIndex;
 					continue;
 				}
-
-				stationsArr.push_back({{"id", name},
-									   {"name", name},
-									   {"position_km", pos},
-									   {"platforms", json::array()}});
-				row++;
+				double delay = 0.0;
+				if (!parseDoubleToken(values[valueIndex], delay)) {
+					report.skipped("scenarios.rollouts", source);
+					addDiag(SceneSeverity::Warning, "scene.import.parse", "Invalid rollout delay value", source, "scenarios.rollouts", true);
+					++valueIndex;
+					continue;
+				}
+				++valueIndex;
+				json serviceStops;
+				const auto serviceIt = std::find_if(services.begin(), services.end(), [&](const json& service) { return service["id"] == relation.serviceId; });
+				if (serviceIt != services.end()) serviceStops = (*serviceIt)["stops"];
+				bool emitted = false;
+				for (const auto& stop : serviceStops) {
+					const std::string station = stop["station"].get<std::string>();
+					if (station != "Guingamp" && station != "Paimpol") continue;
+					scenario["entrance_delays"].push_back({{"service", relation.serviceId}, {"occurrence", occurrence},
+						{"station", station}, {"delay_seconds", delay}});
+					emitted = true;
+				}
+				if (emitted) report.converted("scenarios.rollouts", source);
+				else report.skipped("scenarios.rollouts", source);
 			}
 		}
-	} else {
-		addDiag(SceneSeverity::Error, "scene.import.missing", "Missing Tracklines/Stations.txt", stationsPath.string());
+		if (valueIndex < values.size()) {
+			report.skipped("scenarios.rollouts", source);
+			addDiag(SceneSeverity::Warning, "scene.import.scenario", "Rollout vector has extra values", source, "scenarios.rollouts", true);
+		}
+		scenarios.push_back(scenario);
+	}
+	scenarios.insert(scenarios.begin(), baseline);
+	report.row("scenarios", "scenarios.json").sourceCount = static_cast<int>(scenarios.size());
+	report.row("scenarios", "scenarios.json").convertedCount = static_cast<int>(scenarios.size());
+
+	// The passenger importer is intentionally gated by the same two exact files
+	// used by DispatchController. It keeps deterministic windows, never random
+	// draws or generated runtime results.
+	const fs::path passengerDir = findChild(legacyPath, "Passengers");
+	const fs::path dasPath = passengerDir.empty() ? fs::path() : passengerDir / "DAS_FrenchCaseStudy.csv";
+	const fs::path routeChoicePath = passengerDir.empty() ? fs::path() : passengerDir / "RouteChoiceFC_EQ1.csv";
+	const bool hasDas = !passengerDir.empty() && fs::is_regular_file(dasPath);
+	const bool hasRouteChoice = !passengerDir.empty() && fs::is_regular_file(routeChoicePath);
+	const std::string dasSource = (passengerDir / "DAS_FrenchCaseStudy.csv").string();
+	const std::string routeChoiceSource = (passengerDir / "RouteChoiceFC_EQ1.csv").string();
+	if (hasDas && hasRouteChoice) {
+		std::unordered_map<std::string, std::size_t> passengerIndex;
+		std::unordered_map<std::string, std::vector<std::pair<std::size_t, std::size_t>>> journeysByPersonDestination;
+		std::string content;
+		readFile(dasPath, content);
+		std::stringstream input(content);
+		std::string line;
+		bool header = true;
+		int rowNo = 0;
+		while (std::getline(input, line)) {
+			if (header) { header = false; continue; }
+			if (trim(line).empty()) continue;
+			++rowNo;
+			report.source("passengers.das", dasSource);
+			const auto fields = splitCsvNaive(line);
+			if (fields.size() <= 14) {
+				report.skipped("passengers.das", dasSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed passenger DAS row " + std::to_string(rowNo), dasPath.string());
+				continue;
+			}
+			const std::string personId = fields[1];
+			if (personId.empty()) {
+				report.skipped("passengers.das", dasSource);
+				addDiag(SceneSeverity::Warning, "scene.import.ref", "Passenger row has no person id", dasPath.string(), "passengers.das", true);
+				continue;
+			}
+			std::size_t pIndex = 0;
+			const auto foundPassenger = passengerIndex.find(personId);
+			if (foundPassenger == passengerIndex.end()) {
+				pIndex = passengers.size();
+				passengerIndex[personId] = pIndex;
+				passengers.push_back({{"id", personId}, {"journeys", json::array()}});
+			} else pIndex = foundPassenger->second;
+			std::string journeyId = personId + ":" + (fields[4].empty() ? std::to_string(rowNo) : fields[4]);
+			const std::string originalJourneyId = journeyId;
+			for (int suffix = 2;; ++suffix) {
+				bool duplicate = false;
+				for (const auto& journey : passengers[pIndex]["journeys"])
+					if (journey["id"] == journeyId) duplicate = true;
+				if (!duplicate) break;
+				journeyId = originalJourneyId + "_" + std::to_string(suffix);
+			}
+			bool ambiguousOrigin = false, ambiguousDestination = false;
+			const std::string origin = stationIdFor(fields[12], ambiguousOrigin);
+			const std::string destination = stationIdFor(fields[6], ambiguousDestination);
+			if (ambiguousOrigin || ambiguousDestination
+					|| std::none_of(stations.begin(), stations.end(), [&](const json& value) { return value["id"] == origin; })
+					|| std::none_of(stations.begin(), stations.end(), [&](const json& value) { return value["id"] == destination; })) {
+				addDiag(SceneSeverity::Warning, "scene.import.ref", "Passenger journey has an unresolved station reference", dasPath.string(), "passengers.das", true);
+			}
+			const auto departure = passengerTimeWindow(fields[14]);
+			const auto arrival = passengerTimeWindow(fields[10]);
+			json journey = {{"id", journeyId}, {"activity", fields[5]}, {"origin", origin}, {"destination", destination},
+				{"planned_departure", {{"start_seconds", departure.first}, {"end_seconds", departure.second}}},
+				{"planned_arrival", {{"start_seconds", arrival.first}, {"end_seconds", arrival.second}}}, {"legs", json::array()}};
+			const std::size_t jIndex = passengers[pIndex]["journeys"].size();
+			passengers[pIndex]["journeys"].push_back(journey);
+			journeysByPersonDestination[personId + "\n" + destination].push_back({pIndex, jIndex});
+			report.converted("passengers.das", dasSource);
+		}
+
+		readFile(routeChoicePath, content);
+		std::stringstream routeInput(content);
+		std::string routeLine;
+		std::vector<std::string> headers;
+		std::vector<std::size_t> transferColumns;
+		std::vector<std::size_t> serviceColumns;
+		bool routeHeader = true;
+		int routeRow = 0;
+		while (std::getline(routeInput, routeLine)) {
+			if (routeHeader) {
+				routeHeader = false;
+				headers = splitCsvNaive(routeLine);
+				for (std::size_t i = 0; i < headers.size(); ++i) {
+					const std::string lower = lowerCopy(headers[i]);
+					if (lower.rfind("transfer_n", 0) == 0) transferColumns.push_back(i);
+					if (lower.rfind("r_service_lines_id", 0) == 0) serviceColumns.push_back(i);
+				}
+				continue;
+			}
+			if (trim(routeLine).empty()) continue;
+			++routeRow;
+			report.source("passengers.route_choice", routeChoiceSource);
+			const auto fields = splitCsvNaive(routeLine);
+			if (fields.size() < headers.size()) {
+				report.skipped("passengers.route_choice", routeChoiceSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Malformed passenger route-choice row " + std::to_string(routeRow), routeChoicePath.string());
+				continue;
+			}
+			auto column = [&](std::initializer_list<const char*> wanted) -> std::size_t {
+				for (std::size_t i = 0; i < headers.size(); ++i) {
+					const std::string header = lowerCopy(headers[i]);
+					for (const char* value : wanted)
+						if (header == value) return i;
+				}
+				return headers.size();
+			};
+			const std::size_t personColumn = column({"person_id", "person"});
+			const std::size_t destinationColumn = column({"destination"});
+			const std::size_t transferCountColumn = column({"nb_transfers"});
+			int transferCount = 0;
+			if (personColumn == headers.size() || destinationColumn == headers.size() || transferCountColumn == headers.size()
+				|| !parseIntegerToken(fields[transferCountColumn], transferCount) || transferCount < 0) {
+				report.skipped("passengers.route_choice", routeChoiceSource);
+				addDiag(SceneSeverity::Warning, "scene.import.parse", "Passenger route-choice header or transfer count is invalid", routeChoicePath.string(), "passengers.route_choice", true);
+				continue;
+			}
+			const std::string personId = fields[personColumn];
+			bool destinationAmbiguous = false;
+			const std::string destination = stationIdFor(fields[destinationColumn], destinationAmbiguous);
+			const auto journeyIt = journeysByPersonDestination.find(personId + "\n" + destination);
+			if (destinationAmbiguous || journeyIt == journeysByPersonDestination.end() || journeyIt->second.size() != 1) {
+				report.skipped("passengers.route_choice", routeChoiceSource);
+				addDiag(SceneSeverity::Warning, "scene.import.ref", "Passenger route-choice journey reference is missing or ambiguous", routeChoicePath.string(), "passengers.route_choice", true);
+				continue;
+			}
+			const auto target = journeyIt->second.front();
+			std::vector<std::string> transferStations;
+			for (int i = 0; i < transferCount; ++i) {
+				if (static_cast<std::size_t>(i) >= transferColumns.size()) break;
+				transferStations.push_back(fields[transferColumns[static_cast<std::size_t>(i)]]);
+			}
+			if (static_cast<int>(transferStations.size()) != transferCount || static_cast<std::size_t>(transferCount + 1) > serviceColumns.size()) {
+				report.skipped("passengers.route_choice", routeChoiceSource);
+				addDiag(SceneSeverity::Warning, "scene.import.ref", "Passenger route-choice leg columns are incomplete", routeChoicePath.string(), "passengers.route_choice", true);
+				continue;
+			}
+			std::vector<std::string> legServices;
+			for (int i = 0; i <= transferCount; ++i) legServices.push_back(fields[serviceColumns[static_cast<std::size_t>(i)]]);
+			std::vector<std::string> legStations;
+			legStations.push_back(passengers[target.first]["journeys"][target.second]["origin"].get<std::string>());
+			bool transferAmbiguous = false;
+			for (const auto& transfer : transferStations) {
+				bool ambiguous = false;
+				legStations.push_back(stationIdFor(transfer, ambiguous));
+				transferAmbiguous = transferAmbiguous || ambiguous;
+			}
+			legStations.push_back(passengers[target.first]["journeys"][target.second]["destination"].get<std::string>());
+			if (transferAmbiguous) {
+				addDiag(SceneSeverity::Warning, "scene.import.ref", "Passenger route-choice transfer station is ambiguous",
+						routeChoicePath.string(), "passengers.route_choice", true);
+			}
+			for (std::size_t i = 0; i < legServices.size(); ++i) {
+				const std::string token = legServices[i];
+				std::string serviceId;
+				int occurrence = 1;
+				bool serviceAmbiguous = false;
+				for (const auto& service : services) {
+					const std::string prefix = service.value("operating_code",
+							service["id"].get<std::string>()) + "-";
+					if (token.rfind(prefix, 0) != 0) continue;
+					int candidateOccurrence = 0;
+					if (!parseIntegerToken(token.substr(prefix.size()), candidateOccurrence) || candidateOccurrence < 1) continue;
+					if (!serviceId.empty()) serviceAmbiguous = true;
+					serviceId = service["id"].get<std::string>();
+					occurrence = candidateOccurrence;
+				}
+				if (serviceAmbiguous)
+					serviceId.clear();
+				bool originAmbiguous = false, destinationAmbiguous = false;
+				if (i >= legStations.size() - 1) break;
+				const std::string origin = stationIdFor(legStations[i], originAmbiguous);
+				const std::string destinationStation = stationIdFor(legStations[i + 1], destinationAmbiguous);
+				if (serviceId.empty() || serviceAmbiguous || originAmbiguous || destinationAmbiguous) {
+					addDiag(SceneSeverity::Warning, "scene.import.ref", "Passenger route-choice service or station reference is ambiguous", routeChoicePath.string(), "passengers.route_choice", true);
+				}
+				passengers[target.first]["journeys"][target.second]["legs"].push_back({
+					{"id", passengers[target.first]["journeys"][target.second]["id"].get<std::string>() + ".leg." + std::to_string(i + 1)},
+					{"origin", origin}, {"destination", destinationStation}, {"service", serviceId.empty() ? token : serviceId}, {"occurrence", occurrence}});
+			}
+			report.converted("passengers.route_choice", routeChoiceSource);
+		}
+	} else if (hasDas || hasRouteChoice) {
+		if (hasDas) report.skipped("passengers.das", dasSource);
+		if (hasRouteChoice) report.skipped("passengers.route_choice", routeChoiceSource);
+		addDiag(SceneSeverity::Warning, "scene.import.passengers", "Passenger import requires both exact DAS and route-choice files", passengerDir.string(), "passengers", true);
 	}
 
-	json sceneJson = {
-		{"schema_version", 1},
-		{"name", sceneName},
-		{"legacy_source", legacyDir}};
-	json infraJson = {
-		{"nodes", json::array()},
-		{"arcs", json::array()}};
-	json signallingJson = {
-		{"signals", json::array()},
-		{"routes", routesArr}};
-	json rollingJson = {
-		{"train_units", trainUnitsArr},
-		{"compositions", compositionsArr}};
-	json outServicesJson = {
-		{"services", servicesArr}};
-	json outStationsJson = {
-		{"stations", stationsArr}};
+	json sceneJson = {{"schema_version", 1}, {"name", sceneName},
+		{"units", {{"distance", "m"}, {"time", "s"}, {"speed", "m/s"}}}};
+	if (knownSettings) {
+		sceneJson["base_time"] = baseTime;
+		sceneJson["simulation_settings"] = {{"duration_seconds", durationSeconds}, {"buffer_time_seconds", 0.0}, {"recovery_time_percent", 0.0}};
+	}
+	sceneJson["import_report"] = json::array();
+	for (const auto& row : report.rows) {
+		sceneJson["import_report"].push_back({{"category", row.category}, {"source_file", row.sourceFile},
+			{"source_count", row.sourceCount}, {"converted_count", row.convertedCount},
+			{"skipped_count", row.skippedCount}, {"unresolved_references", row.unresolvedReferences}});
+	}
+	json signalling = {{"signals", json::array()}, {"routes", routes}, {"block_dependencies", blockDependencies},
+		{"single_track_restrictions", singleTrackRestrictions}, {"station_boundaries", stationBoundaries}};
+	json rollingStock = {{"train_units", trainUnits}, {"compositions", compositions}};
+	json servicesFile = {{"services", services}};
+	json stationsFile = {{"stations", stations}};
+	json scenariosFile = {{"default_scenario_id", "baseline"}, {"scenarios", scenarios}};
 
-	// Do not touch the selected destination after any parser/reference error.
-	if (hasErrors(result.diagnostics))
-		return result;
-
+	// Preserve atomic staging/publish semantics: no destination is touched while
+	// parsing, validation, or passthrough copying can still fail.
+	if (hasErrors(result.diagnostics)) return result;
 	std::error_code ec;
 	fs::path sceneParent = scenePath.parent_path();
-	if (sceneParent.empty())
-		sceneParent = ".";
+	if (sceneParent.empty()) sceneParent = ".";
 	fs::create_directories(sceneParent, ec);
 	if (ec) {
 		addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot create scene parent directory: " + ec.message(), scenePath.string());
 		return result;
 	}
-
 	std::error_code stagingPathEc;
 	const fs::path stagingPath = uniqueSiblingPath(scenePath, "importing", stagingPathEc);
-	fs::path backupPath;
+	if (stagingPathEc) {
+		addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot inspect scene destination: " + stagingPathEc.message(), scenePath.string());
+		return result;
+	}
 	auto removeStaging = [&]() {
-		if (stagingPath.empty())
-			return;
+		if (stagingPath.empty()) return;
 		std::error_code cleanupEc;
 		fs::remove_all(stagingPath, cleanupEc);
 	};
-	if (stagingPathEc) {
-		addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot inspect scene destination: " + stagingPathEc.message(), scenePath.string());
-		removeStaging();
-		return result;
-	}
-
 	fs::create_directories(stagingPath, ec);
 	if (ec) {
 		addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot create staging directory: " + ec.message(), scenePath.string());
 		removeStaging();
 		return result;
 	}
-
-	// Reimports replace the passthrough subtree exactly inside staging; the
-	// existing destination remains untouched until the final publish rename.
 	fs::path outLegacy = stagingPath / "legacy";
 	fs::create_directories(outLegacy, ec);
 	if (ec) {
-		addDiag(SceneSeverity::Error, "scene.import.missing",
-				"Cannot create legacy passthrough directory: " + ec.message(), (scenePath / "legacy").string());
+		addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot create legacy passthrough directory: " + ec.message(), (scenePath / "legacy").string());
 		removeStaging();
 		return result;
 	}
-
 	bool allWritten = true;
-	auto writeJson = [&](const std::string& filename, const json& j) {
-		const fs::path outputPath = stagingPath / filename;
-		std::ofstream out(outputPath);
-		out << j.dump(4) << "\n";
-		if (!out.good()) {
-			addDiag(SceneSeverity::Error, "scene.import.missing", "Failed to write " + filename,
-					(scenePath / filename).string());
+	auto writeJson = [&](const std::string& filename, const json& value) {
+		std::ofstream output(stagingPath / filename);
+		if (!output) {
+			addDiag(SceneSeverity::Error, "scene.import.write", "Failed to write " + filename, (scenePath / filename).string());
+			allWritten = false;
+			return;
+		}
+		output << value.dump(4) << "\n";
+		if (!output.good()) {
+			addDiag(SceneSeverity::Error, "scene.import.write", "Failed to write " + filename, (scenePath / filename).string());
 			allWritten = false;
 		}
 	};
-
 	writeJson("scene.json", sceneJson);
-	writeJson("infrastructure.json", infraJson);
-	writeJson("signalling.json", signallingJson);
-	writeJson("rolling_stock.json", rollingJson);
-	writeJson("services.json", outServicesJson);
-	writeJson("stations.json", outStationsJson);
+	writeJson("infrastructure.json", infrastructure);
+	writeJson("stations.json", stationsFile);
+	writeJson("signalling.json", signalling);
+	writeJson("rolling_stock.json", rollingStock);
+	writeJson("services.json", servicesFile);
+	writeJson("scenarios.json", scenariosFile);
+	if (hasDas && hasRouteChoice) writeJson("passengers.json", {{"passengers", passengers}});
 	if (!allWritten) {
 		removeStaging();
 		return result;
 	}
 
-	// Legacy passthrough: unconverted runtime inputs travel with the scene so
-	// the future exporter can rebuild a runnable legacy folder from it alone.
+	// Keep the existing passthrough boundary. Canonical files own converted
+	// fields; unconverted runtime support folders remain available to the
+	// directional exporter without serialising generated caches.
 	auto copyInto = [&](const fs::path& from, const fs::path& to) {
 		std::error_code copyEc;
 		fs::path failedPath = from;
@@ -714,88 +1664,53 @@ SceneImportResult importLegacyScene(const std::string& legacyDir,
 				for (fs::recursive_directory_iterator it(from, copyEc), end; it != end && !copyEc; it.increment(copyEc)) {
 					failedPath = it->path();
 					const fs::path relative = fs::relative(it->path(), from, copyEc);
-					if (copyEc)
-						break;
+					if (copyEc) break;
 					const fs::path target = to / relative;
-					if (it->is_directory(copyEc)) {
-						fs::create_directories(target, copyEc);
-					} else if (it->is_regular_file(copyEc)) {
+					if (it->is_directory(copyEc)) fs::create_directories(target, copyEc);
+					else if (it->is_regular_file(copyEc)) {
 						fs::create_directories(target.parent_path(), copyEc);
-						if (!copyEc)
-							fs::copy_file(it->path(), target, fs::copy_options::overwrite_existing, copyEc);
+						if (!copyEc) fs::copy_file(it->path(), target, fs::copy_options::overwrite_existing, copyEc);
 					}
 				}
 			}
 		} else {
 			fs::create_directories(to.parent_path(), copyEc);
-			if (!copyEc)
-				fs::copy_file(from, to, fs::copy_options::overwrite_existing, copyEc);
+			if (!copyEc) fs::copy_file(from, to, fs::copy_options::overwrite_existing, copyEc);
 		}
-		if (copyEc) {
-			addDiag(SceneSeverity::Error, "scene.import.missing",
-					"Could not copy legacy data " + from.filename().string() + ": " + copyEc.message(), failedPath.string());
-		}
+		if (copyEc) addDiag(SceneSeverity::Error, "scene.import.missing", "Could not copy legacy data: " + copyEc.message(), failedPath.string());
 	};
-	std::vector<std::string> passDirs = {"Tracklines", "TrackLines", "TMS", "TDS", "GUI", "Rescheduling", "Passengers", "RoutesToWrite"};
+	std::vector<std::string> passDirs = {"TrackLines", "TMS", "TDS", "GUI", "Rescheduling", "Passengers", "RoutesToWrite"};
 	std::unordered_set<std::string> copiedDirs;
-	for (const auto& d : passDirs) {
-		fs::path p = resolvePath(legacyPath, d);
-		if (fs::is_directory(p, ec)) {
-			// Canonical keys stop the same directory being copied twice when the
-			// filesystem is case-insensitive and both name variants resolve.
-			fs::path canon = fs::weakly_canonical(p, ec);
-			std::string key = ec ? p.lexically_normal().string() : canon.string();
-			if (copiedDirs.insert(key).second) {
-				copyInto(p, outLegacy / p.filename());
-			}
-		}
+	for (const auto& directory : passDirs) {
+		const fs::path source = resolvePath(legacyPath, directory);
+		if (!fs::is_directory(source, ec)) continue;
+		const fs::path canonical = fs::weakly_canonical(source, ec);
+		const std::string key = ec ? source.lexically_normal().string() : canonical.string();
+		if (copiedDirs.insert(key).second) copyInto(source, outLegacy / source.filename());
 	}
+	const bool flatInfrastructure = trackRoot == legacyPath;
 	if (flatInfrastructure) {
 		const fs::path flatTracklines = outLegacy / "Tracklines";
-		const std::vector<std::string> flatFiles = {"Stations.txt", "Connections.txt", "TrackandStations.txt"};
-		for (const auto& name : flatFiles) {
-			fs::path source = resolvePath(legacyPath, name);
-			if (fs::is_regular_file(source, ec))
-				copyInto(source, flatTracklines / source.filename());
+		for (const auto& name : {"Stations.txt", "Connections.txt", "TrackandStations.txt"}) {
+			const fs::path source = resolvePath(legacyPath, name);
+			if (fs::is_regular_file(source, ec)) copyInto(source, flatTracklines / source.filename());
 		}
-		for (const auto& entry : fs::directory_iterator(legacyPath, ec)) {
-			if (!entry.is_directory())
-				continue;
+		for (const auto& track : trackDirs) copyInto(track.second, flatTracklines / track.second.filename());
+	}
+	if (!timetableRoot.empty() && fs::is_directory(timetableRoot, ec)) {
+		for (const auto& entry : fs::directory_iterator(timetableRoot, ec)) {
+			if (!entry.is_directory(ec)) continue;
+			if (lowerCopy(entry.path().filename().string()).rfind("scenarios_", 0) == 0)
+				copyInto(entry.path(), outLegacy / "Timetable" / entry.path().filename());
+		}
+	}
+	if (!routesDir.empty() && fs::is_directory(routesDir, ec)) {
+		for (const auto& entry : fs::directory_iterator(routesDir, ec)) {
+			if (!entry.is_regular_file(ec)) continue;
 			const std::string name = entry.path().filename().string();
-			const bool isBlock = name.size() > 1 && name[0] == 'B'
-				&& std::all_of(name.begin() + 1, name.end(), [](char c) {
-					return std::isdigit(static_cast<unsigned char>(c));
-				});
-			if (isBlock)
-				copyInto(entry.path(), flatTracklines / name);
+			if (lowerCopy(name).rfind("route", 0) != 0) copyInto(entry.path(), outLegacy / "Routes" / name);
 		}
 	}
-	// Scenario folders live inside the timetable directory next to the
-	// per-service files; only the folders are passed through.
-	fs::path ttDir = resolvePath(legacyPath, "Timetable");
-	if (fs::is_directory(ttDir, ec)) {
-		for (const auto& entry : fs::directory_iterator(ttDir, ec)) {
-			if (entry.is_directory()) {
-				std::string dirName = entry.path().filename().string();
-				if (dirName.find("Scenarios_") == 0) {
-					copyInto(entry.path(), outLegacy / "Timetable" / dirName);
-				}
-			}
-		}
-	}
-	// Routes/ keeps its non-Route<N> support files.
-	fs::path rDir = resolvePath(legacyPath, "Routes");
-	if (fs::is_directory(rDir, ec)) {
-		for (const auto& entry : fs::directory_iterator(rDir, ec)) {
-			if (entry.is_regular_file()) {
-				std::string name = entry.path().filename().string();
-				if (name.find("Route") != 0 && name.find("route") != 0) {
-					copyInto(entry.path(), outLegacy / "Routes" / name);
-				}
-			}
-		}
-	}
-
 	if (hasErrors(result.diagnostics)) {
 		removeStaging();
 		return result;
@@ -808,11 +1723,12 @@ SceneImportResult importLegacyScene(const std::string& legacyDir,
 		removeStaging();
 		return result;
 	}
+	fs::path backupPath;
 	if (destinationExists) {
-		std::error_code backupPathEc;
-		backupPath = uniqueSiblingPath(scenePath, "backup", backupPathEc);
-		if (backupPathEc) {
-			addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot inspect scene destination: " + backupPathEc.message(), scenePath.string());
+		std::error_code backupEc;
+		backupPath = uniqueSiblingPath(scenePath, "backup", backupEc);
+		if (backupEc) {
+			addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot inspect scene destination: " + backupEc.message(), scenePath.string());
 			removeStaging();
 			return result;
 		}
@@ -823,7 +1739,6 @@ SceneImportResult importLegacyScene(const std::string& legacyDir,
 			return result;
 		}
 	}
-
 	fs::rename(stagingPath, scenePath, destinationEc);
 	if (destinationEc) {
 		addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot publish scene destination: " + destinationEc.message(), scenePath.string());
@@ -831,23 +1746,14 @@ SceneImportResult importLegacyScene(const std::string& legacyDir,
 		if (!backupPath.empty()) {
 			std::error_code restoreEc;
 			fs::rename(backupPath, scenePath, restoreEc);
-			if (restoreEc)
-				addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot restore existing scene: " + restoreEc.message(), backupPath.string());
-			else
-				backupPath.clear();
+			if (restoreEc) addDiag(SceneSeverity::Error, "scene.import.missing", "Cannot restore existing scene: " + restoreEc.message(), backupPath.string());
 		}
 		return result;
 	}
-
 	if (!backupPath.empty()) {
 		std::error_code cleanupEc;
 		fs::remove_all(backupPath, cleanupEc);
-		if (cleanupEc) {
-			// Publishing already succeeded; leave the valid destination in place
-			// and report cleanup as a warning so callers can retry removal.
-			addDiag(SceneSeverity::Warning, "scene.import.cleanup",
-					"Could not remove import backup: " + cleanupEc.message(), backupPath.string());
-		}
+		if (cleanupEc) addDiag(SceneSeverity::Warning, "scene.import.cleanup", "Could not remove import backup: " + cleanupEc.message(), backupPath.string());
 	}
 	result.wroteScene = true;
 	return result;

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
@@ -1,25 +1,29 @@
 #include "scene/SceneModel.h"
+
 #include <algorithm>
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 #include <nlohmann/json.hpp>
 
 using json = nlohmann::json;
 namespace fs = std::filesystem;
 
-static bool readFile(const std::string& path, std::string& content) {
-	std::ifstream f(path);
-	if (!f.good())
+namespace {
+
+bool readFile(const fs::path& path, std::string& content) {
+	std::ifstream input(path);
+	if (!input)
 		return false;
-	content.assign((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+	content.assign(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
 	return true;
 }
 
-static std::string joinPath(const std::string& parent, const std::string& key) {
+std::string joinPath(const std::string& parent, const std::string& key) {
 	return parent.empty() ? key : parent + "." + key;
 }
 
-static SceneLoadedData makeLoadedData(const std::string& category, const std::string& sourceFile, int parsedCount, const std::string& status) {
+SceneLoadedData makeLoadedData(const std::string& category, const std::string& sourceFile,
+		int parsedCount, const std::string& status) {
 	SceneLoadedData data;
 	data.category = category;
 	data.sourceFile = sourceFile;
@@ -28,7 +32,7 @@ static SceneLoadedData makeLoadedData(const std::string& category, const std::st
 	return data;
 }
 
-static std::string loadedDataDiagnosticStatus(const SceneDiagnosticCounts& counts) {
+std::string loadedDataDiagnosticStatus(const SceneDiagnosticCounts& counts) {
 	std::vector<std::string> parts;
 	if (counts.errors > 0)
 		parts.push_back(std::to_string(counts.errors) + (counts.errors == 1 ? " error" : " errors"));
@@ -38,13 +42,13 @@ static std::string loadedDataDiagnosticStatus(const SceneDiagnosticCounts& count
 		parts.push_back(std::to_string(counts.infos) + (counts.infos == 1 ? " info" : " infos"));
 	if (parts.empty())
 		return "ok";
-	std::string status = parts[0];
+	std::string status = parts.front();
 	for (std::size_t i = 1; i < parts.size(); ++i)
 		status += ", " + parts[i];
 	return status;
 }
 
-static std::size_t loadedDataIndexForDiagnostic(const SceneModel& scene, const SceneDiagnostic& diagnostic) {
+std::size_t loadedDataIndexForDiagnostic(const SceneModel& scene, const SceneDiagnostic& diagnostic) {
 	if (!diagnostic.file.empty()) {
 		for (std::size_t i = 0; i < scene.loadedData.size(); ++i) {
 			if (scene.loadedData[i].sourceFile == diagnostic.file)
@@ -58,66 +62,131 @@ static std::size_t loadedDataIndexForDiagnostic(const SceneModel& scene, const S
 	return 0;
 }
 
+} // namespace
+
+SceneScenario* defaultScenario(SceneModel& scene) {
+	if (scene.scenarios.empty()) {
+		SceneScenario baseline;
+		baseline.id = "baseline";
+		baseline.name = "Baseline";
+		scene.scenarios.push_back(baseline);
+	}
+	if (scene.defaultScenarioId.empty())
+		scene.defaultScenarioId = scene.scenarios.front().id;
+	for (auto& scenario : scene.scenarios) {
+		if (scenario.id == scene.defaultScenarioId)
+			return &scenario;
+	}
+	return &scene.scenarios.front();
+}
+
+const SceneScenario* defaultScenario(const SceneModel& scene) {
+	if (scene.scenarios.empty())
+		return nullptr;
+	if (scene.defaultScenarioId.empty())
+		return &scene.scenarios.front();
+	for (const auto& scenario : scene.scenarios) {
+		if (scenario.id == scene.defaultScenarioId)
+			return &scenario;
+	}
+	return &scene.scenarios.front();
+}
+
+std::vector<SceneIncident>& defaultScenarioIncidents(SceneModel& scene) {
+	return defaultScenario(scene)->incidents;
+}
+
+const std::vector<SceneIncident>& defaultScenarioIncidents(const SceneModel& scene) {
+	static const std::vector<SceneIncident> empty;
+	const SceneScenario* scenario = defaultScenario(scene);
+	return scenario ? scenario->incidents : empty;
+}
+
 void refreshLoadedDataSummary(SceneModel& scene) {
 	scene.loadedData.clear();
 
-	auto add = [&](const std::string& category, const std::string& sourceFile, int parsedCount, const std::string& status) {
+	auto statusForFile = [&](const std::string& sourceFile) {
+		return scene.sourceFiles.count(sourceFile) > 0 ? "loaded" : "missing";
+	};
+	auto add = [&](const std::string& category, const std::string& sourceFile, int parsedCount) {
+		const std::string status = statusForFile(sourceFile);
 		SceneLoadedData data = makeLoadedData(category, sourceFile, parsedCount, status);
 		if (!sourceFile.empty()) {
 			data.children.push_back(makeLoadedData("raw_file", sourceFile, status == "loaded" ? 1 : 0, status));
 			data.children.push_back(makeLoadedData("parsed_objects", sourceFile, parsedCount, status));
-			data.children.push_back(makeLoadedData("derived_simulation", "", 0, status == "loaded" ? "not_built" : status));
+			data.children.push_back(makeLoadedData("derived_simulation", "", 0,
+					status == "loaded" ? "not_built" : status));
 		}
 		scene.loadedData.push_back(data);
 	};
-	auto statusForFile = [&](const std::string& sourceFile) {
-		return scene.sourceFiles.count(sourceFile) > 0 ? "loaded" : "missing";
+	auto addChild = [&](const std::string& category, const std::string& sourceFile, int parsedCount,
+			const std::string& status) {
+		scene.loadedData.back().children.push_back(makeLoadedData(category, sourceFile, parsedCount, status));
 	};
 
-	add("scene", "scene.json", scene.schemaVersion > 0 ? 1 : 0, statusForFile("scene.json"));
-	add("infrastructure", "infrastructure.json", 0, statusForFile("infrastructure.json"));
-	add("stations", "stations.json", static_cast<int>(scene.stations.size()), statusForFile("stations.json"));
-	add("timetable", "services.json", static_cast<int>(scene.services.size()), statusForFile("services.json"));
-	add("rolling_stock", "rolling_stock.json",
-			static_cast<int>(scene.trainUnits.size() + scene.compositions.size()),
-			statusForFile("rolling_stock.json"));
-	{
-		SceneLoadedData& rollingStock = scene.loadedData.back();
-		const std::string status = rollingStock.status;
-		rollingStock.children.push_back(makeLoadedData("train_units", "rolling_stock.json",
-				static_cast<int>(scene.trainUnits.size()), status));
-		rollingStock.children.push_back(makeLoadedData("compositions", "rolling_stock.json",
-				static_cast<int>(scene.compositions.size()), status));
+	add("scene", "scene.json", scene.schemaVersion > 0 ? 1 : 0);
+	add("infrastructure", "infrastructure.json", static_cast<int>(scene.tracks.size() + scene.nodes.size()
+			+ scene.arcs.size() + scene.blocks.size() + scene.connections.size()));
+	const std::string infrastructureStatus = scene.loadedData.back().status;
+	addChild("tracks", "infrastructure.json", static_cast<int>(scene.tracks.size()), infrastructureStatus);
+	addChild("nodes", "infrastructure.json", static_cast<int>(scene.nodes.size()), infrastructureStatus);
+	addChild("arcs", "infrastructure.json", static_cast<int>(scene.arcs.size()), infrastructureStatus);
+	addChild("blocks", "infrastructure.json", static_cast<int>(scene.blocks.size()), infrastructureStatus);
+	addChild("connections", "infrastructure.json", static_cast<int>(scene.connections.size()), infrastructureStatus);
 
-		SceneLoadedData sourceFiles = makeLoadedData("source_files", "",
-				0, "missing");
-		for (const auto& unit : scene.trainUnits) {
-			if (!unit.sourceDataFile.empty()) {
-				sourceFiles.children.push_back(makeLoadedData("data_file", unit.sourceDataFile, 1, "loaded"));
-				++sourceFiles.parsedCount;
-			}
-			if (!unit.sourceTractionFile.empty()) {
-				sourceFiles.children.push_back(makeLoadedData("traction_file", unit.sourceTractionFile, 1, "loaded"));
-				++sourceFiles.parsedCount;
-			}
+	add("stations", "stations.json", static_cast<int>(scene.stations.size()));
+	int platformCount = 0;
+	for (const auto& station : scene.stations)
+		platformCount += static_cast<int>(station.platforms.size());
+	addChild("platforms", "stations.json", platformCount, scene.loadedData.back().status);
+
+	add("timetable", "services.json", static_cast<int>(scene.services.size()));
+
+	add("rolling_stock", "rolling_stock.json", static_cast<int>(scene.trainUnits.size()
+			+ scene.compositions.size()));
+	const std::string rollingStatus = scene.loadedData.back().status;
+	addChild("train_units", "rolling_stock.json", static_cast<int>(scene.trainUnits.size()), rollingStatus);
+	addChild("compositions", "rolling_stock.json", static_cast<int>(scene.compositions.size()), rollingStatus);
+	SceneLoadedData sourceFiles = makeLoadedData("source_files", "", 0, "missing");
+	for (const auto& unit : scene.trainUnits) {
+		if (!unit.sourceDataFile.empty()) {
+			sourceFiles.children.push_back(makeLoadedData("data_file", unit.sourceDataFile, 1, "loaded"));
+			++sourceFiles.parsedCount;
 		}
-		if (sourceFiles.parsedCount > 0)
-			sourceFiles.status = "loaded";
-		rollingStock.children.push_back(sourceFiles);
+		if (!unit.sourceTractionFile.empty()) {
+			sourceFiles.children.push_back(makeLoadedData("traction_file", unit.sourceTractionFile, 1, "loaded"));
+			++sourceFiles.parsedCount;
+		}
 	}
-	add("signalling", "signalling.json",
-			static_cast<int>(scene.signals.size() + scene.routes.size()),
-			statusForFile("signalling.json"));
-	{
-		SceneLoadedData& signalling = scene.loadedData.back();
-		const std::string status = signalling.status;
-		signalling.children.push_back(makeLoadedData("signals", "signalling.json",
-				static_cast<int>(scene.signals.size()), status));
-		signalling.children.push_back(makeLoadedData("routes", "signalling.json",
-				static_cast<int>(scene.routes.size()), status));
+	if (sourceFiles.parsedCount > 0)
+		sourceFiles.status = "loaded";
+	scene.loadedData.back().children.push_back(sourceFiles);
+
+	int signallingCount = static_cast<int>(scene.signals.size() + scene.routes.size()
+			+ scene.blockDependencies.size() + scene.singleTrackRestrictions.size()
+			+ scene.stationBoundaries.size());
+	add("signalling", "signalling.json", signallingCount);
+	const std::string signallingStatus = scene.loadedData.back().status;
+	addChild("signals", "signalling.json", static_cast<int>(scene.signals.size()), signallingStatus);
+	addChild("routes", "signalling.json", static_cast<int>(scene.routes.size()), signallingStatus);
+	addChild("dependencies", "signalling.json", static_cast<int>(scene.blockDependencies.size()), signallingStatus);
+	addChild("restrictions", "signalling.json", static_cast<int>(scene.singleTrackRestrictions.size()
+			+ scene.stationBoundaries.size()), signallingStatus);
+
+	int incidentCount = 0;
+	int entranceDelayCount = 0;
+	for (const auto& scenario : scene.scenarios) {
+		incidentCount += static_cast<int>(scenario.incidents.size());
+		entranceDelayCount += static_cast<int>(scenario.entranceDelays.size());
 	}
-	add("incidents", "incidents.json", static_cast<int>(scene.incidents.size()), statusForFile("incidents.json"));
-	add("passenger_data", "", 0, "unimplemented");
+	add("scenarios", "scenarios.json", static_cast<int>(scene.scenarios.size()));
+	const std::string scenariosStatus = scene.loadedData.back().status;
+	const std::string incidentSource = scene.sourceFiles.count("scenarios.json") > 0
+			? "scenarios.json" : "incidents.json";
+	addChild("incidents", incidentSource, incidentCount, scenariosStatus);
+	addChild("entrance_delays", "scenarios.json", entranceDelayCount, scenariosStatus);
+
+	add("passengers", "passengers.json", static_cast<int>(scene.passengers.size()));
 }
 
 void refreshLoadedDataDiagnostics(SceneModel& scene, const std::vector<SceneDiagnostic>& diagnostics) {
@@ -128,9 +197,9 @@ void refreshLoadedDataDiagnostics(SceneModel& scene, const std::vector<SceneDiag
 
 	std::vector<SceneDiagnosticCounts> counts(scene.loadedData.size());
 	for (auto& item : scene.loadedData) {
-		item.children.erase(std::remove_if(item.children.begin(), item.children.end(), [](const SceneLoadedData& child) {
-			return child.category == "validation";
-		}), item.children.end());
+		item.children.erase(std::remove_if(item.children.begin(), item.children.end(),
+				[](const SceneLoadedData& child) { return child.category == "validation"; }),
+			item.children.end());
 	}
 	for (const auto& diagnostic : diagnostics) {
 		SceneDiagnosticCounts& count = counts[loadedDataIndexForDiagnostic(scene, diagnostic)];
@@ -148,370 +217,755 @@ void refreshLoadedDataDiagnostics(SceneModel& scene, const std::vector<SceneDiag
 	}
 	for (std::size_t i = 0; i < scene.loadedData.size(); ++i) {
 		const SceneDiagnosticCounts& count = counts[i];
-		int total = count.errors + count.warnings + count.infos;
-		scene.loadedData[i].children.push_back(makeLoadedData("validation", scene.loadedData[i].sourceFile, total, loadedDataDiagnosticStatus(count)));
+		const int total = count.errors + count.warnings + count.infos;
+		scene.loadedData[i].children.push_back(makeLoadedData("validation", scene.loadedData[i].sourceFile,
+				total, loadedDataDiagnosticStatus(count)));
 	}
 }
 
 void refreshSavedSceneMetadata(SceneModel& scene) {
-	scene.sourceFiles.insert("scene.json");
-	scene.sourceFiles.insert("infrastructure.json");
-	scene.sourceFiles.insert("stations.json");
-	scene.sourceFiles.insert("signalling.json");
-	scene.sourceFiles.insert("rolling_stock.json");
-	scene.sourceFiles.insert("services.json");
-	if (!scene.incidents.empty())
-		scene.sourceFiles.insert("incidents.json");
+	for (const char* file : {"scene.json", "infrastructure.json", "stations.json", "signalling.json",
+			"rolling_stock.json", "services.json", "scenarios.json"})
+		scene.sourceFiles.insert(file);
+	scene.sourceFiles.erase("incidents.json");
+	if (scene.passengers.empty())
+		scene.sourceFiles.erase("passengers.json");
 	else
-		scene.sourceFiles.erase("incidents.json");
+		scene.sourceFiles.insert("passengers.json");
 	refreshLoadedDataSummary(scene);
 }
 
 SceneLoadResult loadScene(const std::string& sceneDir) {
 	SceneLoadResult result;
-	auto addError = [&](const std::string& code, const std::string& file, const std::string& msg, const std::string& path = "") {
-		SceneDiagnostic d;
-		d.severity = SceneSeverity::Error;
-		d.code = code;
-		d.file = file;
-		d.message = msg;
-		d.path = path;
-		result.diagnostics.push_back(d);
+	auto addDiagnostic = [&](SceneSeverity severity, const std::string& code,
+			const std::string& file, const std::string& message, const std::string& path = "") {
+		SceneDiagnostic diagnostic;
+		diagnostic.severity = severity;
+		diagnostic.code = code;
+		diagnostic.file = file;
+		diagnostic.message = message;
+		diagnostic.path = path;
+		result.diagnostics.push_back(diagnostic);
+	};
+	auto addError = [&](const std::string& code, const std::string& file,
+			const std::string& message, const std::string& path = "") {
+		addDiagnostic(SceneSeverity::Error, code, file, message, path);
+	};
+	auto addWarning = [&](const std::string& code, const std::string& file,
+			const std::string& message, const std::string& path = "") {
+		addDiagnostic(SceneSeverity::Warning, code, file, message, path);
 	};
 
-	if (!fs::exists(sceneDir) || !fs::is_directory(sceneDir)) {
+	if (!fs::is_directory(sceneDir)) {
 		addError("scene.dir.missing", "", "Scene directory missing or invalid");
 		return result;
 	}
 
-	auto parseJsonFile = [&](const std::string& filename, json& outJson) -> bool {
-		std::string path = (fs::path(sceneDir) / filename).string();
+	auto parseObject = [&](const std::string& file, json& value, bool required) {
 		std::string content;
-		if (!readFile(path, content)) {
-			addError("scene.file.missing", filename, "Required file is missing");
+		if (!readFile(fs::path(sceneDir) / file, content)) {
+			if (required)
+				addError("scene.file.missing", file, "Required file is missing");
 			return false;
 		}
 		try {
-			outJson = json::parse(content);
-		} catch (const json::parse_error& e) {
-			addError("scene.json.parse", filename, std::string("JSON parse error: ") + e.what());
+			value = json::parse(content);
+		} catch (const json::parse_error& error) {
+			addError("scene.json.parse", file, std::string("JSON parse error: ") + error.what());
 			return false;
 		}
-		if (!outJson.is_object()) {
-			addError("scene.section.missing", filename, "Root element must be an object");
+		if (!value.is_object()) {
+			addError("scene.section.missing", file, "Root element must be an object");
 			return false;
 		}
-		result.scene.sourceFiles.insert(filename);
+		result.scene.sourceFiles.insert(file);
 		return true;
+	};
+	auto arraySection = [&](const json& object, const char* key, const std::string& file,
+			const std::string& path, bool required) {
+		if (!object.is_object()) {
+			addError("scene.item.invalid", file, "Expected an object", path);
+			return false;
+		}
+		if (!object.contains(key)) {
+			if (required)
+				addError("scene.section.missing", file, std::string("Missing ") + key + " section",
+						joinPath(path, key));
+			return false;
+		}
+		if (!object[key].is_array()) {
+			addError("scene.section.missing", file, std::string("Mistyped ") + key + " section",
+					joinPath(path, key));
+			return false;
+		}
+		return true;
+	};
+	auto stringField = [&](const json& object, const char* key, const std::string& file,
+			const std::string& path, std::string& output, bool required = true) {
+		if (!object.is_object()) {
+			addError("scene.item.invalid", file, "Array item must be an object", path);
+			return false;
+		}
+		if (!object.contains(key)) {
+			if (required)
+				addError("scene.field.missing", file, std::string("Missing ") + key,
+						joinPath(path, key));
+			return false;
+		}
+		if (!object[key].is_string() || (required && object[key].get<std::string>().empty())) {
+			addError("scene.field.missing", file, std::string("Invalid ") + key,
+					joinPath(path, key));
+			return false;
+		}
+		output = object[key].get<std::string>();
+		return true;
+	};
+	auto numberField = [&](const json& object, const char* key, const std::string& file,
+			const std::string& path, double& output, bool required = true) {
+		if (!object.is_object()) {
+			addError("scene.item.invalid", file, "Array item must be an object", path);
+			return false;
+		}
+		if (!object.contains(key)) {
+			if (required)
+				addError("scene.field.missing", file, std::string("Missing ") + key,
+						joinPath(path, key));
+			return false;
+		}
+		if (!object[key].is_number()) {
+			addError("scene.field.missing", file, std::string("Invalid ") + key,
+					joinPath(path, key));
+			return false;
+		}
+		output = object[key].get<double>();
+		return true;
+	};
+	auto integerField = [&](const json& object, const char* key, const std::string& file,
+			const std::string& path, int& output, bool required = true) {
+		if (!object.is_object()) {
+			addError("scene.item.invalid", file, "Array item must be an object", path);
+			return false;
+		}
+		if (!object.contains(key)) {
+			if (required)
+				addError("scene.field.missing", file, std::string("Missing ") + key,
+						joinPath(path, key));
+			return false;
+		}
+		if (!object[key].is_number_integer()) {
+			addError("scene.field.missing", file, std::string("Invalid ") + key,
+					joinPath(path, key));
+			return false;
+		}
+		output = object[key].get<int>();
+		return true;
+	};
+	auto isSimulationResultField = [](const std::string& name) {
+		return name == "results" || name == "simulation_results"
+				|| name.find("simulated_") == 0 || name.find("actual_") == 0
+				|| name == "delay_seconds"
+				|| name.find("arrival_delay") != std::string::npos
+				|| name.find("departure_delay") != std::string::npos;
 	};
 
-	// A required top-level key that must hold an array.
-	auto requireArraySection = [&](const json& root, const char* key, const std::string& file) -> bool {
-		if (!root.contains(key) || !root[key].is_array()) {
-			addError("scene.section.missing", file, std::string("Missing or mistyped ") + key + " section");
-			return false;
-		}
-		return true;
-	};
-	// A required field that must hold a non-empty string. Reports and returns
-	// false on failure; loading continues so one pass surfaces every problem.
-	auto requireString = [&](const json& obj, const char* key, const std::string& file, const std::string& path, std::string& out) -> bool {
-		if (!obj.contains(key) || !obj[key].is_string() || obj[key].get<std::string>().empty()) {
-			addError("scene.field.missing", file, std::string("Missing or invalid ") + key, joinPath(path, key));
-			return false;
-		}
-		out = obj[key].get<std::string>();
-		return true;
-	};
-	auto requireNumber = [&](const json& obj, const char* key, const std::string& file, const std::string& path, double& out) -> bool {
-		if (!obj.contains(key) || !obj[key].is_number()) {
-			addError("scene.field.missing", file, std::string("Missing or invalid ") + key, joinPath(path, key));
-			return false;
-		}
-		out = obj[key].get<double>();
-		return true;
-	};
-
-	json sceneJson, infraJson, stationsJson, sigJson, rollingJson, servicesJson;
-	bool sceneOk = parseJsonFile("scene.json", sceneJson);
-	bool infraOk = parseJsonFile("infrastructure.json", infraJson);
-	bool stationsOk = parseJsonFile("stations.json", stationsJson);
-	bool sigOk = parseJsonFile("signalling.json", sigJson);
-	bool rollingOk = parseJsonFile("rolling_stock.json", rollingJson);
-	bool servicesOk = parseJsonFile("services.json", servicesJson);
-
-	// Optional files
-	json incidentsJson, viewsJson;
-	bool incidentsOk = false;
-	if (fs::exists(fs::path(sceneDir) / "incidents.json")) {
-		incidentsOk = parseJsonFile("incidents.json", incidentsJson);
-	}
-	if (fs::exists(fs::path(sceneDir) / "views.json")) {
-		parseJsonFile("views.json", viewsJson); // just parse-check
-	}
+	json sceneJson;
+	json infrastructureJson;
+	json stationsJson;
+	json signallingJson;
+	json rollingStockJson;
+	json servicesJson;
+	json scenariosJson;
+	json incidentsJson;
+	json passengersJson;
+	json viewsJson;
+	const bool sceneOk = parseObject("scene.json", sceneJson, true);
+	const bool infrastructureOk = parseObject("infrastructure.json", infrastructureJson, true);
+	const bool stationsOk = parseObject("stations.json", stationsJson, true);
+	const bool signallingOk = parseObject("signalling.json", signallingJson, true);
+	const bool rollingStockOk = parseObject("rolling_stock.json", rollingStockJson, true);
+	const bool servicesOk = parseObject("services.json", servicesJson, true);
+	const bool scenariosPresent = fs::exists(fs::path(sceneDir) / "scenarios.json");
+	const bool incidentsPresent = fs::exists(fs::path(sceneDir) / "incidents.json");
+	const bool scenariosOk = parseObject("scenarios.json", scenariosJson, scenariosPresent);
+	const bool incidentsOk = !scenariosPresent
+			&& parseObject("incidents.json", incidentsJson, incidentsPresent);
+	const bool passengersOk = parseObject("passengers.json", passengersJson,
+			fs::exists(fs::path(sceneDir) / "passengers.json"));
+	parseObject("views.json", viewsJson, false);
 
 	if (sceneOk) {
 		if (!sceneJson.contains("schema_version")) {
-			addError("scene.version.missing", "scene.json", "Missing schema_version");
-		} else if (!sceneJson["schema_version"].is_number_integer() || sceneJson["schema_version"].get<int>() != 1) {
-			addError("scene.version.unsupported", "scene.json", "Unsupported schema_version, must be the integer 1");
+			addError("scene.version.missing", "scene.json", "Missing schema_version", "schema_version");
+		} else if (!sceneJson["schema_version"].is_number_integer()
+				|| sceneJson["schema_version"].get<int>() != 1) {
+			addError("scene.version.unsupported", "scene.json",
+					"Unsupported schema_version, must be the integer 1", "schema_version");
 		} else {
 			result.scene.schemaVersion = sceneJson["schema_version"].get<int>();
 		}
-		requireString(sceneJson, "name", "scene.json", "", result.scene.name);
-		if (sceneJson.contains("description")) {
-			if (sceneJson["description"].is_string()) {
-				result.scene.description = sceneJson["description"].get<std::string>();
-			} else {
-				addError("scene.field.missing", "scene.json", "description must be a string", "description");
-			}
-		}
-		if (sceneJson.contains("base_time")) {
-			if (sceneJson["base_time"].is_string()) {
-				result.scene.baseTime = sceneJson["base_time"].get<std::string>();
-			} else {
-				addError("scene.field.missing", "scene.json", "base_time must be a string", "base_time");
-			}
-		}
+		stringField(sceneJson, "name", "scene.json", "", result.scene.name);
+		stringField(sceneJson, "description", "scene.json", "", result.scene.description, false);
+		stringField(sceneJson, "base_time", "scene.json", "", result.scene.baseTime, false);
 		if (sceneJson.contains("units")) {
-			if (!sceneJson["units"].is_object()) {
+			const json& units = sceneJson["units"];
+			if (!units.is_object()) {
 				addError("scene.field.missing", "scene.json", "units must be an object", "units");
 			} else {
-				const auto& units = sceneJson["units"];
-				if (units.contains("distance") && units["distance"] != "m") {
-					addError("scene.units.unsupported", "scene.json", "Distance unit must be m", "units.distance");
+				for (const auto& unit : {std::pair<const char*, const char*>("distance", "m"),
+						std::pair<const char*, const char*>("time", "s"),
+						std::pair<const char*, const char*>("speed", "m/s")}) {
+					if (units.contains(unit.first) && (!units[unit.first].is_string()
+							|| units[unit.first].get<std::string>() != unit.second)) {
+						addError("scene.units.unsupported", "scene.json",
+								std::string("Unsupported ") + unit.first + " unit",
+								std::string("units.") + unit.first);
+					}
 				}
-				if (units.contains("time") && units["time"] != "s") {
-					addError("scene.units.unsupported", "scene.json", "Time unit must be s", "units.time");
-				}
-				if (units.contains("speed") && units["speed"] != "m/s") {
-					addError("scene.units.unsupported", "scene.json", "Speed unit must be m/s", "units.speed");
+			}
+		}
+		if (sceneJson.contains("simulation_settings")) {
+			const json& settings = sceneJson["simulation_settings"];
+			if (!settings.is_object()) {
+				addError("scene.field.missing", "scene.json",
+						"simulation_settings must be an object", "simulation_settings");
+			} else {
+				result.scene.settings.hasDuration = numberField(settings, "duration_seconds", "scene.json",
+						"simulation_settings", result.scene.settings.durationSeconds, false);
+				result.scene.settings.hasBufferTime = numberField(settings, "buffer_time_seconds", "scene.json",
+						"simulation_settings", result.scene.settings.bufferTimeSeconds, false);
+				result.scene.settings.hasRecoveryTime = numberField(settings, "recovery_time_percent", "scene.json",
+						"simulation_settings", result.scene.settings.recoveryTimePercent, false);
+			}
+		}
+		if (sceneJson.contains("import_report")) {
+			if (arraySection(sceneJson, "import_report", "scene.json", "", false)) {
+				for (std::size_t index = 0; index < sceneJson["import_report"].size(); ++index) {
+					const json& value = sceneJson["import_report"][index];
+					const std::string path = "import_report[" + std::to_string(index) + "]";
+					SceneImportReportRow row;
+					stringField(value, "category", "scene.json", path, row.category);
+					stringField(value, "source_file", "scene.json", path, row.sourceFile, false);
+					integerField(value, "source_count", "scene.json", path, row.sourceCount);
+					integerField(value, "converted_count", "scene.json", path, row.convertedCount);
+					integerField(value, "skipped_count", "scene.json", path, row.skippedCount);
+					integerField(value, "unresolved_references", "scene.json", path,
+							row.unresolvedReferences);
+					result.scene.importReport.push_back(row);
 				}
 			}
 		}
 	}
 
-	if (infraOk) {
-		requireArraySection(infraJson, "nodes", "infrastructure.json");
-		requireArraySection(infraJson, "arcs", "infrastructure.json");
-	}
-
-	if (stationsOk && requireArraySection(stationsJson, "stations", "stations.json")) {
-		size_t idx = 0;
-		for (const auto& st : stationsJson["stations"]) {
-			std::string path = "stations[" + std::to_string(idx++) + "]";
-			SceneStation s;
-			requireString(st, "id", "stations.json", path, s.id);
-			requireString(st, "name", "stations.json", path, s.name);
-			if (st.contains("platforms") && st["platforms"].is_array()) {
-				size_t pidx = 0;
-				for (const auto& pf : st["platforms"]) {
-					ScenePlatform p;
-					requireString(pf, "id", "stations.json", path + ".platforms[" + std::to_string(pidx++) + "]", p.id);
-					s.platforms.push_back(p);
-				}
+	if (infrastructureOk) {
+		if (arraySection(infrastructureJson, "tracks", "infrastructure.json", "", false)) {
+			for (std::size_t index = 0; index < infrastructureJson["tracks"].size(); ++index) {
+				const std::string path = "tracks[" + std::to_string(index) + "]";
+				SceneTrack track;
+				stringField(infrastructureJson["tracks"][index], "id", "infrastructure.json", path, track.id);
+				result.scene.tracks.push_back(track);
 			}
-			result.scene.stations.push_back(s);
+		}
+		if (arraySection(infrastructureJson, "nodes", "infrastructure.json", "", true)) {
+			for (std::size_t index = 0; index < infrastructureJson["nodes"].size(); ++index) {
+				const std::string path = "nodes[" + std::to_string(index) + "]";
+				SceneNode node;
+				stringField(infrastructureJson["nodes"][index], "id", "infrastructure.json", path, node.id);
+				stringField(infrastructureJson["nodes"][index], "track", "infrastructure.json", path,
+						node.trackId);
+				numberField(infrastructureJson["nodes"][index], "x_km", "infrastructure.json", path,
+						node.xKm);
+				numberField(infrastructureJson["nodes"][index], "y_km", "infrastructure.json", path,
+						node.yKm);
+				result.scene.nodes.push_back(node);
+			}
+		}
+		if (arraySection(infrastructureJson, "arcs", "infrastructure.json", "", true)) {
+			for (std::size_t index = 0; index < infrastructureJson["arcs"].size(); ++index) {
+				const std::string path = "arcs[" + std::to_string(index) + "]";
+				SceneArc arc;
+				stringField(infrastructureJson["arcs"][index], "id", "infrastructure.json", path, arc.id);
+				stringField(infrastructureJson["arcs"][index], "track", "infrastructure.json", path,
+						arc.trackId);
+				stringField(infrastructureJson["arcs"][index], "from", "infrastructure.json", path,
+						arc.fromNodeId);
+				stringField(infrastructureJson["arcs"][index], "to", "infrastructure.json", path,
+						arc.toNodeId);
+				numberField(infrastructureJson["arcs"][index], "curvature_radius_m", "infrastructure.json",
+						path, arc.curvatureRadiusM);
+				numberField(infrastructureJson["arcs"][index], "gradient_percent", "infrastructure.json",
+						path, arc.gradientPercent);
+				numberField(infrastructureJson["arcs"][index], "speed_limit_ms", "infrastructure.json",
+						path, arc.speedLimitMs);
+				result.scene.arcs.push_back(arc);
+			}
+		}
+		if (arraySection(infrastructureJson, "blocks", "infrastructure.json", "", false)) {
+			for (std::size_t index = 0; index < infrastructureJson["blocks"].size(); ++index) {
+				const std::string path = "blocks[" + std::to_string(index) + "]";
+				SceneBlock block;
+				stringField(infrastructureJson["blocks"][index], "id", "infrastructure.json", path,
+						block.id);
+				stringField(infrastructureJson["blocks"][index], "track", "infrastructure.json", path,
+						block.trackId);
+				numberField(infrastructureJson["blocks"][index], "length_km", "infrastructure.json", path,
+						block.lengthKm);
+				result.scene.blocks.push_back(block);
+			}
+		}
+		if (arraySection(infrastructureJson, "connections", "infrastructure.json", "", false)) {
+			for (std::size_t index = 0; index < infrastructureJson["connections"].size(); ++index) {
+				const std::string path = "connections[" + std::to_string(index) + "]";
+				SceneConnection connection;
+				stringField(infrastructureJson["connections"][index], "id", "infrastructure.json", path,
+						connection.id);
+				stringField(infrastructureJson["connections"][index], "from", "infrastructure.json", path,
+						connection.fromNodeId);
+				stringField(infrastructureJson["connections"][index], "to", "infrastructure.json", path,
+						connection.toNodeId);
+				connection.hasSpeedLimit = numberField(infrastructureJson["connections"][index],
+						"speed_limit_ms", "infrastructure.json", path, connection.speedLimitMs, false);
+				result.scene.connections.push_back(connection);
+			}
 		}
 	}
 
-	if (sigOk) {
-		if (requireArraySection(sigJson, "signals", "signalling.json")) {
-			size_t idx = 0;
-			for (const auto& sg : sigJson["signals"]) {
-				SceneSignal s;
-				requireString(sg, "id", "signalling.json", "signals[" + std::to_string(idx++) + "]", s.id);
-				result.scene.signals.push_back(s);
-			}
-		}
-		if (requireArraySection(sigJson, "routes", "signalling.json")) {
-			size_t idx = 0;
-			for (const auto& rt : sigJson["routes"]) {
-				std::string path = "routes[" + std::to_string(idx++) + "]";
-				SceneRoute r;
-				requireString(rt, "id", "signalling.json", path, r.id);
-				if (!rt.contains("blocks") || !rt["blocks"].is_array()) {
-					addError("scene.field.missing", "signalling.json", "Missing or invalid blocks", path + ".blocks");
+	if (stationsOk && arraySection(stationsJson, "stations", "stations.json", "", true)) {
+		for (std::size_t index = 0; index < stationsJson["stations"].size(); ++index) {
+			const std::string stationPath = "stations[" + std::to_string(index) + "]";
+			const json& value = stationsJson["stations"][index];
+			SceneStation station;
+			stringField(value, "id", "stations.json", stationPath, station.id);
+			stringField(value, "name", "stations.json", stationPath, station.name);
+			station.hasPosition = numberField(value, "position_km", "stations.json", stationPath,
+					station.positionKm, false);
+			if (value.contains("platforms")) {
+				if (!value["platforms"].is_array()) {
+					addError("scene.field.missing", "stations.json", "platforms must be an array",
+							stationPath + ".platforms");
 				} else {
-					for (const auto& blk : rt["blocks"]) {
-						if (blk.is_string())
-							r.blocks.push_back(blk.get<std::string>());
-					}
-				}
-				result.scene.routes.push_back(r);
-			}
-		}
-	}
-
-	if (rollingOk) {
-		if (requireArraySection(rollingJson, "train_units", "rolling_stock.json")) {
-			size_t idx = 0;
-			for (const auto& tu : rollingJson["train_units"]) {
-				std::string tuPath = "train_units[" + std::to_string(idx++) + "]";
-				SceneTrainUnit t;
-				requireString(tu, "id", "rolling_stock.json", tuPath, t.id);
-				if (tu.contains("physical")) {
-					if (!tu["physical"].is_object()) {
-						addError("scene.field.missing", "rolling_stock.json", "physical must be an object", tuPath + ".physical");
-					} else {
-						t.hasPhysical = true;
-						auto& ph = tu["physical"];
-						requireNumber(ph, "mass_of_traction_unit_kg", "rolling_stock.json", tuPath + ".physical", t.physical.mass_of_traction_unit_kg);
-						requireNumber(ph, "mass_of_a_wagon_kg", "rolling_stock.json", tuPath + ".physical", t.physical.mass_of_a_wagon_kg);
-						requireNumber(ph, "number_of_wagons", "rolling_stock.json", tuPath + ".physical", t.physical.number_of_wagons);
-						requireNumber(ph, "max_speed_ms", "rolling_stock.json", tuPath + ".physical", t.physical.max_speed_ms);
-						requireNumber(ph, "max_deceleration_ms2", "rolling_stock.json", tuPath + ".physical", t.physical.max_deceleration_ms2);
-						requireNumber(ph, "frontal_area_m2", "rolling_stock.json", tuPath + ".physical", t.physical.frontal_area_m2);
-						requireNumber(ph, "resistance_coefficient", "rolling_stock.json", tuPath + ".physical", t.physical.resistance_coefficient);
-						requireNumber(ph, "jerk_ms3", "rolling_stock.json", tuPath + ".physical", t.physical.jerk_ms3);
-						requireNumber(ph, "length_m", "rolling_stock.json", tuPath + ".physical", t.physical.length_m);
-					}
-				}
-				if (tu.contains("traction_curve")) {
-					if (!tu["traction_curve"].is_array()) {
-						addError("scene.field.missing", "rolling_stock.json", "traction_curve must be an array", tuPath + ".traction_curve");
-					} else {
-						size_t tcIdx = 0;
-						for (const auto& row : tu["traction_curve"]) {
-							if (!row.is_array() || row.size() != 5) {
-								addError("scene.field.missing", "rolling_stock.json", "traction_curve row must be an array of 5 numbers", tuPath + ".traction_curve[" + std::to_string(tcIdx) + "]");
+					for (std::size_t platformIndex = 0; platformIndex < value["platforms"].size();
+							++platformIndex) {
+						const std::string platformPath = stationPath + ".platforms["
+								+ std::to_string(platformIndex) + "]";
+						const json& platformValue = value["platforms"][platformIndex];
+						ScenePlatform platform;
+						stringField(platformValue, "id", "stations.json", platformPath, platform.id);
+						if (platformValue.contains("nodes")) {
+							if (!platformValue["nodes"].is_array()) {
+								addError("scene.field.missing", "stations.json",
+										"nodes must be an array", platformPath + ".nodes");
 							} else {
-								bool ok = true;
-								std::array<double, 5> arr;
-								for (int i = 0; i < 5; ++i) {
-									if (!row[i].is_number()) {
-										ok = false;
-										break;
+								for (std::size_t nodeIndex = 0; nodeIndex < platformValue["nodes"].size();
+										++nodeIndex) {
+									if (!platformValue["nodes"][nodeIndex].is_string()) {
+										addError("scene.field.missing", "stations.json",
+												"Platform node reference must be a string",
+												platformPath + ".nodes["
+												+ std::to_string(nodeIndex) + "]");
+										continue;
 									}
-									arr[i] = row[i].get<double>();
-								}
-								if (!ok) {
-									addError("scene.field.missing", "rolling_stock.json", "traction_curve row must contain numbers", tuPath + ".traction_curve[" + std::to_string(tcIdx) + "]");
-								} else {
-									t.tractionCurve.push_back(arr);
+									platform.nodeIds.push_back(platformValue["nodes"][nodeIndex].get<std::string>());
 								}
 							}
-							tcIdx++;
 						}
+						station.platforms.push_back(platform);
 					}
 				}
-				if (tu.contains("source")) {
-					if (!tu["source"].is_object()) {
-						addError("scene.field.missing", "rolling_stock.json", "source must be an object", tuPath + ".source");
+			}
+			result.scene.stations.push_back(station);
+		}
+	}
+
+	if (signallingOk) {
+		if (arraySection(signallingJson, "signals", "signalling.json", "", true)) {
+			for (std::size_t index = 0; index < signallingJson["signals"].size(); ++index) {
+				const std::string path = "signals[" + std::to_string(index) + "]";
+				SceneSignal signal;
+				stringField(signallingJson["signals"][index], "id", "signalling.json", path, signal.id);
+				result.scene.signals.push_back(signal);
+			}
+		}
+		if (arraySection(signallingJson, "routes", "signalling.json", "", true)) {
+			for (std::size_t index = 0; index < signallingJson["routes"].size(); ++index) {
+				const std::string path = "routes[" + std::to_string(index) + "]";
+				const json& value = signallingJson["routes"][index];
+				SceneRoute route;
+				stringField(value, "id", "signalling.json", path, route.id);
+				if (arraySection(value, "blocks", "signalling.json", path, true)) {
+					for (std::size_t blockIndex = 0; blockIndex < value["blocks"].size(); ++blockIndex) {
+						if (!value["blocks"][blockIndex].is_string()) {
+							addError("scene.field.missing", "signalling.json",
+									"Route block reference must be a string",
+									path + ".blocks[" + std::to_string(blockIndex) + "]");
+							continue;
+						}
+						route.blocks.push_back(value["blocks"][blockIndex].get<std::string>());
+					}
+				}
+				route.hasCorridor = stringField(value, "corridor", "signalling.json", path,
+						route.corridor, false);
+				if (value.contains("reversed")) {
+					if (!value["reversed"].is_boolean())
+						addError("scene.field.missing", "signalling.json", "reversed must be a boolean",
+								path + ".reversed");
+					else
+						route.reversed = value["reversed"].get<bool>();
+				}
+				result.scene.routes.push_back(route);
+			}
+		}
+		if (arraySection(signallingJson, "block_dependencies", "signalling.json", "", false)) {
+			for (std::size_t index = 0; index < signallingJson["block_dependencies"].size(); ++index) {
+				const std::string path = "block_dependencies[" + std::to_string(index) + "]";
+				SceneBlockDependency dependency;
+				stringField(signallingJson["block_dependencies"][index], "block", "signalling.json", path,
+						dependency.block);
+				stringField(signallingJson["block_dependencies"][index], "depends_on", "signalling.json",
+						path, dependency.dependsOn);
+				result.scene.blockDependencies.push_back(dependency);
+			}
+		}
+		if (arraySection(signallingJson, "single_track_restrictions", "signalling.json", "", false)) {
+			for (std::size_t index = 0; index < signallingJson["single_track_restrictions"].size(); ++index) {
+				const std::string path = "single_track_restrictions[" + std::to_string(index) + "]";
+				const json& value = signallingJson["single_track_restrictions"][index];
+				SceneSingleTrackRestriction restriction;
+				stringField(value, "start_block", "signalling.json", path, restriction.startBlock);
+				stringField(value, "end_block", "signalling.json", path, restriction.endBlock);
+				stringField(value, "protected_start_block", "signalling.json", path,
+						restriction.protectedStartBlock);
+				stringField(value, "protected_end_block", "signalling.json", path,
+						restriction.protectedEndBlock);
+				result.scene.singleTrackRestrictions.push_back(restriction);
+			}
+		}
+		if (arraySection(signallingJson, "station_boundaries", "signalling.json", "", false)) {
+			for (std::size_t index = 0; index < signallingJson["station_boundaries"].size(); ++index) {
+				const std::string path = "station_boundaries[" + std::to_string(index) + "]";
+				const json& value = signallingJson["station_boundaries"][index];
+				SceneStationBoundary boundary;
+				stringField(value, "entrance_block", "signalling.json", path, boundary.entranceBlock);
+				boundary.hasExitBlock = stringField(value, "exit_block", "signalling.json", path,
+						boundary.exitBlock, false);
+				if (value.contains("direction")) {
+					if (!value["direction"].is_boolean())
+						addError("scene.field.missing", "signalling.json", "direction must be a boolean",
+								path + ".direction");
+					else
+						boundary.direction = value["direction"].get<bool>();
+				}
+				result.scene.stationBoundaries.push_back(boundary);
+			}
+		}
+	}
+
+	if (rollingStockOk) {
+		if (arraySection(rollingStockJson, "train_units", "rolling_stock.json", "", true)) {
+			for (std::size_t index = 0; index < rollingStockJson["train_units"].size(); ++index) {
+				const std::string path = "train_units[" + std::to_string(index) + "]";
+				const json& value = rollingStockJson["train_units"][index];
+				SceneTrainUnit unit;
+				stringField(value, "id", "rolling_stock.json", path, unit.id);
+				if (value.contains("physical")) {
+					if (!value["physical"].is_object()) {
+						addError("scene.field.missing", "rolling_stock.json", "physical must be an object",
+								path + ".physical");
 					} else {
-						auto& src = tu["source"];
-						requireString(src, "data_file", "rolling_stock.json", tuPath + ".source", t.sourceDataFile);
-						requireString(src, "traction_file", "rolling_stock.json", tuPath + ".source", t.sourceTractionFile);
+						const json& physical = value["physical"];
+						unit.hasPhysical = true;
+						numberField(physical, "mass_of_traction_unit_kg", "rolling_stock.json",
+								path + ".physical", unit.physical.mass_of_traction_unit_kg);
+						numberField(physical, "mass_of_a_wagon_kg", "rolling_stock.json",
+								path + ".physical", unit.physical.mass_of_a_wagon_kg);
+						numberField(physical, "number_of_wagons", "rolling_stock.json",
+								path + ".physical", unit.physical.number_of_wagons);
+						numberField(physical, "max_speed_ms", "rolling_stock.json",
+								path + ".physical", unit.physical.max_speed_ms);
+						numberField(physical, "max_deceleration_ms2", "rolling_stock.json",
+								path + ".physical", unit.physical.max_deceleration_ms2);
+						numberField(physical, "frontal_area_m2", "rolling_stock.json",
+								path + ".physical", unit.physical.frontal_area_m2);
+						numberField(physical, "resistance_coefficient", "rolling_stock.json",
+								path + ".physical", unit.physical.resistance_coefficient);
+						numberField(physical, "jerk_ms3", "rolling_stock.json",
+								path + ".physical", unit.physical.jerk_ms3);
+						numberField(physical, "length_m", "rolling_stock.json",
+								path + ".physical", unit.physical.length_m);
 					}
 				}
-				result.scene.trainUnits.push_back(t);
+				if (value.contains("traction_curve")) {
+					if (!value["traction_curve"].is_array()) {
+						addError("scene.field.missing", "rolling_stock.json",
+								"traction_curve must be an array", path + ".traction_curve");
+					} else {
+						for (std::size_t rowIndex = 0; rowIndex < value["traction_curve"].size(); ++rowIndex) {
+							const json& row = value["traction_curve"][rowIndex];
+							const std::string rowPath = path + ".traction_curve["
+									+ std::to_string(rowIndex) + "]";
+							if (!row.is_array() || row.size() != 5) {
+								addError("scene.field.missing", "rolling_stock.json",
+										"traction_curve row must contain five numbers", rowPath);
+								continue;
+							}
+							std::array<double, 5> values{};
+							bool valid = true;
+							for (std::size_t valueIndex = 0; valueIndex < values.size(); ++valueIndex) {
+								if (!row[valueIndex].is_number()) {
+									valid = false;
+									break;
+								}
+								values[valueIndex] = row[valueIndex].get<double>();
+							}
+							if (!valid) {
+								addError("scene.field.missing", "rolling_stock.json",
+										"traction_curve row must contain numbers", rowPath);
+							} else {
+								unit.tractionCurve.push_back(values);
+							}
+						}
+					}
+				}
+				if (value.contains("source")) {
+					if (!value["source"].is_object()) {
+						addError("scene.field.missing", "rolling_stock.json", "source must be an object",
+								path + ".source");
+					} else {
+						const json& source = value["source"];
+						stringField(source, "data_file", "rolling_stock.json", path + ".source",
+								unit.sourceDataFile, false);
+						stringField(source, "traction_file", "rolling_stock.json", path + ".source",
+								unit.sourceTractionFile, false);
+					}
+				}
+				result.scene.trainUnits.push_back(unit);
 			}
 		}
-		if (requireArraySection(rollingJson, "compositions", "rolling_stock.json")) {
-			size_t idx = 0;
-			for (const auto& cp : rollingJson["compositions"]) {
-				std::string path = "compositions[" + std::to_string(idx++) + "]";
-				SceneComposition c;
-				requireString(cp, "id", "rolling_stock.json", path, c.id);
-				if (!cp.contains("units") || !cp["units"].is_array()) {
-					addError("scene.field.missing", "rolling_stock.json", "Missing or invalid units", path + ".units");
-				} else {
-					for (const auto& u : cp["units"]) {
-						if (u.is_string())
-							c.units.push_back(u.get<std::string>());
+		if (arraySection(rollingStockJson, "compositions", "rolling_stock.json", "", true)) {
+			for (std::size_t index = 0; index < rollingStockJson["compositions"].size(); ++index) {
+				const std::string path = "compositions[" + std::to_string(index) + "]";
+				const json& value = rollingStockJson["compositions"][index];
+				SceneComposition composition;
+				stringField(value, "id", "rolling_stock.json", path, composition.id);
+				if (!arraySection(value, "units", "rolling_stock.json", path, true)) {
+					result.scene.compositions.push_back(composition);
+					continue;
+				}
+				for (std::size_t unitIndex = 0; unitIndex < value["units"].size(); ++unitIndex) {
+					if (!value["units"][unitIndex].is_string()) {
+						addError("scene.field.missing", "rolling_stock.json",
+								"Composition unit reference must be a string",
+								path + ".units[" + std::to_string(unitIndex) + "]");
+						continue;
 					}
+					composition.units.push_back(value["units"][unitIndex].get<std::string>());
 				}
-				result.scene.compositions.push_back(c);
+				result.scene.compositions.push_back(composition);
 			}
-		}
-	}
-
-	if (servicesOk && requireArraySection(servicesJson, "services", "services.json")) {
-		size_t idx = 0;
-		for (const auto& sv : servicesJson["services"]) {
-			std::string path = "services[" + std::to_string(idx++) + "]";
-			SceneService s;
-			requireString(sv, "id", "services.json", path, s.id);
-			requireString(sv, "composition", "services.json", path, s.composition);
-			requireString(sv, "route", "services.json", path, s.route);
-			if (sv.contains("through")) {
-				if (sv["through"].is_boolean()) {
-					s.through = sv["through"].get<bool>();
-				} else {
-					addError("scene.field.missing", "services.json", "through must be a boolean", path + ".through");
-				}
-			}
-			if (sv.contains("entry_time_seconds")) {
-				if (sv["entry_time_seconds"].is_number()) {
-					s.hasEntryTime = true;
-					s.entryTimeSeconds = sv["entry_time_seconds"].get<double>();
-				} else {
-					addError("scene.field.missing", "services.json", "entry_time_seconds must be a number", path + ".entry_time_seconds");
-				}
-			}
-			if (sv.contains("repeat")) {
-				if (!sv["repeat"].is_object()) {
-					addError("scene.field.missing", "services.json", "repeat must be an object", path + ".repeat");
-				} else {
-					s.hasRepeat = true;
-					requireNumber(sv["repeat"], "headway_seconds", "services.json", path + ".repeat", s.headwaySeconds);
-				}
-			}
-			if (!sv.contains("stops") || !sv["stops"].is_array()) {
-				addError("scene.field.missing", "services.json", "Missing or invalid stops", path + ".stops");
-			} else {
-				size_t sidx = 0;
-				for (const auto& stp : sv["stops"]) {
-					std::string stopPath = path + ".stops[" + std::to_string(sidx) + "]";
-					SceneStop t;
-					requireString(stp, "station", "services.json", stopPath, t.stationId);
-					if (stp.contains("platform")) {
-						if (stp["platform"].is_string()) {
-							t.platformId = stp["platform"].get<std::string>();
-						} else {
-							addError("scene.field.missing", "services.json", "platform must be a string", stopPath + ".platform");
-						}
-					}
-					// arrival_seconds is optional on any stop: an absent arrival
-					// means the stop has no scheduled arrival time.
-					if (stp.contains("arrival_seconds")) {
-						if (stp["arrival_seconds"].is_number()) {
-							t.hasArrival = true;
-							t.arrivalSeconds = stp["arrival_seconds"].get<double>();
-						} else {
-							addError("scene.field.missing", "services.json", "arrival_seconds must be a number", stopPath + ".arrival_seconds");
-						}
-					}
-					if (stp.contains("departure_seconds")) {
-						if (stp["departure_seconds"].is_number()) {
-							t.hasDeparture = true;
-							t.departureSeconds = stp["departure_seconds"].get<double>();
-						} else {
-							addError("scene.field.missing", "services.json", "departure_seconds must be a number", stopPath + ".departure_seconds");
-						}
-					} else if (sidx < sv["stops"].size() - 1) {
-						addError("scene.field.missing", "services.json", "Missing departure_seconds (only the last stop may omit it)", stopPath + ".departure_seconds");
-					}
-					requireNumber(stp, "dwell_seconds", "services.json", stopPath, t.dwellSeconds);
-					s.stops.push_back(t);
-					++sidx;
-				}
-			}
-			result.scene.services.push_back(s);
 		}
 	}
 
-	if (incidentsOk && requireArraySection(incidentsJson, "incidents", "incidents.json")) {
-		size_t idx = 0;
-		for (const auto& inc : incidentsJson["incidents"]) {
-			std::string path = "incidents[" + std::to_string(idx++) + "]";
-			SceneIncident i;
-			requireString(inc, "id", "incidents.json", path, i.id);
-			requireString(inc, "type", "incidents.json", path, i.type);
-			requireString(inc, "target", "incidents.json", path, i.target);
-			requireNumber(inc, "start_seconds", "incidents.json", path, i.startSeconds);
-			requireNumber(inc, "end_seconds", "incidents.json", path, i.endSeconds);
-			result.scene.incidents.push_back(i);
+	if (servicesOk && arraySection(servicesJson, "services", "services.json", "", true)) {
+		for (std::size_t index = 0; index < servicesJson["services"].size(); ++index) {
+			const std::string path = "services[" + std::to_string(index) + "]";
+			const json& value = servicesJson["services"][index];
+			SceneService service;
+			stringField(value, "id", "services.json", path, service.id);
+			stringField(value, "operating_code", "services.json", path, service.operatingCode, false);
+			stringField(value, "composition", "services.json", path, service.composition);
+			stringField(value, "route", "services.json", path, service.route);
+			if (value.contains("through")) {
+				if (!value["through"].is_boolean())
+					addError("scene.field.missing", "services.json", "through must be a boolean",
+							path + ".through");
+				else
+					service.through = value["through"].get<bool>();
+			}
+			service.hasEntryTime = numberField(value, "entry_time_seconds", "services.json", path,
+					service.entryTimeSeconds, false);
+			if (value.contains("repeat")) {
+				if (!value["repeat"].is_object()) {
+					addError("scene.field.missing", "services.json", "repeat must be an object",
+							path + ".repeat");
+				} else {
+					service.hasRepeat = true;
+					numberField(value["repeat"], "headway_seconds", "services.json", path + ".repeat",
+							service.headwaySeconds);
+				}
+			}
+			if (arraySection(value, "stops", "services.json", path, true)) {
+				for (std::size_t stopIndex = 0; stopIndex < value["stops"].size(); ++stopIndex) {
+					const std::string stopPath = path + ".stops[" + std::to_string(stopIndex) + "]";
+					const json& stopValue = value["stops"][stopIndex];
+					SceneStop stop;
+					if (stopValue.is_object()) {
+						for (const auto& field : stopValue.items()) {
+							if (isSimulationResultField(field.key()))
+								addError("scene.timetable.results", "services.json",
+										"Service stop input must not contain simulation-result fields",
+										stopPath + "." + field.key());
+						}
+					}
+					stringField(stopValue, "station", "services.json", stopPath, stop.stationId);
+					stringField(stopValue, "platform", "services.json", stopPath, stop.platformId, false);
+					stop.hasPlannedArrival = numberField(stopValue, "planned_arrival_seconds", "services.json",
+							stopPath, stop.plannedArrivalSeconds, false);
+					if (!stop.hasPlannedArrival)
+						stop.hasPlannedArrival = numberField(stopValue, "arrival_seconds", "services.json",
+								stopPath, stop.plannedArrivalSeconds, false);
+					stop.hasPlannedDeparture = numberField(stopValue, "planned_departure_seconds", "services.json",
+							stopPath, stop.plannedDepartureSeconds, false);
+					if (!stop.hasPlannedDeparture)
+						stop.hasPlannedDeparture = numberField(stopValue, "departure_seconds", "services.json",
+								stopPath, stop.plannedDepartureSeconds, false);
+					numberField(stopValue, "dwell_seconds", "services.json", stopPath, stop.dwellSeconds);
+					service.stops.push_back(stop);
+				}
+			}
+			result.scene.services.push_back(service);
+		}
+	}
+
+	auto parseIncidentArray = [&](const json& root, const std::string& file, const std::string& path,
+			std::vector<SceneIncident>& output) {
+		if (!arraySection(root, "incidents", file, path, true))
+			return;
+		for (std::size_t index = 0; index < root["incidents"].size(); ++index) {
+			const std::string incidentPath = path.empty()
+					? "incidents[" + std::to_string(index) + "]"
+					: path + ".incidents[" + std::to_string(index) + "]";
+			const json& value = root["incidents"][index];
+			SceneIncident incident;
+			stringField(value, "id", file, incidentPath, incident.id);
+			stringField(value, "type", file, incidentPath, incident.type);
+			stringField(value, "target", file, incidentPath, incident.target);
+			numberField(value, "start_seconds", file, incidentPath, incident.startSeconds);
+			numberField(value, "end_seconds", file, incidentPath, incident.endSeconds);
+			output.push_back(incident);
+		}
+	};
+
+	if (scenariosPresent && incidentsPresent) {
+		addWarning("scene.compatibility.incidents_ignored", "incidents.json",
+				"scenarios.json is authoritative; incidents.json was ignored for compatibility");
+	}
+	if (scenariosPresent) {
+		if (scenariosOk) {
+			stringField(scenariosJson, "default_scenario_id", "scenarios.json", "",
+					result.scene.defaultScenarioId);
+			if (arraySection(scenariosJson, "scenarios", "scenarios.json", "", true)) {
+				for (std::size_t index = 0; index < scenariosJson["scenarios"].size(); ++index) {
+					const std::string path = "scenarios[" + std::to_string(index) + "]";
+					const json& value = scenariosJson["scenarios"][index];
+					SceneScenario scenario;
+					stringField(value, "id", "scenarios.json", path, scenario.id);
+					stringField(value, "name", "scenarios.json", path, scenario.name);
+					stringField(value, "description", "scenarios.json", path, scenario.description, false);
+					parseIncidentArray(value, "scenarios.json", path, scenario.incidents);
+					if (arraySection(value, "entrance_delays", "scenarios.json", path, false)) {
+						for (std::size_t delayIndex = 0; delayIndex < value["entrance_delays"].size();
+								++delayIndex) {
+							const std::string delayPath = path + ".entrance_delays["
+									+ std::to_string(delayIndex) + "]";
+							const json& delayValue = value["entrance_delays"][delayIndex];
+							SceneEntranceDelay delay;
+							stringField(delayValue, "service", "scenarios.json", delayPath, delay.serviceId);
+							integerField(delayValue, "occurrence", "scenarios.json", delayPath,
+									delay.occurrence, false);
+							stringField(delayValue, "station", "scenarios.json", delayPath, delay.stationId);
+							numberField(delayValue, "delay_seconds", "scenarios.json", delayPath,
+								delay.delaySeconds);
+							scenario.entranceDelays.push_back(delay);
+						}
+					}
+					result.scene.scenarios.push_back(scenario);
+				}
+			}
+		}
+	} else {
+		SceneScenario baseline;
+		baseline.id = "baseline";
+		baseline.name = "Baseline";
+		result.scene.defaultScenarioId = baseline.id;
+		if (incidentsPresent && incidentsOk)
+			parseIncidentArray(incidentsJson, "incidents.json", "", baseline.incidents);
+		result.scene.scenarios.push_back(baseline);
+	}
+
+	if (passengersOk && arraySection(passengersJson, "passengers", "passengers.json", "", true)) {
+		auto rejectSimulationResultFields = [&](const json& object, const std::string& path) {
+			if (!object.is_object())
+				return;
+			for (const auto& key : object.items()) {
+				if (isSimulationResultField(key.key())) {
+					addError("scene.passengers.results", "passengers.json",
+							"Passenger input must not contain simulation-result fields",
+							path + "." + key.key());
+				}
+			}
+		};
+		for (std::size_t passengerIndex = 0; passengerIndex < passengersJson["passengers"].size();
+				++passengerIndex) {
+			const std::string passengerPath = "passengers[" + std::to_string(passengerIndex) + "]";
+			const json& value = passengersJson["passengers"][passengerIndex];
+			ScenePassenger passenger;
+			stringField(value, "id", "passengers.json", passengerPath, passenger.id);
+			rejectSimulationResultFields(value, passengerPath);
+			if (arraySection(value, "journeys", "passengers.json", passengerPath, true)) {
+				for (std::size_t journeyIndex = 0; journeyIndex < value["journeys"].size(); ++journeyIndex) {
+					const std::string journeyPath = passengerPath + ".journeys["
+							+ std::to_string(journeyIndex) + "]";
+					const json& journeyValue = value["journeys"][journeyIndex];
+					ScenePassengerJourney journey;
+					rejectSimulationResultFields(journeyValue, journeyPath);
+					stringField(journeyValue, "id", "passengers.json", journeyPath, journey.id);
+					stringField(journeyValue, "activity", "passengers.json", journeyPath, journey.activity, false);
+					stringField(journeyValue, "origin", "passengers.json", journeyPath,
+							journey.originStationId);
+					stringField(journeyValue, "destination", "passengers.json", journeyPath,
+							journey.destinationStationId);
+					if (journeyValue.contains("planned_departure")
+							&& journeyValue["planned_departure"].is_object()) {
+						const std::string windowPath = journeyPath + ".planned_departure";
+						numberField(journeyValue["planned_departure"], "start_seconds", "passengers.json",
+								windowPath, journey.plannedDepartureStartSeconds);
+						numberField(journeyValue["planned_departure"], "end_seconds", "passengers.json",
+								windowPath, journey.plannedDepartureEndSeconds);
+					} else {
+						addError("scene.field.missing", "passengers.json",
+								"Missing planned_departure window", journeyPath + ".planned_departure");
+					}
+					if (journeyValue.contains("planned_arrival")
+							&& journeyValue["planned_arrival"].is_object()) {
+						const std::string windowPath = journeyPath + ".planned_arrival";
+						numberField(journeyValue["planned_arrival"], "start_seconds", "passengers.json",
+								windowPath, journey.plannedArrivalStartSeconds);
+						numberField(journeyValue["planned_arrival"], "end_seconds", "passengers.json",
+								windowPath, journey.plannedArrivalEndSeconds);
+					} else {
+						addError("scene.field.missing", "passengers.json",
+								"Missing planned_arrival window", journeyPath + ".planned_arrival");
+					}
+					if (arraySection(journeyValue, "legs", "passengers.json", journeyPath, true)) {
+						for (std::size_t legIndex = 0; legIndex < journeyValue["legs"].size(); ++legIndex) {
+							const std::string legPath = journeyPath + ".legs["
+									+ std::to_string(legIndex) + "]";
+							const json& legValue = journeyValue["legs"][legIndex];
+							ScenePassengerLeg leg;
+							rejectSimulationResultFields(legValue, legPath);
+							stringField(legValue, "id", "passengers.json", legPath, leg.id);
+							stringField(legValue, "origin", "passengers.json", legPath, leg.originStationId);
+							stringField(legValue, "destination", "passengers.json", legPath,
+									leg.destinationStationId);
+							stringField(legValue, "service", "passengers.json", legPath, leg.serviceId);
+							integerField(legValue, "occurrence", "passengers.json", legPath,
+									leg.occurrence, false);
+							journey.legs.push_back(leg);
+						}
+					}
+					passenger.journeys.push_back(journey);
+				}
+			}
+			result.scene.passengers.push_back(passenger);
 		}
 	}
 

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.h
@@ -2,27 +2,93 @@
 #define SCENEMODEL_H
 
 #include "scene/SceneDiagnostic.h"
+#include <array>
 #include <set>
 #include <string>
 #include <vector>
 
+struct SceneSimulationSettings {
+	bool hasDuration = false;
+	double durationSeconds = 0.0;
+	bool hasBufferTime = false;
+	double bufferTimeSeconds = 0.0;
+	bool hasRecoveryTime = false;
+	double recoveryTimePercent = 0.0;
+};
+
+struct SceneTrack { std::string id; };
+
+struct SceneNode {
+	std::string id;
+	std::string trackId;
+	double xKm = 0.0;
+	double yKm = 0.0;
+};
+
+struct SceneArc {
+	std::string id;
+	std::string trackId;
+	std::string fromNodeId;
+	std::string toNodeId;
+	double curvatureRadiusM = 0.0;
+	double gradientPercent = 0.0;
+	double speedLimitMs = 0.0;
+};
+
+struct SceneBlock {
+	std::string id;
+	std::string trackId;
+	double lengthKm = 0.0;
+};
+
+struct SceneConnection {
+	std::string id;
+	std::string fromNodeId;
+	std::string toNodeId;
+	bool hasSpeedLimit = false;
+	double speedLimitMs = 0.0;
+};
+
 struct ScenePlatform {
 	std::string id;
+	std::vector<std::string> nodeIds;
 };
 
 struct SceneStation {
 	std::string id;
 	std::string name;
+	bool hasPosition = false;
+	double positionKm = 0.0;
 	std::vector<ScenePlatform> platforms;
 };
 
-struct SceneSignal {
-	std::string id;
-};
+struct SceneSignal { std::string id; };
 
 struct SceneRoute {
 	std::string id;
 	std::vector<std::string> blocks;
+	bool hasCorridor = false;
+	std::string corridor;
+	bool reversed = false;
+};
+
+struct SceneBlockDependency {
+	std::string block;
+	std::string dependsOn;
+};
+
+struct SceneSingleTrackRestriction {
+	std::string startBlock;
+	std::string endBlock;
+	std::string protectedStartBlock;
+	std::string protectedEndBlock;
+};
+
+struct SceneStationBoundary {
+	std::string entranceBlock;
+	bool hasExitBlock = false;
+	std::string exitBlock;
+	bool direction = false;
 };
 
 struct SceneTrainPhysical {
@@ -54,15 +120,16 @@ struct SceneComposition {
 struct SceneStop {
 	std::string stationId;
 	std::string platformId;
-	bool hasArrival = false;
-	bool hasDeparture = false;
-	double arrivalSeconds = 0.0;
-	double departureSeconds = 0.0;
+	bool hasPlannedArrival = false;
+	bool hasPlannedDeparture = false;
+	double plannedArrivalSeconds = 0.0;
+	double plannedDepartureSeconds = 0.0;
 	double dwellSeconds = 0.0;
 };
 
 struct SceneService {
 	std::string id;
+	std::string operatingCode;
 	std::string composition;
 	std::string route;
 	bool through = false;
@@ -81,6 +148,46 @@ struct SceneIncident {
 	double endSeconds = 0.0;
 };
 
+struct SceneEntranceDelay {
+	std::string serviceId;
+	int occurrence = 1;
+	std::string stationId;
+	double delaySeconds = 0.0;
+};
+
+struct SceneScenario {
+	std::string id;
+	std::string name;
+	std::string description;
+	std::vector<SceneIncident> incidents;
+	std::vector<SceneEntranceDelay> entranceDelays;
+};
+
+struct ScenePassengerLeg {
+	std::string id;
+	std::string originStationId;
+	std::string destinationStationId;
+	std::string serviceId;
+	int occurrence = 1;
+};
+
+struct ScenePassengerJourney {
+	std::string id;
+	std::string activity;
+	std::string originStationId;
+	std::string destinationStationId;
+	double plannedDepartureStartSeconds = 0.0;
+	double plannedDepartureEndSeconds = 0.0;
+	double plannedArrivalStartSeconds = 0.0;
+	double plannedArrivalEndSeconds = 0.0;
+	std::vector<ScenePassengerLeg> legs;
+};
+
+struct ScenePassenger {
+	std::string id;
+	std::vector<ScenePassengerJourney> journeys;
+};
+
 struct SceneLoadedData {
 	std::string category;
 	std::string sourceFile;
@@ -89,26 +196,54 @@ struct SceneLoadedData {
 	std::vector<SceneLoadedData> children;
 };
 
+struct SceneImportReportRow {
+	std::string category;
+	std::string sourceFile;
+	int sourceCount = 0;
+	int convertedCount = 0;
+	int skippedCount = 0;
+	int unresolvedReferences = 0;
+};
+
 struct SceneModel {
 	int schemaVersion = 0;
 	std::string name;
 	std::string description;
 	std::string baseTime;
+	SceneSimulationSettings settings;
 
 	std::vector<SceneLoadedData> loadedData;
 	std::set<std::string> sourceFiles;
+	std::vector<SceneImportReportRow> importReport;
+	std::vector<SceneTrack> tracks;
+	std::vector<SceneNode> nodes;
+	std::vector<SceneArc> arcs;
+	std::vector<SceneBlock> blocks;
+	std::vector<SceneConnection> connections;
 	std::vector<SceneStation> stations;
 	std::vector<SceneSignal> signals;
 	std::vector<SceneRoute> routes;
+	std::vector<SceneBlockDependency> blockDependencies;
+	std::vector<SceneSingleTrackRestriction> singleTrackRestrictions;
+	std::vector<SceneStationBoundary> stationBoundaries;
 	std::vector<SceneTrainUnit> trainUnits;
 	std::vector<SceneComposition> compositions;
 	std::vector<SceneService> services;
-	std::vector<SceneIncident> incidents;
+	std::string defaultScenarioId;
+	std::vector<SceneScenario> scenarios;
+	std::vector<ScenePassenger> passengers;
 };
 
+// GUI/editor callers use the preferred scenario without a duplicate flat
+// incident vector in SceneModel.
+SceneScenario* defaultScenario(SceneModel& scene);
+const SceneScenario* defaultScenario(const SceneModel& scene);
+std::vector<SceneIncident>& defaultScenarioIncidents(SceneModel& scene);
+const std::vector<SceneIncident>& defaultScenarioIncidents(const SceneModel& scene);
+
 struct SceneLoadResult {
-	SceneModel scene;						  // partial on failure
-	std::vector<SceneDiagnostic> diagnostics; // structural problems
+	SceneModel scene; // partial on structural failure
+	std::vector<SceneDiagnostic> diagnostics;
 };
 
 SceneLoadResult loadScene(const std::string& sceneDir);

--- a/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
@@ -1,276 +1,631 @@
 #include "scene/SceneValidator.h"
-#include <unordered_set>
-#include <unordered_map>
-#include <regex>
 
-std::vector<SceneDiagnostic> validateSceneDirectory(const std::string& sceneDir) {
-	SceneLoadResult loadRes = loadScene(sceneDir);
-	if (hasErrors(loadRes.diagnostics)) {
-		return loadRes.diagnostics;
+#include <algorithm>
+#include <cmath>
+#include <regex>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace {
+
+struct DiagnosticBuilder {
+	std::vector<SceneDiagnostic>& diagnostics;
+
+	void add(SceneSeverity severity, const std::string& code, const std::string& message,
+			const std::string& file, const std::string& itemType = "",
+			const std::string& itemId = "", const std::string& path = "",
+			const std::string& relatedId = "", const std::string& suggestedFix = "") {
+		SceneDiagnostic diagnostic;
+		diagnostic.severity = severity;
+		diagnostic.code = code;
+		diagnostic.message = message;
+		diagnostic.file = file;
+		diagnostic.itemType = itemType;
+		diagnostic.itemId = itemId;
+		diagnostic.path = path;
+		diagnostic.relatedId = relatedId;
+		diagnostic.suggestedFix = suggestedFix;
+		diagnostics.push_back(diagnostic);
 	}
-	std::vector<SceneDiagnostic> semantic = validateScene(loadRes.scene);
-	std::vector<SceneDiagnostic> combined = loadRes.diagnostics; // keeps warnings/infos if any
-	combined.insert(combined.end(), semantic.begin(), semantic.end());
-	return combined;
+
+	void error(const std::string& code, const std::string& message, const std::string& file,
+			const std::string& itemType = "", const std::string& itemId = "",
+			const std::string& path = "", const std::string& relatedId = "",
+			const std::string& suggestedFix = "") {
+		add(SceneSeverity::Error, code, message, file, itemType, itemId, path, relatedId, suggestedFix);
+	}
+
+	void warning(const std::string& code, const std::string& message, const std::string& file,
+			const std::string& itemType = "", const std::string& itemId = "",
+			const std::string& path = "", const std::string& relatedId = "",
+			const std::string& suggestedFix = "") {
+		add(SceneSeverity::Warning, code, message, file, itemType, itemId, path, relatedId, suggestedFix);
+	}
+};
+
+std::string basicBlockId(const std::string& token) {
+	if (!token.empty() && token.front() == '@') {
+		const std::size_t end = token.find('@', 1);
+		if (end != std::string::npos)
+			return token.substr(1, end - 1);
+	}
+	const std::size_t position = token.find('@');
+	return position == std::string::npos ? token : token.substr(0, position);
 }
 
-std::vector<SceneDiagnostic> validateScene(const SceneModel& scene) {
-	std::vector<SceneDiagnostic> diags;
-	auto addDiag = [&](SceneSeverity sev, const std::string& code, const std::string& msg,
-					   const std::string& file, const std::string& itemType, const std::string& itemId,
-					   const std::string& path = "", const std::string& relatedId = "", const std::string& suggestedFix = "") {
-		SceneDiagnostic d;
-		d.severity = sev;
-		d.code = code;
-		d.message = msg;
-		d.file = file;
-		d.itemType = itemType;
-		d.itemId = itemId;
-		d.path = path;
-		d.relatedId = relatedId;
-		d.suggestedFix = suggestedFix;
-		diags.push_back(d);
-	};
+std::vector<std::string> routeComponents(const std::string& token) {
+	std::vector<std::string> components;
+	std::size_t begin = 0;
+	while (begin <= token.size()) {
+		const std::size_t slash = token.find('/', begin);
+		const std::string part = token.substr(begin,
+				slash == std::string::npos ? std::string::npos : slash - begin);
+		if (!part.empty())
+			components.push_back(basicBlockId(part));
+		if (slash == std::string::npos)
+			break;
+		begin = slash + 1;
+	}
+	return components;
+}
+
+bool hasId(const std::unordered_set<std::string>& ids, const std::string& id) {
+	return !id.empty() && ids.find(id) != ids.end();
+}
+
+template <typename T>
+void collectIds(const std::vector<T>& items, const std::string& file, const std::string& type,
+		const std::string& category, DiagnosticBuilder& diagnostics,
+		std::unordered_set<std::string>& ids) {
+	for (std::size_t index = 0; index < items.size(); ++index) {
+		const std::string& id = items[index].id;
+		const std::string path = category + "[" + std::to_string(index) + "].id";
+		if (!ids.insert(id).second) {
+			diagnostics.error("scene.id.duplicate", "Duplicate " + type + " id", file, type, id,
+					path, id, "Give each " + type + " a unique id");
+		}
+	}
+}
+
+std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable) {
+	std::vector<SceneDiagnostic> result;
+	DiagnosticBuilder diagnostics{result};
 
 	if (!scene.baseTime.empty()) {
-		std::regex re("^\\d{2}:\\d{2}:\\d{2}$");
-		if (!std::regex_match(scene.baseTime, re)) {
-			addDiag(SceneSeverity::Error, "scene.basetime.invalid", "Invalid base_time format, must be HH:MM:SS",
+		static const std::regex timePattern("^[0-2][0-9]:[0-5][0-9]:[0-5][0-9]$");
+		if (!std::regex_match(scene.baseTime, timePattern)) {
+			diagnostics.error("scene.basetime.invalid", "Invalid base_time format, must be HH:MM:SS",
 					"scene.json", "scene", "", "base_time", "",
 					"Write the base time as HH:MM:SS, for example 08:00:00");
 		}
 	}
-
-	if (scene.compositions.empty() || scene.trainUnits.empty()) {
-		addDiag(SceneSeverity::Error, "scene.trains.none", "No trains defined",
-				"rolling_stock.json", "", "", "", "",
+	if (scene.settings.hasDuration && scene.settings.durationSeconds <= 0.0) {
+		diagnostics.error("scene.duration.invalid", "Simulation duration must be positive", "scene.json",
+				"scene", "", "simulation_settings.duration_seconds", "",
+				"Use a duration greater than 0 seconds");
+	}
+	if (scene.settings.hasBufferTime && scene.settings.bufferTimeSeconds < 0.0) {
+		diagnostics.error("scene.buffer.invalid", "Simulation buffer time cannot be negative", "scene.json",
+				"scene", "", "simulation_settings.buffer_time_seconds", "",
+				"Use a buffer time of 0 or more seconds");
+	}
+	if (scene.settings.hasRecoveryTime && scene.settings.recoveryTimePercent < 0.0) {
+		diagnostics.error("scene.recovery.invalid", "Recovery time cannot be negative", "scene.json",
+				"scene", "", "simulation_settings.recovery_time_percent", "",
+				"Use a recovery value of 0 or more");
+	}
+	if (scene.trainUnits.empty() || scene.compositions.empty())
+		diagnostics.error("scene.trains.none", "No trains defined", "rolling_stock.json", "", "", "", "",
 				"Add at least one train unit and one composition to rolling_stock.json");
-	}
-	if (scene.services.empty()) {
-		addDiag(SceneSeverity::Error, "scene.services.none", "No services defined",
-				"services.json", "", "", "", "",
+	if (scene.services.empty())
+		diagnostics.error("scene.services.none", "No services defined", "services.json", "", "", "", "",
 				"Add at least one service to services.json");
+
+	std::unordered_set<std::string> trackIds;
+	collectIds(scene.tracks, "infrastructure.json", "track", "tracks", diagnostics, trackIds);
+	std::unordered_set<std::string> nodeIds;
+	collectIds(scene.nodes, "infrastructure.json", "node", "nodes", diagnostics, nodeIds);
+	std::unordered_set<std::string> arcIds;
+	collectIds(scene.arcs, "infrastructure.json", "arc", "arcs", diagnostics, arcIds);
+	std::unordered_set<std::string> blockIds;
+	collectIds(scene.blocks, "infrastructure.json", "block", "blocks", diagnostics, blockIds);
+	std::unordered_set<std::string> connectionIds;
+	collectIds(scene.connections, "infrastructure.json", "connection", "connections", diagnostics,
+			connectionIds);
+	for (std::size_t index = 0; index < scene.nodes.size(); ++index) {
+		const SceneNode& node = scene.nodes[index];
+		if (!hasId(trackIds, node.trackId)) {
+			diagnostics.error("scene.ref.unresolved", "Node refers to unknown track", "infrastructure.json",
+					"node", node.id, "nodes[" + std::to_string(index) + "].track", node.trackId,
+					"Add track " + node.trackId + " or reference an existing track");
+		}
+	}
+	for (std::size_t index = 0; index < scene.arcs.size(); ++index) {
+		const SceneArc& arc = scene.arcs[index];
+		const std::string path = "arcs[" + std::to_string(index) + "]";
+		if (!hasId(trackIds, arc.trackId))
+			diagnostics.error("scene.ref.unresolved", "Arc refers to unknown track", "infrastructure.json",
+					"arc", arc.id, path + ".track", arc.trackId);
+		if (!hasId(nodeIds, arc.fromNodeId))
+			diagnostics.error("scene.ref.unresolved", "Arc refers to unknown start node", "infrastructure.json",
+					"arc", arc.id, path + ".from", arc.fromNodeId);
+		if (!hasId(nodeIds, arc.toNodeId))
+			diagnostics.error("scene.ref.unresolved", "Arc refers to unknown end node", "infrastructure.json",
+					"arc", arc.id, path + ".to", arc.toNodeId);
+	}
+	for (std::size_t index = 0; index < scene.blocks.size(); ++index) {
+		if (!hasId(trackIds, scene.blocks[index].trackId))
+			diagnostics.error("scene.ref.unresolved", "Block refers to unknown track", "infrastructure.json",
+					"block", scene.blocks[index].id, "blocks[" + std::to_string(index) + "].track",
+					scene.blocks[index].trackId);
+	}
+	for (std::size_t index = 0; index < scene.connections.size(); ++index) {
+		const SceneConnection& connection = scene.connections[index];
+		const std::string path = "connections[" + std::to_string(index) + "]";
+		if (!hasId(nodeIds, connection.fromNodeId))
+			diagnostics.error("scene.ref.unresolved", "Connection refers to unknown start node",
+					"infrastructure.json", "connection", connection.id, path + ".from",
+					connection.fromNodeId);
+		if (!hasId(nodeIds, connection.toNodeId))
+			diagnostics.error("scene.ref.unresolved", "Connection refers to unknown end node",
+					"infrastructure.json", "connection", connection.id, path + ".to",
+					connection.toNodeId);
 	}
 
-	std::unordered_map<std::string, const SceneStation*> stationMap;
 	std::unordered_set<std::string> stationIds;
-	for (const auto& st : scene.stations) {
-		if (!stationIds.insert(st.id).second) {
-			addDiag(SceneSeverity::Error, "scene.id.duplicate", "Duplicate station id",
-					"stations.json", "station", st.id, "", "stations.json",
-					"Give each station a unique id");
+	std::unordered_map<std::string, const SceneStation*> stations;
+	for (std::size_t index = 0; index < scene.stations.size(); ++index) {
+		const SceneStation& station = scene.stations[index];
+		const std::string path = "stations[" + std::to_string(index) + "]";
+		if (!stationIds.insert(station.id).second) {
+			diagnostics.error("scene.id.duplicate", "Duplicate station id", "stations.json", "station",
+					station.id, path + ".id", station.id);
 		}
-		stationMap[st.id] = &st;
+		stations[station.id] = &station;
+		std::unordered_set<std::string> platformIds;
+		for (std::size_t platformIndex = 0; platformIndex < station.platforms.size(); ++platformIndex) {
+			const ScenePlatform& platform = station.platforms[platformIndex];
+			const std::string platformPath = path + ".platforms[" + std::to_string(platformIndex) + "]";
+			if (!platformIds.insert(platform.id).second)
+				diagnostics.error("scene.id.duplicate", "Duplicate platform id on station", "stations.json",
+						"platform", platform.id, platformPath + ".id", station.id);
+			for (std::size_t nodeIndex = 0; nodeIndex < platform.nodeIds.size(); ++nodeIndex) {
+				if (!hasId(nodeIds, platform.nodeIds[nodeIndex])) {
+					diagnostics.error("scene.ref.unresolved", "Platform refers to unknown node", "stations.json",
+							"platform", platform.id, platformPath + ".nodes[" + std::to_string(nodeIndex) + "]",
+							platform.nodeIds[nodeIndex]);
+				}
+			}
+		}
 	}
 
 	std::unordered_set<std::string> signalIds;
-	for (const auto& sig : scene.signals) {
-		if (!signalIds.insert(sig.id).second) {
-			addDiag(SceneSeverity::Error, "scene.id.duplicate", "Duplicate signal id",
-					"signalling.json", "signal", sig.id, "", "signalling.json",
-					"Give each signal a unique id");
+	collectIds(scene.signals, "signalling.json", "signal", "signals", diagnostics, signalIds);
+	std::unordered_set<std::string> routeIds;
+	collectIds(scene.routes, "signalling.json", "route", "routes", diagnostics, routeIds);
+	std::unordered_set<std::string> routeBlockIds;
+	for (std::size_t index = 0; index < scene.routes.size(); ++index) {
+		const SceneRoute& route = scene.routes[index];
+		const std::string path = "routes[" + std::to_string(index) + "]";
+		if (route.blocks.empty()) {
+			diagnostics.error("scene.route.empty", "Route has no blocks", "signalling.json", "route", route.id,
+					path + ".blocks", "", "List the block ids the route runs through");
+		}
+		for (const auto& token : route.blocks) {
+			for (const auto& component : routeComponents(token))
+				routeBlockIds.insert(component);
+		}
+		if (!blockIds.empty()) {
+			for (std::size_t blockIndex = 0; blockIndex < route.blocks.size(); ++blockIndex) {
+				const std::string blockPath = path + ".blocks[" + std::to_string(blockIndex) + "]";
+				for (const auto& component : routeComponents(route.blocks[blockIndex])) {
+					if (!hasId(blockIds, component)) {
+						diagnostics.error("scene.ref.unresolved", "Route refers to unknown block",
+								"signalling.json", "route", route.id, blockPath, component,
+								"Add block " + component + " or fix the route token");
+					}
+				}
+			}
 		}
 	}
-
-	std::unordered_set<std::string> routeIds;
-	for (const auto& r : scene.routes) {
-		if (!routeIds.insert(r.id).second) {
-			addDiag(SceneSeverity::Error, "scene.id.duplicate", "Duplicate route id",
-					"signalling.json", "route", r.id, "", "signalling.json",
-					"Give each route a unique id");
+	auto blockReferenceKnown = [&](const std::string& reference) {
+		const std::vector<std::string> components = routeComponents(reference);
+		if (components.empty())
+			return false;
+		for (const auto& component : components) {
+			const bool found = blockIds.empty() ? hasId(routeBlockIds, component)
+					: hasId(blockIds, component);
+			if (!found)
+				return false;
 		}
-		if (r.blocks.empty()) {
-			addDiag(SceneSeverity::Error, "scene.route.empty", "Route has no blocks",
-					"signalling.json", "route", r.id, "routes[" + r.id + "].blocks", "",
-					"List the block ids the route runs through");
+		return true;
+	};
+	for (std::size_t index = 0; index < scene.blockDependencies.size(); ++index) {
+		const SceneBlockDependency& dependency = scene.blockDependencies[index];
+		const std::string path = "block_dependencies[" + std::to_string(index) + "]";
+		if (!blockReferenceKnown(dependency.block))
+			diagnostics.error("scene.ref.unresolved", "Block dependency refers to unknown block",
+					"signalling.json", "block_dependency", dependency.block, path + ".block",
+					dependency.block);
+		if (!blockReferenceKnown(dependency.dependsOn))
+			diagnostics.error("scene.ref.unresolved", "Block dependency refers to unknown dependency",
+					"signalling.json", "block_dependency", dependency.block, path + ".depends_on",
+					dependency.dependsOn);
+	}
+	for (std::size_t index = 0; index < scene.singleTrackRestrictions.size(); ++index) {
+		const SceneSingleTrackRestriction& restriction = scene.singleTrackRestrictions[index];
+		const std::string path = "single_track_restrictions[" + std::to_string(index) + "]";
+		const std::array<std::pair<const char*, const std::string*>, 4> roles = {{
+			{"start_block", &restriction.startBlock},
+			{"end_block", &restriction.endBlock},
+			{"protected_start_block", &restriction.protectedStartBlock},
+			{"protected_end_block", &restriction.protectedEndBlock},
+		}};
+		for (const auto& role : roles) {
+			if (!blockReferenceKnown(*role.second))
+				diagnostics.error("scene.ref.unresolved", "Single-track restriction refers to unknown block",
+						"signalling.json", "single_track_restriction", *role.second,
+						path + "." + role.first, *role.second);
 		}
+	}
+	for (std::size_t index = 0; index < scene.stationBoundaries.size(); ++index) {
+		const SceneStationBoundary& boundary = scene.stationBoundaries[index];
+		const std::string path = "station_boundaries[" + std::to_string(index) + "]";
+		if (!blockReferenceKnown(boundary.entranceBlock))
+			diagnostics.error("scene.ref.unresolved", "Station boundary refers to unknown entrance block",
+					"signalling.json", "station_boundary", boundary.entranceBlock,
+					path + ".entrance_block", boundary.entranceBlock);
+		if (boundary.hasExitBlock && !blockReferenceKnown(boundary.exitBlock))
+			diagnostics.error("scene.ref.unresolved", "Station boundary refers to unknown exit block",
+					"signalling.json", "station_boundary", boundary.exitBlock,
+					path + ".exit_block", boundary.exitBlock);
 	}
 
 	std::unordered_set<std::string> trainUnitIds;
-	for (const auto& tu : scene.trainUnits) {
-		if (!trainUnitIds.insert(tu.id).second) {
-			addDiag(SceneSeverity::Error, "scene.id.duplicate", "Duplicate train unit id",
-					"rolling_stock.json", "train_unit", tu.id, "", "rolling_stock.json",
-					"Give each train unit a unique id");
-		}
-		const std::string tractionPath = "train_units[" + tu.id + "].traction_curve";
-		if (tu.tractionCurve.empty()) {
-			addDiag(SceneSeverity::Error, "scene.train.traction.empty", "Train unit has no traction data",
-					"rolling_stock.json", "train_unit", tu.id, tractionPath, "",
+	collectIds(scene.trainUnits, "rolling_stock.json", "train unit", "train_units", diagnostics,
+			trainUnitIds);
+	for (std::size_t index = 0; index < scene.trainUnits.size(); ++index) {
+		const SceneTrainUnit& unit = scene.trainUnits[index];
+		const std::string path = "train_units[" + std::to_string(index) + "]";
+		if (unit.tractionCurve.empty()) {
+			diagnostics.error("scene.train.traction.empty", "Train unit has no traction data",
+					"rolling_stock.json", "train_unit", unit.id, path + ".traction_curve", "",
 					"Add at least one traction curve row");
 		}
-		for (size_t rowIndex = 0; rowIndex < tu.tractionCurve.size(); ++rowIndex) {
-			const auto& row = tu.tractionCurve[rowIndex];
-			if (row[0] >= row[1]) {
-				addDiag(SceneSeverity::Error, "scene.train.traction.interval", "Traction curve lower speed must be below upper speed",
-						"rolling_stock.json", "train_unit", tu.id,
-						tractionPath + "[" + std::to_string(rowIndex) + "]", "",
+		if (runnable && !unit.hasPhysical) {
+			diagnostics.error("scene.train.physical.missing", "Train unit has no physical parameters",
+					"rolling_stock.json", "train_unit", unit.id, path + ".physical", "",
+					"Add the train-unit physical parameters");
+		}
+		for (std::size_t rowIndex = 0; rowIndex < unit.tractionCurve.size(); ++rowIndex) {
+			const auto& row = unit.tractionCurve[rowIndex];
+			const std::string rowPath = path + ".traction_curve[" + std::to_string(rowIndex) + "]";
+			if (!(row[0] < row[1])) {
+				diagnostics.error("scene.train.traction.interval",
+						"Traction curve lower speed must be below upper speed", "rolling_stock.json",
+						"train_unit", unit.id, rowPath, "",
 						"Set the lower speed below the upper speed");
 			}
-			if (rowIndex == 0)
-				continue;
-			const auto& previous = tu.tractionCurve[rowIndex - 1];
-			if (row[0] < previous[0]) {
-				addDiag(SceneSeverity::Error, "scene.train.traction.order", "Traction curve rows are not in ascending speed order",
-						"rolling_stock.json", "train_unit", tu.id, tractionPath, "",
-						"Order rows by increasing lower speed");
-			} else if (row[0] < previous[1]) {
-				addDiag(SceneSeverity::Error, "scene.train.traction.overlap", "Traction curve intervals overlap",
-						"rolling_stock.json", "train_unit", tu.id, tractionPath, "",
-						"Adjust adjacent bounds so intervals do not overlap");
+			if (rowIndex > 0) {
+				const auto& previous = unit.tractionCurve[rowIndex - 1];
+				if (row[0] < previous[0]) {
+					diagnostics.error("scene.train.traction.order",
+							"Traction curve rows are not in ascending speed order", "rolling_stock.json",
+							"train_unit", unit.id, rowPath, "", "Order rows by increasing lower speed");
+				} else if (row[0] < previous[1]) {
+					diagnostics.error("scene.train.traction.overlap", "Traction curve intervals overlap",
+							"rolling_stock.json", "train_unit", unit.id, rowPath, "",
+							"Adjust adjacent bounds so intervals do not overlap");
+				}
 			}
 		}
 	}
 
 	std::unordered_set<std::string> compositionIds;
-	for (const auto& c : scene.compositions) {
-		std::string path = "compositions[" + c.id + "]";
-		if (!compositionIds.insert(c.id).second) {
-			addDiag(SceneSeverity::Error, "scene.id.duplicate", "Duplicate composition id",
-					"rolling_stock.json", "composition", c.id, "", "rolling_stock.json",
-					"Give each composition a unique id");
-		}
-		if (c.units.empty()) {
-			addDiag(SceneSeverity::Error, "scene.composition.empty", "Composition has no units",
-					"rolling_stock.json", "composition", c.id, path + ".units", "",
+	collectIds(scene.compositions, "rolling_stock.json", "composition", "compositions", diagnostics,
+			compositionIds);
+	for (std::size_t index = 0; index < scene.compositions.size(); ++index) {
+		const SceneComposition& composition = scene.compositions[index];
+		const std::string path = "compositions[" + std::to_string(index) + "]";
+		if (composition.units.empty()) {
+			diagnostics.error("scene.composition.empty", "Composition has no units", "rolling_stock.json",
+					"composition", composition.id, path + ".units", "",
 					"List at least one train unit id");
-		} else {
-			for (const auto& u : c.units) {
-				if (trainUnitIds.find(u) == trainUnitIds.end()) {
-					addDiag(SceneSeverity::Error, "scene.ref.unresolved", "Composition refers to unknown train unit",
-							"rolling_stock.json", "composition", c.id, path + ".units", u,
-							"Add train unit " + u + " to rolling_stock.json or reference an existing one");
-				}
-			}
+		}
+		for (std::size_t unitIndex = 0; unitIndex < composition.units.size(); ++unitIndex) {
+			if (!hasId(trainUnitIds, composition.units[unitIndex]))
+				diagnostics.error("scene.ref.unresolved", "Composition refers to unknown train unit",
+						"rolling_stock.json", "composition", composition.id,
+						path + ".units[" + std::to_string(unitIndex) + "]", composition.units[unitIndex]);
 		}
 	}
 
 	std::unordered_set<std::string> serviceIds;
-	for (const auto& s : scene.services) {
-		std::string servicePath = "services[" + s.id + "]";
-		if (!serviceIds.insert(s.id).second) {
-			addDiag(SceneSeverity::Error, "scene.id.duplicate", "Duplicate service id",
-					"services.json", "service", s.id, "", "services.json",
-					"Give each service a unique id");
-		}
-		if (compositionIds.find(s.composition) == compositionIds.end()) {
-			addDiag(SceneSeverity::Error, "scene.ref.unresolved", "Service refers to unknown composition",
-					"services.json", "service", s.id, servicePath + ".composition", s.composition,
-					"Add composition " + s.composition + " to rolling_stock.json or reference an existing one");
-		}
-		if (routeIds.find(s.route) == routeIds.end()) {
-			addDiag(SceneSeverity::Error, "scene.ref.unresolved", "Service refers to unknown route",
-					"services.json", "service", s.id, servicePath + ".route", s.route,
-					"Add route " + s.route + " to signalling.json or reference an existing one");
-		}
-		if (s.hasRepeat && s.headwaySeconds <= 0.0) {
-			addDiag(SceneSeverity::Error, "scene.repeat.invalid", "Non-positive headway",
-					"services.json", "service", s.id, servicePath + ".repeat.headway_seconds", "",
+	collectIds(scene.services, "services.json", "service", "services", diagnostics, serviceIds);
+	for (std::size_t index = 0; index < scene.services.size(); ++index) {
+		const SceneService& service = scene.services[index];
+		const std::string path = "services[" + service.id + "]";
+		if (!hasId(compositionIds, service.composition))
+			diagnostics.error("scene.ref.unresolved", "Service refers to unknown composition", "services.json",
+					"service", service.id, path + ".composition", service.composition);
+		if (!hasId(routeIds, service.route))
+			diagnostics.error("scene.ref.unresolved", "Service refers to unknown route", "services.json",
+					"service", service.id, path + ".route", service.route);
+		if (service.hasRepeat && service.headwaySeconds <= 0.0)
+			diagnostics.error("scene.repeat.invalid", "Non-positive headway", "services.json", "service",
+					service.id, path + ".repeat.headway_seconds", "",
 					"Use a headway greater than 0 seconds");
+		if (service.stops.empty()) {
+			if (!service.through)
+				diagnostics.warning("scene.service.no_stops", "Service has no stops", "services.json",
+						"service", service.id, path + ".stops", "",
+						"Add at least one stop or mark the service through");
+		} else if (service.through) {
+			diagnostics.warning("scene.service.through_stops", "Through service has stops", "services.json",
+					"service", service.id, path + ".through");
 		}
-		if (s.stops.empty()) {
-			if (!s.through) {
-				addDiag(SceneSeverity::Warning, "scene.service.no_stops", "Service has no stops",
-						"services.json", "service", s.id, servicePath + ".stops", "",
-						"Add at least one stop to the service");
+		bool hasPreviousDeparture = false;
+		double previousDeparture = 0.0;
+		for (std::size_t stopIndex = 0; stopIndex < service.stops.size(); ++stopIndex) {
+			const SceneStop& stop = service.stops[stopIndex];
+			const std::string stopPath = path + ".stops[" + std::to_string(stopIndex) + "]";
+			auto station = stations.find(stop.stationId);
+			if (station == stations.end()) {
+				diagnostics.error("scene.ref.unresolved", "Stop refers to unknown station", "services.json",
+						"service", service.id, stopPath + ".station", stop.stationId);
+			} else if (!stop.platformId.empty()) {
+				bool platformFound = false;
+				for (const auto& platform : station->second->platforms) {
+					if (platform.id == stop.platformId) {
+						platformFound = true;
+						break;
+					}
+				}
+				if (!platformFound)
+					diagnostics.error("scene.ref.platform", "Stop refers to platform not on station",
+							"services.json", "service", service.id, stopPath + ".platform", stop.platformId);
 			}
-		} else {
-			if (s.through) {
-				addDiag(SceneSeverity::Warning, "scene.service.through_stops", "Through service has stops",
-						"services.json", "service", s.id, servicePath + ".through", "",
-						"Remove the through flag or the stops");
+			if (stop.hasPlannedArrival && stop.hasPlannedDeparture
+					&& stop.plannedDepartureSeconds < stop.plannedArrivalSeconds) {
+				diagnostics.error("scene.time.invalid", "Departure before arrival", "services.json",
+						"service", service.id, stopPath + ".planned_departure_seconds");
 			}
-			bool hasLastDeparture = false;
-			double lastDeparture = 0.0;
-			for (size_t i = 0; i < s.stops.size(); ++i) {
-				const auto& stop = s.stops[i];
-				std::string stopPath = servicePath + ".stops[" + std::to_string(i) + "]";
-				auto it = stationMap.find(stop.stationId);
-				if (it == stationMap.end()) {
-					addDiag(SceneSeverity::Error, "scene.ref.unresolved", "Stop refers to unknown station",
-							"services.json", "service", s.id, stopPath + ".station", stop.stationId,
-							"Add station " + stop.stationId + " to stations.json or reference an existing one");
-				} else if (!stop.platformId.empty()) {
-					bool found = false;
-					for (const auto& p : it->second->platforms) {
-						if (p.id == stop.platformId) {
-							found = true;
-							break;
-						}
-					}
-					if (!found) {
-						addDiag(SceneSeverity::Error, "scene.ref.platform", "Stop refers to platform not on station",
-								"services.json", "service", s.id, stopPath + ".platform", stop.platformId,
-								"Use a platform defined on station " + stop.stationId);
-					}
-				}
-
-				// Negative times are allowed: schedules may reference instants
-				// before the scene base time (real case-study data does this).
-				if (stop.hasDeparture) {
-					if (stop.hasArrival && stop.departureSeconds < stop.arrivalSeconds) {
-						addDiag(SceneSeverity::Error, "scene.time.invalid", "Departure before arrival",
-								"services.json", "service", s.id, stopPath + ".departure_seconds", "",
-								"Set departure_seconds at or after arrival_seconds");
-					}
-					if (hasLastDeparture && stop.departureSeconds < lastDeparture) {
-						addDiag(SceneSeverity::Warning, "scene.time.order", "Non-increasing departure times",
-								"services.json", "service", s.id, stopPath + ".departure_seconds", "",
-								"Order stops by increasing departure time");
-					}
-					hasLastDeparture = true;
-					lastDeparture = stop.departureSeconds;
-				}
-
-				if (stop.dwellSeconds < 0.0) {
-					addDiag(SceneSeverity::Error, "scene.dwell.invalid", "Negative dwell time",
-							"services.json", "service", s.id, stopPath + ".dwell_seconds", "",
-							"Use a dwell time of 0 or more seconds");
-				}
-				if (stop.hasArrival && stop.hasDeparture) {
-					double window = stop.departureSeconds - stop.arrivalSeconds;
-					if (stop.dwellSeconds > window) {
-						addDiag(SceneSeverity::Warning, "scene.dwell.exceeds_window", "Dwell time exceeds departure - arrival window",
-								"services.json", "service", s.id, stopPath + ".dwell_seconds", "",
-								"Widen the arrival-departure window or reduce dwell_seconds");
-					}
-				}
+			if (stop.hasPlannedDeparture) {
+				if (hasPreviousDeparture && stop.plannedDepartureSeconds < previousDeparture)
+					diagnostics.warning("scene.time.order", "Non-increasing departure times", "services.json",
+							"service", service.id, stopPath + ".planned_departure_seconds");
+				hasPreviousDeparture = true;
+				previousDeparture = stop.plannedDepartureSeconds;
+			} else if (stopIndex + 1 < service.stops.size()) {
+				diagnostics.warning("scene.time.departure.missing",
+						"Intermediate stop has no planned departure", "services.json", "service", service.id,
+						stopPath + ".planned_departure_seconds");
+			}
+			if (stop.dwellSeconds < 0.0)
+				diagnostics.error("scene.dwell.invalid", "Negative dwell time", "services.json", "service",
+						service.id, stopPath + ".dwell_seconds", "",
+						"Use a dwell time of 0 or more seconds");
+			if (stop.hasPlannedArrival && stop.hasPlannedDeparture
+					&& stop.dwellSeconds > stop.plannedDepartureSeconds - stop.plannedArrivalSeconds) {
+				diagnostics.warning("scene.dwell.exceeds_window",
+						"Dwell time exceeds departure - arrival window", "services.json", "service", service.id,
+						stopPath + ".dwell_seconds");
 			}
 		}
 	}
 
+	std::unordered_set<std::string> scenarioIds;
 	std::unordered_set<std::string> incidentIds;
-	for (const auto& inc : scene.incidents) {
-		std::string path = "incidents[" + inc.id + "]";
-		if (!incidentIds.insert(inc.id).second) {
-			addDiag(SceneSeverity::Error, "scene.id.duplicate", "Duplicate incident id",
-					"incidents.json", "incident", inc.id, "", "incidents.json",
-					"Give each incident a unique id");
-		}
-		if (inc.type == "signal_failure") {
-			if (signalIds.find(inc.target) == signalIds.end()) {
-				addDiag(SceneSeverity::Error, "scene.ref.unresolved", "Incident refers to unknown signal",
-						"incidents.json", "incident", inc.id, path + ".target", inc.target,
-						"Point the incident at a signal defined in signalling.json");
+	for (std::size_t scenarioIndex = 0; scenarioIndex < scene.scenarios.size(); ++scenarioIndex) {
+		const SceneScenario& scenario = scene.scenarios[scenarioIndex];
+		const std::string scenarioPath = "scenarios[" + std::to_string(scenarioIndex) + "]";
+		if (!scenarioIds.insert(scenario.id).second)
+			diagnostics.error("scene.id.duplicate", "Duplicate scenario id", "scenarios.json", "scenario",
+					scenario.id, scenarioPath + ".id", scenario.id);
+		for (std::size_t incidentIndex = 0; incidentIndex < scenario.incidents.size(); ++incidentIndex) {
+			const SceneIncident& incident = scenario.incidents[incidentIndex];
+			const std::string path = scenarioPath + ".incidents[" + std::to_string(incidentIndex) + "]";
+			if (!incidentIds.insert(incident.id).second)
+				diagnostics.error("scene.id.duplicate", "Duplicate incident id", "scenarios.json", "incident",
+						incident.id, path + ".id", incident.id);
+			if (incident.type == "signal_failure") {
+				bool targetFound = hasId(signalIds, incident.target);
+				if (!targetFound)
+					targetFound = blockReferenceKnown(incident.target);
+				if (!targetFound)
+					diagnostics.error("scene.ref.unresolved", "Signal failure refers to unknown signal or block",
+							"scenarios.json", "incident", incident.id, path + ".target", incident.target);
+			} else if (incident.type == "train_breakdown") {
+				if (!hasId(serviceIds, incident.target))
+					diagnostics.error("scene.ref.unresolved", "Train breakdown refers to unknown service",
+							"scenarios.json", "incident", incident.id, path + ".target", incident.target);
+			} else {
+				diagnostics.error("scene.incident.type", "Unknown incident type", "scenarios.json", "incident",
+						incident.id, path + ".type", incident.type,
+						"Use signal_failure or train_breakdown");
 			}
-		} else if (inc.type == "train_breakdown") {
-			if (serviceIds.find(inc.target) == serviceIds.end()) {
-				addDiag(SceneSeverity::Error, "scene.ref.unresolved", "Incident refers to unknown service",
-						"incidents.json", "incident", inc.id, path + ".target", inc.target,
-						"Point the incident at a service defined in services.json");
-			}
-		} else {
-			addDiag(SceneSeverity::Error, "scene.incident.type", "Unknown incident type",
-					"incidents.json", "incident", inc.id, path + ".type", inc.type,
-					"Use signal_failure or train_breakdown");
+			if (incident.endSeconds <= incident.startSeconds || incident.startSeconds < 0.0
+					|| incident.endSeconds < 0.0)
+				diagnostics.error("scene.incident.window", "Invalid incident time window", "scenarios.json",
+						"incident", incident.id, path, "",
+						"Set end_seconds after start_seconds, both 0 or more");
 		}
+		for (std::size_t delayIndex = 0; delayIndex < scenario.entranceDelays.size(); ++delayIndex) {
+			const SceneEntranceDelay& delay = scenario.entranceDelays[delayIndex];
+			const std::string path = scenarioPath + ".entrance_delays[" + std::to_string(delayIndex) + "]";
+			if (!hasId(serviceIds, delay.serviceId))
+				diagnostics.error("scene.ref.unresolved", "Entrance delay refers to unknown service",
+						"scenarios.json", "entrance_delay", delay.serviceId, path + ".service", delay.serviceId);
+			if (!hasId(stationIds, delay.stationId))
+				diagnostics.error("scene.ref.unresolved", "Entrance delay refers to unknown station",
+						"scenarios.json", "entrance_delay", delay.serviceId, path + ".station", delay.stationId);
+			if (delay.occurrence <= 0)
+				diagnostics.error("scene.occurrence.invalid", "Entrance delay occurrence must be positive",
+						"scenarios.json", "entrance_delay", delay.serviceId, path + ".occurrence");
+			if (delay.delaySeconds < 0.0)
+				diagnostics.error("scene.delay.invalid", "Entrance delay cannot be negative", "scenarios.json",
+						"entrance_delay", delay.serviceId, path + ".delay_seconds");
+		}
+	}
+	if (!scene.defaultScenarioId.empty() && !hasId(scenarioIds, scene.defaultScenarioId))
+		diagnostics.error("scene.ref.unresolved", "Default scenario refers to unknown scenario",
+				"scenarios.json", "scene", "", "default_scenario_id", scene.defaultScenarioId);
 
-		if (inc.endSeconds <= inc.startSeconds || inc.startSeconds < 0.0 || inc.endSeconds < 0.0) {
-			addDiag(SceneSeverity::Error, "scene.incident.window", "Invalid incident time window",
-					"incidents.json", "incident", inc.id, path, "",
-					"Set end_seconds after start_seconds, both 0 or more");
+	std::unordered_set<std::string> passengerIds;
+	std::unordered_set<std::string> journeyIds;
+	std::unordered_set<std::string> passengerLegIds;
+	for (std::size_t passengerIndex = 0; passengerIndex < scene.passengers.size(); ++passengerIndex) {
+		const ScenePassenger& passenger = scene.passengers[passengerIndex];
+		const std::string passengerPath = "passengers[" + std::to_string(passengerIndex) + "]";
+		if (!passengerIds.insert(passenger.id).second)
+			diagnostics.error("scene.id.duplicate", "Duplicate passenger id", "passengers.json", "passenger",
+					passenger.id, passengerPath + ".id", passenger.id);
+		for (std::size_t journeyIndex = 0; journeyIndex < passenger.journeys.size(); ++journeyIndex) {
+			const ScenePassengerJourney& journey = passenger.journeys[journeyIndex];
+			const std::string journeyPath = passengerPath + ".journeys[" + std::to_string(journeyIndex) + "]";
+			if (!journeyIds.insert(journey.id).second)
+				diagnostics.error("scene.id.duplicate", "Duplicate passenger journey id", "passengers.json",
+						"journey", journey.id, journeyPath + ".id", journey.id);
+			if (!hasId(stationIds, journey.originStationId))
+				diagnostics.error("scene.ref.unresolved", "Journey refers to unknown origin station",
+						"passengers.json", "journey", journey.id, journeyPath + ".origin", journey.originStationId);
+			if (!hasId(stationIds, journey.destinationStationId))
+				diagnostics.error("scene.ref.unresolved", "Journey refers to unknown destination station",
+						"passengers.json", "journey", journey.id, journeyPath + ".destination",
+						journey.destinationStationId);
+			if (journey.plannedDepartureStartSeconds < 0.0
+					|| journey.plannedDepartureEndSeconds < journey.plannedDepartureStartSeconds)
+				diagnostics.error("scene.passenger.window", "Invalid planned departure window", "passengers.json",
+						"journey", journey.id, journeyPath + ".planned_departure");
+			if (journey.plannedArrivalStartSeconds < 0.0
+					|| journey.plannedArrivalEndSeconds < journey.plannedArrivalStartSeconds)
+				diagnostics.error("scene.passenger.window", "Invalid planned arrival window", "passengers.json",
+						"journey", journey.id, journeyPath + ".planned_arrival");
+			if (journey.legs.empty())
+				diagnostics.warning("scene.passenger.legs.empty", "Journey has no route-choice legs", "passengers.json",
+						"journey", journey.id, journeyPath + ".legs");
+			for (std::size_t legIndex = 0; legIndex < journey.legs.size(); ++legIndex) {
+				const ScenePassengerLeg& leg = journey.legs[legIndex];
+				const std::string legPath = journeyPath + ".legs[" + std::to_string(legIndex) + "]";
+				if (!passengerLegIds.insert(leg.id).second)
+					diagnostics.error("scene.id.duplicate", "Duplicate passenger leg id", "passengers.json",
+							"leg", leg.id, legPath + ".id", leg.id);
+				if (!hasId(stationIds, leg.originStationId))
+					diagnostics.error("scene.ref.unresolved", "Passenger leg refers to unknown origin station",
+							"passengers.json", "leg", leg.id, legPath + ".origin", leg.originStationId);
+				if (!hasId(stationIds, leg.destinationStationId))
+					diagnostics.error("scene.ref.unresolved", "Passenger leg refers to unknown destination station",
+							"passengers.json", "leg", leg.id, legPath + ".destination",
+							leg.destinationStationId);
+				if (!hasId(serviceIds, leg.serviceId))
+					diagnostics.error("scene.ref.unresolved", "Passenger leg refers to unknown service",
+							"passengers.json", "leg", leg.id, legPath + ".service", leg.serviceId);
+				if (leg.occurrence <= 0)
+					diagnostics.error("scene.occurrence.invalid", "Passenger leg occurrence must be positive",
+							"passengers.json", "leg", leg.id, legPath + ".occurrence");
+				if (legIndex == 0 && leg.originStationId != journey.originStationId)
+					diagnostics.error("scene.passenger.continuity", "First passenger leg does not start at journey origin",
+							"passengers.json", "journey", journey.id, legPath + ".origin", leg.originStationId);
+				if (legIndex > 0 && leg.originStationId != journey.legs[legIndex - 1].destinationStationId)
+					diagnostics.error("scene.passenger.continuity", "Passenger legs are not continuous",
+							"passengers.json", "journey", journey.id, legPath + ".origin", leg.originStationId);
+				if (legIndex + 1 == journey.legs.size()
+						&& leg.destinationStationId != journey.destinationStationId)
+					diagnostics.error("scene.passenger.continuity",
+							"Last passenger leg does not end at journey destination", "passengers.json", "journey",
+							journey.id, legPath + ".destination", leg.destinationStationId);
+			}
 		}
 	}
 
-	return diags;
+	if (runnable) {
+		if (scene.baseTime.empty())
+			diagnostics.error("scene.basetime.missing", "Runnable scene requires base_time", "scene.json",
+					"scene", "", "base_time", "", "Set scene.json base_time to HH:MM:SS");
+		if (!scene.settings.hasDuration)
+			diagnostics.error("scene.duration.missing", "Runnable scene requires a positive duration",
+					"scene.json", "scene", "", "simulation_settings.duration_seconds");
+		if (scene.tracks.empty())
+			diagnostics.error("scene.topology.tracks.none", "Runnable scene has no tracks",
+					"infrastructure.json", "track", "", "tracks");
+		if (scene.nodes.empty())
+			diagnostics.error("scene.topology.nodes.none", "Runnable scene has no nodes",
+					"infrastructure.json", "node", "", "nodes");
+		if (scene.arcs.empty())
+			diagnostics.error("scene.topology.arcs.none", "Runnable scene has no arcs",
+					"infrastructure.json", "arc", "", "arcs");
+		if (scene.blocks.empty())
+			diagnostics.error("scene.topology.blocks.none", "Runnable scene has no blocks",
+					"infrastructure.json", "block", "", "blocks");
+		if (scene.stations.empty())
+			diagnostics.error("scene.stations.none", "Runnable scene has no stations", "stations.json",
+					"station", "", "stations");
+		std::unordered_set<std::string> usedPlatforms;
+		for (const auto& service : scene.services) {
+			for (const auto& stop : service.stops) {
+				if (!stop.platformId.empty())
+					usedPlatforms.insert(stop.stationId + "\n" + stop.platformId);
+			}
+		}
+		int boundPlatformCount = 0;
+		for (std::size_t stationIndex = 0; stationIndex < scene.stations.size(); ++stationIndex) {
+			const SceneStation& station = scene.stations[stationIndex];
+			const std::string stationPath = "stations[" + std::to_string(stationIndex) + "]";
+			for (const auto& platform : station.platforms) {
+				if (!platform.nodeIds.empty())
+					++boundPlatformCount;
+				if (usedPlatforms.count(station.id + "\n" + platform.id) > 0 && platform.nodeIds.empty())
+					diagnostics.error("scene.platform.nodes.none", "Platform has no bound nodes", "stations.json",
+							"platform", platform.id, stationPath + ".platforms");
+			}
+		}
+		if (boundPlatformCount == 0)
+			diagnostics.error("scene.platforms.none", "Runnable scene has no bound platform nodes",
+					"stations.json", "station", "", "stations[].platforms[].nodes");
+		if (scene.routes.empty())
+			diagnostics.error("scene.routes.none", "Runnable scene has no routes", "signalling.json", "route",
+					"", "routes");
+		if (scene.scenarios.empty())
+			diagnostics.error("scene.scenarios.none", "Runnable scene has no scenarios", "scenarios.json",
+					"scenario", "", "scenarios");
+		if (scene.defaultScenarioId.empty())
+			diagnostics.error("scene.scenario.default.missing", "Runnable scene requires a default scenario",
+					"scenarios.json", "scene", "", "default_scenario_id");
+	}
+
+	return result;
+}
+
+} // namespace
+
+std::vector<SceneDiagnostic> validateSceneStructure(const std::string& sceneDir) {
+	return loadScene(sceneDir).diagnostics;
+}
+
+std::vector<SceneDiagnostic> validateScene(const SceneModel& scene) {
+	return validateCore(scene, false);
+}
+
+std::vector<SceneDiagnostic> validateRunnableScene(const SceneModel& scene) {
+	return validateCore(scene, true);
+}
+
+std::vector<SceneDiagnostic> validateSceneDirectory(const std::string& sceneDir) {
+	SceneLoadResult loadResult = loadScene(sceneDir);
+	if (hasErrors(loadResult.diagnostics))
+		return loadResult.diagnostics;
+	std::vector<SceneDiagnostic> diagnostics = loadResult.diagnostics;
+	const std::vector<SceneDiagnostic> semantic = validateScene(loadResult.scene);
+	diagnostics.insert(diagnostics.end(), semantic.begin(), semantic.end());
+	return diagnostics;
+}
+
+std::vector<SceneDiagnostic> validateRunnableSceneDirectory(const std::string& sceneDir) {
+	SceneLoadResult loadResult = loadScene(sceneDir);
+	if (hasErrors(loadResult.diagnostics))
+		return loadResult.diagnostics;
+	std::vector<SceneDiagnostic> diagnostics = loadResult.diagnostics;
+	const std::vector<SceneDiagnostic> runnable = validateRunnableScene(loadResult.scene);
+	diagnostics.insert(diagnostics.end(), runnable.begin(), runnable.end());
+	return diagnostics;
 }

--- a/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
@@ -92,7 +92,7 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 	DiagnosticBuilder diagnostics{result};
 
 	if (!scene.baseTime.empty()) {
-		static const std::regex timePattern("^[0-2][0-9]:[0-5][0-9]:[0-5][0-9]$");
+		static const std::regex timePattern("^([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$");
 		if (!std::regex_match(scene.baseTime, timePattern)) {
 			diagnostics.error("scene.basetime.invalid", "Invalid base_time format, must be HH:MM:SS",
 					"scene.json", "scene", "", "base_time", "",

--- a/EGTRAIN/QEGTRAIN/scene/SceneValidator.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneValidator.h
@@ -5,12 +5,22 @@
 #include <vector>
 #include <string>
 
+// Validate only the scene files and JSON shape.  No cross-file semantic
+// checks are performed, so callers can show useful parse diagnostics for an
+// incomplete historical scene without a cascade of reference errors.
+std::vector<SceneDiagnostic> validateSceneStructure(const std::string& sceneDir);
+
 // Semantically validate the loaded model.
 std::vector<SceneDiagnostic> validateScene(const SceneModel& scene);
 
-// Convenience: load, then validate ONLY if loading produced no Error diagnostics.
-// Structural errors must be fixed first; this prevents cascade noise (semantic
-// checks against a half-loaded model) in the future validation panel.
+// Validate the minimum complete model needed by a runnable simulation.
+std::vector<SceneDiagnostic> validateRunnableScene(const SceneModel& scene);
+
+// Load, then validate ONLY if loading produced no Error diagnostics. Structural
+// errors must be fixed first to avoid semantic cascades from a partial model.
 std::vector<SceneDiagnostic> validateSceneDirectory(const std::string& sceneDir);
+
+// The same directory boundary with runnable-completeness checks included.
+std::vector<SceneDiagnostic> validateRunnableSceneDirectory(const std::string& sceneDir);
 
 #endif // SCENEVALIDATOR_H

--- a/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
@@ -11,25 +11,25 @@ bool SceneSaveResult::success() const {
 	return wroteAll && !hasErrors(diagnostics);
 }
 
-static void addWriteError(SceneSaveResult& result, const std::string& file, const std::string& message) {
-	SceneDiagnostic d;
-	d.severity = SceneSeverity::Error;
-	d.code = "scene.save.write";
-	d.file = file;
-	d.message = message;
-	result.diagnostics.push_back(d);
+static void addWriteError(SceneSaveResult& result, const std::string& file,
+		const std::string& message) {
+	SceneDiagnostic diagnostic;
+	diagnostic.severity = SceneSeverity::Error;
+	diagnostic.code = "scene.save.write";
+	diagnostic.file = file;
+	diagnostic.message = message;
+	result.diagnostics.push_back(diagnostic);
 }
 
-static bool writeJsonFile(SceneSaveResult& result, const fs::path& scenePath, const std::string& filename, const json& value) {
-	fs::path path = scenePath / filename;
-	std::ofstream out(path);
-	if (!out.good()) {
+static bool writeJsonFile(SceneSaveResult& result, const fs::path& scenePath,
+		const std::string& filename, const json& value) {
+	std::ofstream output(scenePath / filename);
+	if (!output) {
 		addWriteError(result, filename, "Cannot open " + filename + " for writing");
 		return false;
 	}
-
-	out << value.dump(4) << "\n";
-	if (!out.good()) {
+	output << value.dump(4) << "\n";
+	if (!output) {
 		addWriteError(result, filename, "Cannot write " + filename);
 		return false;
 	}
@@ -50,36 +50,26 @@ static json writePhysical(const SceneTrainPhysical& physical) {
 	};
 }
 
-static json writeTractionCurve(const SceneTrainUnit& unit) {
-	json curve = json::array();
-	for (const auto& row : unit.tractionCurve) {
-		curve.push_back({row[0], row[1], row[2], row[3], row[4]});
-	}
-	return curve;
-}
-
 static json writeTrainUnits(const SceneModel& scene) {
 	json trainUnits = json::array();
 	for (const auto& unit : scene.trainUnits) {
-		json unitJson = {
-			{"id", unit.id}};
-		if (unit.hasPhysical) {
-			unitJson["physical"] = writePhysical(unit.physical);
-		}
+		json value = {{"id", unit.id}};
+		if (unit.hasPhysical)
+			value["physical"] = writePhysical(unit.physical);
 		if (!unit.tractionCurve.empty()) {
-			unitJson["traction_curve"] = writeTractionCurve(unit);
+			value["traction_curve"] = json::array();
+			for (const auto& row : unit.tractionCurve)
+				value["traction_curve"].push_back({row[0], row[1], row[2], row[3], row[4]});
 		}
-
 		if (!unit.sourceDataFile.empty() || !unit.sourceTractionFile.empty()) {
 			json source = json::object();
 			if (!unit.sourceDataFile.empty())
 				source["data_file"] = unit.sourceDataFile;
 			if (!unit.sourceTractionFile.empty())
 				source["traction_file"] = unit.sourceTractionFile;
-			unitJson["source"] = source;
+			value["source"] = source;
 		}
-
-		trainUnits.push_back(unitJson);
+		trainUnits.push_back(value);
 	}
 	return trainUnits;
 }
@@ -87,14 +77,7 @@ static json writeTrainUnits(const SceneModel& scene) {
 static json writeCompositions(const SceneModel& scene) {
 	json compositions = json::array();
 	for (const auto& composition : scene.compositions) {
-		json units = json::array();
-		for (const auto& unit : composition.units) {
-			units.push_back(unit);
-		}
-		compositions.push_back({
-			{"id", composition.id},
-			{"units", units},
-		});
+		compositions.push_back({{"id", composition.id}, {"units", composition.units}});
 	}
 	return compositions;
 }
@@ -102,17 +85,17 @@ static json writeCompositions(const SceneModel& scene) {
 static json writeStops(const SceneService& service) {
 	json stops = json::array();
 	for (const auto& stop : service.stops) {
-		json stopJson = {
+		json value = {
 			{"station", stop.stationId},
 			{"dwell_seconds", stop.dwellSeconds},
 		};
 		if (!stop.platformId.empty())
-			stopJson["platform"] = stop.platformId;
-		if (stop.hasArrival)
-			stopJson["arrival_seconds"] = stop.arrivalSeconds;
-		if (stop.hasDeparture)
-			stopJson["departure_seconds"] = stop.departureSeconds;
-		stops.push_back(stopJson);
+			value["platform"] = stop.platformId;
+		if (stop.hasPlannedArrival)
+			value["planned_arrival_seconds"] = stop.plannedArrivalSeconds;
+		if (stop.hasPlannedDeparture)
+			value["planned_departure_seconds"] = stop.plannedDepartureSeconds;
+		stops.push_back(value);
 	}
 	return stops;
 }
@@ -120,28 +103,110 @@ static json writeStops(const SceneService& service) {
 static json writeServices(const SceneModel& scene) {
 	json services = json::array();
 	for (const auto& service : scene.services) {
-		json serviceJson = {
+		json value = {
 			{"id", service.id},
 			{"composition", service.composition},
 			{"route", service.route},
+			{"stops", writeStops(service)},
 		};
+		if (!service.operatingCode.empty())
+			value["operating_code"] = service.operatingCode;
 		if (service.through)
-			serviceJson["through"] = true;
+			value["through"] = true;
 		if (service.hasEntryTime)
-			serviceJson["entry_time_seconds"] = service.entryTimeSeconds;
+			value["entry_time_seconds"] = service.entryTimeSeconds;
 		if (service.hasRepeat)
-			serviceJson["repeat"] = {{"headway_seconds", service.headwaySeconds}};
-		serviceJson["stops"] = writeStops(service);
-		services.push_back(serviceJson);
+			value["repeat"] = {{"headway_seconds", service.headwaySeconds}};
+		services.push_back(value);
 	}
 	return services;
 }
 
+static json writeScenarios(const SceneModel& scene) {
+	json scenarios = json::array();
+	if (scene.scenarios.empty()) {
+		scenarios.push_back({
+			{"id", "baseline"},
+			{"name", "Baseline"},
+			{"incidents", json::array()},
+			{"entrance_delays", json::array()},
+		});
+	} else {
+		for (const auto& scenario : scene.scenarios) {
+			json value = {
+				{"id", scenario.id},
+				{"name", scenario.name},
+				{"incidents", json::array()},
+				{"entrance_delays", json::array()},
+			};
+			if (!scenario.description.empty())
+				value["description"] = scenario.description;
+			for (const auto& incident : scenario.incidents) {
+				value["incidents"].push_back({
+					{"id", incident.id},
+					{"type", incident.type},
+					{"target", incident.target},
+					{"start_seconds", incident.startSeconds},
+					{"end_seconds", incident.endSeconds},
+				});
+			}
+			for (const auto& delay : scenario.entranceDelays) {
+				value["entrance_delays"].push_back({
+					{"service", delay.serviceId},
+					{"occurrence", delay.occurrence},
+					{"station", delay.stationId},
+					{"delay_seconds", delay.delaySeconds},
+				});
+			}
+			scenarios.push_back(value);
+		}
+	}
+	std::string defaultId = scene.defaultScenarioId;
+	if (defaultId.empty())
+		defaultId = scene.scenarios.empty() ? "baseline" : scene.scenarios.front().id;
+	return {{"default_scenario_id", defaultId}, {"scenarios", scenarios}};
+}
 
+static json writePassengers(const SceneModel& scene) {
+	json passengers = json::array();
+	for (const auto& passenger : scene.passengers) {
+		json value = {{"id", passenger.id}, {"journeys", json::array()}};
+		for (const auto& journey : passenger.journeys) {
+			json journeyValue = {
+				{"id", journey.id},
+				{"origin", journey.originStationId},
+				{"destination", journey.destinationStationId},
+				{"planned_departure", {
+					{"start_seconds", journey.plannedDepartureStartSeconds},
+					{"end_seconds", journey.plannedDepartureEndSeconds},
+				}},
+				{"planned_arrival", {
+					{"start_seconds", journey.plannedArrivalStartSeconds},
+					{"end_seconds", journey.plannedArrivalEndSeconds},
+				}},
+				{"legs", json::array()},
+			};
+			if (!journey.activity.empty())
+				journeyValue["activity"] = journey.activity;
+			for (const auto& leg : journey.legs) {
+				journeyValue["legs"].push_back({
+					{"id", leg.id},
+					{"origin", leg.originStationId},
+					{"destination", leg.destinationStationId},
+					{"service", leg.serviceId},
+					{"occurrence", leg.occurrence},
+				});
+			}
+			value["journeys"].push_back(journeyValue);
+		}
+		passengers.push_back(value);
+	}
+	return {{"passengers", passengers}};
+}
 
 SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) {
 	SceneSaveResult result;
-	fs::path scenePath(sceneDir);
+	const fs::path scenePath(sceneDir);
 	std::error_code ec;
 	fs::create_directories(scenePath, ec);
 	if (ec) {
@@ -152,71 +217,159 @@ SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) 
 	json sceneJson = {
 		{"schema_version", scene.schemaVersion},
 		{"name", scene.name},
+		{"units", {{"distance", "m"}, {"time", "s"}, {"speed", "m/s"}}},
 	};
 	if (!scene.description.empty())
 		sceneJson["description"] = scene.description;
 	if (!scene.baseTime.empty())
 		sceneJson["base_time"] = scene.baseTime;
-	sceneJson["units"] = {{"distance", "m"}, {"time", "s"}, {"speed", "m/s"}};
+	json settings = json::object();
+	if (scene.settings.hasDuration)
+		settings["duration_seconds"] = scene.settings.durationSeconds;
+	if (scene.settings.hasBufferTime)
+		settings["buffer_time_seconds"] = scene.settings.bufferTimeSeconds;
+	if (scene.settings.hasRecoveryTime)
+		settings["recovery_time_percent"] = scene.settings.recoveryTimePercent;
+	if (!settings.empty())
+		sceneJson["simulation_settings"] = settings;
+	if (!scene.importReport.empty()) {
+		sceneJson["import_report"] = json::array();
+		for (const auto& row : scene.importReport) {
+			sceneJson["import_report"].push_back({
+				{"category", row.category},
+				{"source_file", row.sourceFile},
+				{"source_count", row.sourceCount},
+				{"converted_count", row.convertedCount},
+				{"skipped_count", row.skippedCount},
+				{"unresolved_references", row.unresolvedReferences},
+			});
+		}
+	}
+
+	json infrastructure = {
+		{"tracks", json::array()},
+		{"nodes", json::array()},
+		{"arcs", json::array()},
+		{"blocks", json::array()},
+		{"connections", json::array()},
+	};
+	for (const auto& track : scene.tracks)
+		infrastructure["tracks"].push_back({{"id", track.id}});
+	for (const auto& node : scene.nodes) {
+		infrastructure["nodes"].push_back({
+			{"id", node.id},
+			{"track", node.trackId},
+			{"x_km", node.xKm},
+			{"y_km", node.yKm},
+		});
+	}
+	for (const auto& arc : scene.arcs) {
+		infrastructure["arcs"].push_back({
+			{"id", arc.id},
+			{"track", arc.trackId},
+			{"from", arc.fromNodeId},
+			{"to", arc.toNodeId},
+			{"curvature_radius_m", arc.curvatureRadiusM},
+			{"gradient_percent", arc.gradientPercent},
+			{"speed_limit_ms", arc.speedLimitMs},
+		});
+	}
+	for (const auto& block : scene.blocks) {
+		infrastructure["blocks"].push_back({
+			{"id", block.id},
+			{"track", block.trackId},
+			{"length_km", block.lengthKm},
+		});
+	}
+	for (const auto& connection : scene.connections) {
+		json value = {
+			{"id", connection.id},
+			{"from", connection.fromNodeId},
+			{"to", connection.toNodeId},
+		};
+		if (connection.hasSpeedLimit)
+			value["speed_limit_ms"] = connection.speedLimitMs;
+		infrastructure["connections"].push_back(value);
+	}
 
 	json stations = json::array();
 	for (const auto& station : scene.stations) {
-		json platforms = json::array();
+		json value = {{"id", station.id}, {"name", station.name}, {"platforms", json::array()}};
+		if (station.hasPosition)
+			value["position_km"] = station.positionKm;
 		for (const auto& platform : station.platforms) {
-			platforms.push_back({{"id", platform.id}});
+			value["platforms"].push_back({{"id", platform.id}, {"nodes", platform.nodeIds}});
 		}
-		stations.push_back({
-			{"id", station.id},
-			{"name", station.name},
-			{"platforms", platforms},
-		});
+		stations.push_back(value);
 	}
 
-	json signals = json::array();
-	for (const auto& signal : scene.signals) {
-		signals.push_back({{"id", signal.id}});
-	}
-
-	json routes = json::array();
+	json signalling = {
+		{"signals", json::array()},
+		{"routes", json::array()},
+		{"block_dependencies", json::array()},
+		{"single_track_restrictions", json::array()},
+		{"station_boundaries", json::array()},
+	};
+	for (const auto& signal : scene.signals)
+		signalling["signals"].push_back({{"id", signal.id}});
 	for (const auto& route : scene.routes) {
-		json blocks = json::array();
-		for (const auto& block : route.blocks) {
-			blocks.push_back(block);
-		}
-		routes.push_back({
-			{"id", route.id},
-			{"blocks", blocks},
+		json value = {{"id", route.id}, {"blocks", route.blocks}};
+		if (route.hasCorridor || !route.corridor.empty())
+			value["corridor"] = route.corridor;
+		if (route.reversed)
+			value["reversed"] = true;
+		signalling["routes"].push_back(value);
+	}
+	for (const auto& dependency : scene.blockDependencies) {
+		signalling["block_dependencies"].push_back({
+			{"block", dependency.block},
+			{"depends_on", dependency.dependsOn},
 		});
 	}
+	for (const auto& restriction : scene.singleTrackRestrictions) {
+		signalling["single_track_restrictions"].push_back({
+			{"start_block", restriction.startBlock},
+			{"end_block", restriction.endBlock},
+			{"protected_start_block", restriction.protectedStartBlock},
+			{"protected_end_block", restriction.protectedEndBlock},
+		});
+	}
+	for (const auto& boundary : scene.stationBoundaries) {
+		json value = {{"entrance_block", boundary.entranceBlock}, {"direction", boundary.direction}};
+		if (boundary.hasExitBlock || !boundary.exitBlock.empty())
+			value["exit_block"] = boundary.exitBlock;
+		signalling["station_boundaries"].push_back(value);
+	}
 
-	bool wroteAll = writeJsonFile(result, scenePath, "scene.json", sceneJson) &&
-					writeJsonFile(result, scenePath, "infrastructure.json", {{"nodes", json::array()}, {"arcs", json::array()}}) &&
-					writeJsonFile(result, scenePath, "stations.json", {{"stations", stations}}) &&
-					writeJsonFile(result, scenePath, "signalling.json", {{"signals", signals}, {"routes", routes}}) &&
-					writeJsonFile(result, scenePath, "rolling_stock.json", {{"train_units", writeTrainUnits(scene)}, {"compositions", writeCompositions(scene)}}) &&
-					writeJsonFile(result, scenePath, "services.json", {{"services", writeServices(scene)}});
+	bool wroteAll = true;
+	wroteAll = writeJsonFile(result, scenePath, "scene.json", sceneJson) && wroteAll;
+	wroteAll = writeJsonFile(result, scenePath, "infrastructure.json", infrastructure) && wroteAll;
+	wroteAll = writeJsonFile(result, scenePath, "stations.json", {{"stations", stations}}) && wroteAll;
+	wroteAll = writeJsonFile(result, scenePath, "signalling.json", signalling) && wroteAll;
+	wroteAll = writeJsonFile(result, scenePath, "rolling_stock.json",
+			{{"train_units", writeTrainUnits(scene)}, {"compositions", writeCompositions(scene)}}) && wroteAll;
+	wroteAll = writeJsonFile(result, scenePath, "services.json", {{"services", writeServices(scene)}}) && wroteAll;
+	wroteAll = writeJsonFile(result, scenePath, "scenarios.json", writeScenarios(scene)) && wroteAll;
+	if (!scene.passengers.empty()) {
+		wroteAll = writeJsonFile(result, scenePath, "passengers.json", writePassengers(scene)) && wroteAll;
+	}
 
-	fs::path incidentsPath = scenePath / "incidents.json";
+	// Keep the old flat file until every new canonical file was persisted.
 	if (wroteAll) {
-		if (scene.incidents.empty()) {
+		ec.clear();
+		fs::remove(scenePath / "incidents.json", ec);
+		if (ec) {
+			addWriteError(result, "incidents.json", "Cannot remove incidents.json: " + ec.message());
+			wroteAll = false;
+		}
+		if (scene.passengers.empty()) {
 			ec.clear();
-			fs::remove(incidentsPath, ec);
+			fs::remove(scenePath / "passengers.json", ec);
 			if (ec) {
-				addWriteError(result, "incidents.json", "Cannot remove incidents.json: " + ec.message());
+				addWriteError(result, "passengers.json",
+						"Cannot remove passengers.json: " + ec.message());
 				wroteAll = false;
 			}
-		} else {
-			json incidents = json::array();
-			for (const auto& incident : scene.incidents) {
-				incidents.push_back({
-					{"id", incident.id},
-					{"type", incident.type},
-					{"target", incident.target},
-					{"start_seconds", incident.startSeconds},
-					{"end_seconds", incident.endSeconds},
-				});
-			}
-			wroteAll = writeJsonFile(result, scenePath, "incidents.json", {{"incidents", incidents}});
 		}
 	}
 

--- a/EGTRAIN/QEGTRAIN/tests/test_sceneexporter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_sceneexporter.cpp
@@ -538,10 +538,10 @@ int main(int argc, char** argv) {
 			<< R"({"train_units":[{"id":"u1","physical":{"mass_of_traction_unit_kg":100,"mass_of_a_wagon_kg":50,"number_of_wagons":2,"max_speed_ms":80,"max_deceleration_ms2":1,"frontal_area_m2":10,"resistance_coefficient":0.01,"jerk_ms3":0.5,"length_m":50},"traction_curve":[[0,90,1,0,0]]}],"compositions":[{"id":"c1","units":["u1"]}]})"
 			<< "\n";
 		std::ofstream(scene / "services.json")
-			<< R"({"services":[{"id":"svc1","composition":"c1","route":"route0","entry_time_seconds":0,"stops":[{"station":"st","departure_seconds":0,"dwell_seconds":0}]}]})"
+			<< R"({"services":[{"id":"svc1","operating_code":"legacy-svc","composition":"c1","route":"route0","entry_time_seconds":0,"stops":[{"station":"st","departure_seconds":0,"dwell_seconds":0}]}]})"
 			<< "\n";
-		std::ofstream(scene / "incidents.json")
-			<< R"({"incidents":[{"id":"inc1","type":"signal_failure","target":"12-B0","start_seconds":100,"end_seconds":300},{"id":"inc2","type":"train_breakdown","target":"svc1","start_seconds":50,"end_seconds":150},{"id":"inc3","type":"signal_failure","target":"nope","start_seconds":1,"end_seconds":2}]})"
+		std::ofstream(scene / "scenarios.json")
+			<< R"({"default_scenario_id":"baseline","scenarios":[{"id":"baseline","name":"Baseline","incidents":[{"id":"inc1","type":"signal_failure","target":"12-B0","start_seconds":100,"end_seconds":300},{"id":"inc3","type":"signal_failure","target":"nope","start_seconds":1,"end_seconds":2},{"id":"inc4","type":"train_breakdown","target":"svc1","start_seconds":25,"end_seconds":35}]},{"id":"alternate","name":"Alternate","incidents":[{"id":"inc2","type":"train_breakdown","target":"svc1","start_seconds":50,"end_seconds":150}]}]})"
 			<< "\n";
 
 		auto res = exportLegacyScene(sceneDir.dir, outDir.dir);
@@ -550,13 +550,16 @@ int main(int argc, char** argv) {
 
 		std::ifstream inf(fs::path(outDir.dir) / "Incidents.txt");
 		if (expect(inf.good(), "Incidents.txt exists")) {
-			std::string l1, l2, l3;
+			std::string l1, l2, l3, l4;
 			std::getline(inf, l1);
 			std::getline(inf, l2);
 			std::getline(inf, l3);
+			std::getline(inf, l4);
 			ok &= expect(l1 == "signal_failure\t12-B0\t100\t300", ("Signal failure line correct: " + l1).c_str());
-			ok &= expect(l2 == "train_breakdown\tsvc1\t50\t150", ("Breakdown line correct: " + l2).c_str());
-			ok &= expect(l3 == "signal_failure\tnope\t1\t2", ("Unmatched target still written: " + l3).c_str());
+			ok &= expect(l2 == "signal_failure\tnope\t1\t2", ("Unmatched target still written: " + l2).c_str());
+			ok &= expect(l3 == "train_breakdown\tlegacy-svc\t25\t35",
+					("Breakdown uses the active operating code: " + l3).c_str());
+			ok &= expect(l4.empty(), "Non-default scenario incident is not exported");
 		}
 		ok &= expect(hasDiag(res.diagnostics, "scene.export.adjusted", SceneSeverity::Warning), "Unmatched signal target warned");
 	}

--- a/EGTRAIN/QEGTRAIN/tests/test_sceneimporter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_sceneimporter.cpp
@@ -1,724 +1,300 @@
 #include "scene/SceneImporter.h"
-#include "scene/SceneModel.h"
 #include "scene/SceneValidator.h"
-#include <iostream>
+
+#include <chrono>
 #include <filesystem>
 #include <fstream>
-#include <sstream>
-#include <chrono>
+#include <iostream>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
-static bool expect(bool condition, const char* message) {
+static bool expect(bool condition, const std::string& message) {
 	if (!condition)
 		std::cerr << "failed: " << message << "\n";
 	return condition;
 }
 
-static bool hasDiag(const std::vector<SceneDiagnostic>& diags, const std::string& code, SceneSeverity sev = SceneSeverity::Error) {
-	for (const auto& d : diags) {
-		if (d.code == code && d.severity == sev)
+static bool hasDiag(const std::vector<SceneDiagnostic>& diagnostics, const std::string& code,
+		SceneSeverity severity) {
+	for (const auto& diagnostic : diagnostics) {
+		if (diagnostic.code == code && diagnostic.severity == severity)
 			return true;
 	}
 	return false;
-}
-
-static int countDiag(const std::vector<SceneDiagnostic>& diags, const std::string& code, SceneSeverity sev) {
-	int count = 0;
-	for (const auto& d : diags) {
-		if (d.code == code && d.severity == sev)
-			count++;
-	}
-	return count;
 }
 
 struct TempDir {
 	std::string dir;
 	TempDir() {
 		static int counter = 0;
-		auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
-		fs::path temp = fs::temp_directory_path() /
-						("scene_test_" + std::to_string(stamp) + "_" + std::to_string(counter++));
-		fs::create_directories(temp);
-		dir = temp.string();
+		const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+		const fs::path path = fs::temp_directory_path()
+				/ ("scene_import_test_" + std::to_string(stamp) + "_" + std::to_string(counter++));
+		fs::create_directories(path);
+		dir = path.string();
 	}
 	~TempDir() {
-		std::error_code ec;
-		fs::remove_all(dir, ec);
+		std::error_code error;
+		fs::remove_all(dir, error);
 	}
 };
 
-static std::vector<std::string> readTokens(const std::string& line) {
-	std::vector<std::string> tokens;
-	std::stringstream ss(line);
-	std::string token;
-	while (ss >> token) {
-		tokens.push_back(token);
-	}
-	return tokens;
+static void writeText(const fs::path& path, const std::string& content) {
+	fs::create_directories(path.parent_path());
+	std::ofstream output(path);
+	output << content;
 }
 
-static void printErrors(const std::vector<SceneDiagnostic>& diags, const char* label) {
-	for (const auto& d : diags) {
-		if (d.severity == SceneSeverity::Error)
-			std::cerr << label << ": " << toDisplayText(d) << "\n";
+static bool readJson(const fs::path& path, json& value) {
+	std::ifstream input(path);
+	if (!input)
+		return false;
+	try {
+		input >> value;
+		return true;
+	} catch (...) {
+		return false;
 	}
 }
 
 int main(int argc, char** argv) {
 	if (argc < 7) {
-		std::cerr << "Usage: test_sceneimporter <copenhagen_dir> <brescia_dir> <netherlands_dir> <banedanmark_dir> <paimpol_dir> <paimpol_alt_dir>\n";
+		std::cerr << "Usage: test_sceneimporter <copenhagen_dir> <brescia_dir> <netherlands_dir> "
+				"<banedanmark_dir> <paimpol_dir> <paimpol_alt_dir>\n";
 		return 1;
 	}
-	std::string copDir = argv[1];
-	std::string breDir = argv[2];
-	std::string nlDir = argv[3];
-	std::string banDir = argv[4];
-	std::string paimpolDir = argv[5];
-	std::string paimpolAltDir = argv[6];
 	bool ok = true;
 
-	auto runPreservationSweep = [&](const std::string& legacyDir, const std::string& sceneDir) {
-		fs::path lPath(legacyDir);
-		fs::path sPath(sceneDir);
-		std::ifstream sJsonFile(sPath / "services.json");
-		json sJson;
-		sJsonFile >> sJson;
-		std::ifstream rJsonFile(sPath / "rolling_stock.json");
-		json rJson;
-		rJsonFile >> rJson;
-
-		auto hasUnit = [&](const std::string& id) {
-			for (const auto& tu : rJson["train_units"]) {
-				if (tu["id"] == id)
-					return true;
-			}
-			return false;
-		};
-
-		std::vector<std::string> trains;
-		std::ifstream tnFile(lPath / "trainNames.txt");
-		if (tnFile.good()) {
-			std::string line;
-			while (std::getline(tnFile, line)) {
-				std::stringstream ss(line);
-				std::string t;
-				ss >> t;
-				if (!t.empty() && t.find("txt") != std::string::npos)
-					trains.push_back(t);
-				else if (!t.empty() && t.find("TXT") != std::string::npos)
-					trains.push_back(t);
-			}
-		}
-
-		for (const auto& tf : trains) {
-			fs::path tfPath = lPath / "Trains" / tf;
-			std::ifstream f(tfPath);
-			std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
-			auto tokens = readTokens(content);
-			if (tokens.size() < 7)
-				continue;
-
-			std::string sName = tokens[0];
-			std::string routeId = "route" + tokens[3];
-			fs::path dp(tokens[4]);
-			std::string compId = dp.stem().string();
-
-			// Expected stop sequence straight from the legacy timetable: the
-			// station name is every token before the last three numbers, joined
-			// without a separator, exactly as the importer writes it.
-			std::string ttPathRel = tokens[6];
-			if (!ttPathRel.empty() && (ttPathRel[0] == '/' || ttPathRel[0] == '\\')) {
-				ttPathRel = ttPathRel.substr(1);
-			}
-			std::ifstream ttf(lPath / ttPathRel);
-			std::vector<std::string> stations;
-			std::vector<double> dwells;
-			std::string ttLine;
-			while (std::getline(ttf, ttLine)) {
-				auto ttTokens = readTokens(ttLine);
-				if (ttTokens.size() < 4)
-					continue;
-				std::string station = ttTokens[0];
-				for (size_t i = 1; i + 3 < ttTokens.size(); ++i)
-					station += ttTokens[i];
-				stations.push_back(station);
-				dwells.push_back(std::stod(ttTokens[ttTokens.size() - 3]));
-			}
-
-			bool foundSvc = false;
-			for (const auto& s : sJson["services"]) {
-				if (s["id"] == sName) {
-					foundSvc = true;
-					ok &= expect(s["route"] == routeId, ("Route matched for " + sName).c_str());
-					ok &= expect(s["composition"] == compId, ("Composition matched for " + sName).c_str());
-					bool countOk = s["stops"].size() == stations.size();
-					ok &= expect(countOk, ("Stop count matched for " + sName).c_str());
-					if (countOk) {
-						for (size_t i = 0; i < stations.size(); ++i) {
-							ok &= expect(s["stops"][i]["station"] == stations[i],
-										 ("Stop " + std::to_string(i) + " station matched for " + sName).c_str());
-							ok &= expect(s["stops"][i]["dwell_seconds"] == dwells[i],
-										 ("Stop " + std::to_string(i) + " dwell matched for " + sName).c_str());
-						}
-					}
-					break;
-				}
-			}
-			ok &= expect(foundSvc, ("Service found in output for " + sName).c_str());
-			ok &= expect(hasUnit(compId), ("Unit found for " + compId).c_str());
-		}
-
-		// Legacy passthrough assertions
-		ok &= expect(fs::exists(sPath / "legacy"), "Legacy dir exists");
-		bool hasTracklines = fs::exists(sPath / "legacy" / "Tracklines") || fs::exists(sPath / "legacy" / "TrackLines");
-		ok &= expect(hasTracklines, "Tracklines legacy passthrough");
-
-		std::ifstream sceneFile(sPath / "scene.json");
-		json scJson;
-		sceneFile >> scJson;
-		ok &= expect(scJson.contains("legacy_source") && scJson["legacy_source"] == legacyDir, "Legacy source present in scene.json");
+	// Keep the committed-case entity coverage small and explicit. These counts
+	// catch dropped records without copying any real input into the fixture.
+	struct CaseCounts {
+		const char* name;
+		const char* legacy;
+		size_t stations;
+		size_t units;
+		size_t services;
+		size_t routes;
 	};
+	const std::vector<CaseCounts> cases = {
+		{"Copenhagen", argv[1], 94, 1, 24, 24},
+		{"Brescia", argv[2], 29, 16, 62, 48},
+		{"Netherlands", argv[3], 41, 1, 8, 74},
+		{"Banedanmark", argv[4], 94, 1, 24, 24},
+		{"Paimpol", argv[5], 10, 1, 2, 15},
+		{"Paimpol alternative journeys", argv[6], 10, 1, 1, 14},
+	};
+	for (const auto& testCase : cases) {
+		TempDir output;
+		const auto result = importLegacyScene(testCase.legacy, output.dir, testCase.name);
+		ok &= expect(result.success(), std::string(testCase.name) + " import succeeds");
+		if (!result.wroteScene)
+			continue;
 
-	// 1-5. Copenhagen
-	{
-		TempDir outDir;
-		auto res = importLegacyScene(copDir, outDir.dir, "Copenhagen");
-		printErrors(res.diagnostics, "Copenhagen import");
-		ok &= expect(res.success(), "Copenhagen import succeeds with zero errors");
-		// The known data anomaly (E_Holte_Koge_2: departure before arrival at
-		// KogeNord) must surface as an adjustment warning, not vanish silently.
-		ok &= expect(hasDiag(res.diagnostics, "scene.import.adjusted", SceneSeverity::Warning),
-					 "Copenhagen data anomaly reported as adjustment warning");
+		json scene, stations, rolling, services, signalling;
+		ok &= expect(readJson(fs::path(output.dir) / "scene.json", scene),
+				std::string(testCase.name) + " scene.json readable");
+		ok &= expect(readJson(fs::path(output.dir) / "stations.json", stations),
+				std::string(testCase.name) + " stations.json readable");
+		ok &= expect(readJson(fs::path(output.dir) / "rolling_stock.json", rolling),
+				std::string(testCase.name) + " rolling_stock.json readable");
+		ok &= expect(readJson(fs::path(output.dir) / "services.json", services),
+				std::string(testCase.name) + " services.json readable");
+		ok &= expect(readJson(fs::path(output.dir) / "signalling.json", signalling),
+				std::string(testCase.name) + " signalling.json readable");
+		if (!stations.is_object() || !rolling.is_object() || !services.is_object() || !signalling.is_object())
+			continue;
+		ok &= expect(stations["stations"].size() == testCase.stations,
+				std::string(testCase.name) + " station count");
+		ok &= expect(rolling["train_units"].size() == testCase.units,
+				std::string(testCase.name) + " train-unit count");
+		ok &= expect(rolling["compositions"].size() == testCase.units,
+				std::string(testCase.name) + " composition count");
+		ok &= expect(services["services"].size() == testCase.services,
+				std::string(testCase.name) + " service count");
+		ok &= expect(signalling["routes"].size() == testCase.routes,
+				std::string(testCase.name) + " route count");
+		ok &= expect(fs::exists(fs::path(output.dir) / "legacy"),
+				std::string(testCase.name) + " legacy passthrough exists");
 
-		auto vDiags = validateSceneDirectory(outDir.dir);
-		printErrors(vDiags, "Copenhagen validate");
-		ok &= expect(!hasErrors(vDiags), "Copenhagen validate zero errors");
-
-		std::ifstream sFile(fs::path(outDir.dir) / "services.json");
-		json sJson;
-		sFile >> sJson;
-		ok &= expect(sJson["services"].size() == 24, "Copenhagen 24 services");
-
-		std::ifstream rFile(fs::path(outDir.dir) / "signalling.json");
-		json rJson;
-		rFile >> rJson;
-		ok &= expect(rJson["routes"].size() == 24, "Copenhagen 24 routes");
-
-		std::ifstream stFile(fs::path(outDir.dir) / "stations.json");
-		json stJson;
-		stFile >> stJson;
-		ok &= expect(stJson["stations"].size() == 94, "Copenhagen 94 stations");
-
-		std::ifstream rsFile(fs::path(outDir.dir) / "rolling_stock.json");
-		json rsJson;
-		rsFile >> rsJson;
-		ok &= expect(rsJson["train_units"].size() > 0, "Copenhagen has train units");
-
-		bool foundA = false;
-		for (const auto& s : sJson["services"]) {
-			if (s["id"] == "A-Hillerod-Hundige") {
-				foundA = true;
-				ok &= expect(s["route"] == "route12", "A-Hillerod-Hundige route12");
-				ok &= expect(s["entry_time_seconds"] == 400.0, "entry_time_seconds 400");
-				ok &= expect(s.contains("repeat") && s["repeat"]["headway_seconds"] == 1200.0, "headway 1200");
-				ok &= expect(s["stops"].size() == 23, "23 stops");
-				ok &= expect(s["stops"][0]["departure_seconds"] == 460.0, "First stop departure 460");
-				ok &= expect(!s["stops"][0].contains("arrival_seconds"), "First stop no arrival");
-				ok &= expect(s["stops"].back()["arrival_seconds"] == 4300.0, "Last stop arrival 4300");
-				ok &= expect(!s["stops"].back().contains("departure_seconds"), "Last stop no departure");
-				ok &= expect(s["stops"][0]["dwell_seconds"] == 20.0, "Dwell 20 on stop 0");
+		bool hasRootReport = false;
+		for (const auto& row : scene.value("import_report", json::array())) {
+			if (row.value("category", "") == "legacy_root"
+					&& row.value("source_file", "") == testCase.legacy)
+				hasRootReport = row.value("source_count", 0) == 1
+						&& row.value("converted_count", 0) == 1;
+		}
+		ok &= expect(hasRootReport, std::string(testCase.name) + " legacy root report");
+		ok &= expect(!scene.contains("legacy_source"), std::string(testCase.name) + " report-only provenance");
+		if (std::string(testCase.name) == "Copenhagen") {
+			ok &= expect(hasDiag(result.diagnostics, "scene.import.timetable", SceneSeverity::Warning),
+					"Copenhagen inconsistent timetable is diagnosed");
+			const auto validation = validateSceneDirectory(output.dir);
+			ok &= expect(hasDiag(validation, "scene.time.invalid", SceneSeverity::Error),
+					"Copenhagen validator preserves the timetable ordering diagnostic");
+		}
+		if (std::string(testCase.name) == "Brescia") {
+			int code9707 = 0, code9709 = 0;
+			bool has9707Suffix = false, has9709Suffix = false;
+			for (const auto& service : services["services"]) {
+				const std::string id = service.value("id", "");
+				const std::string code = service.value("operating_code", id);
+				if (code == "9707") ++code9707;
+				if (code == "9709") ++code9709;
+				has9707Suffix = has9707Suffix || id == "9707_2";
+				has9709Suffix = has9709Suffix || id == "9709_2";
 			}
+			ok &= expect(code9707 == 2 && code9709 == 2 && has9707Suffix && has9709Suffix,
+					"Brescia duplicate operating codes retain unique canonical ids");
 		}
-		ok &= expect(foundA, "Spot-check A-Hillerod-Hundige found");
-
-		bool foundH = false;
-		for (const auto& st : stJson["stations"]) {
-			if (st["id"] == "Hillerod")
-				foundH = true;
-		}
-		ok &= expect(foundH, "Hillerod station found");
-
-		bool foundL = false;
-		for (const auto& tu : rsJson["train_units"]) {
-			if (tu["id"] == "LITRA_SA") {
-				foundL = true;
-				ok &= expect(tu["physical"]["length_m"] == 84.0, "LITRA_SA length 84");
-				ok &= expect(tu["traction_curve"].size() > 0, "LITRA_SA has traction curve");
-			}
-		}
-		ok &= expect(foundL, "LITRA_SA unit found");
-
-		runPreservationSweep(copDir, outDir.dir);
-	}
-
-	// 6-7. Brescia
-	{
-		TempDir outDir;
-		auto res = importLegacyScene(breDir, outDir.dir, "Brescia");
-		printErrors(res.diagnostics, "Brescia import");
-		ok &= expect(res.success(), "Brescia import succeeds with zero errors");
-
-		auto vDiags = validateSceneDirectory(outDir.dir);
-		printErrors(vDiags, "Brescia validate");
-		ok &= expect(!hasErrors(vDiags), "Brescia validate zero errors");
-		// Several services depart their first stop before the scene base time;
-		// a negative first departure is legal and is not an ordering warning.
-		ok &= expect(!hasDiag(vDiags, "scene.time.order", SceneSeverity::Warning),
-					 "Brescia has no departure ordering warnings");
-		// Stop-less services import as through services, so a fresh import
-		// carries no missing-stops warnings.
-		ok &= expect(!hasDiag(vDiags, "scene.service.no_stops", SceneSeverity::Warning),
-					 "Brescia import has no missing-stops warnings");
-
-		std::ifstream sFile(fs::path(outDir.dir) / "services.json");
-		json sJson;
-		sFile >> sJson;
-		ok &= expect(sJson["services"].size() == 62, "Brescia 62 services");
-		int throughCount = 0;
-		for (const auto& s : sJson["services"]) {
-			if (s.value("through", false)) {
-				throughCount++;
-				ok &= expect(s["stops"].empty(), "through services import without stops");
-			}
-		}
-		ok &= expect(throughCount == 22, "Brescia imports 22 through services");
-
-		std::ifstream rFile(fs::path(outDir.dir) / "signalling.json");
-		json rJson;
-		rFile >> rJson;
-		ok &= expect(rJson["routes"].size() == 48, "Brescia 48 routes");
-
-		bool found10450 = false;
-		int repeatCount = 0;
-		for (const auto& s : sJson["services"]) {
-			if (s["id"] == "10450") {
-				found10450 = true;
-				ok &= expect(s["entry_time_seconds"] == 115.0, "10450 entry 115");
-				ok &= expect(!s.contains("repeat"), "10450 no repeat");
-				ok &= expect(s["route"] == "route44", "10450 route44");
-			}
-			if (s.contains("repeat"))
-				repeatCount++;
-		}
-		ok &= expect(found10450, "10450 found");
-		ok &= expect(repeatCount == 2, "Exactly 2 services have repeat field");
-
-		runPreservationSweep(breDir, outDir.dir);
-	}
-
-	// 8. Netherlands assignment source imports into a validated scene.
-	{
-		TempDir outDir;
-		auto res = importLegacyScene(nlDir, outDir.dir, "Netherlands");
-		printErrors(res.diagnostics, "Netherlands import");
-		ok &= expect(res.success(), "Netherlands import succeeds with zero errors");
-		ok &= expect(countDiag(res.diagnostics, "scene.import.parse", SceneSeverity::Warning) == 0,
-					 "Netherlands complex route tokens are preserved without parse warnings");
-
-		auto vDiags = validateSceneDirectory(outDir.dir);
-		printErrors(vDiags, "Netherlands validate");
-		ok &= expect(!hasErrors(vDiags), "Netherlands validate zero errors");
-
-		std::ifstream sFile(fs::path(outDir.dir) / "services.json");
-		json sJson;
-		sFile >> sJson;
-		ok &= expect(sJson["services"].size() == 8, "Netherlands 8 services");
-
-		std::ifstream rsFile(fs::path(outDir.dir) / "rolling_stock.json");
-		json rsJson;
-		rsFile >> rsJson;
-		ok &= expect(rsJson["train_units"].size() == 1, "Netherlands 1 train unit");
-		ok &= expect(rsJson["compositions"].size() == 1, "Netherlands 1 composition");
-
-		std::ifstream rFile(fs::path(outDir.dir) / "signalling.json");
-		json rJson;
-		rFile >> rJson;
-		ok &= expect(rJson["routes"].size() == 74, "Netherlands 74 routes");
-		ok &= expect(rJson["routes"][0]["blocks"].size() == 53, "Netherlands route0 preserves every token");
-		bool route0HasSwitchToken = false;
-		for (const auto& block : rJson["routes"][0]["blocks"]) {
-			if (block.get<std::string>().find('/') != std::string::npos) {
-				route0HasSwitchToken = true;
-				break;
-			}
-		}
-		ok &= expect(route0HasSwitchToken, "Netherlands route0 preserves switch transition token");
-	}
-
-	// 9. Error: Nonexistent directory
-	{
-		TempDir outDir;
-		auto res = importLegacyScene("/no/such/legacy/dir", outDir.dir, "NoDir");
-		ok &= expect(!res.wroteScene, "Nonexistent legacy dir wroteScene false");
-		ok &= expect(!res.success(), "Nonexistent legacy dir success false");
-		ok &= expect(hasDiag(res.diagnostics, "scene.import.missing"), "scene.import.missing produced");
-	}
-
-	// 10. Error: Synthetic mini legacy folder
-	{
-		TempDir lDir, outDir;
-		fs::create_directories(fs::path(lDir.dir) / "Trains");
-
-		std::ofstream tf1(fs::path(lDir.dir) / "Trains" / "t1.txt");
-		tf1 << "Svc1 0 99999999 999 /Data.txt /Trac.txt /TT.txt\n"; // route 999
-		tf1.close();
-
-		std::ofstream tf2(fs::path(lDir.dir) / "Trains" / "t2.txt");
-		tf2 << "Svc2 0 99999999\n"; // truncated
-		tf2.close();
-
-		auto res = importLegacyScene(lDir.dir, outDir.dir, "Synth");
-		ok &= expect(hasDiag(res.diagnostics, "scene.import.ref"), "scene.import.ref for route out of range");
-		ok &= expect(hasDiag(res.diagnostics, "scene.import.parse"), "scene.import.parse for truncated file");
-	}
-
-	// 11. Error: malformed route tokens still report parse warnings.
-	{
-		TempDir lDir, outDir;
-		fs::create_directories(fs::path(lDir.dir) / "Routes");
-		std::ofstream route(fs::path(lDir.dir) / "Routes" / "Route0.txt");
-		route << "@A@1.000/@B@2.000\n";
-		route << "not-a-route-token\n";
-		route.close();
-
-		auto res = importLegacyScene(lDir.dir, outDir.dir, "MalformedRoute");
-		ok &= expect(countDiag(res.diagnostics, "scene.import.parse", SceneSeverity::Warning) == 1,
-					 "scene.import.parse warning only for malformed route token");
-
-		bool malformedRowFlagged = false;
-		for (const auto& d : res.diagnostics) {
-			if (d.code == "scene.import.parse" && d.severity == SceneSeverity::Warning &&
-				d.message == "Malformed route block token at row 1")
-				malformedRowFlagged = true;
-		}
-		ok &= expect(malformedRowFlagged, "parse warning names the malformed token row");
-	}
-
-	// 12. Non-ASCII route filenames are not treated as decimal route numbers.
-	{
-		TempDir lDir, outDir;
-		fs::create_directories(fs::path(lDir.dir) / "Routes");
-		fs::create_directories(fs::path(lDir.dir) / "TrackLines");
-		std::ofstream(lDir.dir + "/TrackLines/Stations.txt") << "0\tASCII\n";
-		std::ofstream(lDir.dir + "/Routes/Route12.txt") << "@ASCII@\n";
-		const std::string nonAsciiRoute = std::string("Route") + "\xC3\xA9.txt";
-		std::ofstream(fs::path(lDir.dir) / "Routes" / nonAsciiRoute) << "@NonAscii@\n";
-
-		auto res = importLegacyScene(lDir.dir, outDir.dir, "NonAsciiRouteFilename");
-		printErrors(res.diagnostics, "Non-ASCII route filename import");
-		ok &= expect(res.success(), "Non-ASCII route filename import succeeds");
-
-		std::ifstream signalling(fs::path(outDir.dir) / "signalling.json");
-		json signallingJson;
-		signalling >> signallingJson;
-		ok &= expect(signallingJson["routes"].size() == 1, "Non-ASCII route filename is skipped");
-		if (!signallingJson["routes"].empty()) {
-			ok &= expect(signallingJson["routes"][0]["id"] == "route12", "ASCII route filename remains accepted");
-			ok &= expect(signallingJson["routes"][0]["blocks"][0] == "ASCII", "ASCII route contents remain unchanged");
-		}
-	}
-
-	// 13. Flat Tracklines payloads import without inventing semantic data and
-	// preserve the canonical runtime infrastructure layout.
-	{
-		TempDir lDir, outDir;
-		fs::create_directories(fs::path(outDir.dir) / "legacy/Tracklines/B7");
-		std::ofstream(fs::path(outDir.dir) / "legacy/Tracklines/B7/stale.txt") << "stale\n";
-		std::ofstream(lDir.dir + "/Stations.txt") << "0\tFlatStart\n1.5\tFlatEnd\n";
-		std::ofstream(lDir.dir + "/Connections.txt") << "0\t0.5\t1\t0.5\n";
-		std::ofstream(lDir.dir + "/TrackandStations.txt") << "0\nFlatStart FlatEnd\n";
-		fs::create_directories(fs::path(lDir.dir) / "B0");
-		std::ofstream(lDir.dir + "/B0/NodiCumPari.txt") << "1\t0\t0\n2\t1\t0\n";
-		std::ofstream(lDir.dir + "/unrelated.txt") << "must not be copied\n";
-
-		auto res = importLegacyScene(lDir.dir, outDir.dir, "FlatFixture");
-		printErrors(res.diagnostics, "Flat fixture import");
-		ok &= expect(res.success(), "Flat fixture import succeeds");
-
-		std::ifstream stations(fs::path(outDir.dir) / "stations.json");
-		json stationsJson;
-		stations >> stationsJson;
-		ok &= expect(stationsJson["stations"].size() == 2, "Flat fixture stations parsed");
-		ok &= expect(stationsJson["stations"][0]["id"] == "FlatStart", "Flat fixture first station parsed");
-
-		std::ifstream services(fs::path(outDir.dir) / "services.json");
-		json servicesJson;
-		services >> servicesJson;
-		ok &= expect(servicesJson["services"].empty(), "Flat fixture has no invented services");
-		std::ifstream rolling(fs::path(outDir.dir) / "rolling_stock.json");
-		json rollingJson;
-		rolling >> rollingJson;
-		ok &= expect(rollingJson["train_units"].empty(), "Flat fixture has no invented train units");
-		ok &= expect(rollingJson["compositions"].empty(), "Flat fixture has no invented compositions");
-		std::ifstream signalling(fs::path(outDir.dir) / "signalling.json");
-		json signallingJson;
-		signalling >> signallingJson;
-		ok &= expect(signallingJson["routes"].empty(), "Flat fixture has no invented routes");
-
-		auto validation = validateSceneDirectory(outDir.dir);
-		ok &= expect(hasDiag(validation, "scene.trains.none"), "Flat fixture reports no trains semantic diagnostic");
-		ok &= expect(hasDiag(validation, "scene.services.none"), "Flat fixture reports no services semantic diagnostic");
-		ok &= expect(fs::exists(fs::path(outDir.dir) / "legacy/Tracklines/Stations.txt"), "Flat fixture canonical stations passthrough");
-		ok &= expect(fs::exists(fs::path(outDir.dir) / "legacy/Tracklines/Connections.txt"), "Flat fixture canonical connections passthrough");
-		ok &= expect(fs::exists(fs::path(outDir.dir) / "legacy/Tracklines/TrackandStations.txt"), "Flat fixture canonical track passthrough");
-		ok &= expect(fs::exists(fs::path(outDir.dir) / "legacy/Tracklines/B0/NodiCumPari.txt"), "Flat fixture block passthrough");
-		ok &= expect(!fs::exists(fs::path(outDir.dir) / "legacy/Tracklines/B7"), "Flat fixture removes stale block passthrough");
-		ok &= expect(!fs::exists(fs::path(outDir.dir) / "legacy/unrelated.txt"), "Flat fixture excludes unrelated root files");
-	}
-
-	// 14. Reject overlapping source and destination paths before touching either.
-	{
-		TempDir root;
-		const fs::path legacyPath = fs::path(root.dir) / "legacy";
-		const fs::path scenePath = legacyPath / "nested-scene";
-		fs::create_directories(fs::path(legacyPath) / "TrackLines");
-		const fs::path markerPath = fs::path(legacyPath) / "source-marker.txt";
-		std::ofstream(markerPath) << "source stays unchanged\n";
-		std::ofstream(fs::path(legacyPath) / "TrackLines/Stations.txt") << "0\tNestedSource\n";
-
-		auto res = importLegacyScene(legacyPath.string(), scenePath.string(), "NestedDestination");
-		ok &= expect(!res.wroteScene, "Destination inside source is rejected");
-		ok &= expect(hasDiag(res.diagnostics, "scene.import.path", SceneSeverity::Error),
-					 "Destination inside source reports a path error");
-		std::ifstream marker(markerPath);
-		std::string markerContent((std::istreambuf_iterator<char>(marker)), std::istreambuf_iterator<char>());
-		ok &= expect(markerContent == "source stays unchanged\n", "Destination inside source preserves source marker");
-		ok &= expect(!fs::exists(scenePath), "Destination inside source does not create destination");
-	}
-
-	{
-		TempDir root;
-		const fs::path legacyPath = fs::path(root.dir) / "legacy";
-		fs::create_directories(fs::path(legacyPath) / "TrackLines");
-		const fs::path markerPath = fs::path(legacyPath) / "source-marker.txt";
-		std::ofstream(markerPath) << "identical source stays unchanged\n";
-		std::ofstream(fs::path(legacyPath) / "TrackLines/Stations.txt") << "0\tIdenticalSource\n";
-
-		auto res = importLegacyScene(legacyPath.string(), legacyPath.string(), "IdenticalPaths");
-		ok &= expect(!res.wroteScene, "Identical source and destination are rejected");
-		ok &= expect(hasDiag(res.diagnostics, "scene.import.path", SceneSeverity::Error),
-					 "Identical source and destination report a path error");
-		std::ifstream marker(markerPath);
-		std::string markerContent((std::istreambuf_iterator<char>(marker)), std::istreambuf_iterator<char>());
-		ok &= expect(markerContent == "identical source stays unchanged\n", "Identical paths preserve source marker");
-		ok &= expect(!fs::exists(legacyPath / "scene.json"), "Identical paths do not write scene");
-	}
-
-	{
-		TempDir root;
-		const fs::path scenePath = fs::path(root.dir) / "scene";
-		const fs::path legacyPath = scenePath / "legacy";
-		fs::create_directories(fs::path(legacyPath) / "TrackLines");
-		const fs::path markerPath = fs::path(legacyPath) / "source-marker.txt";
-		std::ofstream(markerPath) << "nested source stays unchanged\n";
-		std::ofstream(fs::path(legacyPath) / "TrackLines/Stations.txt") << "0\tNestedSource\n";
-
-		auto res = importLegacyScene(legacyPath.string(), scenePath.string(), "LegacySubdirectory");
-		ok &= expect(!res.wroteScene, "Source at destination legacy is rejected");
-		ok &= expect(hasDiag(res.diagnostics, "scene.import.path", SceneSeverity::Error),
-					 "Source at destination legacy reports a path error");
-		std::ifstream marker(markerPath);
-		std::string markerContent((std::istreambuf_iterator<char>(marker)), std::istreambuf_iterator<char>());
-		ok &= expect(markerContent == "nested source stays unchanged\n", "Source at destination legacy preserves marker");
-		ok &= expect(!fs::exists(scenePath / "scene.json"), "Source at destination legacy does not write scene");
-	}
-
-	// A shared path prefix is not containment: sibling destinations remain valid.
-	{
-		TempDir root;
-		const fs::path legacyPath = fs::path(root.dir) / "legacy";
-		const fs::path scenePath = fs::path(root.dir) / "legacy-copy";
-		fs::create_directories(fs::path(legacyPath) / "TrackLines");
-		std::ofstream(fs::path(legacyPath) / "TrackLines/Stations.txt") << "0\tSiblingSource\n";
-
-		auto res = importLegacyScene(legacyPath.string(), scenePath.string(), "SiblingDestination");
-		ok &= expect(res.success(), "Sibling destination with shared prefix remains valid");
-		ok &= expect(fs::exists(scenePath / "scene.json"), "Sibling destination receives scene");
-	}
-
-	// 16. Import errors preserve an existing destination and clean temporary
-	// siblings instead of publishing a partial scene.
-	{
-		TempDir lDir, outDir;
-		fs::create_directories(fs::path(lDir.dir) / "TrackLines");
-		fs::create_directories(fs::path(lDir.dir) / "Trains");
-		std::ofstream(lDir.dir + "/TrackLines/Stations.txt") << "0\tPreservedSource\n";
-		std::ofstream(lDir.dir + "/Trains/broken.txt") << "malformed train input\n";
-
-		fs::create_directories(fs::path(outDir.dir) / "legacy");
-		std::ofstream(fs::path(outDir.dir) / "scene.json") << "existing scene bytes\n";
-		std::ofstream(fs::path(outDir.dir) / "services.json") << "existing services bytes\n";
-		std::ofstream(fs::path(outDir.dir) / "legacy/stale.txt") << "existing passthrough bytes\n";
-
-		std::vector<std::string> siblingsBefore;
-		for (const auto& entry : fs::directory_iterator(fs::path(outDir.dir).parent_path()))
-			siblingsBefore.push_back(entry.path().filename().string());
-		std::sort(siblingsBefore.begin(), siblingsBefore.end());
-
-		auto res = importLegacyScene(lDir.dir, outDir.dir, "PreservedDestination");
-		ok &= expect(!res.success(), "Malformed source import fails");
-		ok &= expect(!res.wroteScene, "Failed import does not publish a scene");
-
-		std::ifstream sceneFile(fs::path(outDir.dir) / "scene.json");
-		std::string sceneBytes((std::istreambuf_iterator<char>(sceneFile)), std::istreambuf_iterator<char>());
-		ok &= expect(sceneBytes == "existing scene bytes\n", "Failed import preserves existing scene bytes");
-		std::ifstream servicesFile(fs::path(outDir.dir) / "services.json");
-		std::string servicesBytes((std::istreambuf_iterator<char>(servicesFile)), std::istreambuf_iterator<char>());
-		ok &= expect(servicesBytes == "existing services bytes\n", "Failed import preserves existing JSON bytes");
-		std::ifstream staleFile(fs::path(outDir.dir) / "legacy/stale.txt");
-		std::string staleBytes((std::istreambuf_iterator<char>(staleFile)), std::istreambuf_iterator<char>());
-		ok &= expect(staleBytes == "existing passthrough bytes\n", "Failed import preserves existing passthrough");
-
-		std::vector<std::string> siblingsAfter;
-		for (const auto& entry : fs::directory_iterator(fs::path(outDir.dir).parent_path()))
-			siblingsAfter.push_back(entry.path().filename().string());
-		std::sort(siblingsAfter.begin(), siblingsAfter.end());
-		ok &= expect(siblingsAfter == siblingsBefore, "Failed import cleans staging and backup siblings");
-	}
-
-	// 17. Permission errors while selecting a staging sibling return without
-	// publishing or changing an existing destination.
-	{
-		TempDir lDir, outDir;
-		fs::create_directories(fs::path(lDir.dir) / "TrackLines");
-		std::ofstream(lDir.dir + "/TrackLines/Stations.txt") << "0\tPermissionSource\n";
-
-		const fs::path destinationParent = fs::path(outDir.dir) / "restricted";
-		const fs::path scenePath = destinationParent / "scene";
-		fs::create_directories(scenePath);
-		const fs::path markerPath = scenePath / "marker.txt";
-		std::ofstream(markerPath) << "destination stays unchanged\n";
-
-		std::error_code statusEc;
-		const fs::perms originalPermissions = fs::status(destinationParent, statusEc).permissions();
-		if (statusEc) {
-			std::cerr << "skipped: unable to inspect destination parent permissions: " << statusEc.message() << "\n";
-		} else {
-			std::error_code restrictEc;
-			fs::permissions(destinationParent, fs::perms::none, fs::perm_options::replace, restrictEc);
-			if (restrictEc) {
-				std::error_code restoreEc;
-				fs::permissions(destinationParent, originalPermissions, fs::perm_options::replace, restoreEc);
-				ok &= expect(!restoreEc, "Permission test restores destination parent after setup failure");
-				std::cerr << "skipped: unable to remove destination parent access: " << restrictEc.message() << "\n";
-			} else {
-				std::error_code probeEc;
-				fs::exists(destinationParent / "probe", probeEc);
-				if (!probeEc) {
-					std::error_code restoreEc;
-					fs::permissions(destinationParent, originalPermissions, fs::perm_options::replace, restoreEc);
-					ok &= expect(!restoreEc, "Permission test restores destination parent when probe succeeds");
-					std::cerr << "skipped: destination parent permissions did not produce an fs::exists error\n";
-				} else {
-					auto res = importLegacyScene(lDir.dir, scenePath.string(), "PermissionError");
-					std::error_code restoreEc;
-					fs::permissions(destinationParent, originalPermissions, fs::perm_options::replace, restoreEc);
-					ok &= expect(!restoreEc, "Permission test restores destination parent after import");
-					if (!restoreEc) {
-						ok &= expect(!res.wroteScene, "Permission-error import wroteScene false");
-						ok &= expect(!res.success(), "Permission-error import success false");
-						bool foundDestinationDiagnostic = false;
-						for (const auto& d : res.diagnostics) {
-							if (d.severity == SceneSeverity::Error && d.code == "scene.import.missing"
-								&& d.file == scenePath.string()) {
-								foundDestinationDiagnostic = true;
-								break;
-							}
-						}
-						ok &= expect(foundDestinationDiagnostic,
-								"Permission-error import names the scene destination");
-						std::ifstream marker(markerPath);
-						std::string markerContent((std::istreambuf_iterator<char>(marker)), std::istreambuf_iterator<char>());
-						ok &= expect(markerContent == "destination stays unchanged\n",
-								"Permission-error import preserves destination marker");
+		if (std::string(testCase.name) == "Paimpol") {
+			json passengerFile;
+			const bool readable = readJson(fs::path(output.dir) / "passengers.json", passengerFile);
+			ok &= expect(readable, "Paimpol passengers imported");
+			if (readable) {
+				std::unordered_set<std::string> journeyIds;
+				size_t journeyCount = 0, legCount = 0;
+				for (const auto& passenger : passengerFile["passengers"]) {
+					for (const auto& journey : passenger["journeys"]) {
+						++journeyCount;
+						legCount += journey["legs"].size();
+						journeyIds.insert(journey["id"].get<std::string>());
 					}
+				}
+				ok &= expect(journeyCount == 376 && legCount == 14,
+						"Paimpol DAS rows and route-choice legs retained");
+				ok &= expect(journeyIds.size() == journeyCount, "Paimpol journey ids are globally stable");
+				if (!passengerFile["passengers"].empty()
+						&& !passengerFile["passengers"][0]["journeys"].empty()) {
+					const auto& journey = passengerFile["passengers"][0]["journeys"][0];
+					ok &= expect(journey.contains("planned_departure")
+							&& journey.contains("planned_arrival"), "Paimpol absolute passenger windows retained");
 				}
 			}
 		}
 	}
 
-	// 18. Import errors identify the concrete source path that failed.
+	// One small fixture exercises the new fields together, including explicit
+	// Trains provenance and a coordinate that must remain unresolved.
 	{
-		TempDir lDir, outDir;
-		fs::create_directories(fs::path(lDir.dir) / "TrackLines");
-		fs::create_directories(fs::path(lDir.dir) / "Trains");
-		std::ofstream(lDir.dir + "/TrackLines/Stations.txt") << "0\tDiagnosticSource\n";
-		std::ofstream(lDir.dir + "/Trains/reference.txt")
-			<< "Svc 0 99999999 0 /Data.txt /Trac.txt /MissingTimetable.txt\n";
-		std::ofstream(lDir.dir + "/Trains/traction-reference.txt")
-			<< "SvcTraction 0 99999999 0 /ValidData.txt /MissingTraction.txt /MissingTimetable2.txt\n";
-		std::ofstream(lDir.dir + "/ValidData.txt") << "1 2 3 4 5 6 7 8 9\n";
+		TempDir legacyDir, output;
+		const fs::path legacy(legacyDir.dir);
+		writeText(legacy / "TrackLines/B0/NodiCumPari.txt", "1 0 0\n2 1 0\n");
+		writeText(legacy / "TrackLines/B1/NodiCumPari.txt", "1 0 1\n2 1 1\n");
+		writeText(legacy / "TrackLines/B0/ArchiCumPari.txt", "7 1 2 100 2 30\n");
+		writeText(legacy / "TrackLines/B1/ArchiCumPari.txt", "7 1 2 200 3 40\n");
+		writeText(legacy / "TrackLines/B0/BlockCumPari.txt", "99 0.5\n");
+		writeText(legacy / "TrackLines/B1/BlockCumPari.txt", "88 0.6\n");
+		writeText(legacy / "TrackLines/Connections.txt", "0 0 1 0 7\n0 9 1 9 8\n");
+		writeText(legacy / "TrackLines/Stations.txt", "0\tGuingamp\n1\tPaimpol\n");
+		writeText(legacy / "Routes/Route0.txt", "@0-B0@\n");
+		writeText(legacy / "Routes/Route2.txt", "@0-B1@\n");
+		writeText(legacy / "RoutesToWrite/RoutesToJoin.txt", "0 2 Reverse\n");
+		writeText(legacy / "GUI/caseStudyRouteCorridors.txt", "0\tfixture-corridor\n");
+		writeText(legacy / "GUI/singleTrackLimits.txt", "@0-B0@\t@0-B1@\t@0-B0@\t@0-B1@\n");
+		writeText(legacy / "GUI/stationBoundarySections.txt", "@0-B0@\t@0-B1@\t1\n");
+		writeText(legacy / "trainNames.txt", "fixture.txt\nfixture-duplicate.txt\n");
+		writeText(legacy / "Trains/fixture.txt",
+				"FixtureService 0 99999999 0 /vehicle.dat /effort-curve.dat /TimeTable/fixture.txt\n");
+		writeText(legacy / "Trains/fixture-duplicate.txt",
+				"FixtureService 0 99999999 2 /vehicle.dat /effort-curve.dat /TimeTable/fixture.txt\n");
+		writeText(legacy / "vehicle.dat", "1 2 3 4 5 6 7 8 9\n");
+		writeText(legacy / "effort-curve.dat", "0 1 2 3 4\n");
+		writeText(legacy / "TimeTable/fixture.txt", "Guingamp 2 -1 10\nPaimpol 3 20 -1\n");
+		writeText(legacy / "Incidents.txt",
+				"signal_failure\t0-B0\t10\t20\ntrain_breakdown\tFixtureService\t30\t40\n");
+		writeText(legacy / "TimeTable/Scenarios_Entrance_Delays/Rollout_1.txt", "15\n20\n");
 
-		auto res = importLegacyScene(lDir.dir, outDir.dir, "DiagnosticPaths");
-		bool allErrorsNamePaths = true;
-		for (const auto& d : res.diagnostics) {
-			if (d.severity == SceneSeverity::Error && d.file.empty())
-				allErrorsNamePaths = false;
+		const auto result = importLegacyScene(legacyDir.dir, output.dir, "Paimpol");
+		ok &= expect(result.success(), "Complete synthetic fixture imports");
+		if (result.wroteScene) {
+			json scene, infrastructure, rolling, services, signalling, scenarios;
+			ok &= expect(readJson(fs::path(output.dir) / "scene.json", scene), "Synthetic scene readable");
+			ok &= expect(readJson(fs::path(output.dir) / "infrastructure.json", infrastructure), "Synthetic infrastructure readable");
+			ok &= expect(readJson(fs::path(output.dir) / "rolling_stock.json", rolling), "Synthetic rolling stock readable");
+			ok &= expect(readJson(fs::path(output.dir) / "services.json", services), "Synthetic services readable");
+			ok &= expect(readJson(fs::path(output.dir) / "signalling.json", signalling), "Synthetic signalling readable");
+			ok &= expect(readJson(fs::path(output.dir) / "scenarios.json", scenarios), "Synthetic scenarios readable");
+			ok &= expect(scene["base_time"] == "07:10:40"
+					&& scene["simulation_settings"]["duration_seconds"] == 9000.0, "Known settings imported");
+			bool rootReport = false, coordinateReport = false;
+			for (const auto& row : scene["import_report"]) {
+				if (row["category"] == "legacy_root")
+					rootReport = row["source_count"] == 1 && row["converted_count"] == 1;
+				if (row["category"] == "infrastructure.connections")
+					coordinateReport = row["source_count"] == 2 && row["converted_count"] == 1
+							&& row["skipped_count"] == 1 && row["unresolved_references"] == 1;
+			}
+			ok &= expect(rootReport, "Synthetic root provenance report");
+			ok &= expect(coordinateReport, "Synthetic unresolved coordinate report");
+			ok &= expect(infrastructure["nodes"][0]["id"] == "B0.node.1", "Stable node id");
+			ok &= expect(infrastructure["arcs"][0]["from"] == "B0.node.1"
+					&& infrastructure["arcs"][0]["to"] == "B0.node.2", "Arc node references");
+			ok &= expect(infrastructure["blocks"][0]["id"] == "0-B0"
+					&& infrastructure["blocks"][0]["length_km"] == 0.5, "Row-position block id");
+			ok &= expect(infrastructure["connections"].size() == 1
+					&& infrastructure["connections"][0]["from"] == "B0.node.1", "Resolved connection ref");
+			ok &= expect(rolling["train_units"].size() == 1
+					&& rolling["train_units"][0]["source"]["data_file"] == "/vehicle.dat"
+					&& rolling["train_units"][0]["source"]["traction_file"] == "/effort-curve.dat",
+					"Rolling relation follows explicit Trains paths");
+			ok &= expect(services["services"][0]["operating_code"] == "FixtureService",
+					"Active legacy train identity is retained separately from the service id");
+			const auto& stops = services["services"][0]["stops"];
+			ok &= expect(stops[0].contains("planned_departure_seconds")
+					&& !stops[0].contains("planned_arrival_seconds")
+					&& !stops[0].contains("departure_seconds"), "Missing arrival stays absent");
+			ok &= expect(stops[1].contains("planned_arrival_seconds")
+					&& !stops[1].contains("planned_departure_seconds")
+					&& !stops[1].contains("arrival_seconds"), "Missing departure stays absent");
+			ok &= expect(signalling["routes"][0]["corridor"] == "fixture-corridor"
+					&& signalling["single_track_restrictions"][0]["start_block"] == "0-B0"
+					&& signalling["station_boundaries"][0]["entrance_block"] == "0-B0", "Signalling roles imported");
+			ok &= expect(signalling["routes"].size() == 3
+					&& signalling["routes"][2]["id"] == "route3"
+					&& signalling["routes"][2]["reversed"] == true,
+					"Sparse route ids leave a stable append id for joined routes");
+			ok &= expect(scenarios["default_scenario_id"] == "baseline"
+					&& scenarios["scenarios"].size() == 2
+					&& scenarios["scenarios"][0]["incidents"].size() == 3
+					&& scenarios["scenarios"][1]["incidents"].size() == 3
+					&& scenarios["scenarios"][1]["incidents"][0]["id"] == "rollout_1.incident.1"
+					&& scenarios["scenarios"][1]["entrance_delays"].size() == 4,
+					"Rollout retains global incidents and entrance delays");
+			ok &= expect(scenarios["scenarios"][0]["incidents"][1]["target"] == "FixtureService"
+					&& scenarios["scenarios"][0]["incidents"][2]["target"] == "FixtureService_2"
+					&& hasDiag(result.diagnostics, "scene.import.expanded", SceneSeverity::Warning),
+					"Duplicate operating-code incident expands to every matching canonical service");
 		}
-		ok &= expect(allErrorsNamePaths, "Every import error names a failing path");
-
-		const fs::path missingTimetable = fs::path(lDir.dir) / "MissingTimetable.txt";
-		const fs::path missingData = fs::path(lDir.dir) / "Data.txt";
-		const fs::path missingTraction = fs::path(lDir.dir) / "MissingTraction.txt";
-		const fs::path missingRoute = fs::path(lDir.dir) / "Routes/Route0.txt";
-		bool foundTimetable = false;
-		bool foundData = false;
-		bool foundTraction = false;
-		bool foundRoute = false;
-		for (const auto& d : res.diagnostics) {
-			if (d.code == "scene.import.ref" && d.message.find("Missing timetable file") != std::string::npos)
-				foundTimetable = foundTimetable || d.file == missingTimetable.string();
-			if (d.code == "scene.import.ref" && d.message.find("Missing train data file") != std::string::npos)
-				foundData = foundData || d.file == missingData.string();
-			if (d.code == "scene.import.ref" && d.message.find("Missing traction file") != std::string::npos)
-				foundTraction = foundTraction || d.file == missingTraction.string();
-			if (d.code == "scene.import.ref" && d.message.find("Missing route file") != std::string::npos)
-				foundRoute = foundRoute || d.file == missingRoute.string();
-		}
-		ok &= expect(foundTimetable, "Missing timetable diagnostic names referenced timetable path");
-		ok &= expect(foundData, "Missing train data diagnostic names referenced data path");
-		ok &= expect(foundTraction, "Missing traction diagnostic names referenced traction path");
-		ok &= expect(foundRoute, "Missing route diagnostic names referenced route path");
 	}
 
-	// 19. Every committed legacy input, including the Banedanmark alias and
-	// both Paimpol variants, keeps the importer output shape.
-	auto checkCommittedImport = [&](const std::string& legacyDir, const std::string& sceneName,
-								   size_t stationCount, size_t unitCount, size_t serviceCount, size_t routeCount) {
-		TempDir outDir;
-		auto res = importLegacyScene(legacyDir, outDir.dir, sceneName);
-		printErrors(res.diagnostics, (sceneName + " import").c_str());
-		ok &= expect(res.success(), (sceneName + " import succeeds").c_str());
-
-		std::ifstream sceneFile(fs::path(outDir.dir) / "scene.json");
-		json sceneJson;
-		sceneFile >> sceneJson;
-		ok &= expect(sceneJson["name"] == sceneName, (sceneName + " scene name preserved").c_str());
-		std::ifstream stationsFile(fs::path(outDir.dir) / "stations.json");
-		json stationsJson;
-		stationsFile >> stationsJson;
-		std::ifstream rollingFile(fs::path(outDir.dir) / "rolling_stock.json");
-		json rollingJson;
-		rollingFile >> rollingJson;
-		std::ifstream servicesFile(fs::path(outDir.dir) / "services.json");
-		json servicesJson;
-		servicesFile >> servicesJson;
-		std::ifstream signallingFile(fs::path(outDir.dir) / "signalling.json");
-		json signallingJson;
-		signallingFile >> signallingJson;
-		ok &= expect(stationsJson["stations"].size() == stationCount, (sceneName + " station output shape").c_str());
-		ok &= expect(rollingJson["train_units"].size() == unitCount, (sceneName + " train-unit output shape").c_str());
-		ok &= expect(rollingJson["compositions"].size() == unitCount, (sceneName + " composition output shape").c_str());
-		ok &= expect(servicesJson["services"].size() == serviceCount, (sceneName + " service output shape").c_str());
-		ok &= expect(signallingJson["routes"].size() == routeCount, (sceneName + " route output shape").c_str());
-		ok &= expect(fs::exists(fs::path(outDir.dir) / "legacy"), (sceneName + " legacy passthrough exists").c_str());
-	};
-	checkCommittedImport(banDir, "Banedanmark", 94, 1, 24, 24);
-	checkCommittedImport(paimpolDir, "Paimpol", 10, 1, 2, 15);
-	checkCommittedImport(paimpolAltDir, "Paimpol alternative journeys", 10, 1, 1, 14);
+	// Atomic path safety: reject overlap, and preserve an existing destination
+	// when malformed legacy input cannot be imported.
+	{
+		TempDir root;
+		const fs::path legacy = fs::path(root.dir) / "legacy";
+		const fs::path nestedScene = legacy / "nested-scene";
+		writeText(legacy / "TrackLines/Stations.txt", "0\tSource\n");
+		const auto result = importLegacyScene(legacy.string(), nestedScene.string(), "Overlap");
+		ok &= expect(!result.wroteScene && hasDiag(result.diagnostics, "scene.import.path", SceneSeverity::Error),
+				"Overlapping source and destination are rejected");
+		ok &= expect(!fs::exists(nestedScene), "Overlap rejection does not create destination");
+	}
+	{
+		TempDir legacyDir, output;
+		writeText(fs::path(legacyDir.dir) / "TrackLines/Stations.txt", "0\tSource\n");
+		writeText(fs::path(legacyDir.dir) / "Trains/broken.txt", "malformed\n");
+		writeText(fs::path(output.dir) / "scene.json", "existing scene bytes\n");
+		const auto result = importLegacyScene(legacyDir.dir, output.dir, "Malformed");
+		ok &= expect(!result.success() && !result.wroteScene, "Malformed source is not published");
+		std::ifstream scene(fs::path(output.dir) / "scene.json");
+		std::string bytes((std::istreambuf_iterator<char>(scene)), std::istreambuf_iterator<char>());
+		ok &= expect(bytes == "existing scene bytes\n", "Malformed import preserves destination");
+	}
 
 	if (!ok)
 		return 1;

--- a/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
@@ -1,13 +1,9 @@
 #include "scene/SceneModel.h"
 #include "scene/SceneValidator.h"
-#include <iostream>
-#include <filesystem>
-#include <fstream>
-#include <chrono>
-#include <nlohmann/json.hpp>
 
-namespace fs = std::filesystem;
-using json = nlohmann::json;
+#include <iostream>
+#include <string>
+#include <vector>
 
 static bool expect(bool condition, const char* message) {
 	if (!condition)
@@ -15,49 +11,90 @@ static bool expect(bool condition, const char* message) {
 	return condition;
 }
 
-static bool hasDiag(const std::vector<SceneDiagnostic>& diags, const std::string& code, SceneSeverity sev = SceneSeverity::Error) {
-	for (const auto& d : diags) {
-		if (d.code == code && d.severity == sev)
+static bool hasCode(const std::vector<SceneDiagnostic>& diagnostics, const std::string& code) {
+	for (const auto& diagnostic : diagnostics) {
+		if (diagnostic.code == code)
 			return true;
 	}
 	return false;
 }
 
-static bool expectDiag(const std::vector<SceneDiagnostic>& diags, const std::string& code, SceneSeverity sev = SceneSeverity::Error) {
-	if (!hasDiag(diags, code, sev)) {
-		std::cerr << "failed: expected diagnostic " << code << "\n";
-		return false;
-	}
-	return true;
-}
+static SceneModel completeScene() {
+	SceneModel scene;
+	scene.schemaVersion = 1;
+	scene.name = "Validator scene";
+	scene.baseTime = "08:00:00";
+	scene.settings.hasDuration = true;
+	scene.settings.durationSeconds = 3600.0;
+	scene.tracks.push_back({"track-1"});
+	scene.nodes.push_back({"node-1", "track-1", 0.0, 0.0});
+	scene.nodes.push_back({"node-2", "track-1", 1.0, 0.0});
+	scene.arcs.push_back({"arc-1", "track-1", "node-1", "node-2", 0.0, 0.0, 40.0});
+	scene.blocks.push_back({"block-1", "track-1", 0.5});
+	scene.blocks.push_back({"block-2", "track-1", 0.5});
+	scene.connections.push_back({"connection-1", "node-1", "node-2", false, 0.0});
 
-// Copy of the fixture scene in a unique temp directory, removed on scope exit.
-struct TempScene {
-	std::string dir;
-	explicit TempScene(const std::string& fixtureDir) {
-		static int counter = 0;
-		auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
-		fs::path temp = fs::temp_directory_path() /
-						("scene_test_" + std::to_string(stamp) + "_" + std::to_string(counter++));
-		fs::create_directories(temp);
-		fs::copy(fixtureDir, temp, fs::copy_options::recursive);
-		dir = temp.string();
-	}
-	~TempScene() {
-		std::error_code ec;
-		fs::remove_all(dir, ec);
-	}
-};
+	SceneStation origin;
+	origin.id = "station-1";
+	origin.name = "Origin";
+	origin.platforms.push_back({"platform-1", {"node-1"}});
+	scene.stations.push_back(origin);
+	SceneStation destination;
+	destination.id = "station-2";
+	destination.name = "Destination";
+	destination.platforms.push_back({"platform-2", {"node-2"}});
+	scene.stations.push_back(destination);
 
-static void modifyFile(const std::string& dir, const std::string& filename, std::function<void(json&)> modifier) {
-	fs::path path = fs::path(dir) / filename;
-	std::ifstream in(path);
-	json j;
-	in >> j;
-	in.close();
-	modifier(j);
-	std::ofstream out(path);
-	out << j.dump(4);
+	scene.signals.push_back({"signal-1"});
+	scene.routes.push_back({"route-1", {"block-1", "block-2"}, false, "", false});
+
+	SceneTrainUnit unit;
+	unit.id = "unit-1";
+	unit.hasPhysical = true;
+	unit.physical.max_speed_ms = 40.0;
+	unit.tractionCurve.push_back({{0.0, 40.0, 100000.0, 0.0, 0.0}});
+	scene.trainUnits.push_back(unit);
+	scene.compositions.push_back({"composition-1", {"unit-1"}});
+
+	SceneService service;
+	service.id = "service-1";
+	service.composition = "composition-1";
+	service.route = "route-1";
+	SceneStop first;
+	first.stationId = "station-1";
+	first.platformId = "platform-1";
+	first.hasPlannedDeparture = true;
+	first.plannedDepartureSeconds = 100.0;
+	SceneStop last;
+	last.stationId = "station-2";
+	last.platformId = "platform-2";
+	last.hasPlannedArrival = true;
+	last.plannedArrivalSeconds = 200.0;
+	service.stops = {first, last};
+	scene.services.push_back(service);
+
+	SceneScenario scenario;
+	scenario.id = "baseline";
+	scenario.name = "Baseline";
+	scenario.incidents.push_back({"incident-1", "signal_failure", "signal-1", 300.0, 600.0});
+	scenario.entranceDelays.push_back({"service-1", 1, "station-1", 10.0});
+	scene.scenarios.push_back(scenario);
+	scene.defaultScenarioId = "baseline";
+
+	ScenePassenger passenger;
+	passenger.id = "passenger-1";
+	ScenePassengerJourney journey;
+	journey.id = "journey-1";
+	journey.originStationId = "station-1";
+	journey.destinationStationId = "station-2";
+	journey.plannedDepartureStartSeconds = 0.0;
+	journey.plannedDepartureEndSeconds = 120.0;
+	journey.plannedArrivalStartSeconds = 180.0;
+	journey.plannedArrivalEndSeconds = 300.0;
+	journey.legs.push_back({"leg-1", "station-1", "station-2", "service-1", 1});
+	passenger.journeys.push_back(journey);
+	scene.passengers.push_back(passenger);
+	return scene;
 }
 
 int main(int argc, char** argv) {
@@ -65,418 +102,72 @@ int main(int argc, char** argv) {
 		std::cerr << "Usage: test_scenevalidator <fixture_dir>\n";
 		return 1;
 	}
-	std::string fixtureDir = argv[1];
+
 	bool ok = true;
+	const SceneModel clean = completeScene();
+	ok &= expect(!hasCode(validateScene(clean), "scene.topology.tracks.none"),
+			"semantic validation does not reject complete topology");
+	ok &= expect(validateScene(clean).empty(), "complete scene passes semantic validation");
+	ok &= expect(validateRunnableScene(clean).empty(), "complete scene passes runnable validation");
 
-	// 1. valid fixture
-	auto diags = validateSceneDirectory(fixtureDir);
-	ok &= expect(expectDiag(diags, "scene.train.traction.empty"), "bare fixture reports empty traction data");
-
-	// 2. nonexistent directory
-	diags = validateSceneDirectory("/no/such/scene/dir");
-	ok &= expect(expectDiag(diags, "scene.dir.missing"), "scene.dir.missing on nonexistent directory");
-
-	// 3. deleted services.json
-	{
-		TempScene tmp(fixtureDir);
-		fs::remove(fs::path(tmp.dir) / "services.json");
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.file.missing"), "scene.file.missing for services.json");
+	struct FailureCase {
+		const char* name;
+		void (*mutate)(SceneModel&);
+		const char* code;
+	};
+	const FailureCase cases[] = {
+		{"duplicate route id", [](SceneModel& scene) { scene.routes.push_back(scene.routes[0]); },
+				"scene.id.duplicate"},
+		{"unknown composition unit", [](SceneModel& scene) { scene.compositions[0].units[0] = "missing-unit"; },
+				"scene.ref.unresolved"},
+		{"unknown stop platform", [](SceneModel& scene) { scene.services[0].stops[0].platformId = "missing-platform"; },
+				"scene.ref.platform"},
+		{"unknown scenario incident target", [](SceneModel& scene) {
+				scene.scenarios[0].incidents[0].target = "missing-signal";
+			}, "scene.ref.unresolved"},
+		{"missing base time", [](SceneModel& scene) { scene.baseTime.clear(); }, "scene.basetime.missing"},
+		{"non-positive duration", [](SceneModel& scene) { scene.settings.durationSeconds = 0.0; },
+				"scene.duration.invalid"},
+		{"empty tracks", [](SceneModel& scene) { scene.tracks.clear(); }, "scene.topology.tracks.none"},
+		{"unbound platform", [](SceneModel& scene) { scene.stations[0].platforms[0].nodeIds.clear(); },
+				"scene.platform.nodes.none"},
+		{"unknown route block", [](SceneModel& scene) { scene.routes[0].blocks[0] = "missing-block"; },
+				"scene.ref.unresolved"},
+		{"unknown default scenario", [](SceneModel& scene) { scene.defaultScenarioId = "missing"; },
+				"scene.ref.unresolved"},
+		{"discontinuous passenger leg", [](SceneModel& scene) {
+				scene.passengers[0].journeys[0].legs[0].destinationStationId = "station-1";
+			}, "scene.passenger.continuity"},
+	};
+	for (const auto& test : cases) {
+		SceneModel broken = clean;
+		test.mutate(broken);
+		const auto diagnostics = validateRunnableScene(broken);
+		ok &= expect(hasCode(diagnostics, test.code), test.name);
 	}
 
-	// 4. truncated JSON in stations.json
-	{
-		TempScene tmp(fixtureDir);
-		std::ofstream out(fs::path(tmp.dir) / "stations.json", std::ios::trunc);
-		out << "{ \"stations\": ["; // Truncated
-		out.close();
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.json.parse"), "scene.json.parse for truncated JSON");
-	}
+	// Composite route entries resolve each basic block after stripping @...@ positions.
+	SceneModel composite = clean;
+	composite.routes[0].blocks = {"@block-1@-10/@block-2@-20"};
+	composite.blockDependencies.push_back({"@block-1@-10/@block-2@-20", "@block-1@-10"});
+	composite.singleTrackRestrictions.push_back({"@block-1@-10", "@block-2@-20",
+			"@block-1@-10", "@block-2@-20"});
+	composite.stationBoundaries.push_back({"@block-1@-10", true, "@block-2@-20", false});
+	ok &= expect(validateScene(composite).empty(), "composite route block components validate");
+	composite.scenarios[0].incidents[0].target = "block-2";
+	ok &= expect(validateScene(composite).empty(), "signal failure accepts a basic block target");
 
-	// 5. scene.json without schema_version
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "scene.json", [](json& j) { j.erase("schema_version"); });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.version.missing"), "scene.version.missing");
-	}
-
-	// 6. schema_version 999
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "scene.json", [](json& j) { j["schema_version"] = 999; });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.version.unsupported"), "scene.version.unsupported");
-	}
-
-	// 7. stop with unknown station id
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) { j["services"][0]["stops"][0]["station"] = "unknown_st"; });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.ref.unresolved"), "unknown station -> scene.ref.unresolved");
-		bool found = false;
-		for (const auto& d : diags) {
-			if (d.code == "scene.ref.unresolved" && !d.itemId.empty() && d.relatedId == "unknown_st") {
-				found = true;
-			}
-		}
-		ok &= expect(found, "unresolved station diagnostic carries itemId and relatedId");
-	}
-
-	// 8. service with unknown composition
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) { j["services"][0]["composition"] = "unknown_comp"; });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.ref.unresolved"), "unknown comp -> scene.ref.unresolved");
-	}
-
-	// 9. platform not on stop's station
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) { j["services"][0]["stops"][0]["platform"] = "unknown_plat"; });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.ref.platform"), "unknown platform -> scene.ref.platform");
-	}
-
-	// 10. compositions emptied; services emptied
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "rolling_stock.json", [](json& j) { j["compositions"] = json::array(); j["train_units"] = json::array(); });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.trains.none"), "scene.trains.none");
-
-		modifyFile(tmp.dir, "services.json", [](json& j) { j["services"] = json::array(); });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.services.none"), "scene.services.none");
-	}
-
-	// 11. empty stops and the through flag
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) {
-			j["services"][0]["stops"] = json::array();
-			j["services"][0]["through"] = true;
-		});
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(!hasDiag(diags, "scene.service.no_stops", SceneSeverity::Warning), "empty stops with through=true -> no scene.service.no_stops");
-	}
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) { j["services"][0]["stops"] = json::array(); });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.service.no_stops", SceneSeverity::Warning), "empty stops without through -> scene.service.no_stops");
-	}
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) { j["services"][0]["through"] = true; });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.service.through_stops", SceneSeverity::Warning), "through=true with stops -> scene.service.through_stops");
-	}
-
-	// 11b. departure order: a negative first departure is legal, a decreasing departure is not
-	{
-		TempScene tmp(fixtureDir);
-		std::string id0, id1;
-		modifyFile(tmp.dir, "services.json", [&](json& j) {
-			id0 = j["services"][0]["id"].get<std::string>();
-			id1 = j["services"][1]["id"].get<std::string>();
-			j["services"][0]["stops"][0]["departure_seconds"] = -600;
-			j["services"][0]["stops"][1]["arrival_seconds"] = 240;
-			j["services"][0]["stops"][1]["departure_seconds"] = 300;
-			j["services"][1]["stops"][1]["arrival_seconds"] = 240;
-			j["services"][1]["stops"][1]["departure_seconds"] = 300;
-		});
-		diags = validateSceneDirectory(tmp.dir);
-		bool orderDiagFirst = false;
-		bool orderDiagSecond = false;
-		for (const auto& d : diags) {
-			if (d.code != "scene.time.order")
-				continue;
-			if (d.itemId == id0)
-				orderDiagFirst = true;
-			if (d.itemId == id1)
-				orderDiagSecond = true;
-		}
-		ok &= expect(!orderDiagFirst, "negative first departure -> no scene.time.order");
-		ok &= expect(orderDiagSecond, "departure before previous stop -> scene.time.order");
-	}
-
-	// 12. departure < arrival; negative dwell
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) {
-			j["services"][0]["stops"][0]["arrival_seconds"] = 100.0;
-			j["services"][0]["stops"][0]["departure_seconds"] = 90.0;
-			j["services"][0]["stops"][0]["dwell_seconds"] = -5.0;
-		});
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.time.invalid"), "departure < arrival -> scene.time.invalid");
-		ok &= expect(expectDiag(diags, "scene.dwell.invalid"), "negative dwell -> scene.dwell.invalid");
-		bool pathFound = false;
-		for (const auto& d : diags) {
-			if (d.code == "scene.time.invalid" && d.path.find("stops[0]") != std::string::npos) {
-				pathFound = true;
-			}
-		}
-		ok &= expect(pathFound, "time diagnostic names the stop in its path");
-	}
-
-	// 13. dwell larger than departure-arrival window
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) {
-			j["services"][0]["stops"][0]["arrival_seconds"] = 100.0;
-			j["services"][0]["stops"][0]["departure_seconds"] = 120.0;
-			j["services"][0]["stops"][0]["dwell_seconds"] = 30.0;
-		});
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.dwell.exceeds_window", SceneSeverity::Warning), "dwell > window -> scene.dwell.exceeds_window Warning");
-	}
-
-	// 14. incident with unknown target
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "incidents.json", [](json& j) { j["incidents"][0]["target"] = "unknown_sig"; });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.ref.unresolved"), "incident unknown target -> scene.ref.unresolved");
-		bool found = false;
-		for (const auto& d : diags) {
-			if (d.code == "scene.ref.unresolved" && d.itemType == "incident") {
-				found = true;
-			}
-		}
-		ok &= expect(found, "unresolved incident target has itemType incident");
-	}
-
-	// 15. composition with unknown unit id; composition with units: []; route with blocks: []
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "rolling_stock.json", [](json& j) {
-			j["compositions"][0]["units"][0] = "unknown_unit";
-		});
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.ref.unresolved"), "unknown unit -> scene.ref.unresolved");
-
-		modifyFile(tmp.dir, "rolling_stock.json", [](json& j) { j["compositions"][0]["units"] = json::array(); });
-		modifyFile(tmp.dir, "signalling.json", [](json& j) { j["routes"][0]["blocks"] = json::array(); });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.composition.empty"), "scene.composition.empty");
-		ok &= expect(expectDiag(diags, "scene.route.empty"), "scene.route.empty");
-	}
-
-	// 16. cascade policy: scene with a structural error -> no semantic ones
-	{
-		TempScene tmp(fixtureDir);
-		std::ofstream out(fs::path(tmp.dir) / "services.json", std::ios::trunc);
-		out << "{ bad json }";
-		out.close();
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.json.parse"), "cascade policy structural error present");
-		ok &= expect(!hasDiag(diags, "scene.services.none", SceneSeverity::Error), "semantic errors skipped");
-	}
-
-	// 17. mistyped required section
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) { j["services"] = json::object(); });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.section.missing"), "mistyped services section -> scene.section.missing");
-	}
-
-	// 18. missing required fields; arrival is optional on any stop
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) {
-			j["services"][0]["stops"][0].erase("departure_seconds"); // first stop -> missing
-			j["services"][0]["stops"][1].erase("arrival_seconds");	 // allowed: no scheduled arrival
-		});
-		modifyFile(tmp.dir, "scene.json", [](json& j) { j.erase("name"); });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.field.missing"), "missing fields -> scene.field.missing");
-		int fieldErrors = 0;
-		for (const auto& d : diags) {
-			if (d.code == "scene.field.missing")
-				++fieldErrors;
-		}
-		ok &= expect(fieldErrors == 2, "missing departure and name reported; omitted arrival is valid");
-	}
-
-	// 18b. repeat headway <= 0
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "services.json", [](json& j) {
-			j["services"][1]["repeat"]["headway_seconds"] = 0;
-		});
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.repeat.invalid"), "headway <= 0 -> scene.repeat.invalid");
-	}
-
-	// 19. unknown incident type
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "incidents.json", [](json& j) { j["incidents"][0]["type"] = "signal_flicker"; });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.incident.type"), "unknown incident type -> scene.incident.type");
-	}
-
-	// 20. unsupported units
-	{
-		TempScene tmp(fixtureDir);
-		modifyFile(tmp.dir, "scene.json", [](json& j) { j["units"]["time"] = "min"; });
-		diags = validateSceneDirectory(tmp.dir);
-		ok &= expect(expectDiag(diags, "scene.units.unsupported"), "unsupported unit -> scene.units.unsupported");
-	}
-
-	// 21. Diagnostic unit checks
-	SceneDiagnostic unitDiag;
-	unitDiag.severity = SceneSeverity::Warning;
-	unitDiag.code = "test.code";
-	unitDiag.message = "Test message";
-	unitDiag.file = "test.json";
-	unitDiag.itemType = "service";
-	unitDiag.itemId = "svc1";
-	unitDiag.path = "services[0].stops[0]";
-	unitDiag.relatedId = "st1";
-	unitDiag.suggestedFix = "Change to st2";
-
-	std::string text = toDisplayText(unitDiag);
-	ok &= expect(text.find("warning") != std::string::npos, "text contains severity");
-	ok &= expect(text.find("test.code") != std::string::npos, "text contains code");
-	ok &= expect(text.find("svc1") != std::string::npos, "text contains itemId");
-	ok &= expect(text.find("services[0].stops[0]") != std::string::npos, "text contains path");
-	ok &= expect(text.find("Change to st2") != std::string::npos, "text contains fix");
-
-	json jDiag = toJson(unitDiag);
-	ok &= expect(jDiag["severity"] == "warning", "json severity");
-	ok &= expect(jDiag["code"] == "test.code", "json code");
-	ok &= expect(jDiag["relatedId"] == "st1", "json relatedId");
-	ok &= expect(jDiag["path"] == "services[0].stops[0]", "json path");
-
-	std::vector<SceneDiagnostic> errs = {unitDiag};
-	ok &= expect(!hasErrors(errs), "warning is not an error");
-	unitDiag.severity = SceneSeverity::Error;
-	errs = {unitDiag};
-	ok &= expect(hasErrors(errs), "error is an error");
-
-	// 22. In-memory SceneModel: countDiagnostics on a clean model vs. one with
-	// a service referencing a nonexistent composition and route.
-	{
-		auto buildCleanModel = []() {
-			SceneModel scene;
-			scene.schemaVersion = 1;
-			scene.name = "unit_test_scene";
-
-			SceneStation station;
-			station.id = "st1";
-			station.name = "Station One";
-			ScenePlatform platform;
-			platform.id = "p1";
-			station.platforms.push_back(platform);
-			scene.stations.push_back(station);
-
-			SceneTrainUnit unit;
-			unit.id = "tu1";
-			unit.tractionCurve.push_back({{0.0, 1.0, 1.0, 0.0, 0.0}});
-			scene.trainUnits.push_back(unit);
-
-			SceneComposition comp;
-			comp.id = "comp1";
-			comp.units.push_back("tu1");
-			scene.compositions.push_back(comp);
-
-			SceneRoute route;
-			route.id = "r1";
-			route.blocks.push_back("b1");
-			scene.routes.push_back(route);
-
-			SceneService service;
-			service.id = "svc1";
-			service.composition = "comp1";
-			service.route = "r1";
-			SceneStop stop;
-			stop.stationId = "st1";
-			stop.platformId = "p1";
-			stop.hasArrival = true;
-			stop.arrivalSeconds = 100.0;
-			stop.hasDeparture = true;
-			stop.departureSeconds = 200.0;
-			stop.dwellSeconds = 50.0;
-			service.stops.push_back(stop);
-			scene.services.push_back(service);
-
-			return scene;
-		};
-
-		SceneModel clean = buildCleanModel();
-		auto cleanDiags = validateScene(clean);
-		SceneDiagnosticCounts cleanCounts = countDiagnostics(cleanDiags);
-		ok &= expect(cleanCounts.errors == 0, "clean in-memory model has zero errors");
-
-		SceneModel broken = buildCleanModel();
-		broken.services[0].composition = "unknown_comp";
-		broken.services[0].route = "unknown_route";
-		auto brokenDiags = validateScene(broken);
-		ok &= expect(hasErrors(brokenDiags), "broken in-memory model reports at least one error");
-		SceneDiagnosticCounts brokenCounts = countDiagnostics(brokenDiags);
-		ok &= expect(brokenCounts.errors >= 2, "unknown composition and route each report an error");
-		ok &= expect(expectDiag(brokenDiags, "scene.ref.unresolved"), "unknown composition/route -> scene.ref.unresolved");
-	}
-
-	// 23. train-unit traction curve semantics
-	{
-		auto buildTractionModel = [](const std::vector<std::array<double, 5>>& curve) {
-			SceneModel scene;
-			scene.schemaVersion = 1;
-			SceneTrainUnit unit;
-			unit.id = "tu_curve";
-			unit.hasPhysical = false;
-			unit.tractionCurve = curve;
-			scene.trainUnits.push_back(unit);
-			SceneComposition composition;
-			composition.id = "comp_curve";
-			composition.units.push_back(unit.id);
-			scene.compositions.push_back(composition);
-			SceneRoute route;
-			route.id = "route_curve";
-			route.blocks.push_back("block_curve");
-			scene.routes.push_back(route);
-			SceneService service;
-			service.id = "svc_curve";
-			service.composition = composition.id;
-			service.route = route.id;
-			service.through = true;
-			scene.services.push_back(service);
-			return scene;
-		};
-
-		auto diagsFor = [&](const std::vector<std::array<double, 5>>& curve) {
-			return validateScene(buildTractionModel(curve));
-		};
-		std::vector<std::array<double, 5>> emptyCurve;
-		ok &= expect(expectDiag(diagsFor(emptyCurve), "scene.train.traction.empty"),
-				"empty traction curve -> scene.train.traction.empty");
-		ok &= expect(expectDiag(diagsFor({{{10.0, 10.0, 1.0, 0.0, 0.0}}}), "scene.train.traction.interval"),
-				"degenerate traction interval -> scene.train.traction.interval");
-		ok &= expect(expectDiag(diagsFor({{{10.0, 20.0, 1.0, 0.0, 0.0}}, {{0.0, 5.0, 1.0, 0.0, 0.0}}}),
-					"scene.train.traction.order"),
-				"descending traction rows -> scene.train.traction.order");
-		ok &= expect(expectDiag(diagsFor({{{0.0, 10.0, 1.0, 0.0, 0.0}}, {{5.0, 20.0, 1.0, 0.0, 0.0}}}),
-					"scene.train.traction.overlap"),
-				"overlapping traction rows -> scene.train.traction.overlap");
-		const auto adjacentDiags = diagsFor({{{0.0, 10.0, 1.0, 0.0, 0.0}}, {{10.0, 20.0, 1.0, 0.0, 0.0}}});
-		ok &= expect(!hasDiag(adjacentDiags, "scene.train.traction.empty")
-				&& !hasDiag(adjacentDiags, "scene.train.traction.interval")
-				&& !hasDiag(adjacentDiags, "scene.train.traction.order")
-				&& !hasDiag(adjacentDiags, "scene.train.traction.overlap"),
-				"adjacent traction rows are valid");
-	}
+	const std::string fixtureDir = argv[1];
+	ok &= expect(!hasErrors(validateSceneStructure(fixtureDir)),
+			"historical fixture remains structurally loadable");
+	const auto runnableFixture = validateRunnableSceneDirectory(fixtureDir);
+	ok &= expect(hasCode(runnableFixture, "scene.topology.tracks.none"),
+			"incomplete historical fixture fails runnable validation");
+	ok &= expect(hasCode(validateSceneStructure("/no/such/scene/dir"), "scene.dir.missing"),
+			"missing directory reports structural error");
 
 	if (!ok)
 		return 1;
-
 	std::cout << "all SceneValidator tests passed\n";
 	return 0;
 }

--- a/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
@@ -126,6 +126,8 @@ int main(int argc, char** argv) {
 				scene.scenarios[0].incidents[0].target = "missing-signal";
 			}, "scene.ref.unresolved"},
 		{"missing base time", [](SceneModel& scene) { scene.baseTime.clear(); }, "scene.basetime.missing"},
+		{"out-of-range base time", [](SceneModel& scene) { scene.baseTime = "24:00:00"; },
+				"scene.basetime.invalid"},
 		{"non-positive duration", [](SceneModel& scene) { scene.settings.durationSeconds = 0.0; },
 				"scene.duration.invalid"},
 		{"empty tracks", [](SceneModel& scene) { scene.tracks.clear(); }, "scene.topology.tracks.none"},

--- a/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 
 namespace fs = std::filesystem;
+using json = nlohmann::json;
 
 static bool expect(bool condition, const char* message) {
 	if (!condition)
@@ -15,350 +16,236 @@ static bool expect(bool condition, const char* message) {
 	return condition;
 }
 
-static void printErrors(const std::vector<SceneDiagnostic>& diags, const char* label) {
-	for (const auto& d : diags) {
-		if (d.severity == SceneSeverity::Error)
-			std::cerr << label << ": " << toDisplayText(d) << "\n";
+static void printErrors(const std::vector<SceneDiagnostic>& diagnostics, const char* label) {
+	for (const auto& diagnostic : diagnostics) {
+		if (diagnostic.severity == SceneSeverity::Error)
+			std::cerr << label << ": " << toDisplayText(diagnostic) << "\n";
 	}
-}
-
-static const SceneLoadedData* findLoadedData(const SceneModel& scene, const std::string& category) {
-	for (const auto& item : scene.loadedData) {
-		if (item.category == category)
-			return &item;
-	}
-	return nullptr;
-}
-
-static const SceneLoadedData* findLoadedDataChild(const SceneLoadedData* parent, const std::string& category) {
-	if (!parent)
-		return nullptr;
-	for (const auto& item : parent->children) {
-		if (item.category == category)
-			return &item;
-	}
-	return nullptr;
-}
-
-static const SceneLoadedData* findLoadedDataChildSource(const SceneLoadedData* parent, const std::string& sourceFile) {
-	if (!parent)
-		return nullptr;
-	for (const auto& item : parent->children) {
-		if (item.sourceFile == sourceFile)
-			return &item;
-	}
-	return nullptr;
-}
-
-struct ExpectedStop {
-	const char* station;
-	double dwell;
-	bool hasArrival;
-	double arrival;
-	bool hasDeparture;
-	double departure;
-};
-
-struct ExpectedService {
-	const char* id;
-	const char* route;
-	double entry;
-	const ExpectedStop* stops;
-	size_t stopCount;
-};
-
-static bool expectAssignmentTimetable(const SceneModel& scene) {
-	static const ExpectedStop ic1723Stops[] = {
-		{"Gvc", 0, false, 0, true, 480},
-		{"Gdg", 60, true, 1440, true, 1500},
-		{"Ut", 0, true, 2580, false, 0},
-	};
-	static const ExpectedStop s19825Stops[] = {
-		{"Gvc", 0, false, 0, true, 660},
-		{"Gdg", 20, true, 2280, false, 0},
-	};
-	static const ExpectedStop ic2025Stops[] = {
-		{"Gvc", 0, false, 0, true, 1380},
-		{"Gdg", 60, true, 2340, true, 2400},
-		{"Ut", 0, true, 3480, false, 0},
-	};
-	static const ExpectedStop s9827Stops[] = {
-		{"Gvc", 0, false, 0, true, 1560},
-		{"Gdg", 20, true, 3180, true, 3540},
-		{"Ut", 0, true, 4920, false, 0},
-	};
-	static const ExpectedService expected[] = {
-		{"IC1723", "route0", 420, ic1723Stops, 3},
-		{"S19825", "route0", 600, s19825Stops, 2},
-		{"IC2025", "route0", 1320, ic2025Stops, 3},
-		{"S9827", "route0", 1500, s9827Stops, 3},
-	};
-
-	bool ok = expect(scene.services.size() == 4, "assignment timetable service count is 4");
-	const size_t count = scene.services.size() < 4 ? scene.services.size() : 4;
-	for (size_t i = 0; i < count; ++i) {
-		const SceneService& service = scene.services[i];
-		const ExpectedService& want = expected[i];
-		ok &= expect(service.id == want.id, "service id and order match assignment timetable");
-		ok &= expect(service.route == want.route, "service route matches assignment timetable");
-		ok &= expect(service.composition == "sprinter_single", "service composition matches assignment timetable");
-		ok &= expect(service.hasEntryTime && service.entryTimeSeconds == want.entry, "service entry time matches assignment timetable");
-		ok &= expect(service.hasRepeat && service.headwaySeconds == 1800, "service repeat headway matches assignment timetable");
-		ok &= expect(service.stops.size() == want.stopCount, "service stop shape matches assignment timetable");
-		const size_t stopCount = service.stops.size() < want.stopCount ? service.stops.size() : want.stopCount;
-		for (size_t j = 0; j < stopCount; ++j) {
-			const SceneStop& stop = service.stops[j];
-			const ExpectedStop& expectedStop = want.stops[j];
-			ok &= expect(stop.stationId == expectedStop.station, "stop station matches assignment timetable");
-			ok &= expect(stop.dwellSeconds == expectedStop.dwell, "stop dwell matches assignment timetable");
-			ok &= expect(stop.hasArrival == expectedStop.hasArrival, "stop arrival shape matches assignment timetable");
-			ok &= expect(!stop.hasArrival || stop.arrivalSeconds == expectedStop.arrival, "stop arrival matches assignment timetable");
-			ok &= expect(stop.hasDeparture == expectedStop.hasDeparture, "stop departure shape matches assignment timetable");
-			ok &= expect(!stop.hasDeparture || stop.departureSeconds == expectedStop.departure, "stop departure matches assignment timetable");
-		}
-	}
-	return ok;
 }
 
 struct TempDir {
-	std::string dir;
+	fs::path path;
 
 	TempDir() {
 		static int counter = 0;
-		auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
-		fs::path temp = fs::temp_directory_path() / ("scene_writer_test_" + std::to_string(stamp) + "_" + std::to_string(counter++));
-		fs::create_directories(temp);
-		dir = temp.string();
+		const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+		path = fs::temp_directory_path() / ("scene_writer_test_" + std::to_string(stamp) + "_"
+				+ std::to_string(counter++));
+		fs::create_directories(path);
 	}
 
 	~TempDir() {
-		std::error_code ec;
-		fs::remove_all(dir, ec);
+		std::error_code error;
+		fs::remove_all(path, error);
 	}
 };
 
-int main(int argc, char** argv) {
-	if (argc < 2) {
-		std::cerr << "Usage: test_scenewriter <scenes_dir>\n";
-		return 1;
-	}
+static SceneModel completeScene() {
+	SceneModel scene;
+	scene.schemaVersion = 1;
+	scene.name = "Canonical complete scene";
+	scene.description = "Writer round-trip";
+	scene.baseTime = "08:00:00";
+	scene.settings.hasDuration = true;
+	scene.settings.durationSeconds = 3600.0;
+	scene.settings.hasBufferTime = true;
+	scene.settings.bufferTimeSeconds = 120.0;
+	scene.settings.hasRecoveryTime = true;
+	scene.settings.recoveryTimePercent = 5.0;
 
+	scene.tracks.push_back({"track-1"});
+	scene.nodes.push_back({"node-1", "track-1", 0.0, 0.0});
+	scene.nodes.push_back({"node-2", "track-1", 1.0, 0.0});
+	scene.arcs.push_back({"arc-1", "track-1", "node-1", "node-2", 0.0, 0.0, 40.0});
+	scene.blocks.push_back({"block-1", "track-1", 0.5});
+	scene.blocks.push_back({"block-2", "track-1", 0.5});
+	scene.connections.push_back({"connection-1", "node-1", "node-2", true, 30.0});
+
+	SceneStation first;
+	first.id = "station-1";
+	first.name = "Origin";
+	first.platforms.push_back({"platform-1", {"node-1"}});
+	scene.stations.push_back(first);
+	SceneStation second;
+	second.id = "station-2";
+	second.name = "Destination";
+	second.platforms.push_back({"platform-2", {"node-2"}});
+	scene.stations.push_back(second);
+
+	scene.signals.push_back({"signal-1"});
+	SceneRoute route;
+	route.id = "route-1";
+	route.blocks = {"block-1", "block-2"};
+	route.hasCorridor = true;
+	route.corridor = "corridor-1";
+	route.reversed = true;
+	scene.routes.push_back(route);
+	scene.blockDependencies.push_back({"block-2", "block-1"});
+	scene.singleTrackRestrictions.push_back({"block-1", "block-2", "block-1", "block-2"});
+	scene.stationBoundaries.push_back({"block-1", true, "block-2", false});
+
+	SceneTrainUnit unit;
+	unit.id = "unit-1";
+	unit.hasPhysical = true;
+	unit.physical.mass_of_traction_unit_kg = 100000.0;
+	unit.physical.max_speed_ms = 40.0;
+	unit.physical.max_deceleration_ms2 = 0.7;
+	unit.physical.length_m = 50.0;
+	unit.tractionCurve.push_back({{0.0, 40.0, 100000.0, 0.0, 0.0}});
+	unit.sourceDataFile = "/TrainData/unit-1.txt";
+	scene.trainUnits.push_back(unit);
+	scene.compositions.push_back({"composition-1", {"unit-1"}});
+
+	SceneService service;
+	service.id = "service-1";
+	service.operatingCode = "R100";
+	service.composition = "composition-1";
+	service.route = "route-1";
+	service.hasEntryTime = true;
+	service.entryTimeSeconds = 60.0;
+	SceneStop origin;
+	origin.stationId = "station-1";
+	origin.platformId = "platform-1";
+	origin.hasPlannedDeparture = true;
+	origin.plannedDepartureSeconds = 100.0;
+	SceneStop destination;
+	destination.stationId = "station-2";
+	destination.platformId = "platform-2";
+	destination.hasPlannedArrival = true;
+	destination.plannedArrivalSeconds = 200.0;
+	service.stops = {origin, destination};
+	scene.services.push_back(service);
+
+	SceneScenario baseline;
+	baseline.id = "baseline";
+	baseline.name = "Baseline";
+	baseline.description = "No disruption";
+	baseline.incidents.push_back({"incident-1", "signal_failure", "signal-1", 300.0, 600.0});
+	baseline.entranceDelays.push_back({"service-1", 1, "station-1", 30.0});
+	scene.scenarios.push_back(baseline);
+	SceneScenario alternate;
+	alternate.id = "alternate";
+	alternate.name = "Alternate";
+	scene.scenarios.push_back(alternate);
+	scene.defaultScenarioId = "baseline";
+
+	ScenePassenger passenger;
+	passenger.id = "passenger-1";
+	ScenePassengerJourney journey;
+	journey.id = "journey-1";
+	journey.activity = "commute";
+	journey.originStationId = "station-1";
+	journey.destinationStationId = "station-2";
+	journey.plannedDepartureStartSeconds = 0.0;
+	journey.plannedDepartureEndSeconds = 120.0;
+	journey.plannedArrivalStartSeconds = 180.0;
+	journey.plannedArrivalEndSeconds = 300.0;
+	journey.legs.push_back({"leg-1", "station-1", "station-2", "service-1", 1});
+	passenger.journeys.push_back(journey);
+	scene.passengers.push_back(passenger);
+
+	scene.importReport.push_back({"stations", "legacy/stations", 2, 2, 0, 0});
+	return scene;
+}
+
+static bool loadHasNoErrors(const fs::path& scenePath, SceneModel& scene) {
+	SceneLoadResult loaded = loadScene(scenePath.string());
+	printErrors(loaded.diagnostics, "load");
+	scene = loaded.scene;
+	return !hasErrors(loaded.diagnostics);
+}
+
+int main() {
 	bool ok = true;
-	fs::path sceneDir = fs::path(argv[1]) / "Assignment_Gvc_Gdg_Ut";
-	auto loadRes = loadScene(sceneDir.string());
-	printErrors(loadRes.diagnostics, "load");
-	ok &= expect(!hasErrors(loadRes.diagnostics), "assignment scene loads without structural errors");
+	TempDir temp;
+	SceneModel source = completeScene();
+	SceneSaveResult saved = saveScene(source, temp.path.string());
+	printErrors(saved.diagnostics, "save");
+	ok &= expect(saved.success(), "complete canonical scene saves");
+	for (const char* file : {"scene.json", "infrastructure.json", "stations.json", "signalling.json",
+			"rolling_stock.json", "services.json", "scenarios.json", "passengers.json"})
+		ok &= expect(fs::exists(temp.path / file), "all canonical files are written");
+	ok &= expect(!fs::exists(temp.path / "incidents.json"), "writer does not emit flat incidents.json");
 
-	const SceneModel& scene = loadRes.scene;
-	ok &= expect(scene.schemaVersion == 1, "schema version loaded");
-	ok &= expect(scene.name == "Assignment Gvc-Gdg-Ut", "scene name loaded");
-	ok &= expect(scene.description == "Den Haag Centraal - Gouda - Utrecht Centraal corridor", "description loaded");
-	ok &= expect(!scene.loadedData.empty(), "loaded data summary present");
-	const SceneLoadedData* sceneData = findLoadedData(scene, "scene");
-	ok &= expect(sceneData && sceneData->sourceFile == "scene.json" && sceneData->parsedCount == 1 && sceneData->status == "loaded", "scene loaded data summary");
-	const SceneLoadedData* stationData = findLoadedData(scene, "stations");
-	ok &= expect(stationData && stationData->sourceFile == "stations.json" && stationData->parsedCount == 3 && stationData->status == "loaded", "stations loaded data summary");
-	const SceneLoadedData* stationRawData = findLoadedDataChild(stationData, "raw_file");
-	ok &= expect(stationRawData && stationRawData->sourceFile == "stations.json" && stationRawData->parsedCount == 1 && stationRawData->status == "loaded", "stations raw file drilldown");
-	const SceneLoadedData* stationParsedData = findLoadedDataChild(stationData, "parsed_objects");
-	ok &= expect(stationParsedData && stationParsedData->sourceFile == "stations.json" && stationParsedData->parsedCount == 3 && stationParsedData->status == "loaded", "stations parsed object drilldown");
-	const SceneLoadedData* timetableData = findLoadedData(scene, "timetable");
-	ok &= expect(timetableData && timetableData->sourceFile == "services.json" && timetableData->parsedCount == 4 && timetableData->status == "loaded", "timetable loaded data summary");
-	const SceneLoadedData* timetableRawData = findLoadedDataChild(timetableData, "raw_file");
-	ok &= expect(timetableRawData && timetableRawData->sourceFile == "services.json" && timetableRawData->parsedCount == 1 && timetableRawData->status == "loaded", "timetable raw file drilldown");
-	const SceneLoadedData* timetableParsedData = findLoadedDataChild(timetableData, "parsed_objects");
-	ok &= expect(timetableParsedData && timetableParsedData->sourceFile == "services.json" && timetableParsedData->parsedCount == 4 && timetableParsedData->status == "loaded", "timetable parsed object drilldown");
-	const SceneLoadedData* passengerData = findLoadedData(scene, "passenger_data");
-	ok &= expect(passengerData && passengerData->status == "unimplemented", "passenger data visible as unimplemented");
-	const SceneLoadedData* signallingData = findLoadedData(scene, "signalling");
-	ok &= expect(signallingData && signallingData->sourceFile == "signalling.json" && signallingData->parsedCount == 2 && signallingData->status == "loaded", "signalling loaded data summary");
-	const SceneLoadedData* signalsData = findLoadedDataChild(signallingData, "signals");
-	ok &= expect(signalsData && signalsData->sourceFile == "signalling.json" && signalsData->parsedCount == 0 && signalsData->status == "loaded", "signalling signals drilldown");
-	const SceneLoadedData* routesData = findLoadedDataChild(signallingData, "routes");
-	ok &= expect(routesData && routesData->sourceFile == "signalling.json" && routesData->parsedCount == 2 && routesData->status == "loaded", "signalling routes drilldown");
+	json services;
 	{
-		SceneModel sceneWithDiagnostics = scene;
-		std::vector<SceneDiagnostic> diagnostics;
-		SceneDiagnostic serviceError;
-		serviceError.severity = SceneSeverity::Error;
-		serviceError.file = "services.json";
-		diagnostics.push_back(serviceError);
-		SceneDiagnostic stationWarning;
-		stationWarning.severity = SceneSeverity::Warning;
-		stationWarning.file = "stations.json";
-		diagnostics.push_back(stationWarning);
-		refreshLoadedDataDiagnostics(sceneWithDiagnostics, diagnostics);
-		const SceneLoadedData* stationValidation = findLoadedDataChild(findLoadedData(sceneWithDiagnostics, "stations"), "validation");
-		ok &= expect(stationValidation && stationValidation->parsedCount == 1 && stationValidation->status == "1 warning", "stations validation warning summary");
-		const SceneLoadedData* timetableValidation = findLoadedDataChild(findLoadedData(sceneWithDiagnostics, "timetable"), "validation");
-		ok &= expect(timetableValidation && timetableValidation->parsedCount == 1 && timetableValidation->status == "1 error", "timetable validation error summary");
-		const SceneLoadedData* rollingValidation = findLoadedDataChild(findLoadedData(sceneWithDiagnostics, "rolling_stock"), "validation");
-		ok &= expect(rollingValidation && rollingValidation->parsedCount == 0 && rollingValidation->status == "ok", "clean category validation summary");
+		std::ifstream input(temp.path / "services.json");
+		input >> services;
 	}
-	ok &= expect(scene.baseTime == "07:00:00", "base_time loaded");
-	ok &= expect(scene.stations.size() == 3, "station count loaded");
-	ok &= expect(scene.routes.size() == 2, "route count loaded");
-	ok &= expectAssignmentTimetable(scene);
-	ok &= expect(scene.trainUnits.size() == 1, "train unit count loaded");
-	ok &= expect(scene.compositions.size() == 1, "composition count loaded");
+	const json& firstStop = services["services"][0]["stops"][0];
+	ok &= expect(services["services"][0]["operating_code"] == "R100",
+			"writer emits the service operating code");
+	ok &= expect(firstStop.contains("planned_departure_seconds"), "writer emits planned departure");
+	ok &= expect(!firstStop.contains("departure_seconds"), "writer omits legacy departure alias");
+	const json& lastStop = services["services"][0]["stops"][1];
+	ok &= expect(lastStop.contains("planned_arrival_seconds"), "writer emits planned arrival");
+	ok &= expect(!lastStop.contains("arrival_seconds"), "writer omits legacy arrival alias");
 
+	json scenarios;
 	{
-		SceneModel sourceScene = scene;
-		sourceScene.trainUnits[0].sourceDataFile = "/TrainData/LITRA_SA.txt";
-		sourceScene.trainUnits[0].sourceTractionFile = "/TrainData/T_LITRA_SA.txt";
-		refreshLoadedDataSummary(sourceScene);
-		const SceneLoadedData* rollingStockData = findLoadedData(sourceScene, "rolling_stock");
-		const SceneLoadedData* trainUnitsData = findLoadedDataChild(rollingStockData, "train_units");
-		ok &= expect(trainUnitsData && trainUnitsData->parsedCount == 1 && trainUnitsData->status == "loaded", "rolling stock train unit drilldown");
-		const SceneLoadedData* compositionsData = findLoadedDataChild(rollingStockData, "compositions");
-		ok &= expect(compositionsData && compositionsData->parsedCount == 1 && compositionsData->status == "loaded", "rolling stock composition drilldown");
-		const SceneLoadedData* sourceFilesData = findLoadedDataChild(rollingStockData, "source_files");
-		ok &= expect(sourceFilesData && sourceFilesData->parsedCount == 2 && sourceFilesData->status == "loaded", "rolling stock source file drilldown");
-		ok &= expect(findLoadedDataChildSource(sourceFilesData, "/TrainData/LITRA_SA.txt") != nullptr, "rolling stock LITRA source file visible");
-		ok &= expect(findLoadedDataChildSource(sourceFilesData, "/TrainData/T_LITRA_SA.txt") != nullptr, "rolling stock T_LITRA source file visible");
+		std::ifstream input(temp.path / "scenarios.json");
+		input >> scenarios;
 	}
+	ok &= expect(scenarios["default_scenario_id"] == "baseline", "writer emits default_scenario_id");
+	ok &= expect(scenarios["scenarios"].size() == 2, "writer emits named scenarios");
 
-	SceneModel sceneToWrite = scene;
-	if (!sceneToWrite.services.empty()) {
-		sceneToWrite.services[0].through = true;
-	}
-
-	TempDir outDir;
-	auto saveRes = saveScene(sceneToWrite, outDir.dir);
-	printErrors(saveRes.diagnostics, "save");
-	ok &= expect(saveRes.success(), "first save succeeds");
-	ok &= expect(!fs::exists(fs::path(outDir.dir) / "legacy"), "saveScene does not create legacy folder");
+	json passengers;
 	{
-		std::ifstream sceneFile(fs::path(outDir.dir) / "scene.json");
-		nlohmann::json sceneJson;
-		sceneFile >> sceneJson;
-		ok &= expect(!sceneJson.contains("loaded_data"), "loaded data metadata is not written to scene.json");
+		std::ifstream input(temp.path / "passengers.json");
+		input >> passengers;
 	}
+	ok &= expect(passengers["passengers"][0]["journeys"][0].contains("planned_departure"),
+			"writer emits passenger departure window");
+	ok &= expect(passengers["passengers"][0]["journeys"][0]["legs"].size() == 1,
+			"writer emits ordered passenger legs");
 
-	auto reloadRes = loadScene(outDir.dir);
-	printErrors(reloadRes.diagnostics, "reload");
-	ok &= expect(!hasErrors(reloadRes.diagnostics), "saved scene reloads without structural errors");
+	SceneModel reloaded;
+	ok &= expect(loadHasNoErrors(temp.path, reloaded), "canonical scene reloads without structural errors");
+	ok &= expect(reloaded.tracks.size() == 1 && reloaded.nodes.size() == 2 && reloaded.blocks.size() == 2,
+			"topology round-trips");
+	ok &= expect(reloaded.routes[0].corridor == "corridor-1" && reloaded.routes[0].reversed,
+			"route corridor and direction round-trip");
+	ok &= expect(reloaded.services[0].stops[0].hasPlannedDeparture
+				&& reloaded.services[0].stops[0].plannedDepartureSeconds == 100.0,
+			"planned departure round-trips");
+	ok &= expect(reloaded.services[0].operatingCode == "R100", "service operating code round-trips");
+	ok &= expect(reloaded.services[0].stops[1].hasPlannedArrival
+				&& reloaded.services[0].stops[1].plannedArrivalSeconds == 200.0,
+			"planned arrival round-trips");
+	ok &= expect(reloaded.defaultScenarioId == "baseline" && reloaded.scenarios.size() == 2,
+			"scenario selection round-trips");
+	ok &= expect(reloaded.passengers.size() == 1 && reloaded.passengers[0].journeys.size() == 1,
+			"passenger journey round-trips");
+	ok &= expect(reloaded.trainUnits[0].sourceDataFile == "/TrainData/unit-1.txt"
+				&& reloaded.trainUnits[0].sourceTractionFile.empty(),
+			"rolling provenance fields are independently optional");
 
-	const SceneModel& reloaded = reloadRes.scene;
-	ok &= expect(reloaded.schemaVersion == 1, "schema version round-trips");
-	ok &= expect(reloaded.name == scene.name, "scene name round-trips");
-	ok &= expect(reloaded.description == scene.description, "description round-trips");
-	ok &= expect(reloaded.baseTime == scene.baseTime, "base_time round-trips");
-	ok &= expect(reloaded.stations.size() == scene.stations.size(), "station count round-trips");
-	ok &= expect(reloaded.routes.size() == scene.routes.size(), "route count round-trips");
-	ok &= expect(reloaded.services.size() == scene.services.size(), "service count round-trips");
-	ok &= expect(reloaded.trainUnits.size() == scene.trainUnits.size(), "train unit count round-trips");
-	ok &= expect(reloaded.compositions.size() == scene.compositions.size(), "composition count round-trips");
-	ok &= expect(reloaded.loadedData.size() == scene.loadedData.size(), "loaded data summary count round-trips");
-	const SceneLoadedData* reloadedSceneData = findLoadedData(reloaded, "scene");
-	ok &= expect(reloadedSceneData && reloadedSceneData->sourceFile == "scene.json" && reloadedSceneData->parsedCount == 1 && reloadedSceneData->status == "loaded", "loaded data scene round-trips");
-	const SceneLoadedData* reloadedStationData = findLoadedData(reloaded, "stations");
-	ok &= expect(reloadedStationData && reloadedStationData->sourceFile == "stations.json" && reloadedStationData->parsedCount == 3 && reloadedStationData->status == "loaded", "loaded data stations round-trips");
-	const SceneLoadedData* reloadedStationRawData = findLoadedDataChild(reloadedStationData, "raw_file");
-	ok &= expect(reloadedStationRawData && reloadedStationRawData->sourceFile == "stations.json" && reloadedStationRawData->parsedCount == 1 && reloadedStationRawData->status == "loaded", "loaded data station raw file round-trips");
-
-	if (!reloaded.stations.empty()) {
-		ok &= expect(reloaded.stations[0].id == "Gvc", "first station id round-trips");
-		ok &= expect(reloaded.stations[0].name == "Den Haag Centraal", "first station name round-trips");
-		ok &= expect(reloaded.stations[0].platforms.size() == 2, "first station platforms round-trip");
-		ok &= expect(reloaded.stations[0].platforms[0].id == "p1", "first station platform id round-trips");
-	}
-	if (!reloaded.routes.empty()) {
-		ok &= expect(reloaded.routes[0].id == "route0", "first route id round-trips");
-		ok &= expect(reloaded.routes[0].blocks.size() == 32, "first route blocks round-trip");
-		ok &= expect(reloaded.routes[0].blocks[0] == "0-B0", "first route block id round-trips");
-	}
-	if (!reloaded.services.empty()) {
-		const SceneService& service = reloaded.services[0];
-		ok &= expect(service.id == "IC1723", "first service id round-trips");
-		ok &= expect(service.through, "first service through flag round-trips");
-		ok &= expect(service.composition == "sprinter_single", "first service composition round-trips");
-		ok &= expect(service.route == "route0", "first service route round-trips");
-		ok &= expect(service.hasEntryTime && service.entryTimeSeconds == 420, "entry time round-trips");
-		ok &= expect(service.hasRepeat && service.headwaySeconds == 1800, "repeat headway round-trips");
-		ok &= expect(service.stops.size() == 3, "first service stop count round-trips");
-		if (service.stops.size() >= 3) {
-			ok &= expect(service.stops[0].stationId == "Gvc", "first stop station round-trips");
-			ok &= expect(!service.stops[0].hasArrival, "first stop missing arrival round-trips");
-			ok &= expect(service.stops[0].hasDeparture && service.stops[0].departureSeconds == 480, "first stop departure round-trips");
-			ok &= expect(service.stops[1].hasArrival && service.stops[1].arrivalSeconds == 1440, "middle stop arrival round-trips");
-			ok &= expect(service.stops[1].hasDeparture && service.stops[1].departureSeconds == 1500, "middle stop departure round-trips");
-			ok &= expect(service.stops[2].hasArrival && service.stops[2].arrivalSeconds == 2580, "last stop arrival round-trips");
-			ok &= expect(!service.stops[2].hasDeparture, "last stop missing departure round-trips");
-		}
-	}
-
+	// Historical aliases and flat incidents remain readable during migration.
+	fs::remove(temp.path / "scenarios.json");
 	{
-		std::ifstream sceneFile(fs::path(outDir.dir) / "services.json");
-		nlohmann::json svcsJson;
-		sceneFile >> svcsJson;
-		ok &= expect(svcsJson["services"][0]["through"] == true, "through written when true");
-		if (svcsJson["services"].size() > 1) {
-			ok &= expect(!svcsJson["services"][1].contains("through"), "through not written when false");
-		}
+		std::ofstream output(temp.path / "incidents.json");
+		output << R"({"incidents":[{"id":"legacy-incident","type":"signal_failure","target":"signal-1","start_seconds":10,"end_seconds":20}]})";
 	}
-
-	auto secondSaveRes = saveScene(reloaded, outDir.dir);
-	printErrors(secondSaveRes.diagnostics, "second save");
-	ok &= expect(secondSaveRes.success(), "second save into same directory succeeds");
-	ok &= expect(!fs::exists(fs::path(outDir.dir) / "legacy"), "second save does not create legacy folder");
-
+	services["services"][0]["stops"][0]["departure_seconds"] = services["services"][0]["stops"][0]["planned_departure_seconds"];
+	services["services"][0]["stops"][0].erase("planned_departure_seconds");
+	services["services"][0]["stops"][1]["arrival_seconds"] = services["services"][0]["stops"][1]["planned_arrival_seconds"];
+	services["services"][0]["stops"][1].erase("planned_arrival_seconds");
 	{
-		SceneModel bareScene;
-		bareScene.schemaVersion = 1;
-		bareScene.name = "Bare";
-
-		SceneTrainUnit bareUnit;
-		bareUnit.id = "bare_unit";
-		bareUnit.hasPhysical = false;
-		bareUnit.tractionCurve.clear();
-		bareScene.trainUnits.push_back(bareUnit);
-
-		SceneComposition comp;
-		comp.id = "bare_comp";
-		comp.units.push_back("bare_unit");
-		bareScene.compositions.push_back(comp);
-
-		TempDir bareOut;
-		auto bareSaveRes = saveScene(bareScene, bareOut.dir);
-		ok &= expect(bareSaveRes.success(), "bare scene save succeeds");
-
-		std::ifstream inFile(fs::path(bareOut.dir) / "rolling_stock.json");
-		nlohmann::json rollingStock;
-		inFile >> rollingStock;
-		auto unitArray = rollingStock["train_units"];
-		ok &= expect(unitArray.is_array() && unitArray.size() == 1, "wrote one unit array");
-		if (unitArray.is_array() && unitArray.size() == 1) {
-			auto obj = unitArray[0];
-			ok &= expect(!obj.contains("physical"), "physical block absent");
-			ok &= expect(!obj.contains("traction_curve"), "traction_curve absent");
-		}
-
-		auto bareReloadRes = loadScene(bareOut.dir);
-		ok &= expect(!hasErrors(bareReloadRes.diagnostics), "bare scene reloads");
-		const SceneLoadedData* bareStationData = findLoadedData(bareReloadRes.scene, "stations");
-		ok &= expect(bareStationData && bareStationData->sourceFile == "stations.json" && bareStationData->parsedCount == 0 && bareStationData->status == "loaded", "empty stations file reported loaded");
-		const SceneLoadedData* bareTimetableData = findLoadedData(bareReloadRes.scene, "timetable");
-		ok &= expect(bareTimetableData && bareTimetableData->sourceFile == "services.json" && bareTimetableData->parsedCount == 0 && bareTimetableData->status == "loaded", "empty services file reported loaded");
+		std::ofstream output(temp.path / "services.json");
+		output << services.dump(2) << "\n";
 	}
+	SceneModel historical;
+	ok &= expect(loadHasNoErrors(temp.path, historical), "historical aliases and flat incidents load");
+	ok &= expect(historical.defaultScenarioId == "baseline" && historical.scenarios.size() == 1,
+			"flat incidents become the implicit baseline");
+	ok &= expect(historical.scenarios[0].incidents.size() == 1
+				&& historical.services[0].stops[0].hasPlannedDeparture,
+			"flat incident and timetable aliases migrate into canonical fields");
 
-	{
-		SceneModel incidentScene = scene;
-		incidentScene.sourceFiles.erase("incidents.json");
-		SceneIncident incident;
-		incident.id = "signal_down";
-		incident.type = "signal_failure";
-		incident.target = "sigA";
-		incidentScene.incidents.push_back(incident);
-		refreshSavedSceneMetadata(incidentScene);
-		const SceneLoadedData* incidentData = findLoadedData(incidentScene, "incidents");
-		ok &= expect(incidentData && incidentData->sourceFile == "incidents.json" && incidentData->parsedCount == 1 && incidentData->status == "loaded", "saved incident metadata reports loaded");
-
-		incidentScene.incidents.clear();
-		refreshSavedSceneMetadata(incidentScene);
-		incidentData = findLoadedData(incidentScene, "incidents");
-		ok &= expect(incidentData && incidentData->sourceFile == "incidents.json" && incidentData->parsedCount == 0 && incidentData->status == "missing", "saved empty incident metadata reports missing");
-	}
+	// A later successful save removes the stale compatibility file.
+	SceneSaveResult resaved = saveScene(source, temp.path.string());
+	ok &= expect(resaved.success() && !fs::exists(temp.path / "incidents.json"),
+			"successful canonical save removes stale incidents after scenarios write");
 
 	if (!ok)
 		return 1;

--- a/docs/architecture/scene-model.md
+++ b/docs/architecture/scene-model.md
@@ -1,68 +1,107 @@
-# Scene Model Design
+# V1 Scene Model
 
-The current scene input is split across many legacy folders and text files. It is hard to validate, hard to edit, and easy to break. V1 should introduce a canonical scene model that sits between the UI and the current simulator input files.
-
-```text
-legacy case folder -> importer -> canonical scene -> validator -> editor UI
-canonical scene -> exporter -> current simulator input files
-```
-
-## Goals
-
-- Use one scene model for validation, UI editing, and export.
-- Keep the current simulator running while the input layer changes.
-- Convert old case-study folders into the new format.
-- Keep scene files readable for instructors and researchers.
-- Make manual text editing optional instead of required.
-
-## Format
-
-Use one directory per scene. Prefer JSON for V1 because Qt can read and write it without a new parser dependency.
+V1 is a directory of canonical JSON files. The model is the hand-off between
+the scene editor and the existing simulator path:
 
 ```text
-scene.json              metadata, schema version, units, base time
-infrastructure.json     nodes, arcs, tracks, switches, speed limits, gradients
-stations.json           stations, station types, platforms
-signalling.json         signals, block sections, routes, corridors
-rolling_stock.json      train units and train compositions
-services.json           services, stops, dwell times, platforms, timetable values
-incidents.json          signal failures, train breakdowns, disruption windows
-views.json              default diagram and viewport settings
+legacy case -> SceneImporter -> canonical SceneModel + legacy passthrough
+canonical files -> loadScene -> validation -> editor
+canonical model -> SceneExporter -> legacy input -> existing simulator
 ```
 
-The schema can be split later if a single-file scene is easier for exchange.
+The last arrow is still the runtime path in this PR. V1 does not make the
+simulator a native JSON consumer.
 
-The V1 schema is defined in scene-schema.md.
+## Canonical directory
 
-## Validator
+| File | Role | Input status |
+| --- | --- | --- |
+| `scene.json` | schema version, identity, units, base time, simulation settings, and optional import report | required |
+| `infrastructure.json` | tracks, nodes, arcs, blocks, and connections | required |
+| `stations.json` | stations, positions, platforms, and platform nodes | required |
+| `signalling.json` | signals, routes, dependencies, single-track restrictions, and station boundaries | required |
+| `rolling_stock.json` | train units, physical data, traction curves, and compositions | required |
+| `services.json` | services, explicit route/composition links, stops, planned times, dwell, and repetition | required |
+| `scenarios.json` | default scenario, named scenarios, incidents, and entrance delays | optional on load; always written by `SceneWriter` |
+| `passengers.json` | passenger journeys and legs | optional |
+| `views.json` | display preferences | optional |
 
-The validator should catch:
+The six required files are the files needed for structural loading. A scene
+may therefore load without scenarios or passengers; the writer creates a
+baseline `scenarios.json` even when there are no named scenarios. Imported
+scenes also carry a `legacy/` tree for files still consumed by the legacy
+runtime.
 
-- missing files
-- unresolved station, route, platform, signal, or train references
-- zero trains
-- empty routes
-- invalid timetable values
-- invalid dwell times
-- incident targets that do not exist
-- output path problems
+## Model ownership
 
-Each error should name the scene item and suggest the smallest fix.
+`SceneModel` owns the canonical values, not a second flat copy of legacy
+incidents. Incidents belong to a `SceneScenario`; the selected scenario is
+identified by `default_scenario_id`. Runtime `loadedData` and `sourceFiles` are
+derived summaries. `import_report` is the persisted conversion summary, with
+one row containing `category`, optional `source_file`, `source_count`,
+`converted_count`, `skipped_count`, and `unresolved_references`.
 
-## Converter
+The scene-level simulation settings are deliberately small: `base_time`,
+`simulation_settings.duration_seconds`,
+`simulation_settings.buffer_time_seconds`, and
+`simulation_settings.recovery_time_percent`. Legacy case counts, GUI flags,
+output paths, and network feature flags are not scene-model settings.
 
-The converter has two directions:
+Services keep physical and traction provenance explicit. A train unit's
+`source.data_file` and `source.traction_file` are independent relationships;
+the model does not infer one from a filename such as `LITRA` or `T_...`.
 
-- Legacy importer: reads existing case-study folders and writes canonical scenes. Implemented; see scene-schema.md for the mapping.
-- Legacy exporter: writes the current simulator input files from a canonical scene. Implemented. The editor->export->simulate path now exists end to end.
+Service stop input uses `planned_arrival_seconds` and
+`planned_departure_seconds`. Each is independently optional on every stop.
+Legacy timetable sentinels such as `-1` become absent planned fields; they
+are not converted into simulation results. An incomplete intermediate
+schedule may produce a validation warning, but departure omission is not
+restricted to the last stop. Dwell and repetition remain planned input as
+well.
 
-The editor should save the canonical scene. The simulation can keep reading exported legacy files until the simulator input layer is replaced.
+Each service also has a unique canonical `id` and an optional
+`operating_code`. The latter defaults to the ID and preserves the active train
+identity consumed by the existing simulator. It is intentionally not required
+to be unique: Milano-Brescia contains distinct service definitions sharing
+codes `9707` and `9709`.
 
-## Migration Path
+Passenger journey windows use absolute seconds from midnight. They are not
+random passenger draws, simulation results, or a replacement for the legacy
+runtime's conditional DAS/RouteChoice CSV loader.
 
-1. Define the scene schema.
-2. Import Copenhagen and Brescia into canonical scenes.
-3. Validate converted scenes.
-4. Export scenes back to current input files.
-5. Add the MVP editor on top of the scene model.
-6. Build the Amsterdam to Hilversum assignment case through the scene model.
+## Validation layers
+
+The public validator separates three questions:
+
+- `validateSceneStructure` checks the directory, JSON, required sections, and
+  field shape without cross-file semantic checks.
+- `validateScene` checks the loaded model: references, identifiers, values,
+  timetable consistency, incidents, and other scene relationships.
+- `validateRunnableScene` checks the minimum complete model needed for a run.
+
+`validateSceneDirectory` loads and performs semantic validation;
+`validateRunnableSceneDirectory` adds runnable-completeness checks. Both run
+model validation only when structural loading has no error diagnostics, which
+avoids cascaded reference errors from partially parsed files.
+
+## Compatibility and scope
+
+The loader accepts historical aliases for existing scenes, while the writer
+emits only preferred V1 keys. The aliases and their exact mappings are listed
+in [Scene Schema Reference](scene-schema.md#historical-compatibility-aliases).
+
+`SceneImporter` maps the legacy seven-token train definition, physical and
+traction source files, timetable rows, routes, and stations into the model;
+runtime support trees that are not yet native inputs are preserved under
+`legacy/`. `SceneExporter` writes the canonical train, service, route, and
+scenario-compatible data and carries the passthrough tree into the temporary
+legacy input used by the current run path.
+
+The compatibility exporter does not synthesize Rollout or passenger CSV files
+from the new scenario/passenger JSON. Those values already round-trip through
+the canonical loader, writer, importer, and validator, but their execution and
+scenario selection remain later-milestone work; the unchanged runtime still
+uses matching files from `legacy/` when present.
+
+Milestone 1 covers this V1 directory and its compatibility path. The `.egscene`
+bundle format and native simulator input are outside this milestone.

--- a/docs/architecture/scene-schema.md
+++ b/docs/architecture/scene-schema.md
@@ -1,220 +1,214 @@
-# Scene Schema Reference
+# V1 Scene Schema Reference
 
-The V1 scene schema defines a canonical JSON-based model. It consists of multiple JSON files within a single directory, each handling a different aspect of the simulation scene.
+V1 is a directory of JSON files. JSON keys are case-sensitive. The writer
+emits the preferred keys below; the historical spellings are accepted only
+for compatibility and are listed in [Historical compatibility aliases](#historical-compatibility-aliases).
 
-## Versioning
+## Version and files
 
-The schema is versioned using an integer `schema_version` inside `scene.json`. The current version is `1`.
+`scene.json.schema_version` is the integer `1`. Structural loading requires:
 
-## File Structure
+| File | Required | Preferred root and purpose |
+| --- | --- | --- |
+| `scene.json` | yes | scene metadata and simulation settings |
+| `infrastructure.json` | yes | tracks, nodes, arcs, blocks, and connections |
+| `stations.json` | yes | stations and platforms |
+| `signalling.json` | yes | signals, routes, and signalling relationships |
+| `rolling_stock.json` | yes | train units and compositions |
+| `services.json` | yes | services and planned timetables |
+| `scenarios.json` | no | `default_scenario_id` and named scenarios; `SceneWriter` always writes it |
+| `passengers.json` | no | passenger journeys and legs |
+| `views.json` | no | display preferences; not simulation input |
 
-| file | required | V1 content |
-|---|---|---|
-| scene.json | yes | `schema_version` (integer, must be 1), `name` (string, non-empty), optional `description`, optional `base_time` ("HH:MM:SS"), optional `units` object. The only supported units are the defaults: `distance: "m"`, `time: "s"`, `speed: "m/s"`. |
-| infrastructure.json | yes | `nodes: []`, `arcs: []` (arrays may be empty in V1; full modelling comes with the importer) |
-| stations.json | yes | `stations: [{id, name, platforms: [{id}]}]` |
-| signalling.json | yes | `signals: [{id}]`, `routes: [{id, blocks: [string]}]` (block ids are opaque strings in V1; they are resolved against real block data once the legacy importer exists) |
-| rolling_stock.json | yes | `train_units: [{id, physical?: {mass_of_traction_unit_kg, mass_of_a_wagon_kg, number_of_wagons, max_speed_ms, max_deceleration_ms2, frontal_area_m2, resistance_coefficient, jerk_ms3, length_m}, traction_curve?: [[v_lower, v_upper, c0, c1, c2]], source?: {data_file, traction_file}}]`, `compositions: [{id, units: [unit-id]}]` |
-| services.json | yes | `services: [{id, composition, route, through?, entry_time_seconds?, repeat?: {headway_seconds}, stops: [{station, platform?, arrival_seconds?, departure_seconds?, dwell_seconds}]}]`. `arrival_seconds` may be omitted on any stop (no scheduled arrival; typical for the first stop). `departure_seconds` may be omitted only on the last stop (terminus). Times are seconds from the scene base time and may be negative (an instant before the base time). A service with an empty `stops` array is a through service that stops nowhere. The optional boolean `through` marks a service that runs the corridor without scheduled stops; the validator skips the no-stops warning for it. |
-| incidents.json | no | `incidents: [{id, type: "signal_failure"\|"train_breakdown", target, start_seconds, end_seconds}]` |
-| views.json | no | free-form display defaults; parse-checked only |
+An imported scene may also contain `legacy/`. The current application exports
+the canonical model to a temporary legacy input tree before starting the
+existing simulator, so that passthrough remains part of the V1 contract.
 
-## Loaded Data Metadata
+## `scene.json`
 
-`loaded_data` is derived provenance metadata maintained by the app at runtime as UI state. The loader recomputes it from the canonical files, so it is not the source of truth and it is not written to `scene.json`. Each row has `category`, `source_file`, `parsed_count`, `status`, and optional recursive `children`.
+Required keys:
 
-Current categories are `scene`, `infrastructure`, `stations`, `timetable`, `rolling_stock`, `signalling`, `incidents`, and `passenger_data`. File-backed categories include drill-down rows for `raw_file`, `parsed_objects`, and `derived_simulation`; the GUI adds validation status rows from current diagnostics. `rolling_stock` also exposes `train_units`, `compositions`, and `source_files`; `source_files` lists linked `data_file` / `traction_file` entries such as `LITRA` and `T_LITRA` files when present. `signalling` exposes `signals` and `routes`.
+- `schema_version`: integer `1`.
+- `name`: non-empty string.
 
-## Examples
+Optional keys:
 
-**scene.json**
-```json
-{
-    "schema_version": 1,
-    "name": "Minimal Test Scene",
-    "description": "A minimal scene for validation tests",
-    "base_time": "08:00:00",
-    "units": {
-        "distance": "m",
-        "time": "s",
-        "speed": "m/s"
-    }
-}
+- `description`: string.
+- `base_time`: `HH:MM:SS` day-clock origin for the simulation.
+- `units`: object containing only `distance: "m"`, `time: "s"`, and
+  `speed: "m/s"` when present.
+- `simulation_settings`: object with optional numeric
+  `duration_seconds`, `buffer_time_seconds`, and
+  `recovery_time_percent`.
+- `import_report`: array of conversion rows.
+
+An `import_report` row has `category`, `source_count`, `converted_count`,
+`skipped_count`, and `unresolved_references`; `source_file` is optional. The
+counts describe the conversion source, not simulation results.
+
+Counts, GUI switches, output paths, and network feature flags from legacy
+`InitialParameters` are not V1 scene keys.
+
+## `infrastructure.json`
+
+The preferred root keys are `tracks`, `nodes`, `arcs`, `blocks`, and
+`connections`. `nodes` and `arcs` are required arrays; the other arrays may be
+empty or omitted on input and are emitted by the writer.
+
+- `tracks[]`: `{ "id": string }`.
+- `nodes[]`: `id`, `track`, numeric `x_km`, numeric `y_km`.
+- `arcs[]`: `id`, `track`, `from`, `to`, numeric `curvature_radius_m`,
+  `gradient_percent`, and `speed_limit_ms`.
+- `blocks[]`: `id`, `track`, numeric `length_km`.
+- `connections[]`: `id`, `from`, `to`, and optional numeric `speed_limit_ms`.
+
+## `stations.json`
+
+The root key is `stations`. Each station has required string `id` and `name`,
+optional numeric `position_km`, and optional `platforms`. A platform has an
+`id` and an optional `nodes` array of node IDs.
+
+## `signalling.json`
+
+Required root arrays are `signals` and `routes`.
+
+- `signals[]`: `{ "id": string }`.
+- `routes[]`: required `id` and string-array `blocks`; optional string
+  `corridor` and boolean `reversed`.
+- `block_dependencies[]`: `{ "block": string, "depends_on": string }`.
+- `single_track_restrictions[]`: preferred explicit
+  `start_block`, `end_block`, `protected_start_block`, and
+  `protected_end_block`.
+- `station_boundaries[]`: required `entrance_block`, optional `exit_block`,
+  and optional boolean `direction`.
+
+## `rolling_stock.json`
+
+Required root arrays are `train_units` and `compositions`.
+
+Each train unit has an `id` and may have:
+
+- `physical`: all nine numeric keys
+  `mass_of_traction_unit_kg`, `mass_of_a_wagon_kg`, `number_of_wagons`,
+  `max_speed_ms`, `max_deceleration_ms2`, `frontal_area_m2`,
+  `resistance_coefficient`, `jerk_ms3`, and `length_m`.
+- `traction_curve`: an array of five-number rows `[v_lower, v_upper, c0, c1, c2]`.
+- `source`: an object whose independent string keys are `data_file` and
+  `traction_file`.
+
+The two source paths are explicit relationships. A `data_file` does not imply
+a matching name, prefix, or `T_` file; the same applies in the other direction.
+
+Each composition has `id` and a string-array `units` of train-unit IDs.
+
+## `services.json`
+
+The root key is `services`. Each service has required `id`, `composition`,
+`route`, and `stops`; it may have boolean `through`, numeric
+`entry_time_seconds`, string `operating_code`, and
+`repeat: { "headway_seconds": number }`. The ID is the unique cross-file
+reference. The operating code defaults to that ID, but may repeat: it preserves
+the active legacy `Trains` token used for `Train::type`, train descriptions,
+and the current compatibility export.
+
+Each stop has required string `station` and numeric `dwell_seconds`, plus an
+optional string `platform`. The planned timetable keys are:
+
+- `planned_arrival_seconds`: optional numeric planned arrival.
+- `planned_departure_seconds`: optional numeric planned departure.
+- `dwell_seconds`: required numeric planned dwell, normally non-negative.
+
+Arrival and departure are independently optional on every stop. There is no
+last-stop-only departure rule. Legacy timetable `-1` values are preserved as
+missing planned fields; the importer does not synthesize a value from the
+other field. Validation may warn when an intermediate schedule is incomplete.
+These are input plans in seconds relative to the scene's base-time origin, not
+simulation results.
+
+An empty `stops` array is valid for a through service; `through: true` records
+that intent explicitly.
+
+## `scenarios.json`
+
+The preferred root keys are `default_scenario_id` and `scenarios`. The default
+ID selects one named scenario. Each scenario has required `id`, `name`, and
+`incidents` array; it may have `description` and `entrance_delays`.
+
+Each incident is concrete input with `id`, `type` (`signal_failure` or
+`train_breakdown`), `target`, `start_seconds`, and `end_seconds`. An entrance
+delay has `service`, optional integer `occurrence`, `station`, and numeric
+`delay_seconds`.
+
+If `scenarios.json` is absent, loading creates a baseline scenario. A legacy
+`incidents.json` is read into that baseline for compatibility. Saving writes
+the scenario model to `scenarios.json` and removes the stale flat file.
+
+## `passengers.json`
+
+This file is optional. Its root key is `passengers`. Each passenger has `id`
+and `journeys`. A journey has `id`, `origin`, `destination`, optional
+`activity`, required `planned_departure` and `planned_arrival` objects, and a
+`legs` array. Each time-window object uses numeric `start_seconds` and
+`end_seconds`, expressed as absolute seconds from midnight, not seconds from
+`base_time`. Each leg has `id`, `origin`, `destination`, `service`, and an
+optional integer `occurrence` that defaults to `1`.
+
+Journey and leg IDs are stable across the scene. A journey may have an empty
+`legs` array when the active legacy route-choice file has no row for it; this
+is reported as a warning rather than inventing a route.
+
+Passenger JSON is distinct from the legacy passenger runtime. Random draws and
+simulation results are not scene input. The legacy DAS/RouteChoice loader is
+used only when both exact files
+`Passengers/DAS_FrenchCaseStudy.csv` and
+`Passengers/RouteChoiceFC_EQ1.csv` exist.
+
+## `views.json` and runtime metadata
+
+`views.json` is optional JSON for display defaults. It is not interpreted as
+simulation input. `loaded_data` and `sourceFiles` are derived in-memory
+metadata; they are recomputed when a scene is loaded and are not the source of
+canonical values.
+
+## Historical compatibility aliases
+
+The loader accepts these old spellings or files when the preferred form is
+absent. New files should use the preferred form, which is what `SceneWriter`
+emits.
+
+| Historical form | Preferred V1 form | Compatibility behavior |
+| --- | --- | --- |
+| stop `arrival_seconds` | `planned_arrival_seconds` | accepted only when the preferred key is absent |
+| stop `departure_seconds` | `planned_departure_seconds` | accepted only when the preferred key is absent |
+| `incidents.json` | scenario `incidents` in `scenarios.json` | loaded into an implicit baseline only when `scenarios.json` is absent |
+
+The old timetable names are compatibility aliases, not preferred examples or
+model terminology.
+
+## Validation and conversion
+
+`validateSceneStructure` checks files, JSON shape, required sections, and field
+types without cross-file reference checks. `validateScene` checks semantic
+relationships and values. `validateRunnableScene` checks the minimum complete
+model needed by a simulation. `validateSceneDirectory` loads and performs
+semantic validation; `validateRunnableSceneDirectory` adds runnable-completeness
+checks. Both stop after structural errors to avoid cascaded diagnostics.
+
+`SceneImporter` reads legacy `trainNames.txt` entries or enumerated train
+files. A legacy train definition has seven whitespace tokens in this order:
+
+```text
+operating_code entry_time_seconds headway_seconds route_index data_file traction_file timetable_file
 ```
 
-**infrastructure.json**
-```json
-{
-    "nodes": [],
-    "arcs": []
-}
-```
+It maps the explicit physical, traction, and timetable relationships into the
+canonical files, imports numeric `Routes/Route<N>.txt` files as routes, and
+reads stations from the legacy track-line station file. Selected runtime
+support trees that still need passthrough are copied below `legacy/`. The
+legacy runtime and export path remains active in Milestone 1.
 
-**stations.json**
-```json
-{
-    "stations": [
-        {
-            "id": "st.hillerod",
-            "name": "Hillerød",
-            "platforms": [{"id": "p1"}, {"id": "p2"}]
-        }
-    ]
-}
-```
-
-**signalling.json**
-```json
-{
-    "signals": [
-        {"id": "sig.01"}
-    ],
-    "routes": [
-        {
-            "id": "rt.main",
-            "blocks": ["blk.01", "blk.02", "blk.03"]
-        }
-    ]
-}
-```
-
-**rolling_stock.json**
-```json
-{
-    "train_units": [
-        {"id": "tu.01"}
-    ],
-    "compositions": [
-        {
-            "id": "comp.01",
-            "units": ["tu.01"]
-        }
-    ]
-}
-```
-
-**services.json**
-```json
-{
-    "services": [
-        {
-            "id": "svc.a1",
-            "composition": "comp.01",
-            "route": "rt.main",
-            "stops": [
-                {
-                    "station": "st.hillerod",
-                    "platform": "p1",
-                    "departure_seconds": 120,
-                    "dwell_seconds": 0
-                }
-            ]
-        }
-    ]
-}
-```
-
-**incidents.json**
-```json
-{
-    "incidents": [
-        {
-            "id": "inc.01",
-            "type": "signal_failure",
-            "target": "sig.01",
-            "start_seconds": 300,
-            "end_seconds": 900
-        }
-    ]
-}
-```
-
-**views.json**
-```json
-{
-    "diagram": {
-        "x": 0,
-        "y": 0,
-        "zoom": 1.0
-    }
-}
-```
-
-## Diagnostics
-
-The validator produces the following diagnostic codes. Note that semantic checks are only executed if structural loading produced no Errors.
-
-**Structural Errors**
-- `scene.dir.missing`: Directory absent.
-- `scene.file.missing`: Missing required file.
-- `scene.json.parse`: Unparseable JSON.
-- `scene.section.missing`: Absent or mistyped required top-level key, or a file whose root is not an object.
-- `scene.field.missing`: Missing or mistyped required field on an item.
-- `scene.version.missing`: Missing `schema_version`.
-- `scene.version.unsupported`: `schema_version` is not the integer `1`.
-- `scene.units.unsupported`: A unit other than `m`, `s`, or `m/s`.
-- `scene.import.missing`: Missing legacy file or directory, or a scene file that could not be written.
-- `scene.import.parse`: Malformed token or row during legacy import.
-- `scene.import.ref`: Unresolved reference during legacy import (e.g. missing referenced timetable or data file, route index out of range).
-
-- `scene.export.write`: A file or directory could not be written during export.
-- `scene.export.ref`: Missing data needed for export (e.g. unit physical data, a service referencing an unknown route).
-- `scene.export.unsupported`: Scene cannot be represented in the legacy format (e.g. station id contains whitespace, or route ids mixing the `route<N>` pattern with other names).
-- `scene.export.adjusted` (Warning): The exporter changed a derived value (e.g. a sanitized service file name collided and was suffixed).
-
-**Semantic Errors**
-- `scene.trains.none`: No compositions or train units.
-- `scene.services.none`: No services.
-- `scene.ref.unresolved`: Reference to missing entity (e.g. service→composition, service→route, stop→station, incident target).
-- `scene.ref.platform`: Stop names a platform not on the stop's station.
-- `scene.composition.empty`: Composition with empty units array.
-- `scene.route.empty`: Route with empty blocks array.
-- `scene.id.duplicate`: Duplicate id within a collection.
-- `scene.time.invalid`: Departure before arrival at a stop.
-- `scene.dwell.invalid`: Dwell < 0.
-- `scene.incident.type`: Incident type other than `signal_failure` or `train_breakdown`.
-- `scene.incident.window`: Incident end <= start, or negative times.
-- `scene.basetime.invalid`: Base time present but not "HH:MM:SS".
-- `scene.repeat.invalid`: Non-positive headway_seconds.
-
-**Semantic Warnings**
-- `scene.dwell.exceeds_window`: Dwell time is larger than the (departure - arrival) window.
-- `scene.service.no_stops`: Service with an empty stops array (a through service; legitimate but worth flagging).
-- `scene.service.through_stops`: Through service has stops.
-- `scene.time.order`: Departure times do not increase along a service's stops.
-
-**Import Warnings and Infos**
-- `scene.import.adjusted` (Warning): The importer changed or dropped a legacy value to fit the schema (e.g. a departure before its arrival raised to the arrival, or a duplicate service name suffixed). The message names the service, station, and values.
-- `scene.import.info` (Info): Non-fatal import notes, such as falling back to directory enumeration when `trainNames.txt` is absent.
-
-## Importing legacy case studies
-
-The `SceneImporter` converts a legacy simulation folder into a canonical V1 scene.
-The mapping is as follows:
-- `trainNames.txt` (or all `Trains/*.txt` files) -> `services.json`
-- `TrainData/*.txt` and `TrainData/T_*.txt` -> `rolling_stock.json`
-- All `Routes/Route<N>.txt` files (numerically sorted) -> `signalling.json` (routes). Unreferenced routes become part of the scene because the simulator loads `Route0`..`Route<N-1>` unconditionally.
-- `Tracklines/Stations.txt` -> `stations.json`
-- Unconverted files (e.g. `TMS`, `TDS`) are copied verbatim to `<sceneDir>/legacy/`
-
-Note on one-shot services: The legacy format uses a headway sentinel of `>= 99999999` to denote a service that runs only once. The importer omits the `repeat` field for such services. The exporter will write `99999999` back when exporting services without a `repeat` block.
-
-## Exporting to legacy input
-
-The `SceneExporter` converts a canonical V1 scene back into the legacy format so the simulator can run it.
-The mapping back is:
-- `services.json` -> `Trains/`, `TimeTable/`, and `trainNames.txt`
-- `rolling_stock.json` -> `TrainData/`
-- `signalling.json` (routes) -> `Routes/`
-- `incidents.json` -> `Incidents.txt` when incidents are present
-- `<sceneDir>/legacy/` is recursively walked and copied to the export directory. During this passthrough, top-level directories named `tracklines` or `timetable` (case-insensitive) are renamed to `TrackLines` and `TimeTable` to match the simulator's hard-coded case-sensitive paths.
-
-What is not exported and why:
-- `stations.json` and `infrastructure.json`: The simulator reads infrastructure from the Tracklines passthrough, so they are not written directly.
-- `views.json`: UI-only preferences, not simulation input.
-
-**Known lossiness during round-trip**:
-- `legacy_source` records provenance when a scene is imported and does not round-trip.
-- A hand-made scene without `entry_time_seconds` gains one on export+re-import (the legacy format requires the token; the exporter defaults it to the first stop's departure, else 0).
-- `99999999` is the scene-layer convention for one-shot services. The legacy format does not have an explicit branch for this; it simply yields one train for any realistic horizon.
-- Station ids cannot contain whitespace (constrained to whitespace-free identifiers), because the legacy timetable format is tokenized by whitespace.
+That bridge does not generate passenger DAS/RouteChoice CSVs or entrance-delay
+Rollout files from canonical JSON. In Milestone 1 those fields are authoritative
+for persistence, import, and validation, while the unchanged simulator still
+uses any corresponding files in `legacy/`. Native scenario selection and
+canonical passenger execution belong to later milestones.

--- a/docs/architecture/scene-schema.md
+++ b/docs/architecture/scene-schema.md
@@ -34,7 +34,7 @@ Required keys:
 Optional keys:
 
 - `description`: string.
-- `base_time`: `HH:MM:SS` day-clock origin for the simulation.
+- `base_time`: `HH:MM:SS` day-clock origin from `00:00:00` through `23:59:59`.
 - `units`: object containing only `distance: "m"`, `time: "s"`, and
   `speed: "m/s"` when present.
 - `simulation_settings`: object with optional numeric

--- a/docs/guides/scenes-and-application.md
+++ b/docs/guides/scenes-and-application.md
@@ -1,222 +1,127 @@
 # Using EGTRAIN and authoring V1 scenes
 
-This guide covers the current V1 scene workflow. Use it to open and edit a scene, convert a legacy case, or prepare a new case for the simulator.
+This guide covers the Milestone 1 scene workflow: open a canonical directory,
+convert a legacy case, edit planned input, validate it, and run through the
+existing compatibility path.
 
-## Build the application
+## Open and run
 
-Run these commands from the repository root:
+Start EGTRAIN from `EGTRAIN/QEGTRAIN`; legacy relative paths resolve from that
+directory. Choose `File > Open Scene...` and select the directory containing
+`scene.json`. Review validation diagnostics, use `Save Scene As...` for a
+working copy, then choose `Run Scene`.
 
-```bash
-cmake -S . -B build -DEGTRAIN_BUILD_TESTS=ON
-cmake --build build
-```
+The application loads the six required JSON files, accepts optional scenarios,
+passengers, views, and historical compatibility data, and validates before a
+run. EGTRAIN exports the canonical fields already supported by the bridge,
+including services, rolling stock, routes, and default-scenario incidents, to a
+temporary legacy directory. It copies required passthrough data and starts the
+existing simulator. This legacy runtime/export path remains in the PR.
 
-On macOS with Homebrew Qt 5:
+## Scene directory
 
-```bash
-cmake -S . -B build -DEGTRAIN_BUILD_TESTS=ON \
-  -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt@5
-cmake --build build
-```
-
-Run the application from `EGTRAIN/QEGTRAIN`. Several legacy paths are relative to that directory.
-
-```bash
-cd EGTRAIN/QEGTRAIN
-../../build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN
-```
-
-The executable is `build/QEGTRAIN` on platforms where CMake does not create a macOS application bundle.
-
-## Open and run a scene
-
-1. Start EGTRAIN.
-2. Choose `File > Open Scene...`.
-3. Select the directory that contains `scene.json`.
-4. Read the `Scene Validation` panel before editing.
-5. Use `Save Scene As...` to make a working copy. Create the empty target directory before selecting it.
-6. Edit compositions, services, timetable values, or incidents in the scene dock.
-7. Choose `Run Scene`.
-
-EGTRAIN validates the scene before each run. Errors block the run. Warnings remain visible but do not block it.
-
-`Save Scene` writes the canonical JSON files. `Save Scene As...` also copies `legacy/` and `views.json`. A run uses the current model, including unsaved edits, and exports it to a temporary legacy input directory.
-
-After setup, use the existing diagram windows to inspect speed, time, distance, delay, train path, and blocking time data.
-
-Use `File > Load Legacy Case...` to convert a legacy folder into an editable V1 scene. Select the legacy source folder first, then a separate destination folder for the generated scene. The source is never modified. EGTRAIN shows importer, structural, and semantic diagnostics before opening the result; structural/import errors leave the current scene unchanged, while semantic errors remain visible in the validation panel so the result can be repaired.
-
-## V1 scene directory
-
-A V1 scene is a directory. Six JSON files are required.
-
-| File | Required | Contents |
+| File | Status | Contents |
 | --- | --- | --- |
-| `scene.json` | yes | Name, schema version, base time, units, and optional source information |
-| `infrastructure.json` | yes | Canonical nodes and arcs |
-| `stations.json` | yes | Stations and platforms |
-| `signalling.json` | yes | Signals, routes, and route block tokens |
-| `rolling_stock.json` | yes | Train units, physical data, traction curves, and compositions |
-| `services.json` | yes | Services, routes, stops, times, and repetition |
-| `incidents.json` | no | Signal failures and train breakdowns |
-| `views.json` | no | Display defaults |
-| `legacy/` | needed by imported cases | Infrastructure and other data still read by the legacy simulator |
+| `scene.json` | required | schema version, name, units, base time, simulation settings, import report |
+| `infrastructure.json` | required | tracks, nodes, arcs, blocks, connections |
+| `stations.json` | required | stations, positions, platforms, platform nodes |
+| `signalling.json` | required | signals, routes, dependencies, restrictions, boundaries |
+| `rolling_stock.json` | required | physical/traction train units and compositions |
+| `services.json` | required | route/composition links and planned timetable stops |
+| `scenarios.json` | optional on load; always written | default scenario, named scenarios, incidents, entrance delays |
+| `passengers.json` | optional | journeys, absolute midnight-second windows, and legs |
+| `views.json` | optional | display defaults |
+| `legacy/` | needed by the current runtime as applicable | passthrough files used by legacy loaders |
 
-The current schema version is `1`. Supported units are metres, seconds, and metres per second.
+The writer emits preferred V1 keys. Stop plans use independently optional
+`planned_arrival_seconds` and `planned_departure_seconds` on any stop, plus
+required `dwell_seconds`. Legacy `-1` values remain omitted planned fields;
+they are not treated as results or filled by a last-stop rule. See [V1 scene
+properties](v1-scene-properties.md) for editing examples.
 
-The main references are:
-
-```text
-services.json
-  composition -> rolling_stock.json
-  route       -> signalling.json
-  stop        -> stations.json
-  platform    -> platform on that station
-
-incidents.json
-  target      -> signal or service
-```
-
-IDs must be unique within their collection. Keep station IDs free of whitespace because the legacy timetable format splits fields on whitespace.
-
-Times in `services.json` are seconds relative to `base_time`. The first stop may omit its arrival. The last stop may omit its departure. A repeated service uses `repeat.headway_seconds`.
-
-`loaded_data` is runtime metadata. EGTRAIN rebuilds it when the scene opens and does not write it to `scene.json`.
-
-Use the [V1 scene property reference](v1-scene-properties.md) while editing JSON. The [scene schema reference](../architecture/scene-schema.md) lists the diagnostic codes and import and export behavior.
-
-## Canonical files and legacy files
-
-The canonical JSON files are the source of truth for an opened V1 scene. Do not edit an exported legacy directory and expect those changes to return to the scene.
-
-The simulator still reads part of the old input structure. Imported scenes keep that data under `legacy/`. During a run, EGTRAIN writes canonical services, rolling stock, routes, and incidents to a temporary input directory, then copies passthrough files that do not replace generated files.
-
-Do not delete files from `legacy/` until the scene exports and runs without them. Track infrastructure under `legacy/Tracklines/` or `legacy/TrackLines/` is required by the current simulator.
+Scenario files use `default_scenario_id`, named `scenarios`, concrete
+`incidents`, and `entrance_delays`. Passenger windows use absolute seconds
+from midnight. The complete key contract and historical aliases are in the
+[schema reference](../architecture/scene-schema.md).
 
 ## Convert a legacy case
 
-Use `scene_tool` when a case already exists in the legacy format, or use `File > Load Legacy Case...` for the same import path inside EGTRAIN. Import into a temporary directory first when checking a case from outside the repository.
+Use the GUI's `File > Load Legacy Case...` or `scene_tool import`. Select a
+separate destination; the importer never modifies the source. A legacy train
+definition is seven whitespace tokens:
+
+```text
+operating_code entry_time_seconds headway_seconds route_index data_file traction_file timetable_file
+```
+
+The importer preserves those explicit physical, traction, and timetable
+relationships, retains the operating code separately from the unique canonical
+service ID, maps numeric `Routes/Route<N>.txt` files to routes, and reads
+stations from the track-line station file. It keeps runtime support trees that
+still need passthrough under `legacy/` and reports missing references,
+malformed rows, and preserved source anomalies. In particular, a timetable
+sentinel of `-1` means the corresponding planned arrival or departure is
+absent; the importer neither synthesizes a result nor changes an inconsistent
+source time.
+
+Example:
 
 ```bash
 ./build/scene_tool import \
   EGTRAIN/QEGTRAIN/Input/Input_EGTRAIN_Netherlands \
   /tmp/netherlands-v1 \
   Netherlands
-
 ./build/scene_tool validate /tmp/netherlands-v1
 ```
 
-The importer maps:
+Inspect importer diagnostics before opening the result. Structural/import
+errors prevent a usable scene from being published; semantic diagnostics stay
+with the scene for repair.
 
-| Legacy source | V1 destination |
-| --- | --- |
-| `trainNames.txt` and `Trains/*.txt` | `services.json` |
-| `TrainData/*.txt` | `rolling_stock.json` |
-| `Routes/Route<N>.txt` | `signalling.json` |
-| `Tracklines/Stations.txt` | `stations.json` |
-| Remaining simulator data | `legacy/` |
+## Edit and validate
 
-Flat legacy payloads with root `Stations.txt`, `Connections.txt`, `TrackandStations.txt`, and numeric `B*` folders are accepted too; the importer places that infrastructure under `legacy/Tracklines/` without changing the source.
+Edit canonical JSON or use the scene editor. Keep IDs unique and keep service
+links consistent:
 
-Inspect every import warning. `scene.import.adjusted` means the importer changed a value. The message names the affected file and service.
-
-Export the result to another temporary directory:
-
-```bash
-./build/scene_tool export /tmp/netherlands-v1 /tmp/netherlands-export
+```text
+service.composition -> rolling_stock.compositions[].id
+service.route       -> signalling.routes[].id
+stop.station        -> stations[].id
+stop.platform       -> platform on that station
+scenario incident   -> signal/block or service target as appropriate
 ```
 
-Open `/tmp/netherlands-v1` in EGTRAIN and run it. Do not replace a committed scene until validation, export, and the simulation have passed.
+`passengers.json` is optional and is not a substitute for the legacy runtime's
+conditional DAS/RouteChoice CSV input. Random passenger draws and simulation
+results are excluded from scene input. Likewise, legacy OL, TDS,
+Rescheduling, and GUI files have their own active/inert/output classifications;
+see the [migration matrix](v1-scene-migration-matrix.md) instead of inferring
+behavior from a filename.
 
-## Start a scene without a legacy case
+Named-scenario selection, canonical entrance-delay execution, and canonical
+passenger execution are not enabled in Milestone 1. The bridge does not create
+Rollout or passenger CSV files from JSON, so current runs still use those files
+from `legacy/` when available. Canonical edits to those fields are persisted and
+validated now; making the simulator consume them is later-milestone work.
 
-Use the minimal test fixture as the starting structure:
-
-```bash
-cp -R \
-  EGTRAIN/QEGTRAIN/tests/fixtures/scenes/minimal \
-  /tmp/my-scene
-./build/scene_tool validate /tmp/my-scene
-```
-
-The fixture shows the required JSON shape. It does not contain enough track infrastructure for a real simulation.
-
-For a runnable scene:
-
-1. Set the name, schema version, base time, and units in `scene.json`.
-2. Add stations and platforms.
-3. Add train units and compositions.
-4. Add routes with real block tokens.
-5. Add services that reference those objects.
-6. Add the required legacy track data.
-7. Validate, export, and run one service.
-8. Add the rest of the timetable after the first service completes its route.
-
-Full infrastructure editing is not available in the V1 GUI. Build or import routes and track data outside the application, then use the GUI for compositions, services, timetable values, and incidents.
-
-## Validation
-
-Run validation after every small group of edits:
+Run the structural and semantic validation command after edits:
 
 ```bash
 ./build/scene_tool validate path/to/scene
 ```
 
-Structural errors include missing files, invalid JSON, missing sections, and an unsupported schema version. EGTRAIN stops before semantic checks when structural loading fails.
+The command preserves support for structurally valid, incomplete historical
+scenes. Run gating additionally uses `validateRunnableScene`; the equivalent
+directory helper is `validateRunnableSceneDirectory`. Structural loading is
+checked first so semantic reference diagnostics do not cascade from malformed
+JSON.
 
-Semantic errors include unresolved references, duplicate IDs, empty compositions or routes, invalid times, invalid dwell values, and bad incident targets. The [schema reference](../architecture/scene-schema.md#diagnostics) lists every code.
+Before committing a scene, validate it, export to a clean temporary directory,
+and run the compatibility path with its required `legacy/` data. Do not edit
+an exported legacy directory expecting those changes to flow back into the
+canonical JSON.
 
-Useful checks for scene work are:
+## Scope
 
-```bash
-ctest --test-dir build -L scene-v1 --output-on-failure
-ctest --test-dir build -L legacy-compat --output-on-failure
-tools/e2e/headless_smoke.py
-tools/e2e/roundtrip_smoke.py
-```
-
-Run the full set after changing committed scene data. For one scene, start with `scene_tool validate`, export it, and run it through the GUI.
-
-## Netherlands case
-
-The full legacy case is in `EGTRAIN/QEGTRAIN/Input/Input_EGTRAIN_Netherlands`. Its V1 counterpart is `EGTRAIN/QEGTRAIN/Scenes/Netherlands`.
-
-The active manifest lists `Spr1.txt` through `Spr8.txt`. These services cover Utrecht (`Ut`), Hilversum (`Hvs`), Baarn (`Brn`), and Den Dolder (`Dld`). The committed train definitions use `SLT06.txt` with the matching `T_SLT06.txt` traction curve.
-
-A fresh import contains:
-
-- 41 stations
-- 74 routes
-- 5,429 route entries
-- 8 services
-- 1 train unit
-- 1 composition
-
-The import reports 30 timetable adjustments for intermediate departures stored as `-1`. These warnings are known. Validation and export still succeed.
-
-The Amsterdam to Hilversum assignment is a separate piece of work. The legacy case contains candidate timetables for Sprinter and Intercity services, plus VIRM train data. Candidate route IDs are 29 through 36, 39 through 42, 53, and 54. Each route must be run and checked before it is assigned to a service.
-
-Keep the full Netherlands scene as the reference case. Build the smaller assignment scene only after the selected Amsterdam to Hilversum services work in the full network.
-
-See [Netherlands assignment brief](netherlands-assignment.md) for the work plan and checklists.
-
-## Lebanon case
-
-The Lebanon scene is at `EGTRAIN/QEGTRAIN/Scenes/Lebanon`. It is an infrastructure shell built from the supplied Lebanon network with `scene_tool import`. The source provides 34 stations and the track folders `B0` through `B7`.
-
-The shell contains the 34 stations and the legacy track files under `legacy/Tracklines`. The network renders and simulates from that legacy passthrough, so the canonical `infrastructure.json` holds no separate arc or node geometry.
-
-Rolling stock, compositions, services, and timetable data were not supplied. The end user adds them in the editor. Until then, validation reports only the missing services and train data, and the run stays gated. After the train data is added, the scene validates, exports, reloads, and runs.
-
-`tools/e2e/lebanon_scene_smoke.sh` checks the station count, the expected missing data, a clean export with the `B0` through `B7` passthrough, and a GUI load that renders the network and gates the run.
-
-## Before committing a scene
-
-- Validate the scene.
-- Export it to a clean temporary directory.
-- Run at least one train through every new route.
-- Check station order and direction.
-- Check planned arrival, departure, dwell, and entry times.
-- Run the scene and legacy compatibility tests.
-- Keep generated output, temporary exports, `.DS_Store`, and logs out of Git.
-- Record source data and unresolved assumptions in the relevant guide.
+This guide describes Milestone 1's canonical directory and legacy bridge. The
+`.egscene` bundle format and native simulator input are outside this milestone.

--- a/docs/guides/v1-scene-migration-matrix.md
+++ b/docs/guides/v1-scene-migration-matrix.md
@@ -1,0 +1,62 @@
+# V1 active-input migration matrix
+
+This matrix records the Milestone 1 boundary traced from live consumers, not
+from filenames alone. `canonical` means structured V1 input, `derived` means
+reconstructed from canonical topology, `output/interoperability` means it is
+not authored simulation input, `dead/inert` means the normal run path does not
+activate it, and `unresolved` marks a relationship that cannot yet be mapped
+without guessing.
+
+| Legacy family | Classification | V1 handling and consumer evidence |
+| --- | --- | --- |
+| `InitialParameters` base time, duration, buffer, recovery | canonical | `SceneModel` and `SceneWriter` use `base_time` plus the three `simulation_settings` values. `InitialParameters::set_case` supplies the known legacy-case values. Counts, UI switches, output paths, and network flags are not independent scene input. |
+| `NodiCumPari`, `ArchiCumPari`, `BlockCumPari` | canonical | `Infrastructure` consumes node coordinates, arc endpoints, curvature, gradient, speed, and block-row lengths. `SceneImporter` maps them to stable track-scoped node/arc IDs and runtime-compatible block IDs. |
+| `Connections.txt` | canonical | `Infrastructure` consumes track/coordinate endpoints and optional speed. The importer resolves exact coordinates to node IDs and reports zero or ambiguous matches instead of guessing. |
+| track-line `Stations.txt` | canonical | `Infrastructure` assigns station anchors by exact X coordinate. V1 stores station positions and platform-to-node references; unmatched coordinates remain reported. |
+| `Routes/Route<N>.txt` | canonical | `Signalling::setUpAllRoutes` consumes ordered block and switch-transition tokens. V1 routes retain that order and resolve services to stable route IDs. |
+| `GUI/caseStudyRouteCorridors.txt` | canonical | `Signalling::loadRouteCorridors` consumes route/corridor rows. The importer stores the value on the corresponding V1 route; it is not treated as a second route definition. |
+| `RoutesToWrite/RoutesToJoin.txt` | canonical when populated | `Signalling::loadAllJoinedRoutes` is active. The importer materializes each non-empty row as an appended route with concatenated blocks and `reversed` metadata. Committed files are empty, so they add no entities today. |
+| ordinary block dependencies, signals, virtual signals, TDS | derived | `Signalling` derives these from blocks, routes, switches, and connections. They are documented derivations rather than duplicate authored inputs; the historical `signals` array remains load-compatible but is not runnable completeness. |
+| Copenhagen `5-B6` dependency exception | canonical | The live signalling path adds a non-derivable dependency from `5-B6` to `@1-B30@-4.592000/@5-B7@-4.620000`. V1 persists that explicit exception and validates each composite component. |
+| `GUI/singleTrackLimits.txt` | canonical | The active reader consumes four distinct block roles. V1 stores `start_block`, `end_block`, `protected_start_block`, and `protected_end_block` explicitly. |
+| `GUI/stationBoundarySections.txt` | canonical | The active reader consumes entrance block, optional exit block, and direction. V1 stores those fields directly. |
+| seven-token `Trains` definitions | canonical | `RollingStock::LoadAllTrainFiles` consumes operating code, entry, headway, route index, physical file, traction file, and timetable file. The importer preserves every explicit relationship. Canonical service IDs remain unique while `operating_code` retains duplicate active codes such as Milano-Brescia `9707` and `9709`. |
+| train-unit physical files | canonical | `RollingStock::loadTrainType` consumes nine physical/operating values. V1 stores them on a generic train unit, independent of `LITRA` terminology. |
+| tractive-effort files | canonical | The runtime consumes five-number curve rows. The train manifest, not `T_` or another filename convention, associates a curve with its train unit. |
+| compositions | canonical | V1 compositions contain ordered train-unit references. Current legacy manifests yield one-unit compositions, without making the source filename a universal train type. |
+| planned timetable arrival, departure, dwell, repetition | canonical | Runtime timetable and train setup consume these values. V1 uses independently optional `planned_arrival_seconds` and `planned_departure_seconds`; `-1` becomes absence and inconsistent source values are reported without alteration. |
+| flat `Incidents.txt` / historical `incidents.json` | canonical compatibility | The active incident loader supports signal failures and train breakdowns. Import places flat incidents in the baseline and copies them into each imported rollout scenario because the legacy runtime applies both inputs together; preferred V1 persistence is `scenarios.json`. |
+| `Rollout_<n>.txt` entrance delays | canonical when resolvable | The active Paimpol path applies the positional vector to service occurrences at Guingamp/Paimpol. The importer maps it only with a known duration and headway; count mismatches or unknown case timing are reported rather than guessed. No committed `.txt` rollout currently exists. |
+| DAS plus RouteChoice passenger CSVs | canonical | `DispatchController` activates passenger loading only when both exact files exist. V1 stores absolute-midnight journey windows and ordered service/occurrence legs; randomized draws and simulated passenger results are excluded. |
+| generated `TrackandStations`, `VisualizeConnections`, `ShowElements`, `List_of_Blocks` | derived/output | Infrastructure and signalling produce these display and route-authoring aids from topology. They are not additional authoritative scene inputs. |
+| `TrackLines/AreasCaseStudy.txt` and historical `Areas*.TXT` | dead/inert in the current source | No current simulation reader consumes these files. The legacy exporter still preserves or synthesizes `AreasCaseStudy.txt` for compatibility with older variants, but it is not a second V1 signalling model. |
+| `Draisy-acceleration.txt` | dead/inert | No normal runtime consumer references this related file; only the explicitly selected physical and traction paths are loaded. It therefore does not justify another canonical data type. |
+| `TimeTable/Scenarios_DW*` | dead/inert | The dwell-disturbance loader call in `DispatchController` is commented out. Directory presence alone does not activate it. |
+| OL train-order lists | dead/inert | `DispatchController` resets `N_OrderLists` to zero before the loader loop, and the `Set_RespectOrder` activation calls are commented. Committed uppercase `.TXT` names also differ from the lowercase lookup on case-sensitive systems. |
+| normal `Rescheduling`, ROMA, and legacy TMS/TDS input trees | dead/inert or derived | ROMA closed-loop loading is not active in normal setup, and TDS is built from topology. Files remain compatibility passthrough where needed, not canonical fields without a live consumer. |
+| `EGTRAINOutput`, ROMA/TDS artifacts, `FolderEGTRAIN`, `OL_LastEntry`, `ScheduledOrder` | output/interoperability | Simulation and integration code write these artifacts. They are not case-scene input. |
+| GUI coordinate/display files other than the explicit corridor/restriction/boundary inputs | output/interoperability | Geocoding and the GUI consume them for display; simulation station X/name values come from track-line data. They remain view/compatibility data rather than a second infrastructure model. |
+| RailML/XML | output/interoperability | `RailMLParser` serializes traffic state and route choice for exchange; it does not import a V1 scene. |
+| `rand1.seed` | output/interoperability | `NumberGenerator` persists mutable process RNG state. It is neither authoritative case input nor a passenger result field in V1. |
+| unknown-case compiled `InitialParameters` mapping | unresolved | The four canonical timing fields are known, but a folder/name outside the explicit case table cannot safely select a `set_case` branch. Import leaves them absent and records the unresolved mapping. |
+
+## Known source ambiguities
+
+- Copenhagen contains a Koge Nord stop whose planned arrival is later than its
+  planned departure. Import preserves both source values, reports the row, and
+  lets semantic validation reject the ordering instead of silently repairing it.
+- The committed Paimpol passenger source has 376 DAS journeys but only 10
+  route-choice rows, producing 14 resolved legs. The remaining 366 journeys are
+  retained without legs and reported. Thirty DAS station references and three
+  route-choice service or station references remain unresolved rather than being
+  matched heuristically.
+- No committed `Rollout_<n>.txt` exists. The importer supports its known
+  positional relationship only where case duration and service headway make the
+  occurrence mapping explicit.
+- Legacy cases outside the compiled `InitialParameters` case table have no
+  reliable timing association. Their V1 timing fields remain absent and the
+  import report records the unresolved mapping.
+
+The compatibility `legacy/` tree remains because the current simulator still
+uses legacy loaders. Its presence does not make every copied file canonical,
+and removing that runtime path belongs to a later milestone.

--- a/docs/guides/v1-scene-properties.md
+++ b/docs/guides/v1-scene-properties.md
@@ -1,198 +1,201 @@
-# V1 scene property reference
+# V1 scene properties
 
-Use this reference while editing a V1 scene by hand. The application guide explains the full workflow: [Using EGTRAIN and authoring V1 scenes](scenes-and-application.md).
-
-Each scene is a directory. JSON object and property names are case sensitive. A property marked "required" must exist and have the stated type. An optional property uses the default listed below when it is absent.
-
-This reference describes the implementation as it works now. V1 is not yet a self-contained simulation format. Some JSON sections are canonical and used by the loader, validator, and exporter; other sections are placeholders or parse-only files. A runnable imported scene still needs files under `legacy/`.
+Use this guide when editing a scene by hand. Keys are case-sensitive and the
+preferred spellings are the ones shown here. The complete type and validation
+reference is [V1 Scene Schema](../architecture/scene-schema.md).
 
 ## `scene.json`
 
-| Property | Type | Required | Meaning | Accepted value and checks |
-| --- | --- | --- | --- | --- |
-| `schema_version` | integer | yes | Version of the canonical scene data | Must be `1`. Other values stop loading. |
-| `name` | string | yes | Scene name shown in the application | Must not be empty. |
-| `description` | string | no | Short note about the case | Defaults to an empty string. |
-| `base_time` | string | no | Clock time used as the zero point for service times | Must match `HH:MM:SS`, for example `08:00:00`. Defaults to an empty value. The validator checks the shape, not the hour, minute, or second ranges. |
-| `units` | object | no | Unit declarations for scene values | Defaults to metres, seconds, and metres per second. |
-| `units.distance` | string | no | Distance unit | If present, it must be `m`. |
-| `units.time` | string | no | Time unit | If present, it must be `s`. |
-| `units.speed` | string | no | Speed unit | If present, it must be `m/s`. |
-| `legacy_source` | string | no | Path recorded by the legacy importer | Kept as provenance only. The V1 loader ignores it and `Save Scene` does not write it back. |
-
-All times in the other files are measured in seconds relative to `base_time`. Negative service times are allowed because a timetable can start before the base time.
-
-## `infrastructure.json`
-
-| Property | Type | Required | Meaning | Accepted value and checks |
-| --- | --- | --- | --- | --- |
-| `nodes` | array | yes | Reserved canonical infrastructure nodes | The loader checks that this is an array but does not read its entries in V1. Use `[]`. |
-| `arcs` | array | yes | Reserved canonical infrastructure links | The loader checks that this is an array but does not read its entries in V1. Use `[]`. |
-
-The current simulator reads track geometry, blocks, switches, gradients, and speed limits from the exported `TrackLines/` directory. The exporter accepts `legacy/Tracklines/` or `legacy/TrackLines/` and normalizes the name. Editing `nodes` or `arcs` has no effect on a run. `Save Scene` rewrites both arrays as `[]`, so it does not preserve entries placed in them.
-
-## `stations.json`
-
-The root property is `stations`, a required array.
-
-| Property | Type | Required | Meaning | Accepted value and checks |
-| --- | --- | --- | --- | --- |
-| `stations[].id` | string | yes | Identifier used by service stops | Must not be empty and must be unique among stations. Keep it free of whitespace so the scene can export to the legacy timetable format. |
-| `stations[].name` | string | yes | Name shown to the user | Must not be empty. It does not act as a reference. |
-| `stations[].position_km` | number | no | Track position emitted by the legacy importer | The V1 loader ignores it and `Save Scene` does not write it back. The simulator obtains the station position from `legacy/TrackLines/`. |
-| `stations[].platforms` | array | no | Platforms that a stop may name | Defaults to an empty array. A value of another type is currently treated as an empty array. |
-| `stations[].platforms[].id` | string | yes, when the platform exists | Platform identifier within the station | Must not be empty. A service platform must match one of the IDs on its station. The validator does not check duplicate platform IDs. |
-
-## `signalling.json`
-
-The root properties `signals` and `routes` are required arrays.
-
-| Property | Type | Required | Meaning | Accepted value and checks |
-| --- | --- | --- | --- | --- |
-| `signals[].id` | string | yes | Signal identifier | Must not be empty and must be unique among signals. A `signal_failure` incident uses this ID as its target. |
-| `routes[].id` | string | yes | Route identifier used by services | Must not be empty and must be unique among routes. Imported legacy routes use IDs such as `route29`. |
-| `routes[].blocks` | array of strings | yes | Ordered block tokens followed by the route | Must contain at least one string. Non-string entries are ignored. The validator checks for an empty result, but it does not resolve block IDs against the legacy track files. |
-
-Route direction and suitability are properties of the ordered block list, not the route number. Run a train over a route before assigning it to a Sprinter or Intercity service.
-
-## `rolling_stock.json`
-
-The root properties `train_units` and `compositions` are required arrays. At least one unit and one composition must exist.
-
-### Train units
-
-| Property | Type | Required | Meaning | Accepted value and checks |
-| --- | --- | --- | --- | --- |
-| `train_units[].id` | string | yes | Train unit identifier | Must not be empty and must be unique among train units. |
-| `train_units[].physical` | object | no for loading | Physical values needed to export and run the unit | If present, all nine properties below are required numbers. Export fails when a service uses a unit without physical data. |
-| `physical.mass_of_traction_unit_kg` | number | with `physical` | Mass of the powered unit in kilograms | The loader does not impose a range. |
-| `physical.mass_of_a_wagon_kg` | number | with `physical` | Mass of one wagon in kilograms | The loader does not impose a range. |
-| `physical.number_of_wagons` | number | with `physical` | Number of wagons attached to the powered unit | Stored as a number for legacy compatibility. The loader does not require an integer or impose a range. |
-| `physical.max_speed_ms` | number | with `physical` | Maximum train speed in metres per second | The loader does not impose a range. Convert km/h by dividing by `3.6`. |
-| `physical.max_deceleration_ms2` | number | with `physical` | Maximum service deceleration in metres per second squared | The loader does not impose a range. |
-| `physical.frontal_area_m2` | number | with `physical` | Frontal area used by the resistance model, in square metres | The loader does not impose a range. |
-| `physical.resistance_coefficient` | number | with `physical` | Coefficient used by the train resistance calculation | The loader does not impose a range. Copy it from verified train data. |
-| `physical.jerk_ms3` | number | with `physical` | Maximum change in acceleration per second | Measured in metres per second cubed. The loader does not impose a range. |
-| `physical.length_m` | number | with `physical` | Total unit length in metres | The loader does not impose a range. |
-| `train_units[].traction_curve` | array | no for loading | Piecewise traction-force curve | Each row must contain exactly five numbers. The shared validator reports an empty curve, non-increasing intervals, rows out of ascending lower-speed order, and overlaps. Export fails when a used unit has no rows. |
-| `traction_curve[][0]` | number | in each row | Lower speed bound, in metres per second | Must be below the upper bound. Rows must be ordered by increasing lower speed; an adjacent lower bound equal to the previous upper bound is allowed. |
-| `traction_curve[][1]` | number | in each row | Upper speed bound, in metres per second | Must be above the lower bound and must not overlap the next interval. |
-| `traction_curve[][2]` | number | in each row | Constant coefficient `C0` | Traction force is `C0 + C1 * v + C2 * v^2` within the row's speed interval. |
-| `traction_curve[][3]` | number | in each row | Linear coefficient `C1` | Used in the traction-force formula above. |
-| `traction_curve[][4]` | number | in each row | Quadratic coefficient `C2` | Used in the traction-force formula above. |
-| `train_units[].source` | object | no | Original legacy train-data paths | If present, both properties below must be non-empty strings. The exporter uses their base filenames. |
-| `source.data_file` | string | with `source` | Source file for the nine physical values | Usually a path such as `/TrainData/SLT06.txt`. |
-| `source.traction_file` | string | with `source` | Source file for the traction curve | Usually a path such as `/TrainData/T_SLT06.txt`. |
-
-### Compositions
-
-| Property | Type | Required | Meaning | Accepted value and checks |
-| --- | --- | --- | --- | --- |
-| `compositions[].id` | string | yes | Identifier used by services | Must not be empty and must be unique among compositions. |
-| `compositions[].units` | array of strings | yes | Ordered train units in the consist | Must contain at least one known train-unit ID. Non-string entries are ignored. Repeating an ID represents coupled copies of that unit. |
-
-When a composition contains several units, the exporter combines their masses, limits, lengths, resistance values, and traction curves into one legacy train definition.
-
-The Train Units dock edits these nine physical values and the five traction columns with numeric controls. Source data and traction filenames are read-only provenance fields. Renaming a unit updates composition references; deleting a referenced unit confirms the action and leaves the dangling reference for the validator to report.
-
-## `services.json`
-
-The root property is `services`, a required array. At least one service must exist.
-
-### Service properties
-
-| Property | Type | Required | Meaning | Accepted value and checks |
-| --- | --- | --- | --- | --- |
-| `services[].id` | string | yes | Service identifier | Must not be empty and must be unique among services. A `train_breakdown` incident uses this ID as its target. |
-| `services[].composition` | string | yes | Train consist used by the service | Must match a composition ID in `rolling_stock.json`. |
-| `services[].route` | string | yes | Infrastructure route used by the service | Must match a route ID in `signalling.json`. |
-| `services[].through` | boolean | no | Marks a service that crosses the scene without scheduled stops | Defaults to `false`. A through service with stops produces a warning. |
-| `services[].entry_time_seconds` | number | no | Time when the train enters the simulation | Defaults to the first stop's departure during legacy export, or `0` if that departure is absent. |
-| `services[].repeat` | object | no | Repetition settings | When absent, the service is exported as a one-shot service. |
-| `services[].repeat.headway_seconds` | number | with `repeat` | Time between repeated trains | Must be greater than `0`. |
-| `services[].stops` | array | yes | Ordered timetable stops | May be empty. An empty non-through service produces a warning. |
-
-### Stop properties
-
-| Property | Type | Required | Meaning | Accepted value and checks |
-| --- | --- | --- | --- | --- |
-| `stops[].station` | string | yes | Station where the train stops | Must match a station ID in `stations.json`. |
-| `stops[].platform` | string | no | Platform used at the station | If present and non-empty, it must match a platform ID on that station. |
-| `stops[].arrival_seconds` | number | no | Planned arrival relative to `base_time` | May be omitted on any stop. It is normally absent at the first stop. Negative values are allowed. |
-| `stops[].departure_seconds` | number | yes, except at the last stop | Planned departure relative to `base_time` | Must be at or after the arrival at the same stop. A lower value than the previous stop's departure produces a warning. Negative values are allowed. |
-| `stops[].dwell_seconds` | number | yes | Planned stationary time at the stop | Must be `0` or greater. A value larger than departure minus arrival produces a warning. |
-
-Keep stops in travel order. Verify that each station belongs to the chosen route because the validator cannot infer station order from legacy block tokens.
-
-## `incidents.json`
-
-This file is optional. When present, its root property `incidents` is a required array.
-
-| Property | Type | Required | Meaning | Accepted value and checks |
-| --- | --- | --- | --- | --- |
-| `incidents[].id` | string | yes | Incident identifier | Must not be empty and must be unique among incidents. |
-| `incidents[].type` | string | yes | Kind of disruption | Must be `signal_failure` or `train_breakdown`. |
-| `incidents[].target` | string | yes | Object affected by the incident | Must match a signal ID for `signal_failure` or a service ID for `train_breakdown`. |
-| `incidents[].start_seconds` | number | yes | Start time relative to `base_time` | Must be `0` or greater. |
-| `incidents[].end_seconds` | number | yes | End time relative to `base_time` | Must be greater than `start_seconds` and `0` or greater. |
-
-`Save Scene` removes `incidents.json` when the scene has no incidents.
-
-## `views.json`
-
-This optional file stores display settings. The V1 loader only checks that it contains valid JSON with an object at the root. It does not interpret or validate any property. `Save Scene As...` copies the file, while `Save Scene` leaves it unchanged.
-
-Do not depend on a `views.json` property for simulation behavior.
-
-## `legacy/`
-
-`legacy/` is a directory, not a JSON property. It contains data that the V1 model does not yet represent. Imported scenes need it for a simulation run.
-
-Common contents include:
-
-| Path | Purpose |
-| --- | --- |
-| `Tracklines/` or `TrackLines/` | Track geometry, block layout, stations, switches, gradients, and speed limits used by the simulator |
-| `TMS/` and `TDS/` | Legacy signalling and train-detection data |
-| `GUI/` | Legacy display coordinates and related settings |
-| `Rescheduling/`, `Passengers/`, and `RoutesToWrite/` | Optional case-specific runtime data not represented by the V1 model |
-| `Timetable/Scenarios_*` | Scenario directories copied through without conversion |
-| Non-route files under `Routes/` | Route support files copied through without conversion |
-
-The exporter writes routes, trains, timetables, and incidents from the canonical JSON first. It then copies files from `legacy/` only when the generated output does not already contain the destination. Do not edit generated files in an export and expect the changes to return to the V1 scene.
-
-### Work that removes the legacy dependency
-
-Issue status checked on 13 July 2026:
-
-- [#83](https://github.com/Ancientkingg/EGTRAIN/issues/83) is the open epic for making the scene model the simulator's native input.
-- [#84](https://github.com/Ancientkingg/EGTRAIN/issues/84) converted the four case studies, but it is complete and did not remove their `legacy/` passthrough.
-- [#85](https://github.com/Ancientkingg/EGTRAIN/issues/85) covers the main format gap: building track, block, switch, station, connection, route, and signalling structures from canonical scene data.
-- [#86](https://github.com/Ancientkingg/EGTRAIN/issues/86) replaces the legacy rolling stock, service, and timetable loaders.
-- [#87](https://github.com/Ancientkingg/EGTRAIN/issues/87) loads incidents directly from the scene model.
-- [#88](https://github.com/Ancientkingg/EGTRAIN/issues/88) changes the GUI and CLI run path so it no longer stages a legacy export before simulation.
-- [#89](https://github.com/Ancientkingg/EGTRAIN/issues/89) removes the old text loaders and input trees after the native path works.
-
-These issues cover the main simulation path, but the tracking is incomplete. No dedicated issue currently converts `GUI/`, `TMS/`, `TDS/`, `Rescheduling/`, `Passengers/`, or `RoutesToWrite/` into canonical scene properties. [#125](https://github.com/Ancientkingg/EGTRAIN/issues/125) makes missing or unimplemented data visible in the UI, but it does not define or load those properties.
-
-Issue #85 also needs a schema and importer step. Its current text says to build infrastructure from `SceneModel`, but the current model has no node or arc fields, the loader only checks that the two arrays exist, and the importer writes both arrays empty.
-
-The compatibility track preview should be removed through three ordered follow-up issues:
-
-1. **Define and persist canonical infrastructure.** Specify V1 fields and validation for tracks, nodes, arcs, switches, connections, gradients, speed limits, blocks, stations, and signalling references. Update scene loading and writing so those values round-trip instead of leaving `nodes` and `arcs` empty.
-2. **Import legacy infrastructure into the canonical model.** Convert `TrackLines`, `Connections.txt`, station anchors, block data, and signalling topology into those fields. Cover all committed case studies with import, validation, and round-trip tests.
-3. **Render and simulate canonical infrastructure.** Build the network view and simulator topology from `SceneModel`, then delete `TrackPreview`, the compatibility rendering hook, and the runtime dependency on `legacy/TrackLines` once canonical coverage is complete.
-
-These issues form a dependency chain: schema and persistence first, import second, native rendering and simulation third.
-
-The bundle work in [#99](https://github.com/Ancientkingg/EGTRAIN/issues/99), [#100](https://github.com/Ancientkingg/EGTRAIN/issues/100), and [#102](https://github.com/Ancientkingg/EGTRAIN/issues/102) says that `.egscene` files exclude `legacy/`. That is not sufficient for the current run path. A portable bundle either needs the native-input work above and coverage for the remaining passthrough data, or it must carry `legacy/` until that migration is complete.
-
-## Validation command
-
-Run the validator after editing any file:
-
-```bash
-./build/scene_tool validate path/to/scene
+```json
+{
+  "schema_version": 1,
+  "name": "Example",
+  "base_time": "08:00:00",
+  "units": {"distance": "m", "time": "s", "speed": "m/s"},
+  "simulation_settings": {
+    "duration_seconds": 3600,
+    "buffer_time_seconds": 0,
+    "recovery_time_percent": 0
+  }
+}
 ```
 
-An error blocks the scene from running. A warning points to a timetable or modelling issue that needs inspection but does not block the run. The full list of diagnostic codes is in the [scene schema reference](../architecture/scene-schema.md#diagnostics).
+`name` and `schema_version` are required. `description`, `base_time`,
+`units`, and `simulation_settings` are optional. An `import_report` array
+records conversion rows with `category`, optional `source_file`,
+`source_count`, `converted_count`, `skipped_count`, and
+`unresolved_references`.
+
+The four simulation settings above are the scene-level timing controls.
+Legacy counts, GUI/output/network flags, and output paths do not belong here.
+
+## Infrastructure and stations
+
+`infrastructure.json` uses these preferred arrays:
+
+```json
+{
+  "tracks": [{"id": "track.1"}],
+  "nodes": [{"id": "node.1", "track": "track.1", "x_km": 0, "y_km": 0}],
+  "arcs": [{"id": "arc.1", "track": "track.1", "from": "node.1", "to": "node.2", "curvature_radius_m": 0, "gradient_percent": 0, "speed_limit_ms": 30}],
+  "blocks": [{"id": "block.1", "track": "track.1", "length_km": 1}],
+  "connections": [{"id": "connection.1", "from": "node.2", "to": "node.3", "speed_limit_ms": 10}]
+}
+```
+
+`nodes` and `arcs` are required arrays. `tracks`, `blocks`, and `connections`
+may be empty or omitted on input. A station has `id`, `name`, optional
+`position_km`, and optional `platforms`; each platform has `id` and a `nodes`
+array of node IDs.
+
+## Signalling
+
+`signalling.json` requires `signals` and `routes` arrays. A signal has `id`.
+A route has `id`, a string-array `blocks`, and optional `corridor` and
+`reversed`.
+
+Use these optional arrays for explicit signalling relationships:
+
+- `block_dependencies`: `{ "block": "...", "depends_on": "..." }`.
+- `single_track_restrictions`: `start_block`, `end_block`,
+  `protected_start_block`, and `protected_end_block`.
+- `station_boundaries`: `entrance_block`, optional `exit_block`, and optional
+  boolean `direction`.
+
+Signals, dependencies, virtual signals, and track-detection sections used by
+the current simulator are not interchangeable: derived runtime topology is
+documented in the [migration matrix](v1-scene-migration-matrix.md).
+
+## Rolling stock
+
+Each `train_units[]` item has an `id` and may have `physical`,
+`traction_curve`, and `source`. `physical` uses the exact nine keys:
+
+```text
+mass_of_traction_unit_kg, mass_of_a_wagon_kg, number_of_wagons,
+max_speed_ms, max_deceleration_ms2, frontal_area_m2,
+resistance_coefficient, jerk_ms3, length_m
+```
+
+Each traction row is `[v_lower, v_upper, c0, c1, c2]`. `source` contains the
+independent optional paths `data_file` and `traction_file`; do not infer a
+traction path from `LITRA`, `T_`, or any other filename convention.
+
+Each `compositions[]` item has an `id` and a non-empty `units` array of train
+unit IDs. Services refer to the composition ID, not directly to a source file.
+
+## Services and planned timetable
+
+The root of `services.json` is `services`. A service requires `id`,
+`composition`, `route`, and `stops`. Optional service properties are
+`operating_code`, `through`, `entry_time_seconds`, and
+`repeat.headway_seconds`. `id` is the unique reference used by the canonical
+model. `operating_code` is the train identity used by the current simulator;
+it defaults to `id` and may be shared by distinct services. The legacy
+importer retains the first token of each `Trains` definition here instead of
+changing it when duplicate canonical IDs need a suffix. A legacy train
+breakdown targeting a shared code is expanded to each matching service because
+the current runtime applies that prefix to every matching train; import reports
+the expansion.
+
+Each stop requires `station` and `dwell_seconds`; `platform` is optional. The
+preferred planned-time keys are independently optional on every stop:
+
+```json
+{
+  "station": "station.1",
+  "planned_arrival_seconds": 120,
+  "planned_departure_seconds": 180,
+  "dwell_seconds": 60
+}
+```
+
+The values are planned seconds relative to the scene base-time origin. A stop
+may omit arrival, departure, either one, or both. Legacy timetable `-1`
+values are imported as absent fields; the importer does not synthesize or
+raise a value. Validation may warn about an incomplete intermediate schedule.
+These fields are input plans, never simulation results. A service with no
+stops may be marked `through: true`; a repeated service uses a positive
+`repeat.headway_seconds`.
+
+## Scenarios
+
+`scenarios.json` uses the preferred root keys `default_scenario_id` and
+`scenarios`:
+
+```json
+{
+  "default_scenario_id": "baseline",
+  "scenarios": [
+    {
+      "id": "baseline",
+      "name": "Baseline",
+      "incidents": [],
+      "entrance_delays": []
+    },
+    {
+      "id": "failure-1",
+      "name": "Signal failure",
+      "incidents": [{"id": "inc.1", "type": "signal_failure", "target": "signal.1", "start_seconds": 300, "end_seconds": 900}],
+      "entrance_delays": [{"service": "service.1", "occurrence": 1, "station": "station.1", "delay_seconds": 120}]
+    }
+  ]
+}
+```
+
+An incident is concrete input with `id`, `type`, `target`, `start_seconds`,
+and `end_seconds`. Valid types are `signal_failure` and `train_breakdown`.
+An entrance delay has `service`, optional `occurrence`, `station`, and
+`delay_seconds`. If no scenario file is supplied, the loader creates a
+baseline; the historical flat incident file is read into that baseline.
+
+## Passengers
+
+`passengers.json` is optional. Its root is `passengers`; each passenger has
+`id` and `journeys`. A journey uses `id`, `origin`, `destination`, optional
+`activity`, required `planned_departure` and `planned_arrival` windows, and
+`legs`. Each window contains `start_seconds` and `end_seconds` as absolute
+seconds from midnight. Each leg has `id`, `origin`, `destination`, `service`,
+and optional `occurrence` (default `1`).
+
+Journey and leg IDs are scene-wide stable IDs. An empty `legs` array preserves
+a DAS journey for which the legacy route-choice input has no matching row; the
+validator warns instead of guessing a route.
+
+Passenger JSON is separate from the runtime's conditional CSV integration.
+That integration reads DAS and RouteChoice only when both exact files exist:
+`Passengers/DAS_FrenchCaseStudy.csv` and
+`Passengers/RouteChoiceFC_EQ1.csv`. Random draws and generated passenger
+results are not scene input.
+
+## Compatibility aliases
+
+The loader accepts these historical forms when the preferred key is absent;
+`SceneWriter` emits the preferred form:
+
+| Historical form | Preferred form |
+| --- | --- |
+| stop `arrival_seconds` | `planned_arrival_seconds` |
+| stop `departure_seconds` | `planned_departure_seconds` |
+| optional `incidents.json` | scenario incidents in `scenarios.json` |
+
+## Save, load, and run
+
+`Save Scene` writes the canonical files and removes stale flat incident data.
+`loaded_data` is runtime metadata, not an editable source section. `views.json`
+is display-only.
+
+The current runtime still needs the legacy compatibility tree for track-line
+data and other input it reads directly. The editor exports canonical data to
+a temporary legacy input tree before starting the simulator; keep `legacy/`
+when preparing an imported scene for a run.
+
+Use the three validation layers before running:
+
+1. structural shape (`validateSceneStructure`),
+2. semantic references and values (`validateScene`),
+3. runnable completeness (`validateRunnableScene`).
+
+See [V1 Scene Schema](../architecture/scene-schema.md) for the exact file
+contract and [V1 migration matrix](v1-scene-migration-matrix.md) for the
+legacy consumers and derived/output families.

--- a/tools/e2e/editor_smoke.sh
+++ b/tools/e2e/editor_smoke.sh
@@ -3,15 +3,27 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 APP="$ROOT/build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN"
-SCENE="${1:-$ROOT/EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut}"
+SCENE_TOOL="$ROOT/build/scene_tool"
 ALT_SCENE="${QEGTRAIN_E2E_SCENE_ALT:-$ROOT/EGTRAIN/QEGTRAIN/Scenes/Copenhagen}"
 OUT="${TMPDIR:-/tmp}/qegtrain-editor-smoke-e2e"
 LOG="${TMPDIR:-/tmp}/qegtrain-editor-smoke-e2e.log"
 
-if [[ ! -x "$APP" ]]; then
-	echo "QEGTRAIN app not found or not executable: $APP" >&2
+if [[ ! -x "$APP" || ! -x "$SCENE_TOOL" ]]; then
+	echo "QEGTRAIN app or scene_tool is not built" >&2
 	exit 1
 fi
+
+if [[ $# -gt 0 ]]; then
+	SCENE="$1"
+else
+	SOURCE="$ROOT/EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut"
+	TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/qegtrain-editor-smoke.XXXXXX")"
+	trap 'rm -rf "$TMP_ROOT"' EXIT
+	SCENE="$TMP_ROOT/scene"
+	"$SCENE_TOOL" import "$SOURCE/legacy" "$SCENE" Assignment
+	cp "$SOURCE/rolling_stock.json" "$SOURCE/services.json" "$SOURCE/signalling.json" "$SCENE/"
+fi
+
 if [[ ! -d "$ALT_SCENE" ]]; then
 	echo "Alternate scene not found: $ALT_SCENE" >&2
 	exit 1

--- a/tools/e2e/scene_render_smoke.sh
+++ b/tools/e2e/scene_render_smoke.sh
@@ -3,13 +3,28 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 APP="$ROOT/build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN"
-SCENE="${1:-$ROOT/EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut}"
+SCENE_TOOL="$ROOT/build/scene_tool"
 OUT="${TMPDIR:-/tmp}/qegtrain-scene-render-e2e.log"
 SHOT="${TMPDIR:-/tmp}/qegtrain-scene-render-e2e.png"
+TMP_ROOT=""
 
-if [[ ! -x "$APP" ]]; then
-	echo "QEGTRAIN app not found or not executable: $APP" >&2
+if [[ ! -x "$APP" || ! -x "$SCENE_TOOL" ]]; then
+	echo "QEGTRAIN app or scene_tool is not built" >&2
 	exit 1
+fi
+
+if [[ $# -gt 0 ]]; then
+	SCENE="$1"
+else
+	# The committed Assignment scene is intentionally loadable but incomplete.
+	# Build a runnable canonical copy from its legacy infrastructure plus its
+	# canonical operations so this smoke exercises the scene-run path.
+	SOURCE="$ROOT/EGTRAIN/QEGTRAIN/Scenes/Assignment_Gvc_Gdg_Ut"
+	TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/qegtrain-scene-render.XXXXXX")"
+	trap 'rm -rf "$TMP_ROOT"' EXIT
+	SCENE="$TMP_ROOT/scene"
+	"$SCENE_TOOL" import "$SOURCE/legacy" "$SCENE" Assignment
+	cp "$SOURCE/rolling_stock.json" "$SOURCE/services.json" "$SOURCE/signalling.json" "$SCENE/"
 fi
 
 rm -f "$SHOT"


### PR DESCRIPTION
## Summary

- represent every actively consumed simulation input in the canonical V1 scene model or document its derivation
- add generic train-unit, traction-curve, composition, timetable, scenario, provenance, passenger, and operational data
- extend scene loading, writing, legacy importing, validation, tests, and format documentation
- document the active-input migration matrix and intentionally excluded legacy data

## Scope

This PR completes the canonical V1 representation. It deliberately does not remove or replace the existing legacy simulation runtime path; runtime cutover belongs to later milestones.

## Verification

- focused scene load/write/reload, importer, rolling-stock association, and validation tests pass
- final fresh-context correctness review found no blocking issues
- documentation and implementation were checked against active runtime consumers