### PR TITLE
Add assignment diagram result parity

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -31,6 +31,9 @@
 #include <QGraphicsSceneHoverEvent>
 #include <QMouseEvent>
 #include <QDialog>
+#include <QComboBox>
+#include <QDoubleSpinBox>
+#include <QFormLayout>
 #include <QVBoxLayout>
 #include <QGridLayout>
 #include <QLabel>
@@ -48,6 +51,8 @@
 #include <QStringList>
 #include <QRegularExpression>
 #include <cstdio>
+#include <algorithm>
+#include <cmath>
 #include <limits>
 #include <map>
 
@@ -100,9 +105,9 @@ std::string csvValue(const RunResultValue& value) {
 	return value.available ? csv::formatDouble(value.value) : std::string(csv::kMissingValue);
 }
 
-// Per-train trajectory: time, position, speed, power, cumulative energy, block.
-// Reads raw simulation samples over the valid trajectory ranges so gaps never
-// produce a false row.
+// Per-train trajectory: identity, time, position, speed, power, wheel effort,
+// cumulative energy, block. Reads raw simulation samples over the valid
+// trajectory ranges so gaps never produce a false row.
 std::string buildTrajectoryCsv(const QStringList& visibleTrainIds) {
 	std::vector<std::vector<std::string>> rows;
 	for (int tr = 0; tr < numRegions; ++tr) {
@@ -125,6 +130,9 @@ std::string buildTrajectoryCsv(const QStringList& visibleTrainIds) {
 					: std::string(csv::kMissingValue);
 				std::vector<std::string> row;
 				row.push_back(train.trainDescription);
+				row.push_back(train.operatingCode);
+				row.push_back(train.serviceId);
+				row.push_back(std::to_string(train.serviceOccurrence));
 				row.push_back(csv::formatDouble(i * timestep));
 				row.push_back(sampleAt(train.instant_spatial_position, i));
 				row.push_back(sampleAt(train.instant_train_speed, i));
@@ -134,7 +142,11 @@ std::string buildTrajectoryCsv(const QStringList& visibleTrainIds) {
 				std::string energy = i >= 0 && i < static_cast<int>(train.instant_train_energy_consumption.size())
 					? csv::formatDouble(train.instant_train_energy_consumption[static_cast<std::size_t>(i)] * kEnergyMJToKWh)
 					: std::string(csv::kMissingValue);
+				std::string effort = i >= 0 && i < static_cast<int>(train.instant_train_tractive_effort.size())
+					? csv::formatDouble(train.instant_train_tractive_effort[static_cast<std::size_t>(i)] / 1000.0)
+					: std::string(csv::kMissingValue);
 				row.push_back(power);
+				row.push_back(effort);
 				row.push_back(energy);
 				row.push_back(block);
 				rows.push_back(std::move(row));
@@ -144,7 +156,7 @@ std::string buildTrajectoryCsv(const QStringList& visibleTrainIds) {
 	if (rows.empty())
 		return std::string();
 	return csv::makeDocument(
-		{"Train", "Time[s]", "Position[m]", "Speed[m/s]", "Power[kW]", "Energy[kWh]", "Block"}, rows);
+		{"Train", "Operating code", "Service ID", "Occurrence", "Time[s]", "Position[m]", "Speed[m/s]", "Power[kW]", "Tractive effort[kN]", "Energy[kWh]", "Block"}, rows);
 }
 
 // Timetable: train, station, planned and simulated arrival and departure, delay.
@@ -183,17 +195,30 @@ const char* blockingSegmentTypeName(BlockingTimeSegmentStyle style) {
 		case BlockingTimeSegmentStyle::SwitchStation:
 			return "switch/station";
 		case BlockingTimeSegmentStyle::Critical:
-			return "critical";
+			return "conflict";
 		case BlockingTimeSegmentStyle::CriticalStation:
-			return "critical/station";
+			return "conflict/station";
 		case BlockingTimeSegmentStyle::Default:
 		default:
 			return "block";
 	}
 }
 
-// Blocking-time: train, block, occupation start, occupation end, position, type.
-std::string buildBlockingTimeCsv(const QStringList& visibleTrainIds) {
+struct BlockingTimeScope {
+	std::vector<std::string> trainIds;
+	std::vector<std::string> blockIds;
+	double startTime = 0.0;
+	double endTime = 0.0;
+	int routeIndex = -1;
+};
+
+BlockingTimeScope defaultBlockingTimeScope() {
+	BlockingTimeScope scope;
+	scope.endTime = std::max(0.0, initial_variables.times * timestep);
+	return scope;
+}
+
+std::vector<BlockingTimeDiagramSegment> buildAllBlockingTimeSegments() {
 	std::vector<std::vector<BlockingTimeDiagramInput>> trains;
 	std::vector<std::string> trainNames;
 	trains.reserve(static_cast<std::size_t>(std::max(0, numRegions)));
@@ -217,7 +242,47 @@ std::string buildBlockingTimeCsv(const QStringList& visibleTrainIds) {
 		trains.push_back(blocks);
 		trainNames.push_back(t.trainDescription);
 	}
-	const auto segments = buildBlockingTimeDiagramSegments(trains, trainNames);
+	return buildBlockingTimeDiagramSegments(trains, trainNames);
+}
+
+std::vector<BlockingTimePlannedReference> buildBlockingTimePlannedReferences(
+	const BlockingTimeScope& scope) {
+	std::vector<BlockingTimePlannedReference> references;
+	if (scope.routeIndex >= 0 && scope.trainIds.empty())
+		return references;
+	for (int i = 0; i < numRegions; ++i) {
+		const Train& train = regional_train[i];
+		if (!scope.trainIds.empty() &&
+			std::find(scope.trainIds.begin(), scope.trainIds.end(), train.trainDescription) == scope.trainIds.end())
+			continue;
+		if (!train.Stations)
+			continue;
+		const int stationCount = std::min(train.numStations, static_cast<int>(Train::kMaxTimetableStations));
+		for (int stationIndex = 0; stationIndex < stationCount; ++stationIndex) {
+			if (!train.stationIsOnRoute(stationIndex, scope.blockIds))
+				continue;
+			const double positionMeters = train.stationRoutePositionMeters(stationIndex);
+			if (!std::isfinite(positionMeters) || positionMeters < 0.0)
+				continue;
+			const double positionKm = positionMeters / 1000.0;
+			const auto append = [&](const char* eventType, double time) {
+				if (!std::isfinite(time) || time < 0.0)
+					return;
+				references.push_back({train.trainDescription, train.stationNameForArrivalStats(stationIndex),
+					eventType, time, positionKm});
+			};
+			append("arrival", train.ScheduledArrivals[stationIndex]);
+			append("departure", train.ScheduledDepartures[stationIndex]);
+		}
+	}
+	return references;
+}
+
+// Blocking-time: keep the occupation-column prefix and append planned
+// reference rows so the visible dashed layer is exportable too.
+std::string buildBlockingTimeCsv(const QStringList& visibleTrainIds,
+	const std::vector<BlockingTimeDiagramSegment>& segments,
+	const std::vector<BlockingTimePlannedReference>& plannedReferences) {
 	std::vector<std::vector<std::string>> rows;
 	for (const BlockingTimeDiagramSegment& s : segments) {
 		if (!trainInVisibleSet(visibleTrainIds, s.trainName))
@@ -228,13 +293,138 @@ std::string buildBlockingTimeCsv(const QStringList& visibleTrainIds) {
 			csv::formatDouble(s.startTime),
 			csv::formatDouble(s.endTime),
 			csv::formatDouble(s.midPositionKm),
-			blockingSegmentTypeName(s.style)});
+			blockingSegmentTypeName(s.style),
+			std::string(),
+			std::string(),
+			std::string()});
+	}
+	for (const BlockingTimePlannedReference& reference : plannedReferences) {
+		if (!trainInVisibleSet(visibleTrainIds, reference.trainName))
+			continue;
+		rows.push_back({
+			reference.trainName,
+			std::string(),
+			std::string(),
+			std::string(),
+			csv::formatDouble(reference.positionKm),
+			"planned reference",
+			reference.eventType,
+			reference.stationName,
+			csv::formatDouble(reference.time)});
 	}
 	if (rows.empty())
 		return std::string();
 	return csv::makeDocument(
-		{"Train", "Block", "Occupation start[s]", "Occupation end[s]", "Position[km]", "Segment type"},
+		{"Train", "Block", "Occupation start[s]", "Occupation end[s]", "Position[km]", "Segment type",
+			"Planned reference", "Station", "Planned time[s]"},
 		rows);
+}
+
+std::string buildBlockingTimeCsv(const QStringList& visibleTrainIds) {
+	const BlockingTimeScope scope = defaultBlockingTimeScope();
+	return buildBlockingTimeCsv(visibleTrainIds,
+		filterBlockingTimeDiagramSegments(buildAllBlockingTimeSegments(), scope.trainIds, scope.blockIds,
+			scope.startTime, scope.endTime),
+		filterBlockingTimePlannedReferences(buildBlockingTimePlannedReferences(scope),
+			scope.startTime, scope.endTime));
+}
+
+bool chooseBlockingTimeScope(QWidget* parent, BlockingTimeScope& scope) {
+	QDialog dialog(parent);
+	dialog.setWindowTitle("Blocking-time scope");
+	auto* form = new QFormLayout(&dialog);
+	auto* routeCombo = new QComboBox(&dialog);
+	routeCombo->addItem("All routes / all corridors", -1);
+	for (std::size_t routeIndex = 0; routeIndex < train_route.size(); ++routeIndex) {
+		const Route& route = train_route[routeIndex];
+		const QString corridor = route.corridor.empty()
+			? QStringLiteral("no corridor") : QString::fromStdString(route.corridor);
+		routeCombo->addItem(QString("%1  (%2)").arg(QString::fromStdString(route.ID), corridor),
+			static_cast<int>(routeIndex));
+	}
+	auto* firstBlock = new QComboBox(&dialog);
+	auto* lastBlock = new QComboBox(&dialog);
+	auto* startTime = new QDoubleSpinBox(&dialog);
+	auto* endTime = new QDoubleSpinBox(&dialog);
+	const double caseEnd = std::max(0.0, initial_variables.times * timestep);
+	for (QDoubleSpinBox* spinBox : {startTime, endTime}) {
+		spinBox->setRange(0.0, caseEnd);
+		spinBox->setDecimals(3);
+		spinBox->setSingleStep(timestep > 0.0 ? timestep : 1.0);
+		spinBox->setSuffix(" s");
+	}
+	startTime->setValue(scope.startTime);
+	endTime->setValue(scope.endTime);
+
+	const auto refillBlocks = [routeCombo, firstBlock, lastBlock]() {
+		firstBlock->clear();
+		lastBlock->clear();
+		const int routeIndex = routeCombo->currentData().toInt();
+		if (routeIndex < 0 || routeIndex >= static_cast<int>(train_route.size())) {
+			firstBlock->addItem("All blocks");
+			lastBlock->addItem("All blocks");
+			firstBlock->setEnabled(false);
+			lastBlock->setEnabled(false);
+			return;
+		}
+		const Route& route = train_route[static_cast<std::size_t>(routeIndex)];
+		for (int blockIndex = 0; blockIndex < route.N_Block_Sections; ++blockIndex) {
+			const QString blockId = QString::fromStdString(route.sequence_of_block_sections[blockIndex].ID);
+			firstBlock->addItem(blockId);
+			lastBlock->addItem(blockId);
+		}
+		const bool hasBlocks = firstBlock->count() > 0;
+		firstBlock->setEnabled(hasBlocks);
+		lastBlock->setEnabled(hasBlocks);
+		if (hasBlocks)
+			lastBlock->setCurrentIndex(lastBlock->count() - 1);
+	};
+	QObject::connect(routeCombo, qOverload<int>(&QComboBox::currentIndexChanged), &dialog,
+		[refillBlocks](int) { refillBlocks(); });
+	refillBlocks();
+
+	form->addRow("Route / corridor:", routeCombo);
+	form->addRow("First block:", firstBlock);
+	form->addRow("Last block:", lastBlock);
+	form->addRow("Start after case base:", startTime);
+	form->addRow("End after case base:", endTime);
+	auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+	QObject::connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+	QObject::connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+	form->addRow(buttons);
+	if (dialog.exec() != QDialog::Accepted)
+		return false;
+
+	scope.startTime = std::min(startTime->value(), endTime->value());
+	scope.endTime = std::max(startTime->value(), endTime->value());
+	if (scope.endTime <= scope.startTime) {
+		const double step = timestep > 0.0 ? timestep : 1.0;
+		if (scope.startTime + step <= caseEnd)
+			scope.endTime = scope.startTime + step;
+		else
+			scope.startTime = std::max(0.0, scope.endTime - step);
+	}
+	if (scope.endTime <= scope.startTime)
+		return false;
+	scope.trainIds.clear();
+	scope.blockIds.clear();
+	const int routeIndex = routeCombo->currentData().toInt();
+	scope.routeIndex = routeIndex >= 0 && routeIndex < static_cast<int>(train_route.size())
+		? routeIndex : -1;
+	if (scope.routeIndex < 0)
+		return true;
+
+	const Route& route = train_route[static_cast<std::size_t>(scope.routeIndex)];
+	const int first = std::min(firstBlock->currentIndex(), lastBlock->currentIndex());
+	const int last = std::max(firstBlock->currentIndex(), lastBlock->currentIndex());
+	for (int blockIndex = first; blockIndex >= 0 && blockIndex <= last && blockIndex < route.N_Block_Sections; ++blockIndex)
+		scope.blockIds.push_back(route.sequence_of_block_sections[blockIndex].ID);
+	for (int trainIndex = 0; trainIndex < numRegions; ++trainIndex) {
+		const Train& train = regional_train[trainIndex];
+		if (train.indexOfRoute == scope.routeIndex || train.TrainRouteID == route.ID)
+			scope.trainIds.push_back(train.trainDescription);
+	}
+	return true;
 }
 
 // Run summary: per-train start, end, travel time, and energy totals, plus a
@@ -1351,7 +1541,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_trainUnitSourceTractionLabel = new QLabel(trainUnitDetailPane);
 	m_trainUnitSourceTractionLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
 	trainUnitDetailLayout->addWidget(m_trainUnitSourceTractionLabel);
-	m_plotTrainUnitTractionButton = new QPushButton("Plot tractive effort", trainUnitDetailPane);
+	m_plotTrainUnitTractionButton = new QPushButton("Plot input traction characteristic", trainUnitDetailPane);
 	trainUnitDetailLayout->addWidget(m_plotTrainUnitTractionButton);
 
 	trainUnitDetailLayout->addWidget(new QLabel("Traction curve", trainUnitDetailPane));
@@ -1460,7 +1650,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_compositionUnitSourceTractionLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
 	m_compositionUnitSourceTractionLabel->setWordWrap(true);
 	compositionDetailLayout->addWidget(m_compositionUnitSourceTractionLabel);
-	m_plotTractionButton = new QPushButton("Plot tractive effort", compositionDetailPane);
+	m_plotTractionButton = new QPushButton("Plot input traction characteristic", compositionDetailPane);
 	compositionDetailLayout->addWidget(m_plotTractionButton);
 	m_compositionUnitWarningLabel = new QLabel(compositionDetailPane);
 	m_compositionUnitWarningLabel->setWordWrap(true);
@@ -1877,6 +2067,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_diagramsMenu->addAction("Speed / Distance (per train)...", this, &MainWindow::showSpeedDistanceDiagram);
 	m_diagramsMenu->addAction("Speed / Time (per train)...", this, &MainWindow::showSpeedTimeDiagram);
 	m_diagramsMenu->addAction("Time / Distance (per train)...", this, &MainWindow::showTimeDistanceDiagram);
+	m_diagramsMenu->addAction("Simulated tractive effort / Distance (per train)...", this, &MainWindow::showTractiveEffortDistanceDiagram);
 	m_diagramsMenu->addSeparator();
 	m_diagramsMenu->addAction("Timetable graph (train graph)...", this, &MainWindow::showTimetableGraph);
 	m_diagramsMenu->addAction("Blocking-time overlay...", this, &MainWindow::showBlockingTimeDiagram);
@@ -4130,7 +4321,7 @@ void MainWindow::plotSelectedCompositionUnitTraction() {
 void MainWindow::plotTrainUnitTraction(const SceneTrainUnit& unit) {
 	const auto samples = sampleTractionCurve(unit.tractionCurve);
 	QChart* chart = new QChart();
-	chart->setTitle(QString("Tractive effort: %1").arg(QString::fromStdString(unit.id)));
+	chart->setTitle(QString("Input traction characteristic: %1").arg(QString::fromStdString(unit.id)));
 	QLineSeries* series = new QLineSeries();
 	series->setName(QString::fromStdString(unit.id));
 	series->setProperty("trainId", QString::fromStdString(unit.id));
@@ -4143,7 +4334,7 @@ void MainWindow::plotTrainUnitTraction(const SceneTrainUnit& unit) {
 	if (!chart->axes(Qt::Vertical).isEmpty())
 		chart->axes(Qt::Vertical).first()->setTitleText("Tractive effort (kN)");
 
-	QString title = QString("Tractive effort: %1").arg(QString::fromStdString(unit.id));
+	QString title = QString("Input traction characteristic: %1").arg(QString::fromStdString(unit.id));
 	if (!unit.sourceTractionFile.empty())
 		title += QString("  (%1)").arg(QString::fromStdString(unit.sourceTractionFile));
 	DiagramWindow* win = new DiagramWindow(title, this);
@@ -9250,7 +9441,7 @@ void MainWindow::runEditorSmokeE2E() {
 		}
 		bool hasPlotButton = false;
 		for (QPushButton* button : findChildren<QPushButton*>())
-			hasPlotButton = hasPlotButton || button->text() == "Plot tractive effort";
+				hasPlotButton = hasPlotButton || button->text() == "Plot input traction characteristic";
 		bool hasPlannedArrival = false;
 		bool hasPlannedDeparture = false;
 		for (QCheckBox* check : findChildren<QCheckBox*>()) {
@@ -11946,6 +12137,7 @@ void MainWindow::setupRunResultsDock() {
 	addResultViewButton("Speed / distance", &MainWindow::showSpeedDistanceDiagram);
 	addResultViewButton("Speed / time", &MainWindow::showSpeedTimeDiagram);
 	addResultViewButton("Time / distance", &MainWindow::showTimeDistanceDiagram);
+	addResultViewButton("Tractive effort / distance", &MainWindow::showTractiveEffortDistanceDiagram);
 	addResultViewButton("Train paths", &MainWindow::displayTrainPathDiagrams);
 	addResultViewButton("Blocking time", &MainWindow::showBlockingTimeDiagram);
 	containerLayout->addLayout(resultViews);
@@ -13774,7 +13966,12 @@ void MainWindow::showTimeDistanceDiagram() {
 	buildPerTrainDiagram(2);
 }
 
-// mode 0: speed vs distance, 1: speed vs time, 2: time vs distance
+void MainWindow::showTractiveEffortDistanceDiagram() {
+	buildPerTrainDiagram(3);
+}
+
+// mode 0: speed vs distance, 1: speed vs time, 2: time vs distance,
+// 3: simulated tractive effort vs distance
 void MainWindow::buildPerTrainDiagram(int mode) {
 	// require a completed run
 	if (!hasRunResults()) {
@@ -13782,7 +13979,7 @@ void MainWindow::buildPerTrainDiagram(int mode) {
 		return;
 	}
 
-	const char* titles[] = {"Speed vs Distance", "Speed vs Time", "Time vs Distance"};
+	const char* titles[] = {"Speed vs Distance", "Speed vs Time", "Time vs Distance", "Simulated Tractive Effort vs Distance"};
 	const QString title = QString("%1 [%2]").arg(titles[mode], scenarioContext());
 	QChart* chart = new QChart();
 	chart->setTitle(title);
@@ -13806,15 +14003,17 @@ void MainWindow::buildPerTrainDiagram(int mode) {
 					series->append(dist, spd); // x: distance (km), y: speed (km/h)
 				else if (mode == 1)
 					series->append(tSec, spd); // x: time (s),      y: speed (km/h)
-				else
+				else if (mode == 2)
 					series->append(tSec, dist); // x: time (s),      y: distance (km)
+				else if (i < static_cast<int>(train.instant_train_tractive_effort.size()))
+					series->append(dist, train.instant_train_tractive_effort[static_cast<std::size_t>(i)] / 1000.0);
 			}
 			chart->addSeries(series);
 		}
 	}
 	chart->createDefaultAxes();
-	const char* xTitles[] = {"Distance (km)", "Time", "Time"};
-	const char* yTitles[] = {"Speed (km/h)", "Speed (km/h)", "Distance (km)"};
+	const char* xTitles[] = {"Distance (km)", "Time", "Time", "Distance (km)"};
+	const char* yTitles[] = {"Speed (km/h)", "Speed (km/h)", "Distance (km)", "Simulated tractive effort (kN)"};
 	if (!chart->axes(Qt::Horizontal).isEmpty())
 		chart->axes(Qt::Horizontal).first()->setTitleText(xTitles[mode]);
 	if (!chart->axes(Qt::Vertical).isEmpty())
@@ -13990,40 +14189,40 @@ void MainWindow::showBlockingTimeDiagram() {
 		return;
 	}
 
-	QChart* chart = new QChart();
-	const QString title = QString("Blocking-time overlay [%1]").arg(scenarioContext());
-	chart->setTitle(title);
-
-	std::vector<std::vector<BlockingTimeDiagramInput>> trains;
-	std::vector<std::string> trainNames;
-	trains.reserve(numRegions);
-	trainNames.reserve(numRegions);
-	for (int i = 0; i < numRegions; i++) {
-		Train& t = regional_train[i];
-		std::vector<BlockingTimeDiagramInput> blocks;
-		blocks.reserve(t.N_BlockTimeComplete);
-		for (int j = 0; j < t.N_BlockTimeComplete; j++) {
-			BlockingTimeDiagramInput block;
-			block.blockId = t.BlockTime[j].BlockID;
-			block.startOccTime = t.BlockTime[j].StartOccTime;
-			block.endOccTime = t.BlockTime[j].EndOccTime;
-			block.posStart = t.BlockTime[j].PosStart;
-			block.posEnd = t.BlockTime[j].PosEnd;
-			block.switchName = t.BlockTime[j].SwitchName;
-			block.stationName = t.BlockTime[j].stationName;
-			block.isComplete = t.BlockTime[j].IsComplete;
-			blocks.push_back(block);
-		}
-		trains.push_back(blocks);
-		trainNames.push_back(t.trainDescription);
-	}
-
-	std::vector<BlockingTimeDiagramSegment> segments = buildBlockingTimeDiagramSegments(trains, trainNames);
-	if (segments.empty()) {
-		delete chart;
+	const std::vector<BlockingTimeDiagramSegment> allSegments = buildAllBlockingTimeSegments();
+	BlockingTimeScope scope = defaultBlockingTimeScope();
+	if (!e2eDialogsSuppressed() && !chooseBlockingTimeScope(this, scope))
+		return;
+	const std::vector<BlockingTimeDiagramSegment> segments =
+		scope.routeIndex >= 0 && scope.trainIds.empty()
+			? std::vector<BlockingTimeDiagramSegment>()
+			: filterBlockingTimeDiagramSegments(allSegments, scope.trainIds, scope.blockIds,
+				scope.startTime, scope.endTime);
+	const std::vector<BlockingTimePlannedReference> plannedReferences =
+		filterBlockingTimePlannedReferences(buildBlockingTimePlannedReferences(scope),
+			scope.startTime, scope.endTime);
+	if (segments.empty() && plannedReferences.empty()) {
 		QMessageBox::information(this, "No Data", "No complete blocking-time data is available for this simulation.");
 		return;
 	}
+
+	QChart* chart = new QChart();
+	QString routeScope = QStringLiteral("all routes");
+	if (scope.routeIndex >= 0 && scope.routeIndex < static_cast<int>(train_route.size())) {
+		const Route& route = train_route[static_cast<std::size_t>(scope.routeIndex)];
+		routeScope = QString::fromStdString(route.ID);
+		if (!route.corridor.empty())
+			routeScope += QString(" / %1").arg(QString::fromStdString(route.corridor));
+		if (!scope.blockIds.empty())
+			routeScope += QString(" / %1 to %2").arg(QString::fromStdString(scope.blockIds.front()),
+				QString::fromStdString(scope.blockIds.back()));
+	}
+	const QString title = QString("Blocking time: actual occupations and dashed planned timetable | %1 | %2 to %3 [%4]")
+		.arg(routeScope,
+			QString::fromStdString(formatSimTime(static_cast<long long>(scope.startTime), m_startOffsetSeconds)),
+			QString::fromStdString(formatSimTime(static_cast<long long>(scope.endTime), m_startOffsetSeconds)),
+			scenarioContext());
+	chart->setTitle(title);
 
 	QColor defaultColor(100, 160, 240, 150);
 	QColor stationColor(60, 110, 190, 180);
@@ -14058,9 +14257,9 @@ void MainWindow::showBlockingTimeDiagram() {
 			case BlockingTimeSegmentStyle::SwitchStation:
 				return " (switch/station)";
 			case BlockingTimeSegmentStyle::Critical:
-				return " (critical)";
+				return " (conflict)";
 			case BlockingTimeSegmentStyle::CriticalStation:
-				return " (critical/station)";
+				return " (conflict/station)";
 			case BlockingTimeSegmentStyle::Default:
 			default:
 				return "";
@@ -14089,6 +14288,29 @@ void MainWindow::showBlockingTimeDiagram() {
 		}
 	}
 
+	const QColor plannedColors[] = {
+		QColor(36, 117, 181), QColor(205, 92, 92), QColor(46, 139, 87),
+		QColor(138, 43, 226), QColor(210, 105, 30), QColor(0, 128, 128)};
+	std::map<std::string, QLineSeries*> plannedSeries;
+	int plannedColorIndex = 0;
+	for (const BlockingTimePlannedReference& reference : plannedReferences) {
+		auto it = plannedSeries.find(reference.trainName);
+		if (it == plannedSeries.end()) {
+			auto* series = new QLineSeries();
+			series->setName(QString::fromStdString(reference.trainName + " (planned reference)"));
+			series->setProperty("trainId", QString::fromStdString(reference.trainName));
+			QPen pen(plannedColors[plannedColorIndex % (sizeof(plannedColors) / sizeof(plannedColors[0]))]);
+			pen.setStyle(Qt::DashLine);
+			pen.setWidthF(2.5);
+			series->setPen(pen);
+			series->setPointsVisible(true);
+			chart->addSeries(series);
+			it = plannedSeries.emplace(reference.trainName, series).first;
+			++plannedColorIndex;
+		}
+		it->second->append(reference.time, reference.positionKm);
+	}
+
 	QLineSeries* dummySwitch = new QLineSeries();
 	dummySwitch->setName("Key: Switch");
 	QPen dummySwitchPen(switchColor);
@@ -14097,7 +14319,7 @@ void MainWindow::showBlockingTimeDiagram() {
 	chart->addSeries(dummySwitch);
 
 	QLineSeries* dummyCritical = new QLineSeries();
-	dummyCritical->setName("Key: Critical");
+	dummyCritical->setName("Key: Conflict");
 	QPen dummyCriticalPen(criticalColor);
 	dummyCriticalPen.setWidthF(4.0);
 	dummyCritical->setPen(dummyCriticalPen);
@@ -14106,6 +14328,8 @@ void MainWindow::showBlockingTimeDiagram() {
 	chart->createDefaultAxes();
 	if (!chart->axes(Qt::Horizontal).isEmpty()) {
 		chart->axes(Qt::Horizontal).first()->setTitleText("Time");
+		if (auto* axis = qobject_cast<QValueAxis*>(chart->axes(Qt::Horizontal).first()))
+			axis->setRange(scope.startTime, scope.endTime);
 	}
 	if (!chart->axes(Qt::Vertical).isEmpty()) {
 		chart->axes(Qt::Vertical).first()->setTitleText("Position (km)");
@@ -14113,7 +14337,11 @@ void MainWindow::showBlockingTimeDiagram() {
 
 	DiagramWindow* win = new DiagramWindow(title, this);
 	win->setChart(chart);
-	win->setCsvProvider(snapshotCsv(&buildBlockingTimeCsv), "blocking_time.csv");
+	const std::function<std::string(const QStringList&)> scopedCsv =
+		[segments, plannedReferences](const QStringList& visibleTrainIds) {
+			return buildBlockingTimeCsv(visibleTrainIds, segments, plannedReferences);
+		};
+	win->setCsvProvider(snapshotCsv(scopedCsv), "blocking_time.csv");
 	connect(win, &DiagramWindow::trainSelected, this, &MainWindow::focusTrainInScene);
 	win->setTimeAxisX(true, m_startOffsetSeconds);
 	win->setAttribute(Qt::WA_DeleteOnClose);

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -536,7 +536,7 @@ private:
 	NetworkLegendWidget* m_networkLegendWidget = nullptr;
 	std::shared_ptr<const GuiSimulationSnapshot> m_snapshot;
 
-	void buildPerTrainDiagram(int mode); // 0 speed/distance, 1 speed/time, 2 time/distance
+	void buildPerTrainDiagram(int mode); // 0 speed/distance, 1 speed/time, 2 time/distance, 3 simulated effort/distance
 	void refreshFollowTrainChoices();
 	void updateSpeedModeDisplay(int value);
 	void updateSceneActions();
@@ -750,6 +750,7 @@ private slots:
 	void showSpeedDistanceDiagram();
 	void showSpeedTimeDiagram();
 	void showTimeDistanceDiagram();
+	void showTractiveEffortDistanceDiagram();
 	void showTimetableGraph();
 	void showTimetableTable();
 	void showDelayDiagram();

--- a/EGTRAIN/QEGTRAIN/diagrams/BlockingTimeDiagram.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/BlockingTimeDiagram.cpp
@@ -30,9 +30,9 @@ std::vector<std::string> comparableBlockTokens(const std::string& blockId) {
 	return tokens;
 }
 
-bool shareBlockId(const BlockingTimeDiagramInput& a, const BlockingTimeDiagramInput& b) {
-	std::vector<std::string> aTokens = comparableBlockTokens(a.blockId);
-	std::vector<std::string> bTokens = comparableBlockTokens(b.blockId);
+bool shareBlockId(const std::string& aBlockId, const std::string& bBlockId) {
+	std::vector<std::string> aTokens = comparableBlockTokens(aBlockId);
+	std::vector<std::string> bTokens = comparableBlockTokens(bBlockId);
 	for (const std::string& aToken : aTokens) {
 		for (const std::string& bToken : bTokens) {
 			if (aToken == bToken)
@@ -40,6 +40,10 @@ bool shareBlockId(const BlockingTimeDiagramInput& a, const BlockingTimeDiagramIn
 		}
 	}
 	return false;
+}
+
+bool shareBlockId(const BlockingTimeDiagramInput& a, const BlockingTimeDiagramInput& b) {
+	return shareBlockId(a.blockId, b.blockId);
 }
 
 bool validInterval(const BlockingTimeDiagramInput& block) {
@@ -112,4 +116,58 @@ std::vector<BlockingTimeDiagramSegment> buildBlockingTimeDiagramSegments(
 		}
 	}
 	return segments;
+}
+
+std::vector<BlockingTimeDiagramSegment> filterBlockingTimeDiagramSegments(
+	const std::vector<BlockingTimeDiagramSegment>& segments,
+	const std::vector<std::string>& allowedTrainIds,
+	const std::vector<std::string>& allowedBlockIds,
+	double startTime,
+	double endTime) {
+	std::vector<BlockingTimeDiagramSegment> filtered;
+	if (!std::isfinite(startTime) || !std::isfinite(endTime) || endTime < startTime)
+		return filtered;
+
+	for (const BlockingTimeDiagramSegment& source : segments) {
+		if ((!allowedTrainIds.empty() &&
+			 std::find(allowedTrainIds.begin(), allowedTrainIds.end(), source.trainName) == allowedTrainIds.end()) ||
+			(!allowedBlockIds.empty() && std::none_of(allowedBlockIds.begin(), allowedBlockIds.end(),
+				[&source](const std::string& allowedBlockId) { return shareBlockId(source.blockId, allowedBlockId); })) ||
+			source.endTime <= startTime || source.startTime >= endTime)
+			continue;
+
+		BlockingTimeDiagramSegment segment = source;
+		segment.startTime = std::max(segment.startTime, startTime);
+		segment.endTime = std::min(segment.endTime, endTime);
+		if (segment.endTime > segment.startTime)
+			filtered.push_back(std::move(segment));
+	}
+	return filtered;
+}
+
+std::vector<BlockingTimePlannedReference> filterBlockingTimePlannedReferences(
+	const std::vector<BlockingTimePlannedReference>& references,
+	double startTime,
+	double endTime) {
+	std::vector<BlockingTimePlannedReference> filtered;
+	if (!std::isfinite(startTime) || !std::isfinite(endTime) || endTime < startTime)
+		return filtered;
+
+	const auto segmentIntersects = [startTime, endTime](double first, double second) {
+		return std::isfinite(first) && std::isfinite(second) &&
+			std::max(first, second) >= startTime && std::min(first, second) <= endTime;
+	};
+	for (std::size_t i = 0; i < references.size(); ++i) {
+		const BlockingTimePlannedReference& reference = references[i];
+		if (!std::isfinite(reference.time))
+			continue;
+		const bool pointVisible = reference.time >= startTime && reference.time <= endTime;
+		const bool previousVisible = i > 0 && references[i - 1].trainName == reference.trainName &&
+			segmentIntersects(references[i - 1].time, reference.time);
+		const bool nextVisible = i + 1 < references.size() && references[i + 1].trainName == reference.trainName &&
+			segmentIntersects(reference.time, references[i + 1].time);
+		if (pointVisible || previousVisible || nextVisible)
+			filtered.push_back(reference);
+	}
+	return filtered;
 }

--- a/EGTRAIN/QEGTRAIN/diagrams/BlockingTimeDiagram.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/BlockingTimeDiagram.h
@@ -34,8 +34,32 @@ struct BlockingTimeDiagramSegment {
 	BlockingTimeSegmentStyle style = BlockingTimeSegmentStyle::Default;
 };
 
+struct BlockingTimePlannedReference {
+	std::string trainName;
+	std::string stationName;
+	std::string eventType;
+	double time = 0.0;
+	double positionKm = 0.0;
+};
+
 std::vector<BlockingTimeDiagramSegment> buildBlockingTimeDiagramSegments(
 	const std::vector<std::vector<BlockingTimeDiagramInput>>& trains,
 	const std::vector<std::string>& trainNames);
+
+// Return copies of already-classified occupation segments in the selected
+// train/block/time scope. Empty train or block lists mean no restriction.
+std::vector<BlockingTimeDiagramSegment> filterBlockingTimeDiagramSegments(
+	const std::vector<BlockingTimeDiagramSegment>& segments,
+	const std::vector<std::string>& allowedTrainIds,
+	const std::vector<std::string>& allowedBlockIds,
+	double startTime,
+	double endTime);
+
+// Keep planned source points that fall in the time window or form a visible
+// line segment across it. Input points for each train must be contiguous.
+std::vector<BlockingTimePlannedReference> filterBlockingTimePlannedReferences(
+	const std::vector<BlockingTimePlannedReference>& references,
+	double startTime,
+	double endTime);
 
 #endif // BLOCKINGTIMEDIAGRAM_H

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
@@ -2441,6 +2441,7 @@ void Train::setTrainVectorSizesFromInput(int vec_size) {
 	instant_train_speed = std::vector<double>(vec_size, 0);
 	instant_spatial_position = std::vector<double>(vec_size, 0);
 	instant_train_power_consumption = std::vector<double>(vec_size, 0);
+	instant_train_tractive_effort = std::vector<double>(vec_size, 0);
 	instant_block_section_occupied = std::vector<std::string>(vec_size);
 	instant_train_energy_consumption = std::vector<double>(vec_size, 0);
 	BX = std::vector<double>(vec_size, 0);

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -570,6 +570,7 @@ public:
 	std::vector<double> instant_spatial_position; // Vector of istantaneous Spatial position of the Train
 	std::vector<std::string> instant_block_section_occupied;
 	std::vector<double> instant_train_power_consumption;  // Vector of istantaneous Train Power Consumption [W]
+	std::vector<double> instant_train_tractive_effort;    // Branch-applied wheel effort [N], aligned with trajectory samples
 	std::vector<double> instant_train_energy_consumption; // Vector of istantaneous Train Energy Consumption [MJ]
 	double TotalEnergyConsumed, TotalEnergySubstationRequest, TotalEnergyConsWithRegBrak, TotalEnergySubstRequestWithRegBrak;
 	// These values represent the total energy consumed by the train with no regenerative braking, the total energy requested to the SubStation, and the TotalEnergy consumed with regenerative braking;
@@ -781,11 +782,15 @@ public:
 	}
 
 	// A completed trajectory can leave a non-finite power sample at End_Time;
-	// treat that boundary sample as zero, matching train_energy_consumption().
+	// treat that boundary sample and its aligned effort as zero, matching
+	// train_energy_consumption().
 	void sanitizeTerminalPowerSample() {
 		if (End_Time >= 0 && End_Time < static_cast<int>(instant_train_power_consumption.size()) &&
-			!std::isfinite(instant_train_power_consumption[static_cast<std::size_t>(End_Time)]))
+			!std::isfinite(instant_train_power_consumption[static_cast<std::size_t>(End_Time)])) {
 			instant_train_power_consumption[static_cast<std::size_t>(End_Time)] = 0.0;
+			if (End_Time < static_cast<int>(instant_train_tractive_effort.size()))
+				instant_train_tractive_effort[static_cast<std::size_t>(End_Time)] = 0.0;
+		}
 	}
 
 	// Function to calculate Total Energy Consumed with and without regenrative braking (the inputs are the Eta of the Substation and the Eta of the regenerative braking)
@@ -3176,11 +3181,12 @@ public:
 		for (int t = 0; t < initial_variables.times; t++) {
 			if (t < departure_time) {
 				instant_spatial_position[t] = train_route[indexOfRoute].x_of_start_node * 1000;
-				instant_train_energy_consumption[t] = instant_train_speed[t] = instant_train_power_consumption[t] = 0;
+				instant_train_energy_consumption[t] = instant_train_speed[t] = instant_train_power_consumption[t] = instant_train_tractive_effort[t] = 0;
 			} else {
 				instant_spatial_position[t] = T_2_Replicate.instant_spatial_position[t - Offset];
 				instant_train_speed[t] = T_2_Replicate.instant_train_speed[t - Offset];
 				instant_train_power_consumption[t] = T_2_Replicate.instant_train_power_consumption[t - Offset];
+				instant_train_tractive_effort[t] = T_2_Replicate.instant_train_tractive_effort[t - Offset];
 				instant_train_energy_consumption[t] = T_2_Replicate.instant_train_energy_consumption[t - Offset];
 				// Updating the status of infrastructure elements
 				if (t > 0) {
@@ -3603,6 +3609,7 @@ public:
 				instant_train_speed[time_seconds] = 0;
 				instant_spatial_position[time_seconds] = instant_spatial_position[time_seconds - 1];
 				instant_train_power_consumption[time_seconds] = 0;
+				instant_train_tractive_effort[time_seconds] = 0;
 				train_energy_consumption(time_seconds);
 				Eq[time_seconds] = 5;
 				return;
@@ -3742,7 +3749,8 @@ public:
 					}
 
 					Eq[time_seconds] = 1;
-					instant_train_power_consumption[time_seconds] = tractiveEffort(instant_train_speed[time_seconds - 1]) * instant_train_speed[time_seconds - 1];
+					instant_train_tractive_effort[time_seconds] = tractiveEffort(instant_train_speed[time_seconds - 1]);
+					instant_train_power_consumption[time_seconds] = instant_train_tractive_effort[time_seconds] * instant_train_speed[time_seconds - 1];
 					train_energy_consumption(time_seconds);
 					temp = time_seconds;
 					stop = time_seconds;
@@ -3831,12 +3839,13 @@ public:
 					instant_train_speed[i]=Vbrak[brakingPoint+counter-1];    if (instant_train_speed[i]<0)instant_train_speed[i]=0;
 					instant_spatial_position[i]=Sbrak[brakingPoint+counter-1];}*/
 
-					instant_train_power_consumption[time_seconds] =
+					instant_train_tractive_effort[time_seconds] =
 						-(brakingEffort((time_seconds - temp - 1) * timestep) +
 						  gradient_resistances(As.gradient) +
 						  curvature_resistances(As.curvature) -
-						  total_train_resistances(instant_train_speed[time_seconds - 1], As.gradient, As.curvature)) *
-						instant_train_speed[time_seconds - 1]; /*Eq[i]=3;*/
+						  total_train_resistances(instant_train_speed[time_seconds - 1], As.gradient, As.curvature));
+					instant_train_power_consumption[time_seconds] =
+						instant_train_tractive_effort[time_seconds] * instant_train_speed[time_seconds - 1]; /*Eq[i]=3;*/
 					train_energy_consumption(time_seconds);
 					stop = time_seconds;
 					BX[time_seconds] = Braking_Distance;
@@ -3853,18 +3862,19 @@ public:
 
 				// Cruising Phase
 				else if ((instant_spatial_position[time_seconds - 1] < Braking_Distance) && (instant_train_speed[time_seconds - 1] >= V_lim) && instant_train_speed[time_seconds - 1] > 0) {
-					if (instant_train_speed[time_seconds - 1] > V_lim) {
+					const bool cappedToLimit = instant_train_speed[time_seconds - 1] > V_lim;
+					if (cappedToLimit)
 						instant_train_speed[time_seconds - 1] = V_lim;
-						instant_spatial_position[time_seconds - 1] = instant_spatial_position[time_seconds - 1];
-						instant_train_power_consumption[time_seconds - 1] = total_train_resistances(instant_train_speed[time_seconds - 1], As.gradient, As.curvature) * instant_train_speed[time_seconds - 1];
+					instant_train_speed[time_seconds] = V_lim;
+					instant_spatial_position[time_seconds] = instant_spatial_position[time_seconds - 1] + instant_train_speed[time_seconds - 1] * timestep;
+					const double cruisingEffort = total_train_resistances(instant_train_speed[time_seconds - 1], As.gradient, As.curvature);
+					if (cappedToLimit) {
+						instant_train_tractive_effort[time_seconds - 1] = cruisingEffort;
+						instant_train_power_consumption[time_seconds - 1] = cruisingEffort * instant_train_speed[time_seconds - 1];
 						train_energy_consumption(time_seconds - 1);
-						instant_train_speed[time_seconds] = V_lim;
-						instant_spatial_position[time_seconds] = instant_spatial_position[time_seconds - 1] + instant_train_speed[time_seconds - 1] * timestep;
-					} else {
-						instant_train_speed[time_seconds] = V_lim;
-						instant_spatial_position[time_seconds] = instant_spatial_position[time_seconds - 1] + instant_train_speed[time_seconds - 1] * timestep;
 					}
-					instant_train_power_consumption[time_seconds] = total_train_resistances(instant_train_speed[time_seconds - 1], As.gradient, As.curvature) * instant_train_speed[time_seconds - 1];
+					instant_train_tractive_effort[time_seconds] = cruisingEffort;
+					instant_train_power_consumption[time_seconds] = cruisingEffort * instant_train_speed[time_seconds - 1];
 					Eq[time_seconds] = 12;
 					train_energy_consumption(time_seconds);
 					temp = time_seconds;
@@ -4017,7 +4027,8 @@ public:
 						instant_spatial_position[time_seconds] = instant_spatial_position[time_seconds - 1] + instant_train_speed[time_seconds - 1] * timestep; // Determining distance
 
 						// Computing power and Energy
-						instant_train_power_consumption[time_seconds] = (Acc_i * total_train_mass * massFactor) * instant_train_speed[time_seconds - 1];
+						instant_train_tractive_effort[time_seconds] = Acc_i * total_train_mass * massFactor;
+						instant_train_power_consumption[time_seconds] = instant_train_tractive_effort[time_seconds] * instant_train_speed[time_seconds - 1];
 						train_energy_consumption(time_seconds);
 						temp = time_seconds;
 						stop = time_seconds;
@@ -4037,6 +4048,7 @@ public:
 					instant_train_speed[time_seconds] = 0;
 					instant_spatial_position[time_seconds] = -9999;
 					instant_train_power_consumption[time_seconds] = -9999;
+					instant_train_tractive_effort[time_seconds] = -9999;
 					Xobmin = train_route[indexOfRoute].x_of_end_node * 1000;
 					Vobmin = train_route[indexOfRoute].sequence_of_block_sections[train_route[indexOfRoute].N_Block_Sections - 1].arcs_in_signalling_block_section[train_route[indexOfRoute].sequence_of_block_sections[train_route[indexOfRoute].N_Block_Sections - 1].total_arcs - 1].speedInBraking; /*This is the speedInBraking of the last Arc of the Route*/
 					relLastSectionMixedSignalling(train_route[indexOfRoute].sequence_of_block_sections[train_route[indexOfRoute].N_Block_Sections - 1].ID);
@@ -4134,6 +4146,7 @@ public:
 							}
 						}
 						instant_train_power_consumption[time_seconds] = 0;
+						instant_train_tractive_effort[time_seconds] = 0;
 						train_energy_consumption(time_seconds);
 					}
 
@@ -4161,6 +4174,7 @@ public:
 						}
 
 						instant_train_power_consumption[time_seconds] = 0;
+						instant_train_tractive_effort[time_seconds] = 0;
 						train_energy_consumption(time_seconds);
 					}
 
@@ -4182,6 +4196,7 @@ public:
 							BrakingForEoA = false; // setting BrakingForEoA to false since the train starts moving again
 						}
 						instant_train_power_consumption[time_seconds] = 0;
+						instant_train_tractive_effort[time_seconds] = 0;
 						train_energy_consumption(time_seconds);
 						counter = 0;
 					}
@@ -4255,6 +4270,7 @@ public:
 						}
 
 						instant_train_power_consumption[time_seconds] = 0;
+						instant_train_tractive_effort[time_seconds] = 0;
 						train_energy_consumption(time_seconds);
 						counter = 0;
 					}
@@ -4287,6 +4303,7 @@ public:
 							XCurrentServiceStop = -1;
 						}
 						instant_train_power_consumption[time_seconds] = 0;
+						instant_train_tractive_effort[time_seconds] = 0;
 						train_energy_consumption(time_seconds);
 						counter = 0;
 					}
@@ -4320,6 +4337,7 @@ public:
 							Eq[time_seconds] = 341;
 						}
 						instant_train_power_consumption[time_seconds] = 0;
+						instant_train_tractive_effort[time_seconds] = 0;
 						train_energy_consumption(time_seconds);
 						counter = 0;
 					}
@@ -4331,6 +4349,7 @@ public:
 						instant_train_speed[time_seconds] = 0;
 						instant_spatial_position[time_seconds] = instant_spatial_position[time_seconds - 1];
 						instant_train_power_consumption[time_seconds] = 0;
+						instant_train_tractive_effort[time_seconds] = 0;
 						train_energy_consumption(time_seconds);
 					}
 					GradientExceptionInBraking = false;
@@ -4355,6 +4374,7 @@ public:
 				instant_spatial_position[time_seconds] = Start_Node_X * 1000;
 				instant_block_section_occupied[time_seconds] = "-";
 				instant_train_power_consumption[time_seconds] = 0.0;
+				instant_train_tractive_effort[time_seconds] = 0.0;
 			}
 			// cout << instant_spatial_position[i] << " " << As.gradient << " " << As.curvature << "\n";
 		} else {
@@ -7647,10 +7667,38 @@ public:
 		}
 	}
 
+	bool stationIsOnRoute(int stationIndex, const vector<string>& allowedBlockIds = {}) const {
+		if (!Stations || stationIndex < 0 || stationIndex >= numStations ||
+			indexOfRoute < 0 || indexOfRoute >= static_cast<int>(train_route.size()))
+			return false;
+		const string& stationName = Stations[stationIndex].stationName;
+		if (stationName.empty() || stationName == "None")
+			return false;
+		const auto matches = [&stationName](const Node& node) {
+			return node.station && node.stationName == stationName;
+		};
+		const Route& route = train_route[indexOfRoute];
+		for (int h = 0; h < route.N_Block_Sections; ++h) {
+			const Section& section = route.sequence_of_block_sections[h];
+			if (!allowedBlockIds.empty() &&
+				std::find(allowedBlockIds.begin(), allowedBlockIds.end(), section.ID) == allowedBlockIds.end())
+				continue;
+			if (matches(section.start_node) || matches(section.end_node))
+				return true;
+			for (int arcIndex = 0; arcIndex < section.total_arcs; ++arcIndex) {
+				if (matches(section.arcs_in_signalling_block_section[arcIndex].endNode))
+					return true;
+			}
+		}
+		return false;
+	}
+
 	double stationRoutePositionMeters(int stationIndex) const {
+		if (!stationIsOnRoute(stationIndex))
+			return -1;
+		const string stationName = stationNameForArrivalStats(stationIndex);
 		double stationX = Stations[stationIndex].X;
 		if (stationX == 0) {
-			const string stationName = stationNameForArrivalStats(stationIndex);
 			for (int h = 0; h < ::numStations; h++) {
 				if (StationArray[h].stationName == stationName) {
 					stationX = StationArray[h].X;
@@ -7658,9 +7706,6 @@ public:
 				}
 			}
 		}
-		if (stationX == 0)
-			return -1;
-
 		const double stationMeters = stationX * 1000.0;
 		for (int h = 0; h < train_route[indexOfRoute].N_Block_Sections; h++) {
 			const Section& section = train_route[indexOfRoute].sequence_of_block_sections[h];

--- a/EGTRAIN/QEGTRAIN/tests/test_blockingtimediagram.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_blockingtimediagram.cpp
@@ -54,6 +54,26 @@ int main() {
 		ok &= expect(segments[2].midPositionKm == 1.25, "critical station midpoint");
 	}
 
+	const std::vector<BlockingTimeDiagramSegment> scoped = filterBlockingTimeDiagramSegments(
+		segments, {"A"}, {"@12-B7@"}, 12.0, 18.0);
+	ok &= expect(scoped.size() == 1, "route block and train scope filters segments");
+	if (!scoped.empty()) {
+		ok &= expect(scoped[0].startTime == 12.0 && scoped[0].endTime == 18.0,
+			"time scope clips copied segment bounds");
+		ok &= expect(scoped[0].style == BlockingTimeSegmentStyle::Critical,
+			"critical style survives when the conflicting train is hidden");
+	}
+
+	const std::vector<BlockingTimePlannedReference> references = {
+		{"A", "Origin", "departure", 10.0, 0.0},
+		{"A", "Destination", "arrival", 30.0, 2.0},
+		{"B", "Other", "departure", 40.0, 0.0}};
+	const auto crossing = filterBlockingTimePlannedReferences(references, 15.0, 25.0);
+	ok &= expect(crossing.size() == 2 && crossing.front().time == 10.0 && crossing.back().time == 30.0,
+		"planned scope retains both source points for a visible line crossing");
+	ok &= expect(filterBlockingTimePlannedReferences(references, 31.0, 39.0).empty(),
+		"off-window planned points do not create an empty scoped chart or export");
+
 	if (!ok)
 		return 1;
 

--- a/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
@@ -162,6 +162,22 @@ int main() {
 	ok &= expect(regional_train[0].ScheduledArrivals[0] == -1.0
 			&& regional_train[0].ScheduledArrivals[1] == 120.0
 			&& regional_train[0].ScheduledDepartures[2] == -1.0, "optional timetable fields retain runtime -1 sentinels");
+	ok &= expect(regional_train[0].stationIsOnRoute(0)
+			&& regional_train[0].stationRoutePositionMeters(0) == 0.0,
+			"planned references retain a valid route-origin station at kilometre zero");
+	Node offRouteStation;
+	offRouteStation.station = true;
+	offRouteStation.stationName = "Outside";
+	Train routeMembershipProbe;
+	routeMembershipProbe.Stations = &offRouteStation;
+	routeMembershipProbe.numStations = 1;
+	routeMembershipProbe.indexOfRoute = regional_train[0].indexOfRoute;
+	ok &= expect(!routeMembershipProbe.stationIsOnRoute(0)
+			&& routeMembershipProbe.stationRoutePositionMeters(0) < 0.0,
+			"route-external static timetable stops remain inert in planned route results");
+	ok &= expect(regional_train[0].instant_train_tractive_effort.size()
+			== regional_train[0].instant_spatial_position.size(),
+			"tractive-effort samples are allocated with the trajectory");
 	ok &= expect(regional_train[1].ScheduledDepartures[0] == 145.0
 			&& regional_train[1].ScheduledDepartures[1] == 160.0
 			&& regional_train[1].EntranceDelay == 5.0, "selected entrance delays apply to the requested occurrence and stops");

--- a/tools/e2e/csv_export_smoke.sh
+++ b/tools/e2e/csv_export_smoke.sh
@@ -33,15 +33,16 @@ for name in trajectory timetable run_summary; do
 	fi
 done
 
-# Blocking-time data is only present when the case study defines complete
-# blocking times, so validate its header only when the file was written.
+# The blocking-time export also carries the visible planned reference layer.
 if [[ -s "$OUTDIR/blocking_time.csv" ]]; then
 	head -n1 "$OUTDIR/blocking_time.csv" | grep -q "^Train,Block,Occupation start\[s\]" \
 		|| { echo "blocking_time.csv header mismatch" >&2; exit 1; }
+	grep -q ",planned reference," "$OUTDIR/blocking_time.csv" \
+		|| { echo "blocking_time.csv missing planned reference rows" >&2; exit 1; }
 fi
 
 # Headers must match the documented schema.
-head -n1 "$OUTDIR/trajectory.csv" | grep -q "^Train,Time\[s\],Position\[m\],Speed\[m/s\],Power\[kW\],Energy\[kWh\],Block" \
+head -n1 "$OUTDIR/trajectory.csv" | grep -q "^Train,Operating code,Service ID,Occurrence,Time\[s\],Position\[m\],Speed\[m/s\],Power\[kW\],Tractive effort\[kN\],Energy\[kWh\],Block" \
 	|| { echo "trajectory.csv header mismatch" >&2; exit 1; }
 head -n1 "$OUTDIR/timetable.csv" | grep -q "^Train,Station,Journey order,Operating code,Planned arrival\[s\]" \
 	|| { echo "timetable.csv header mismatch" >&2; exit 1; }
@@ -53,6 +54,54 @@ traj_rows=$(($(wc -l < "$OUTDIR/trajectory.csv") - 1))
 tt_rows=$(($(wc -l < "$OUTDIR/timetable.csv") - 1))
 if (( traj_rows < 1 )); then echo "trajectory.csv has no data rows" >&2; exit 1; fi
 if (( tt_rows < 1 )); then echo "timetable.csv has no data rows" >&2; exit 1; fi
+
+# The integrator records the effort and power for the interval ending at a row,
+# so the power uses that train's preceding speed sample.  Check that retained
+# relationship in kW; allow 0.05 kW plus 0.1% for CSV decimal formatting.
+awk -F, '
+function abs(value) { return value < 0 ? -value : value }
+NR == 1 {
+	for (i = 1; i <= NF; ++i)
+		column[$i] = i
+	if (!("Operating code" in column) || !("Service ID" in column) || !("Occurrence" in column) ||
+		!("Speed[m/s]" in column) || !("Power[kW]" in column) || !("Tractive effort[kN]" in column)) {
+		print "trajectory.csv identity or force header missing" > "/dev/stderr"
+		schema = 0
+		exit 1
+	}
+	schema = 1
+	next
+}
+{
+	train = $(column["Train"])
+	time = $(column["Time[s]"])
+	effort = $(column["Tractive effort[kN]"])
+	speed = $(column["Speed[m/s]"])
+	power = $(column["Power[kW]"])
+	if (train == "" || time == "" || effort == "" || speed == "" || power == "")
+		next
+	if (effort > 0.001) positive = 1
+	if (effort < -0.001) negative = 1
+	if (abs(effort) <= 0.001) zero = 1
+	if (abs(speed) > 0.001 && (train in previousSpeed) && time > previousTime[train] && abs(previousSpeed[train]) > 0.001) {
+		expected = effort * previousSpeed[train]
+		tolerance = 0.05 + 0.001 * abs(power)
+		if (abs(expected - power) > tolerance) {
+			if (!mismatch)
+				print "force/power mismatch on trajectory row " NR ": " expected " kW vs " power " kW" > "/dev/stderr"
+			mismatch = 1
+		}
+	}
+	previousSpeed[train] = speed
+	previousTime[train] = time
+}
+END {
+	if (!schema || mismatch || !positive || !zero || !negative) {
+		if (!positive || !zero || !negative)
+			print "Paimpol trajectory lacks required force signs: positive=" positive ", zero=" zero ", negative=" negative > "/dev/stderr"
+		exit 1
+	}
+}' "$OUTDIR/trajectory.csv" || exit 1
 
 # The run summary always ends with the network totals row.
 grep -q "^Network total," "$OUTDIR/run_summary.csv" \


### PR DESCRIPTION
## Summary

- retain signed simulated wheel effort beside each active trajectory sample
- add a filtered tractive-effort versus distance result through the existing diagram, PNG, and CSV paths
- distinguish static input traction characteristics from simulated force results
- add route, block, and time scope plus dashed planned references to the blocking-time diagram
- preserve complete occupation conflict classification while filtering presentation copies

## Verification

- complete CMake build
- CTest: 42/42 passed
- CSV export smoke
- visual polish and legacy import smoke
- six-case native headless smoke
- six-case round-trip and reimport smoke

Closes #271
Closes #273
Advances #4