### PR TITLE
Reconcile post-migration roadmap and project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,13 @@ interface.
 
 - [Application and scene guide](docs/guides/scenes-and-application.md)
 - [Scene property reference](docs/guides/v1-scene-properties.md)
-- [Netherlands assignment guide](docs/guides/netherlands-assignment.md)
+- [Assignment corridor](docs/product/assignment-corridor.md)
 - [Assignment workflow](docs/product/assignment-workflow.md)
 - [Scene model architecture](docs/architecture/scene-model.md)
 - [Build and test guide](docs/development/build-and-test.md)
+
+The [superseded Netherlands assignment brief](docs/guides/netherlands-assignment.md)
+is retained as historical exploration.
 
 ## Repository layout
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Start here:
 - [Opening an `.egscene` case study](guides/opening-a-case-study.md)
 - [Lebanon case study guide](guides/lebanon-case-study.md)
 - [V1 scene property reference](guides/v1-scene-properties.md)
-- [Netherlands scene assignment](guides/netherlands-assignment.md)
+- [Assignment corridor](product/assignment-corridor.md)
 - [Assignment workflow](product/assignment-workflow.md)
 - [Scene model design](architecture/scene-model.md)
 - [Roadmap](planning/roadmap.md)
@@ -15,5 +15,9 @@ Start here:
 - [Build and test guide](development/build-and-test.md)
 - [Release testing checklist](development/release-testing-checklist.md)
 - [Writing style](development/writing-style.md)
+
+Historical reference:
+
+- [Superseded Netherlands assignment brief](guides/netherlands-assignment.md)
 
 Keep new documentation short, concrete, and current.

--- a/docs/architecture/scene-model.md
+++ b/docs/architecture/scene-model.md
@@ -71,8 +71,9 @@ to be unique: Milano-Brescia contains distinct service definitions sharing
 codes `9707` and `9709`.
 
 Passenger journey windows use absolute seconds from midnight. They are not
-random passenger draws, simulation results, or a replacement for the legacy
-runtime's conditional DAS/RouteChoice CSV loader.
+random passenger draws or simulation results. DAS and RouteChoice CSV files
+are read only by explicit legacy import and written only by explicit legacy
+export.
 
 The native operations path gives every expanded occurrence the stable runtime
 identity `<service id>-<occurrence>` and uses the canonical service ID for

--- a/docs/development/release-testing-checklist.md
+++ b/docs/development/release-testing-checklist.md
@@ -1,25 +1,78 @@
 # Release Testing Checklist
 
-Use this checklist before merging release workflow changes or pushing a `v*` tag.
+Use this checklist before a student release. Record the tag, commit SHA,
+platform, OS version, package name, case-study bundle, result, and linked defect
+for every rehearsal.
 
-## CI Run
+## Automated release evidence
 
-- Confirm the `Release` workflow finishes with `Package macOS`, `Package Windows`, and `Package Linux` green.
-- Confirm `Publish GitHub Release` is skipped on branch pushes.
-- Download these artifacts from the run:
-  - `QEGTRAIN-macos-arm64`
-  - `QEGTRAIN-windows-x64`
-  - `QEGTRAIN-linux-x86_64`
+Confirm the `Release` workflow finishes with the macOS, Windows, and Linux jobs
+green. The macOS job must also complete its scene-bundle generation and
+validation step.
 
-## Artifact Checks
+Expected application assets:
 
-- macOS: unzip `QEGTRAIN-macos-arm64.zip`; confirm it contains `QEGTRAIN.app`.
-- Windows: unzip `QEGTRAIN-windows-x64.zip`; confirm it contains `QEGTRAIN.exe`, Qt DLLs, `platforms/qwindows.dll`, a `libzmq` DLL, and all six directories under `Scenes/`.
-- Linux: mark `QEGTRAIN-linux-x86_64.AppImage` executable; confirm `--appimage-extract` creates `squashfs-root/usr/bin/QEGTRAIN` and `squashfs-root/usr/bin/Scenes/` with all six scenes.
+- `QEGTRAIN-macos-arm64.zip`
+- `QEGTRAIN-windows-x64.zip`
+- `QEGTRAIN-linux-x86_64.AppImage`
 
-## Tagged Release Rehearsal
+Expected case-study assets:
 
-- Push a pre-release tag such as `v1.0.0-rc1`.
-- Confirm the release job publishes all three platform artifacts.
-- Confirm GitHub marks the tag as a pre-release.
-- Delete the test release and tag after the rehearsal if it was only for CI validation.
+- `Netherlands.egscene`
+- `Paimpol.egscene`
+- `Copenhagen.egscene`
+- `Milano_Brescia.egscene`
+- `Assignment_Gvc_Gdg_Ut.egscene`
+- `Lebanon.egscene`
+
+Confirm the workflow validates all six bundles and publishes exactly the three
+application assets plus the six case-study assets. The macOS job also runs a
+packaged headless case. These checks prove artifact construction, not the GUI
+student workflow.
+
+## Clean-install GUI rehearsal
+
+Run this section on macOS, Windows, and Linux from downloaded release assets.
+Use a clean machine, VM, or user account without a source checkout, Qt, CMake,
+or other development dependencies in the test path.
+
+1. Launch the downloaded application through the platform's normal GUI path.
+2. Open a downloaded `.egscene` through **File > Open Case Study...**.
+3. Confirm the network renders and Loaded Data shows identity, versions,
+   category counts, scenarios, validation, runtime, and result readiness.
+4. Select or edit a scenario and confirm the run review names that scenario.
+5. Use **Save Case Study As...** to write a working copy outside the package.
+   Confirm the downloaded source bundle is unchanged.
+6. Run a short simulation from the working copy.
+7. Open timetable, delay, speed, and blocking-time results where the case
+   supports them. Confirm timetable output separates planned and simulated
+   arrival and departure values.
+8. Export one CSV and one PNG to a user-writable directory.
+9. Quit, relaunch, and reopen the working copy. Confirm saved canonical and
+   scenario edits remain.
+
+Also open `Assignment_Gvc_Gdg_Ut.egscene` and confirm its current data loads.
+Known station and rolling-stock fidelity gaps belong to #182, #228, and #181;
+they are not packaging failures.
+
+## Result record
+
+| Check | macOS | Windows | Linux | Evidence or defect |
+| --- | --- | --- | --- | --- |
+| Clean GUI launch |  |  |  |  |
+| Open downloaded `.egscene` |  |  |  |  |
+| Loaded Data and validation |  |  |  |  |
+| Scenario select or edit |  |  |  |  |
+| Save As outside package |  |  |  |  |
+| Source bundle unchanged |  |  |  |  |
+| GUI simulation completes |  |  |  |  |
+| Result views open |  |  |  |  |
+| CSV export |  |  |  |  |
+| PNG export |  |  |  |  |
+| Saved copy reopens |  |  |  |  |
+| No source or development dependency |  |  |  |  |
+
+The release gate passes only after every required row passes on all three
+platforms or is marked not applicable with a case-specific reason. Open one
+focused defect for each failed root cause instead of adding implementation work
+to issue #74.

--- a/docs/github-issues/README.md
+++ b/docs/github-issues/README.md
@@ -2,7 +2,8 @@
 
 Last updated: 2026-07-06
 
-This directory mirrors GitHub issues that track UI design and release automation work for EGTRAIN. It exists because no local issue mirror was present in the repository.
+This directory is a dated snapshot of issues that tracked UI design and release
+automation work. Use GitHub for current issue state and acceptance criteria.
 
 ## Source Tree Reorganization
 

--- a/docs/guides/netherlands-assignment.md
+++ b/docs/guides/netherlands-assignment.md
@@ -1,5 +1,12 @@
 # Netherlands assignment development brief
 
+This brief records the superseded Amsterdam to Hilversum exploration. Active
+assignment work uses `Assignment_Gvc_Gdg_Ut` and the Den Haag Centraal to
+Utrecht corridor described in
+[Assignment Corridor](../product/assignment-corridor.md).
+The remaining text is retained unchanged as a dated working record and is not
+the current implementation plan.
+
 ## Purpose
 
 This is a working brief for the assignment lead and two teaching assistants. The three of us are co-authors of a new EGTRAIN assignment based on the existing OpenTrack assignment. The teaching assistants are not students completing the assignment.

--- a/docs/planning/github-issues.md
+++ b/docs/planning/github-issues.md
@@ -1,5 +1,8 @@
 # GitHub Issue Plan
 
+This document preserves the initial backlog. See [Roadmap](roadmap.md) for the
+current corridor, completed migration work, and active priorities.
+
 ## Milestones
 
 1. Repository setup

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -1,162 +1,121 @@
 # Roadmap
 
-## Product Target
+## Current product state
 
-EGTRAIN V1 should support the railway traffic management assignment without requiring students to edit legacy input files. The application should load an assignment scene, edit assignment-level train and timetable data, run simulations, show the required diagrams, and export report data.
+EGTRAIN uses canonical V1 scene data for normal GUI, CLI, preview, and
+simulation input. The native builders construct infrastructure, signalling,
+rolling stock, services, timetables, the selected scenario, entrance delays,
+and passengers directly from `SceneModel`. Legacy import and export remain
+explicit interoperability tools.
 
-Full infrastructure editing is not part of V1. It stays on the roadmap after the assignment workflow works.
+Six case studies are committed as canonical scene directories. V2 `.egscene`
+files provide the portable form of the same V1 data. The application can open
+and save both forms. Loaded Data, validation, train and service editors, named
+scenario editing, native simulation, planned and simulated timetable results,
+CSV export, and PNG export are implemented.
 
-## Baseline In Place
+Release automation builds macOS, Windows, and Linux packages and publishes six
+validated `.egscene` bundles. The remaining release gate is a recorded
+clean-install GUI rehearsal, not package generation.
 
-- Qt application build through CMake.
-- Start, pause, stop, and playback speed controls.
-- Worker-thread simulation path.
-- Smooth train drawing and current-speed labels.
-- Timetable, delay, speed, and blocking-time diagrams.
-- Read-only right-side train information.
-- Console logging moved into an in-app log pane.
-- Headless smoke tests for Copenhagen and Brescia.
-- Visual smoke test for the main UI.
-- GitHub Actions build and unit-test workflow.
+## P0: Packaged student release rehearsal
 
-## P0: Repository Setup
+Goal: prove that a student can use a downloaded package and case study without
+a source checkout or development dependencies.
 
-Goal: make the repository buildable, testable, and clean from a fresh clone.
+- Complete and record the Windows, macOS, and Linux rehearsal in issue #74.
+- Open a downloaded `.egscene`, inspect Loaded Data, select or edit a scenario,
+  save a working copy, run it, inspect results, export CSV and PNG files, and
+  reopen the saved copy.
+- Treat CI package and bundle checks as automated evidence. They do not replace
+  the clean-install GUI run.
+- Fold the remaining macOS GUI acceptance from #233 into the same rehearsal.
+  Track any failure as a focused platform issue.
 
-Status: done.
+See [Release Testing Checklist](../development/release-testing-checklist.md).
 
-## P0: Scene Model And Converter
+## P0: Assignment case-study fidelity
 
-Goal: replace the messy scene input workflow with a clean canonical scene format.
+Goal: make `Assignment_Gvc_Gdg_Ut` match the source corridor, stopping patterns,
+and train material without guessed parameters.
 
-Missing work:
+1. Complete #182 for intermediate stations, distinct `Gd` and `Gdg` records,
+   route reachability, and source stopping patterns.
+2. Complete #228 for traceable ICM3, ICM4, IRM3, and SGM3 physical and traction
+   source data. This can proceed alongside #182.
+3. Complete #181 after #228, using that data for train-unit definitions and the
+   four assignment service compositions.
 
-- Define the V1 scene schema.
-- Write a scene validator with user-facing diagnostics.
-- Import legacy case-study folders into the new format.
-- Export canonical scenes back to the current simulator input files.
-- Add conversion tests for Copenhagen and Brescia.
-- Add clear errors for malformed input.
+The assignment epic remains #4. Do not substitute similar train types or infer
+missing physics.
 
-## P0: MVP Scene Editor
+## P1: Assignment-level editing gaps
 
-Goal: let students edit assignment-level data in the app.
+Goal: support the remaining assignment changes through canonical data and the
+GUI.
 
-Missing work:
+- #35: define, persist, and apply per-service performance controls.
+- #36: add repeated-service count and train-number step. Repeat headway editing
+  already exists.
+- #37: add the course-defined timetable rounding workflow.
+- #51: add reduced-speed and recovery behavior for train breakdowns. Basic
+  target and incident-window editing already exists.
+- #164: add passenger record inspection, interactive import, edit/delete,
+  row-context validation, and persistence. Canonical passenger storage and
+  native simulation are already implemented.
 
-- Scene open, save, and save-as flow.
-- Validation panel.
-- Train composition editor.
-- Service and stopping-pattern editor.
-- Timetable editor with half-hour service support.
-- Repeated-service creation.
-- Per-service performance parameter editor.
-- Incident editor for signal failures and train breakdowns.
-- Infrastructure context selection without full track drawing.
+## P1: Assignment analysis and disruption outputs
 
-## P0: Assignment Case Study
+Goal: provide the unfinished assignment analysis workflows without relisting
+basic scenario editing as missing.
 
-Goal: build the first EGTRAIN version of the OpenTrack assignment.
+- #38: support the Gouda overtaking workflow.
+- #45 through #49: add minimum headway, timetable compression, critical-block,
+  buffer-time, and capacity-percentage workflows.
+- #52: report primary, secondary, per-train, and total arrival delay.
 
-Missing work:
+Signal-failure editing and selected-scenario execution are complete.
 
-- Audit and repair Netherlands input data.
-- Verify the Amsterdam to Hilversum route candidates.
-- Build a curated assignment scene.
-- Add train material variants.
-- Add base timetable and disruption scenarios.
-- Add an assignment smoke test.
-- Check the workflow from a student perspective.
+## P1: Focused UI, release, and test reliability
 
-## P1: CI/CD Pipeline
+Keep defects and small workflow gaps as focused issues. Current examples are
+repository hygiene (#68), native migration parity evidence (#85 and #86),
+bundle drag and drop (#103), hostile-bundle regression coverage (#105),
+bundle-guide screenshots (#107), scenario change visibility (#126), export
+provenance (#129), consent-based updates (#155), startup state (#240),
+deterministic train reselection (#244), station-name acronyms (#246), overview
+station markers (#252), and measured startup or case-loading latency (#257).
 
-Goal: make pull requests and release candidates prove that the application builds, runs, and keeps its generated files out of git.
+## P2: Full infrastructure editing
 
-Missing work:
+The full infrastructure editor remains under epic #8 and issues #53 through
+#58. It covers canonical node, arc, track, switch, station, platform, signal,
+block, and topology editing. Normal verification must validate and save the
+canonical scene. Legacy export is an additional compatibility check only where
+the feature promises it.
 
-- Run unit tests on every pull request and push to `main`.
-- Add headless smoke tests to CI.
-- Add visual smoke test to CI where the runner supports it.
-- Upload failure logs and screenshots as workflow artifacts.
-- Add repository hygiene checks for generated files, backup files, and internal notes.
-- Add a release matrix for Windows, macOS, and Linux.
-- Build short-lived artifacts on `main`.
-- Add tagged release workflow for `v*` tags.
-- Package Windows releases as a portable zip first.
-- Package macOS releases as a zipped `.app` first.
-- Package Linux releases as an AppImage or portable archive first.
-- Attach all three platform packages to GitHub Releases.
-- Document a release testing checklist.
+## P2: Measurement-led performance and refactoring
 
-## P1: Student Workflow UI
+Measure before changing storage or ownership. Use #62, #63, and #257 to identify
+the dominant memory, playback, startup, or loading cost. Schedule #60, #61, or
+other storage changes only when measurements support them.
 
-Goal: make the GUI fit the assignment steps.
+Issues #117 through #120 remain valid but deferred. Extract editor or session
+ownership from `MainWindow` only when a product change is blocked, duplicated
+state causes defects, or focused tests cannot be added safely.
 
-Missing work:
+## Completed scene migration
 
-- Make load network the main entry point.
-- Add guided setup for assignment runs.
-- Improve simulation controls and speed control.
-- Use proper `HH:MM:SS` time formatting with a configurable base time.
-- Keep read-only panes clearly read-only.
-- Add camera follow options.
-- Add visual cues for acceleration and braking.
-- Distinguish station, train, and track types.
+| PR | Completed work |
+| --- | --- |
+| #260 | Canonical V1 model coverage |
+| #261 | Native infrastructure and signalling construction |
+| #262 | Native rolling stock, services, scenarios, entrance delays, and passengers |
+| #263 | Normal GUI, CLI, preview, and simulation cutover to canonical scenes |
+| #264 | Portable `.egscene` bundles and release distribution |
+| #265 | Loaded Data inspection and lineage |
+| #266 | Named scenario and transparent results workflow |
+| #267 | Removal of obsolete normal-runtime legacy readers |
 
-## P1: Diagrams And Exports
-
-Goal: support the figures and tables students need in their report.
-
-Missing work:
-
-- Train filtering in diagrams.
-- Hover readouts for graph values.
-- Planned timetable table and graph views.
-- Simulated timetable table and graph views.
-- Blocking-time overlay on the simulated timetable.
-- Speed-distance, speed-time, and single-train time-distance diagrams.
-- PNG export for diagrams.
-- CSV export for tables.
-
-## P1: Capacity And Disruptions
-
-Goal: support the capacity and disruption sections of the assignment.
-
-Missing work:
-
-- Minimum headway workflow.
-- Timetable compression.
-- Critical-block highlighting.
-- Buffer-time calculation.
-- Capacity percentage calculation.
-- Signal failure scenario.
-- Train breakdown scenario.
-- Primary, secondary, and total delay output.
-
-## P2: Full Infrastructure Editor
-
-Goal: edit infrastructure inside the application after V1 works.
-
-Missing work:
-
-- Node and arc editing.
-- Track and switch editing.
-- Gradient, curve, and speed-limit editing.
-- Station and platform editing.
-- Signal and block-section editing.
-- Topology validation.
-- Visual scene editor linked to the tabular model.
-
-## P2: Memory And Performance
-
-Goal: lower memory use without changing simulation behavior.
-
-Missing work:
-
-- Inventory ownership and raw pointer use.
-- Replace oversized fixed arrays one storage type at a time.
-- Start with `BlockSet B[268]`.
-- Then handle `signalling_block_sections[6000]`.
-- Then handle embedded fixed arrays inside `Route`, `BlockSet`, and `Section`.
-- Add memory measurement scripts.
-- Profile GUI playback and simulation step time.
+The migration is complete. Explicit legacy import and export remain supported
+for compatibility and research workflows.

--- a/docs/product/assignment-corridor.md
+++ b/docs/product/assignment-corridor.md
@@ -1,25 +1,25 @@
 # Assignment Corridor
 
 ## Decision
-Use Amsterdam (`Asd`) to Hilversum (`Hvs`) as the V1 assignment corridor.
 
-## Reason
-The Netherlands input contains Amsterdam and Hilversum infrastructure, Sprinter and Intercity timetables, and SLT and VIRM train data. This gives the assignment two train types and different stopping patterns.
+Use Den Haag Centraal (`Gvc`) to Utrecht (`Ut`) via Gouda (`Gd` and `Gdg`) as
+the assignment corridor. `Assignment_Gvc_Gdg_Ut` is the current runnable
+baseline.
 
-The active train set currently contains eight Sprinter services around Utrecht, Hilversum, Baarn, and Den Dolder. Amsterdam services still need to be created and tested.
+## Current gaps
 
-Candidate route IDs are 29 through 36, 39 through 42, 53, and 54. These IDs came from the original case author. Each route must be checked for direction, station sequence, and train type.
+The committed scene has only `Gvc`, `Gdg`, and `Ut`. Issue #182 adds the missing
+intermediate stations, keeps `Gd` and `Gdg` distinct, and applies the source
+stopping patterns.
 
-## Other options
+The scene defines only `SLT_Sprinter`, and all four services use that placeholder
+composition. Issue #228 obtains traceable ICM3, ICM4, IRM3, and SGM3 parameters.
+Issue #181 uses those records to build the source compositions. Do not guess
+train physics while #228 is open.
 
-- Utrecht to Hilversum, Baarn, and Den Dolder already runs with Sprinter services. It remains the baseline but lacks Intercity traffic.
-- The full Netherlands case remains the import and compatibility reference. It is too large for the final teaching scene.
+## Data policy
 
-## Assignment scene
-
-- Keep the full Netherlands legacy and V1 cases intact.
-- Verify one Amsterdam to Hilversum service before building a timetable.
-- Add one Sprinter and one Intercity in each direction.
-- Set planned times from measured runs.
-- Derive a smaller scene after the train set works.
-- Remove only infrastructure that is outside the verified route dependency set.
+- Keep the full canonical Netherlands scene intact as a reference.
+- Use source-backed station, timetable, and train data in the assignment scene.
+- Update the assignment generator, committed scene, and focused checks together.
+- Use legacy import and export only for explicit compatibility work.

--- a/docs/product/assignment-workflow.md
+++ b/docs/product/assignment-workflow.md
@@ -1,6 +1,6 @@
 # Assignment Workflow
 
-EGTRAIN should replace the current OpenTrack workflow used in the railway traffic management assignment. The target V1 scenario is Amsterdam (`Asd`) to Hilversum (`Hvs`), with Sprinter and Intercity services.
+EGTRAIN should replace the OpenTrack workflow used in the railway traffic management assignment. The target corridor is Den Haag Centraal (`Gvc`) to Utrecht (`Ut`) via Gouda (`Gd` and `Gdg`), with Sprinter and Intercity services.
 
 ## Users
 


### PR DESCRIPTION
## Summary

- reflect the completed scene migration in PRs #260 through #267
- update the active roadmap to the remaining release, assignment, editing, analysis, and reliability work
- correct stale assignment, release, and runtime documentation

No production behavior changes. GitHub issue reconciliation will follow after merge.

## Verification

- `git diff --check`
- Markdown structure and local-link check
- active roadmap issue and release-gate audit
- independent acceptance-criteria review