### PR TITLE
Add headway and capacity analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ set(EGTRAIN_SOURCES
     ${SRC_DIR}/diagrams/RunResults.cpp
     ${SRC_DIR}/util/TrajectoryUtil.cpp
     ${SRC_DIR}/diagrams/BlockingTimeDiagram.cpp
+    ${SRC_DIR}/diagrams/CapacityAnalysis.cpp
     ${SRC_DIR}/diagrams/TractionCurve.cpp
     ${SRC_DIR}/graphics/VisualPolish.cpp
     ${SRC_DIR}/scene/SceneExporter.cpp
@@ -196,6 +197,7 @@ set(EGTRAIN_HEADERS
     ${SRC_DIR}/diagrams/RunResults.h
     ${SRC_DIR}/util/TrajectoryUtil.h
     ${SRC_DIR}/diagrams/BlockingTimeDiagram.h
+    ${SRC_DIR}/diagrams/CapacityAnalysis.h
     ${SRC_DIR}/diagrams/TractionCurve.h
     ${SRC_DIR}/graphics/VisualPolish.h
     ${SRC_DIR}/scene/SceneExporter.h
@@ -389,6 +391,12 @@ if(EGTRAIN_BUILD_TESTS)
         ${SRC_DIR}/tests/test_blockingtimediagram.cpp
         ${SRC_DIR}/diagrams/BlockingTimeDiagram.cpp)
     add_test(NAME test_blockingtimediagram COMMAND test_blockingtimediagram)
+
+    add_executable(test_capacityanalysis
+        ${SRC_DIR}/tests/test_capacityanalysis.cpp
+        ${SRC_DIR}/diagrams/CapacityAnalysis.cpp
+        ${SRC_DIR}/diagrams/BlockingTimeDiagram.cpp)
+    add_test(NAME test_capacityanalysis COMMAND test_capacityanalysis)
 
     add_executable(test_diagramwindow
         ${SRC_DIR}/tests/test_diagramwindow.cpp

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include "util/TrajectoryUtil.h"
 #include "util/CsvWriter.h"
 #include "diagrams/BlockingTimeDiagram.h"
+#include "diagrams/CapacityAnalysis.h"
 #include "diagrams/TractionCurve.h"
 #include "graphics/VisualPolish.h"
 #include "scene/SceneBundle.h"
@@ -49,6 +50,7 @@
 #include <QToolButton>
 #include <QTreeWidgetItemIterator>
 #include <QStringList>
+#include <QTabWidget>
 #include <QRegularExpression>
 #include <cstdio>
 #include <algorithm>
@@ -204,6 +206,10 @@ const char* blockingSegmentTypeName(BlockingTimeSegmentStyle style) {
 	}
 }
 
+const char* blockingSegmentTypeName(const BlockingTimeDiagramSegment& segment) {
+	return segment.capacityCritical ? "capacity critical block" : blockingSegmentTypeName(segment.style);
+}
+
 struct BlockingTimeScope {
 	std::vector<std::string> trainIds;
 	std::vector<std::string> blockIds;
@@ -293,7 +299,7 @@ std::string buildBlockingTimeCsv(const QStringList& visibleTrainIds,
 			csv::formatDouble(s.startTime),
 			csv::formatDouble(s.endTime),
 			csv::formatDouble(s.midPositionKm),
-			blockingSegmentTypeName(s.style),
+			blockingSegmentTypeName(s),
 			std::string(),
 			std::string(),
 			std::string()});
@@ -464,6 +470,405 @@ std::string buildRunSummaryCsv() {
 		{"Train", "Operating code", "Performance [%]", "Applied maximum speed [km/h]", "Start[s]", "End[s]", "Travel time[s]", "Energy consumed[kWh]",
 			"Energy with regen[kWh]", "Substation[kWh]", "Substation with regen[kWh]"},
 		rows);
+}
+
+struct CapacityAnalysisScope {
+	int routeIndex = -1;
+	std::vector<std::string> blockIds;
+	std::vector<std::string> occurrenceIds;
+	std::string cycleEndOccurrenceId;
+	double periodSeconds = 3600.0;
+};
+
+BlockingTimeDiagramInput capacityOccupation(const BlockingTimes& source) {
+	BlockingTimeDiagramInput occupation;
+	occupation.blockId = source.BlockID;
+	occupation.startOccTime = source.StartOccTime;
+	occupation.endOccTime = source.EndOccTime;
+	occupation.posStart = source.PosStart;
+	occupation.posEnd = source.PosEnd;
+	occupation.switchName = source.SwitchName;
+	occupation.stationName = source.stationName;
+	occupation.isComplete = source.IsComplete;
+	return occupation;
+}
+
+CapacityAnalysisTrain capacityTrainForScope(const Train& train, const CapacityAnalysisScope& scope) {
+	CapacityAnalysisTrain result;
+	result.runtimeId = train.trainDescription;
+	result.operatingCode = train.operatingCode;
+	if (scope.blockIds.empty())
+		return result;
+
+	const BlockingTimes* reference = nullptr;
+	for (int blockIndex = 0; blockIndex < train.N_BlockTimeComplete; ++blockIndex) {
+		const BlockingTimes& source = train.BlockTime[blockIndex];
+		const BlockingTimeDiagramInput occupation = capacityOccupation(source);
+		if (!validBlockingTimeDiagramInput(occupation))
+			continue;
+		if (!reference && shareBlockingTimeResource(occupation.blockId, scope.blockIds.front()))
+			reference = &source;
+		for (const std::string& selectedBlock : scope.blockIds) {
+			if (shareBlockingTimeResource(occupation.blockId, selectedBlock)) {
+				result.occupations.push_back(occupation);
+				break;
+			}
+		}
+	}
+	if (!reference || !std::isfinite(reference->StartRunTime) || reference->StartRunTime < 0.0) {
+		result.occupations.clear();
+		return result;
+	}
+	result.profileReferenceTime = reference->StartRunTime;
+	result.referenceLabel = "block " + scope.blockIds.front() + " entry";
+	result.referenceSource = "selected section StartRunTime";
+
+	// A boundary stop is the authored reference when its route position matches
+	// the selected section entry. The 5 m tolerance is the native route tolerance.
+	if (train.Stations && reference->PosStart >= 0.0) {
+		const int stationCount = std::min(train.numStations, static_cast<int>(Train::kMaxTimetableStations));
+		for (int stationIndex = 0; stationIndex < stationCount; ++stationIndex) {
+			const double stationPosition = train.stationRoutePositionMeters(stationIndex);
+			if (!std::isfinite(stationPosition) || std::abs(stationPosition - reference->PosStart) > 5.0)
+				continue;
+			const double departure = train.ScheduledDepartures[stationIndex];
+			const double arrival = train.ScheduledArrivals[stationIndex];
+			const double authored = departure >= 0.0 ? departure : arrival;
+			if (!std::isfinite(authored) || authored < 0.0)
+				continue;
+			const std::string station = train.stationNameForArrivalStats(stationIndex);
+			result.scheduledReferenceTime = authored;
+			result.referenceLabel = station + " boundary";
+			result.referenceSource = departure >= 0.0
+				? "authored ScheduledDeparture at boundary station"
+				: "authored ScheduledArrival at boundary station (departure absent)";
+			return result;
+		}
+	}
+
+	if (std::isfinite(train.scheduled_departure_time) && train.scheduled_departure_time >= 0.0
+		&& train.RunStartTime >= 0) {
+		result.scheduledReferenceTime = train.scheduled_departure_time
+			+ (reference->StartRunTime - static_cast<double>(train.RunStartTime));
+		result.referenceSource = "canonical scheduled entry + elapsed from RunStartTime";
+	} else {
+		result.scheduledReferenceTime = result.profileReferenceTime;
+		result.referenceSource = "profile reference fallback (scheduled entry unavailable)";
+	}
+	return result;
+}
+
+std::vector<CapacityAnalysisTrain> capacityTrainsForScope(const CapacityAnalysisScope& scope) {
+	std::vector<CapacityAnalysisTrain> candidates;
+	for (int trainIndex = 0; trainIndex < numRegions; ++trainIndex) {
+		const CapacityAnalysisTrain candidate = capacityTrainForScope(regional_train[trainIndex], scope);
+		if (candidate.occupations.empty())
+			continue;
+		if (!scope.occurrenceIds.empty() && std::find(scope.occurrenceIds.begin(), scope.occurrenceIds.end(),
+			candidate.runtimeId) == scope.occurrenceIds.end())
+			continue;
+		candidates.push_back(candidate);
+	}
+	if (scope.occurrenceIds.empty())
+		return candidates;
+	std::vector<CapacityAnalysisTrain> trains;
+	trains.reserve(scope.occurrenceIds.size());
+	for (const std::string& occurrenceId : scope.occurrenceIds) {
+		const auto it = std::find_if(candidates.begin(), candidates.end(),
+			[&occurrenceId](const CapacityAnalysisTrain& candidate) {
+				return candidate.runtimeId == occurrenceId;
+			});
+		if (it != candidates.end())
+			trains.push_back(*it);
+	}
+	return trains;
+}
+
+CapacityAnalysisScope firstCapacityScopeWithPair() {
+	CapacityAnalysisScope empty;
+	for (std::size_t routeIndex = 0; routeIndex < train_route.size(); ++routeIndex) {
+		const Route& route = train_route[routeIndex];
+		for (int blockIndex = 0; blockIndex < route.N_Block_Sections; ++blockIndex) {
+			CapacityAnalysisScope candidate;
+			candidate.routeIndex = static_cast<int>(routeIndex);
+			candidate.blockIds.push_back(route.sequence_of_block_sections[blockIndex].ID);
+			const auto trains = capacityTrainsForScope(candidate);
+			if (trains.size() < 2)
+				continue;
+			for (const auto& train : trains)
+				candidate.occurrenceIds.push_back(train.runtimeId);
+			return candidate;
+		}
+	}
+	return empty;
+}
+
+QString capacityScopeLabel(const CapacityAnalysisScope& scope) {
+	if (scope.routeIndex < 0 || scope.routeIndex >= static_cast<int>(train_route.size()))
+		return QStringLiteral("no selected route");
+	const Route& route = train_route[static_cast<std::size_t>(scope.routeIndex)];
+	QString label = QString::fromStdString(route.ID);
+	if (!route.corridor.empty())
+		label += QString(" / %1").arg(QString::fromStdString(route.corridor));
+	if (!scope.blockIds.empty())
+		label += QString(" / %1 to %2").arg(QString::fromStdString(scope.blockIds.front()),
+			QString::fromStdString(scope.blockIds.back()));
+	return label;
+}
+
+std::string capacityEvidenceText(const std::vector<CapacityHeadwayEvidence>& evidence) {
+	QStringList values;
+	for (const auto& item : evidence)
+		values << QString("%1/%2 (leader=%3 s; follower=%4 s; candidate=%5 s)")
+			.arg(QString::fromStdString(item.leaderBlockId), QString::fromStdString(item.followerBlockId),
+				QString::fromStdString(csv::formatDouble(item.leaderOffset)),
+				QString::fromStdString(csv::formatDouble(item.followerOffset)),
+				QString::fromStdString(csv::formatDouble(item.candidateHeadway)));
+	return values.join("; ").toStdString();
+}
+
+std::string buildCapacityAnalysisCsv(const CapacityAnalysisResult& result, const QString& sectionLabel) {
+	if (!result.analyzable || result.cycleEndIdentity.empty() || !std::isfinite(result.cycleTime)
+		|| result.cycleTime < 0.0 || !std::isfinite(result.cyclePercentage))
+		return std::string();
+	const std::vector<std::string> header = {
+		"Record type", "Leader", "Follower", "Identity", "Operating code", "Original reference[s]",
+		"Scheduled reference[s]", "Compressed reference[s]", "Shift[s]", "Scheduled headway[s]",
+		"Minimum headway[s]", "Buffer[s]", "Block", "Leader offset[s]", "Follower offset[s]",
+		"Candidate headway[s]", "Gap[s]", "Cycle time[s]", "Period[s]", "Cycle / period [%]",
+		"Section", "Reference label", "Reference source", "Notes"};
+	constexpr std::size_t kColumnCount = 24;
+	std::vector<std::vector<std::string>> rows;
+	const auto referenceSource = [&result](const std::string& identity) {
+		for (std::size_t index = 0; index < result.trainIdentities.size(); ++index)
+			if (result.trainIdentities[index] == identity && index < result.referenceSources.size())
+				return result.referenceSources[index];
+		return std::string();
+	};
+	const auto referenceLabel = [&result](const std::string& identity) {
+		for (std::size_t index = 0; index < result.trainIdentities.size(); ++index)
+			if (result.trainIdentities[index] == identity && index < result.referenceLabels.size())
+				return result.referenceLabels[index];
+		return std::string();
+	};
+	std::vector<std::string> summary(kColumnCount);
+	summary[0] = "summary";
+	summary[1] = result.firstIdentity;
+	summary[2] = result.cycleEndIdentity;
+	summary[17] = csv::formatDouble(result.cycleTime);
+	summary[18] = csv::formatDouble(result.periodSeconds);
+	summary[19] = csv::formatDouble(result.cyclePercentage);
+	summary[20] = sectionLabel.toStdString();
+	summary[21] = referenceLabel(result.firstIdentity) + " -> " + referenceLabel(result.cycleEndIdentity);
+	summary[22] = referenceSource(result.firstIdentity) + " -> " + referenceSource(result.cycleEndIdentity);
+	summary[23] = "explicit cycle start and next-period closing occurrence";
+	rows.push_back(std::move(summary));
+	for (const auto& pair : result.allPairs) {
+		if (pair.governingEvidence.empty()) {
+			std::vector<std::string> record(kColumnCount);
+			record[0] = "pair";
+			record[1] = pair.leaderIdentity;
+			record[2] = pair.followerIdentity;
+			record[9] = csv::formatDouble(pair.scheduledHeadway);
+			record[10] = csv::formatDouble(pair.minimumHeadway);
+			record[11] = csv::formatDouble(pair.buffer);
+			record[20] = sectionLabel.toStdString();
+			record[21] = referenceLabel(pair.leaderIdentity) + " -> " + referenceLabel(pair.followerIdentity);
+			record[22] = referenceSource(pair.leaderIdentity) + " -> " + referenceSource(pair.followerIdentity);
+			record[23] = pair.adjacent ? "no shared constraint" : "nonadjacent; no shared constraint";
+			rows.push_back(std::move(record));
+			continue;
+		}
+		for (const auto& evidence : pair.governingEvidence) {
+			std::vector<std::string> record(kColumnCount);
+			record[0] = "pair";
+			record[1] = pair.leaderIdentity;
+			record[2] = pair.followerIdentity;
+			record[9] = csv::formatDouble(pair.scheduledHeadway);
+			record[10] = csv::formatDouble(pair.minimumHeadway);
+			record[11] = csv::formatDouble(pair.buffer);
+			record[12] = evidence.leaderBlockId + " / " + evidence.followerBlockId;
+			record[13] = csv::formatDouble(evidence.leaderOffset);
+			record[14] = csv::formatDouble(evidence.followerOffset);
+			record[15] = csv::formatDouble(evidence.candidateHeadway);
+			record[20] = sectionLabel.toStdString();
+			record[21] = referenceLabel(pair.leaderIdentity) + " -> " + referenceLabel(pair.followerIdentity);
+			record[22] = referenceSource(pair.leaderIdentity) + " -> " + referenceSource(pair.followerIdentity);
+			record[23] = pair.adjacent ? "governing resource" : "nonadjacent ordered constraint; governing resource";
+			rows.push_back(std::move(record));
+		}
+	}
+	for (const auto& row : result.compression) {
+		const auto appendCompressionRecord = [&](const CapacityCompressionEvidence* governing) {
+			const std::string predecessor = governing ? governing->predecessorIdentity : std::string();
+			std::vector<std::string> record(kColumnCount);
+			record[0] = "compression";
+			record[1] = predecessor;
+			record[3] = row.identity;
+			record[4] = row.operatingCode;
+			record[5] = csv::formatDouble(row.originalReference);
+			record[6] = csv::formatDouble(row.scheduledReference);
+			record[7] = csv::formatDouble(row.compressedReference);
+			record[8] = csv::formatDouble(row.shift);
+			record[12] = governing ? capacityEvidenceText(governing->governingEvidence) : std::string();
+			record[20] = sectionLabel.toStdString();
+			record[21] = referenceLabel(row.identity);
+			record[22] = referenceSource(row.identity);
+			record[23] = "governing predecessor=" + predecessor;
+			rows.push_back(std::move(record));
+		};
+		if (row.governingPredecessors.empty())
+			appendCompressionRecord(nullptr);
+		else
+			for (const auto& governing : row.governingPredecessors)
+				appendCompressionRecord(&governing);
+	}
+	for (const auto& critical : result.criticalBlocks) {
+		std::vector<std::string> record(kColumnCount);
+		record[0] = "critical";
+		record[1] = critical.leaderIdentity;
+		record[2] = critical.followerIdentity;
+		record[12] = critical.leaderBlockId + " / " + critical.followerBlockId;
+		record[16] = csv::formatDouble(critical.gap);
+		record[20] = sectionLabel.toStdString();
+		record[21] = referenceLabel(critical.leaderIdentity) + " -> " + referenceLabel(critical.followerIdentity);
+		record[22] = referenceSource(critical.leaderIdentity) + " -> " + referenceSource(critical.followerIdentity);
+		record[23] = "capacity critical block";
+		rows.push_back(std::move(record));
+	}
+	return csv::makeDocument(header, rows);
+}
+
+bool chooseCapacityAnalysisScope(QWidget* parent, CapacityAnalysisScope& scope) {
+	if (train_route.empty())
+		return false;
+	QDialog dialog(parent);
+	dialog.setWindowTitle("Capacity analysis");
+	auto* layout = new QVBoxLayout(&dialog);
+	auto* form = new QFormLayout();
+	auto* routeCombo = new QComboBox(&dialog);
+	for (std::size_t routeIndex = 0; routeIndex < train_route.size(); ++routeIndex) {
+		const Route& route = train_route[routeIndex];
+		const QString corridor = route.corridor.empty()
+			? QStringLiteral("no corridor") : QString::fromStdString(route.corridor);
+		routeCombo->addItem(QString("%1  (%2)").arg(QString::fromStdString(route.ID), corridor),
+			static_cast<int>(routeIndex));
+	}
+	auto* firstBlock = new QComboBox(&dialog);
+	auto* lastBlock = new QComboBox(&dialog);
+	auto* period = new QDoubleSpinBox(&dialog);
+	period->setRange(0.001, std::numeric_limits<double>::max());
+	period->setDecimals(3);
+	period->setSingleStep(60.0);
+	period->setSuffix(" s");
+	period->setValue(3600.0);
+	auto* cycleEnd = new QComboBox(&dialog);
+	cycleEnd->addItem("Select the first train in the next period...");
+	auto* occurrences = new QListWidget(&dialog);
+	occurrences->setSelectionMode(QAbstractItemView::SingleSelection);
+	occurrences->setDragDropMode(QAbstractItemView::InternalMove);
+	occurrences->setDefaultDropAction(Qt::MoveAction);
+	occurrences->setMinimumHeight(180);
+	form->addRow("Route / corridor:", routeCombo);
+	form->addRow("First block:", firstBlock);
+	form->addRow("Last block:", lastBlock);
+	form->addRow("Analysis period:", period);
+	form->addRow("Cycle-closing occurrence:", cycleEnd);
+	layout->addLayout(form);
+	auto* note = new QLabel(
+		"Checked occurrences are analyzed in the displayed order (A → B); selecting exactly two enables the pair workflow. "
+		"Pre-/post-Gdg order changes are separate explicit sections. Select the occurrence of the first service in the next "
+		"period that closes the capacity cycle; EGTRAIN does not infer it from the last row.", &dialog);
+	note->setWordWrap(true);
+	layout->addWidget(note);
+	layout->addWidget(new QLabel("Occurrences with complete occupations on the selected section:", &dialog));
+	layout->addWidget(occurrences);
+
+	const auto refillBlocks = [routeCombo, firstBlock, lastBlock]() {
+		firstBlock->clear();
+		lastBlock->clear();
+		const int routeIndex = routeCombo->currentData().toInt();
+		if (routeIndex < 0 || routeIndex >= static_cast<int>(train_route.size()))
+			return;
+		const Route& route = train_route[static_cast<std::size_t>(routeIndex)];
+		for (int blockIndex = 0; blockIndex < route.N_Block_Sections; ++blockIndex) {
+			const QString blockId = QString::fromStdString(route.sequence_of_block_sections[blockIndex].ID);
+			firstBlock->addItem(blockId);
+			lastBlock->addItem(blockId);
+		}
+		if (firstBlock->count() > 0)
+			lastBlock->setCurrentIndex(lastBlock->count() - 1);
+	};
+	const auto currentScope = [routeCombo, firstBlock, lastBlock, period]() {
+		CapacityAnalysisScope candidate;
+		candidate.routeIndex = routeCombo->currentData().toInt();
+		candidate.periodSeconds = period->value();
+		if (candidate.routeIndex < 0 || candidate.routeIndex >= static_cast<int>(train_route.size()))
+			return candidate;
+		const Route& route = train_route[static_cast<std::size_t>(candidate.routeIndex)];
+		const int first = std::min(firstBlock->currentIndex(), lastBlock->currentIndex());
+		const int last = std::max(firstBlock->currentIndex(), lastBlock->currentIndex());
+		for (int blockIndex = first; blockIndex <= last && blockIndex < route.N_Block_Sections; ++blockIndex)
+			if (blockIndex >= 0)
+				candidate.blockIds.push_back(route.sequence_of_block_sections[blockIndex].ID);
+		return candidate;
+	};
+	const auto refillOccurrences = [occurrences, cycleEnd, currentScope]() {
+		occurrences->clear();
+		cycleEnd->clear();
+		cycleEnd->addItem("Select the first train in the next period...");
+		const auto trains = capacityTrainsForScope(currentScope());
+		for (const CapacityAnalysisTrain& train : trains) {
+			const QString identity = QString::fromStdString(train.runtimeId);
+			const QString code = QString::fromStdString(train.operatingCode);
+			auto* item = new QListWidgetItem(
+				QString("%1 | %2 | %3").arg(identity, code, QString::fromStdString(train.referenceSource)), occurrences);
+			item->setData(Qt::UserRole, identity);
+			item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsDragEnabled);
+			item->setCheckState(Qt::Checked);
+			cycleEnd->addItem(QString("%1 | %2").arg(identity, code), identity);
+		}
+	};
+	QObject::connect(routeCombo, qOverload<int>(&QComboBox::currentIndexChanged), &dialog,
+		[refillBlocks, refillOccurrences](int) { refillBlocks(); refillOccurrences(); });
+	QObject::connect(firstBlock, qOverload<int>(&QComboBox::currentIndexChanged), &dialog,
+		[refillOccurrences](int) { refillOccurrences(); });
+	QObject::connect(lastBlock, qOverload<int>(&QComboBox::currentIndexChanged), &dialog,
+		[refillOccurrences](int) { refillOccurrences(); });
+	if (routeCombo->count() > 0)
+		routeCombo->setCurrentIndex(0);
+	refillBlocks();
+	refillOccurrences();
+
+	auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+	QObject::connect(buttons, &QDialogButtonBox::accepted, &dialog, [&]() {
+		int selected = 0;
+		for (int row = 0; row < occurrences->count(); ++row)
+			selected += occurrences->item(row)->checkState() == Qt::Checked ? 1 : 0;
+		if (selected < 2) {
+			QMessageBox::information(&dialog, "Capacity analysis", "Select at least two ordered occurrences with a common entry block.");
+			return;
+		}
+		scope = currentScope();
+		scope.occurrenceIds.clear();
+		for (int row = 0; row < occurrences->count(); ++row) {
+			const QListWidgetItem* item = occurrences->item(row);
+			if (item->checkState() == Qt::Checked)
+				scope.occurrenceIds.push_back(item->data(Qt::UserRole).toString().toStdString());
+		}
+		scope.cycleEndOccurrenceId = cycleEnd->currentData().toString().toStdString();
+		const auto selectedCycleEnd = std::find(scope.occurrenceIds.begin(), scope.occurrenceIds.end(),
+			scope.cycleEndOccurrenceId);
+		if (selectedCycleEnd == scope.occurrenceIds.end() || selectedCycleEnd == scope.occurrenceIds.begin()) {
+			QMessageBox::information(&dialog, "Capacity analysis",
+				"Choose a checked cycle-closing occurrence after the first row, normally the first train in the next period.");
+			return;
+		}
+		dialog.accept();
+	});
+	QObject::connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+	layout->addWidget(buttons);
+	return dialog.exec() == QDialog::Accepted;
 }
 
 // Ids of every loaded train, used when a whole result table is exported.
@@ -2071,6 +2476,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_diagramsMenu->addSeparator();
 	m_diagramsMenu->addAction("Timetable graph (train graph)...", this, &MainWindow::showTimetableGraph);
 	m_diagramsMenu->addAction("Blocking-time overlay...", this, &MainWindow::showBlockingTimeDiagram);
+	m_diagramsMenu->addAction("Capacity analysis...", this, &MainWindow::showCapacityAnalysis);
 	m_diagramsMenu->addAction("Timetable table (planned vs simulated)...", this, &MainWindow::showTimetableTable);
 	m_diagramsMenu->addAction("Train delays...", this, &MainWindow::showDelayDiagram);
 	// Train paths belongs with the other charts; retire the one-entry Tools menu.
@@ -11286,6 +11692,19 @@ void MainWindow::onSimulationFinished() {
 			ok &= dump("timetable.csv", buildTimetableCsv(ids));
 			ok &= dump("blocking_time.csv", buildBlockingTimeCsv(ids));
 			ok &= dump("run_summary.csv", buildRunSummaryCsv());
+			const CapacityAnalysisScope capacityScope = firstCapacityScopeWithPair();
+			std::string capacityCsv;
+			if (capacityScope.routeIndex >= 0) {
+				const auto capacityTrains = capacityTrainsForScope(capacityScope);
+				capacityCsv = buildCapacityAnalysisCsv(
+					analyzeCapacity(capacityTrains, capacityScope.periodSeconds,
+						capacityScope.cycleEndOccurrenceId), capacityScopeLabel(capacityScope));
+			}
+			if (capacityCsv.empty()) {
+				std::fprintf(stdout, "E2E_CAPACITY_EXPORT_UNAVAILABLE\n");
+			} else {
+				ok &= dump("capacity_analysis.csv", capacityCsv);
+			}
 		}
 		std::fprintf(ok ? stdout : stderr, ok ? "E2E_CSV_EXPORT_OK\n" : "E2E_CSV_EXPORT_FAIL\n");
 		std::fflush(stdout);
@@ -12140,6 +12559,7 @@ void MainWindow::setupRunResultsDock() {
 	addResultViewButton("Tractive effort / distance", &MainWindow::showTractiveEffortDistanceDiagram);
 	addResultViewButton("Train paths", &MainWindow::displayTrainPathDiagrams);
 	addResultViewButton("Blocking time", &MainWindow::showBlockingTimeDiagram);
+	addResultViewButton("Capacity", &MainWindow::showCapacityAnalysis);
 	containerLayout->addLayout(resultViews);
 	QPushButton* exportCsvBtn = new QPushButton("Export CSV...", container);
 	exportCsvBtn->setObjectName("resultView_ExportCSV");
@@ -14346,6 +14766,248 @@ void MainWindow::showBlockingTimeDiagram() {
 	win->setTimeAxisX(true, m_startOffsetSeconds);
 	win->setAttribute(Qt::WA_DeleteOnClose);
 	win->show();
+}
+
+void MainWindow::showCapacityAnalysis() {
+	if (!hasRunResults()) {
+		statusBar()->showMessage("Run a simulation to open capacity analysis", 5000);
+		return;
+	}
+
+	CapacityAnalysisScope scope = firstCapacityScopeWithPair();
+	if (scope.routeIndex < 0) {
+		QMessageBox::information(this, "Capacity analysis",
+			"No retained native blocking-time section has two occurrences with a common entry block. "
+			"Run a scene with explicit signalling data; EGTRAIN does not infer a signalling system or blocking-time parameters.");
+		return;
+	}
+	if (!e2eDialogsSuppressed() && !chooseCapacityAnalysisScope(this, scope))
+		return;
+	if (scope.routeIndex < 0 || scope.blockIds.empty()) {
+		QMessageBox::information(this, "Capacity analysis",
+			"No route section has two occurrences with a common entry block. Choose a common entry or split the analysis into pre-/post-Gdg sections.");
+		return;
+	}
+	const auto trains = capacityTrainsForScope(scope);
+	if (trains.size() < 2) {
+		QMessageBox::information(this, "Capacity analysis",
+			"Fewer than two occurrences share the selected section entry. Choose a common entry or a narrower section.");
+		return;
+	}
+	const QString sectionLabel = capacityScopeLabel(scope);
+	const CapacityAnalysisResult result = analyzeCapacity(trains, scope.periodSeconds,
+		scope.cycleEndOccurrenceId);
+	if (!result.analyzable) {
+		QMessageBox::information(this, "Capacity analysis",
+			"The selected occurrences do not form a valid shared-resource chain. Choose a common entry or split pre-/post-Gdg order into separate sections.");
+		return;
+	}
+	if (result.cycleEndIdentity.empty() || result.cycleTime < 0.0) {
+		QMessageBox::information(this, "Capacity analysis",
+			"The cycle-closing occurrence must be a selected row after the first occurrence.");
+		return;
+	}
+
+	QDialog* dialog = new QDialog(this);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->setWindowTitle(QString("Capacity analysis | %1").arg(sectionLabel));
+	dialog->setModal(false);
+	dialog->resize(1050, 650);
+	auto* layout = new QVBoxLayout(dialog);
+	auto* summary = new QLabel(dialog);
+	summary->setWordWrap(true);
+	const QString percentage = QString::fromStdString(csv::formatDouble(result.cyclePercentage));
+	const QString cycle = QString::fromStdString(csv::formatDouble(result.cycleTime));
+	const QString period = QString::fromStdString(csv::formatDouble(result.periodSeconds));
+	const auto sourceFor = [&result](const std::string& identity) {
+		for (std::size_t index = 0; index < result.trainIdentities.size(); ++index)
+			if (result.trainIdentities[index] == identity && index < result.referenceSources.size())
+				return QString::fromStdString(result.referenceSources[index]);
+		return QString();
+	};
+	summary->setText(QString("Section: %1 | cycle/occupation time = %2 s | period = %3 s | cycle/period*100 = %4%% | "
+		"cycle start = %5 (%6) | cycle end = %7 (%8) | conflict-free compressed occupations. "
+		"Capacity critical blocks are touching constraints, distinct from overlap/conflict styling.")
+		.arg(sectionLabel, cycle, period, percentage, QString::fromStdString(result.firstIdentity),
+			sourceFor(result.firstIdentity), QString::fromStdString(result.cycleEndIdentity),
+			sourceFor(result.cycleEndIdentity)));
+	layout->addWidget(summary);
+
+	auto* tabs = new QTabWidget(dialog);
+	const auto labelFor = [&result](const std::string& identity) {
+		for (std::size_t index = 0; index < result.trainIdentities.size(); ++index)
+			if (result.trainIdentities[index] == identity && index < result.referenceLabels.size())
+				return QString::fromStdString(result.referenceLabels[index]);
+		return QString();
+	};
+	const auto addTable = [tabs](const QStringList& headers, int rows) {
+		auto* table = new QTableWidget(rows, headers.size(), tabs);
+		table->setHorizontalHeaderLabels(headers);
+		table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+		table->setSelectionBehavior(QAbstractItemView::SelectRows);
+		table->setAlternatingRowColors(true);
+		table->horizontalHeader()->setStretchLastSection(true);
+		tabs->addTab(table, QString());
+		return table;
+	};
+	auto* pairTable = addTable({"Leader", "Follower", "Leader code", "Follower code", "Scheduled headway [s]",
+		"Minimum headway [s]", "Buffer [s]", "Governing block evidence", "Reference label/source (leader → follower)"},
+		static_cast<int>(result.pairs.size()));
+	for (int row = 0; row < pairTable->rowCount(); ++row) {
+		const CapacityPairRow& pair = result.pairs[static_cast<std::size_t>(row)];
+		const std::string evidence = capacityEvidenceText(pair.governingEvidence);
+		const QString source = labelFor(pair.leaderIdentity) + " [" + sourceFor(pair.leaderIdentity) + "] → "
+			+ labelFor(pair.followerIdentity) + " [" + sourceFor(pair.followerIdentity) + "]";
+		const QStringList values = {QString::fromStdString(pair.leaderIdentity), QString::fromStdString(pair.followerIdentity),
+			QString::fromStdString(pair.leaderOperatingCode), QString::fromStdString(pair.followerOperatingCode),
+			QString::fromStdString(csv::formatDouble(pair.scheduledHeadway)), QString::fromStdString(csv::formatDouble(pair.minimumHeadway)),
+			QString::fromStdString(csv::formatDouble(pair.buffer)), QString::fromStdString(evidence), source};
+		for (int column = 0; column < values.size(); ++column)
+			pairTable->setItem(row, column, new QTableWidgetItem(values[column]));
+	}
+	tabs->setTabText(0, QString("Pairs (%1)").arg(pairTable->rowCount()));
+
+	auto* compressionTable = addTable({"Identity", "Operating code", "Original reference [s]", "Scheduled reference [s]",
+		"Compressed reference [s]", "Shift [s]", "Governing predecessor / block evidence"},
+		static_cast<int>(result.compression.size()));
+	for (int row = 0; row < compressionTable->rowCount(); ++row) {
+		const CapacityCompressionRow& compressed = result.compression[static_cast<std::size_t>(row)];
+		QStringList governing;
+		for (const CapacityCompressionEvidence& predecessor : compressed.governingPredecessors)
+			governing << QString("%1 (%2 s): %3").arg(QString::fromStdString(predecessor.predecessorIdentity),
+				QString::fromStdString(csv::formatDouble(predecessor.minimumHeadway)),
+				QString::fromStdString(capacityEvidenceText(predecessor.governingEvidence)));
+		const QStringList values = {QString::fromStdString(compressed.identity), QString::fromStdString(compressed.operatingCode),
+			QString::fromStdString(csv::formatDouble(compressed.originalReference)),
+			QString::fromStdString(csv::formatDouble(compressed.scheduledReference)),
+			QString::fromStdString(csv::formatDouble(compressed.compressedReference)),
+			QString::fromStdString(csv::formatDouble(compressed.shift)), governing.join("; ")};
+		for (int column = 0; column < values.size(); ++column)
+			compressionTable->setItem(row, column, new QTableWidgetItem(values[column]));
+	}
+	tabs->setTabText(1, QString("Compression (%1)").arg(compressionTable->rowCount()));
+
+	auto* criticalTable = addTable({"Leader", "Follower", "Leader block", "Follower block", "Gap [s]"},
+		static_cast<int>(result.criticalBlocks.size()));
+	for (int row = 0; row < criticalTable->rowCount(); ++row) {
+		const CapacityCriticalBlock& critical = result.criticalBlocks[static_cast<std::size_t>(row)];
+		const QStringList values = {QString::fromStdString(critical.leaderIdentity), QString::fromStdString(critical.followerIdentity),
+			QString::fromStdString(critical.leaderBlockId), QString::fromStdString(critical.followerBlockId),
+			QString::fromStdString(csv::formatDouble(critical.gap))};
+		for (int column = 0; column < values.size(); ++column)
+			criticalTable->setItem(row, column, new QTableWidgetItem(values[column]));
+	}
+	tabs->setTabText(2, QString("Critical blocks (%1)").arg(criticalTable->rowCount()));
+	for (int index = 0; index < tabs->count(); ++index)
+		qobject_cast<QTableWidget*>(tabs->widget(index))->resizeColumnsToContents();
+	layout->addWidget(tabs, 1);
+
+	auto* buttons = new QHBoxLayout();
+	QPushButton* exportButton = new QPushButton("Export capacity CSV...", dialog);
+	connect(exportButton, &QPushButton::clicked, dialog, [this, result, sectionLabel]() {
+		saveCsvInteractive(this, "capacity_analysis.csv", buildCapacityAnalysisCsv(result, sectionLabel));
+	});
+	QPushButton* diagramButton = new QPushButton("Open compressed blocking-time diagram", dialog);
+	connect(diagramButton, &QPushButton::clicked, dialog, [this, result, sectionLabel]() {
+		showCompressedBlockingTimeDiagram(result, sectionLabel);
+	});
+	QPushButton* closeButton = new QPushButton("Close", dialog);
+	connect(closeButton, &QPushButton::clicked, dialog, &QDialog::close);
+	buttons->addWidget(exportButton);
+	buttons->addWidget(diagramButton);
+	buttons->addStretch();
+	buttons->addWidget(closeButton);
+	layout->addLayout(buttons);
+	dialog->show();
+}
+
+void MainWindow::showCompressedBlockingTimeDiagram(const CapacityAnalysisResult& result,
+	const QString& sectionLabel) {
+	const std::vector<BlockingTimeDiagramSegment> segments = buildBlockingTimeDiagramSegments(
+		result.compressedOccupations, result.trainIdentities);
+	if (segments.empty()) {
+		QMessageBox::information(this, "Capacity diagram", "No complete compressed occupation data is available.");
+		return;
+	}
+	QChart* chart = new QChart();
+	chart->setTitle(QString("Compressed blocking-time diagram | %1 | cycle %2 to %3")
+		.arg(sectionLabel, QString::fromStdString(result.firstIdentity),
+			QString::fromStdString(result.cycleEndIdentity)));
+	const QColor defaultColor(100, 160, 240, 150);
+	const QColor stationColor(60, 110, 190, 180);
+	const QColor switchColor(240, 210, 40, 180);
+	const QColor switchStationColor(200, 160, 20, 190);
+	const QColor criticalColor(220, 50, 50, 200);
+	const QColor criticalStationColor(170, 30, 30, 220);
+	const QColor capacityColor(235, 175, 20, 230);
+	const auto colorFor = [&](const BlockingTimeDiagramSegment& segment) {
+		if (segment.capacityCritical)
+			return capacityColor;
+		switch (segment.style) {
+			case BlockingTimeSegmentStyle::Station: return stationColor;
+			case BlockingTimeSegmentStyle::Switch: return switchColor;
+			case BlockingTimeSegmentStyle::SwitchStation: return switchStationColor;
+			case BlockingTimeSegmentStyle::Critical: return criticalColor;
+			case BlockingTimeSegmentStyle::CriticalStation: return criticalStationColor;
+			case BlockingTimeSegmentStyle::Default: default: return defaultColor;
+		}
+	};
+	const auto suffixFor = [](const BlockingTimeDiagramSegment& segment) {
+		if (segment.capacityCritical)
+			return " (capacity critical block)";
+		switch (segment.style) {
+			case BlockingTimeSegmentStyle::Station: return " (station)";
+			case BlockingTimeSegmentStyle::Switch: return " (switch)";
+			case BlockingTimeSegmentStyle::SwitchStation: return " (switch/station)";
+			case BlockingTimeSegmentStyle::Critical: return " (conflict)";
+			case BlockingTimeSegmentStyle::CriticalStation: return " (conflict/station)";
+			case BlockingTimeSegmentStyle::Default: default: return "";
+		}
+	};
+	std::map<std::string, bool> legendEntries;
+	for (const BlockingTimeDiagramSegment& segment : segments) {
+		auto* series = new QLineSeries();
+		const std::string legendKey = segment.trainName + suffixFor(segment);
+		series->setName(QString::fromStdString(legendKey));
+		series->setProperty("trainId", QString::fromStdString(segment.trainName));
+		const bool firstLegendEntry = legendEntries.find(legendKey) == legendEntries.end();
+		QPen pen(colorFor(segment));
+		pen.setWidthF(segment.penWidth);
+		series->setPen(pen);
+		series->append(segment.startTime, segment.midPositionKm);
+		series->append(segment.endTime, segment.midPositionKm);
+		chart->addSeries(series);
+		if (!firstLegendEntry)
+			for (QLegendMarker* marker : chart->legend()->markers(series))
+				marker->setVisible(false);
+		legendEntries[legendKey] = true;
+	}
+	auto addKey = [chart](const QString& name, const QColor& color) {
+		auto* series = new QLineSeries();
+		series->setName(name);
+		QPen pen(color);
+		pen.setWidthF(4.0);
+		series->setPen(pen);
+		chart->addSeries(series);
+	};
+	addKey("Key: Conflict", criticalColor);
+	addKey("Key: Capacity critical block (touching)", capacityColor);
+	chart->createDefaultAxes();
+	if (!chart->axes(Qt::Horizontal).isEmpty())
+		chart->axes(Qt::Horizontal).first()->setTitleText("Time");
+	if (!chart->axes(Qt::Vertical).isEmpty())
+		chart->axes(Qt::Vertical).first()->setTitleText("Position (km)");
+	DiagramWindow* window = new DiagramWindow(chart->title(), this);
+	window->setChart(chart);
+	const std::function<std::string(const QStringList&)> csvProvider =
+		[segments](const QStringList& visibleTrainIds) {
+			return buildBlockingTimeCsv(visibleTrainIds, segments, {});
+		};
+	window->setCsvProvider(csvProvider, "capacity_compressed_blocking_time.csv");
+	connect(window, &DiagramWindow::trainSelected, this, &MainWindow::focusTrainInScene);
+	window->setTimeAxisX(true, m_startOffsetSeconds);
+	window->setAttribute(Qt::WA_DeleteOnClose);
+	window->show();
 }
 
 void MainWindow::buildSignalIndex() {

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -128,6 +128,7 @@ class ConsoleWidget; // forward declaration for m_logPane
 #include <QToolBar>
 
 #include "simulation/SimulationWorker.h"
+#include "diagrams/CapacityAnalysis.h"
 
 // boolean to define if GUI is used or not
 extern bool GUI;
@@ -755,6 +756,8 @@ private slots:
 	void showTimetableTable();
 	void showDelayDiagram();
 	void showBlockingTimeDiagram();
+	void showCapacityAnalysis();
+	void showCompressedBlockingTimeDiagram(const CapacityAnalysisResult& result, const QString& sectionLabel);
 	void focusTrainInScene(const QString& trainId); // centre the network view on a diagram selection
 
 };

--- a/EGTRAIN/QEGTRAIN/diagrams/BlockingTimeDiagram.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/BlockingTimeDiagram.cpp
@@ -18,9 +18,6 @@ std::vector<std::string> comparableBlockTokens(const std::string& blockId) {
 	while (std::getline(line, token, '@')) {
 		if (token.empty())
 			continue;
-		size_t suffix = token.find("-B");
-		if (suffix != std::string::npos)
-			token = token.substr(0, suffix);
 		if (validTokenIndex == 0 || validTokenIndex == 2)
 			tokens.push_back(token);
 		validTokenIndex++;
@@ -30,33 +27,9 @@ std::vector<std::string> comparableBlockTokens(const std::string& blockId) {
 	return tokens;
 }
 
-bool shareBlockId(const std::string& aBlockId, const std::string& bBlockId) {
-	std::vector<std::string> aTokens = comparableBlockTokens(aBlockId);
-	std::vector<std::string> bTokens = comparableBlockTokens(bBlockId);
-	for (const std::string& aToken : aTokens) {
-		for (const std::string& bToken : bTokens) {
-			if (aToken == bToken)
-				return true;
-		}
-	}
-	return false;
-}
-
-bool shareBlockId(const BlockingTimeDiagramInput& a, const BlockingTimeDiagramInput& b) {
-	return shareBlockId(a.blockId, b.blockId);
-}
-
-bool validInterval(const BlockingTimeDiagramInput& block) {
-	return block.isComplete &&
-		hasValue(block.blockId) &&
-		block.startOccTime >= 0.0 &&
-		block.endOccTime > block.startOccTime &&
-		block.posStart >= 0.0 &&
-		block.posEnd >= 0.0;
-}
-
 bool overlaps(const BlockingTimeDiagramInput& a, const BlockingTimeDiagramInput& b) {
-	return std::max(a.startOccTime, b.startOccTime) < std::min(a.endOccTime, b.endOccTime);
+	return std::max(a.startOccTime, b.startOccTime)
+		< std::min(a.endOccTime, b.endOccTime) - kBlockingTimeToleranceSeconds;
 }
 
 BlockingTimeSegmentStyle segmentStyle(const BlockingTimeDiagramInput& block, bool critical) {
@@ -71,6 +44,28 @@ BlockingTimeSegmentStyle segmentStyle(const BlockingTimeDiagramInput& block, boo
 
 } // namespace
 
+bool shareBlockingTimeResource(const std::string& aBlockId, const std::string& bBlockId) {
+	std::vector<std::string> aTokens = comparableBlockTokens(aBlockId);
+	std::vector<std::string> bTokens = comparableBlockTokens(bBlockId);
+	for (const std::string& aToken : aTokens) {
+		for (const std::string& bToken : bTokens) {
+			if (aToken == bToken)
+				return true;
+		}
+	}
+	return false;
+}
+
+bool shareBlockingTimeResource(const BlockingTimeDiagramInput& first,
+	const BlockingTimeDiagramInput& second) {
+	return shareBlockingTimeResource(first.blockId, second.blockId);
+}
+
+bool validBlockingTimeDiagramInput(const BlockingTimeDiagramInput& block) {
+	return block.isComplete && hasValue(block.blockId) && block.startOccTime >= 0.0
+		&& block.endOccTime > block.startOccTime && block.posStart >= 0.0 && block.posEnd >= 0.0;
+}
+
 std::vector<BlockingTimeDiagramSegment> buildBlockingTimeDiagramSegments(
 	const std::vector<std::vector<BlockingTimeDiagramInput>>& trains,
 	const std::vector<std::string>& trainNames) {
@@ -80,13 +75,13 @@ std::vector<BlockingTimeDiagramSegment> buildBlockingTimeDiagramSegments(
 
 	for (size_t firstTrain = 0; firstTrain < trains.size(); firstTrain++) {
 		for (size_t firstBlock = 0; firstBlock < trains[firstTrain].size(); firstBlock++) {
-			if (!validInterval(trains[firstTrain][firstBlock]))
+			if (!validBlockingTimeDiagramInput(trains[firstTrain][firstBlock]))
 				continue;
 			for (size_t secondTrain = firstTrain + 1; secondTrain < trains.size(); secondTrain++) {
 				for (size_t secondBlock = 0; secondBlock < trains[secondTrain].size(); secondBlock++) {
-					if (!validInterval(trains[secondTrain][secondBlock]))
+					if (!validBlockingTimeDiagramInput(trains[secondTrain][secondBlock]))
 						continue;
-					if (shareBlockId(trains[firstTrain][firstBlock], trains[secondTrain][secondBlock]) &&
+					if (shareBlockingTimeResource(trains[firstTrain][firstBlock], trains[secondTrain][secondBlock]) &&
 						overlaps(trains[firstTrain][firstBlock], trains[secondTrain][secondBlock])) {
 						critical[firstTrain][firstBlock] = true;
 						critical[secondTrain][secondBlock] = true;
@@ -101,7 +96,7 @@ std::vector<BlockingTimeDiagramSegment> buildBlockingTimeDiagramSegments(
 		const std::string trainName = trainIndex < trainNames.size() ? trainNames[trainIndex] : "";
 		for (size_t blockIndex = 0; blockIndex < trains[trainIndex].size(); blockIndex++) {
 			const BlockingTimeDiagramInput& block = trains[trainIndex][blockIndex];
-			if (!validInterval(block))
+			if (!validBlockingTimeDiagramInput(block))
 				continue;
 
 			BlockingTimeDiagramSegment segment;
@@ -112,6 +107,7 @@ std::vector<BlockingTimeDiagramSegment> buildBlockingTimeDiagramSegments(
 			segment.midPositionKm = ((block.posStart + block.posEnd) / 2.0) / 1000.0;
 			segment.penWidth = std::max(2.0, std::abs(block.posEnd - block.posStart) / 100.0);
 			segment.style = segmentStyle(block, critical[trainIndex][blockIndex]);
+			segment.capacityCritical = block.capacityCritical;
 			segments.push_back(segment);
 		}
 	}
@@ -132,7 +128,9 @@ std::vector<BlockingTimeDiagramSegment> filterBlockingTimeDiagramSegments(
 		if ((!allowedTrainIds.empty() &&
 			 std::find(allowedTrainIds.begin(), allowedTrainIds.end(), source.trainName) == allowedTrainIds.end()) ||
 			(!allowedBlockIds.empty() && std::none_of(allowedBlockIds.begin(), allowedBlockIds.end(),
-				[&source](const std::string& allowedBlockId) { return shareBlockId(source.blockId, allowedBlockId); })) ||
+				[&source](const std::string& allowedBlockId) {
+					return shareBlockingTimeResource(source.blockId, allowedBlockId);
+				})) ||
 			source.endTime <= startTime || source.startTime >= endTime)
 			continue;
 

--- a/EGTRAIN/QEGTRAIN/diagrams/BlockingTimeDiagram.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/BlockingTimeDiagram.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+constexpr double kBlockingTimeToleranceSeconds = 1e-7;
+
 enum class BlockingTimeSegmentStyle {
 	Default,
 	Station,
@@ -22,6 +24,7 @@ struct BlockingTimeDiagramInput {
 	std::string switchName = "None";
 	std::string stationName = "None";
 	bool isComplete = false;
+	bool capacityCritical = false;
 };
 
 struct BlockingTimeDiagramSegment {
@@ -32,6 +35,7 @@ struct BlockingTimeDiagramSegment {
 	double midPositionKm = 0.0;
 	double penWidth = 2.0;
 	BlockingTimeSegmentStyle style = BlockingTimeSegmentStyle::Default;
+	bool capacityCritical = false;
 };
 
 struct BlockingTimePlannedReference {
@@ -45,6 +49,13 @@ struct BlockingTimePlannedReference {
 std::vector<BlockingTimeDiagramSegment> buildBlockingTimeDiagramSegments(
 	const std::vector<std::vector<BlockingTimeDiagramInput>>& trains,
 	const std::vector<std::string>& trainNames);
+
+// Shared resource matcher used by both diagram conflict classification and
+// capacity analysis. It matches exact plain and decorated/composite components.
+bool shareBlockingTimeResource(const std::string& firstBlockId, const std::string& secondBlockId);
+bool shareBlockingTimeResource(const BlockingTimeDiagramInput& first,
+	const BlockingTimeDiagramInput& second);
+bool validBlockingTimeDiagramInput(const BlockingTimeDiagramInput& input);
 
 // Return copies of already-classified occupation segments in the selected
 // train/block/time scope. Empty train or block lists mean no restriction.

--- a/EGTRAIN/QEGTRAIN/diagrams/CapacityAnalysis.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/CapacityAnalysis.cpp
@@ -1,0 +1,233 @@
+#include "diagrams/CapacityAnalysis.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace {
+
+bool finite(double value) {
+	return std::isfinite(value);
+}
+
+bool availableTime(double value) {
+	return finite(value) && value >= 0.0;
+}
+
+double scheduledReference(const CapacityAnalysisTrain& train, double profile) {
+	return availableTime(train.scheduledReferenceTime) ? train.scheduledReferenceTime : profile;
+}
+
+CapacityPairRow pairConstraint(const CapacityAnalysisTrain& leader,
+	const CapacityAnalysisTrain& follower, double leaderProfile, double followerProfile,
+	bool adjacent) {
+	CapacityPairRow row;
+	row.leaderIdentity = leader.runtimeId;
+	row.followerIdentity = follower.runtimeId;
+	row.leaderOperatingCode = leader.operatingCode;
+	row.followerOperatingCode = follower.operatingCode;
+	row.adjacent = adjacent;
+	if (!availableTime(leaderProfile) || !availableTime(followerProfile))
+		return row;
+	const double leaderScheduled = scheduledReference(leader, leaderProfile);
+	const double followerScheduled = scheduledReference(follower, followerProfile);
+	if (availableTime(leaderScheduled) && availableTime(followerScheduled)) {
+		row.scheduledHeadway = followerScheduled - leaderScheduled;
+	}
+
+	double maximumCandidate = -std::numeric_limits<double>::infinity();
+	for (const BlockingTimeDiagramInput& leaderOccupation : leader.occupations) {
+		if (!validBlockingTimeDiagramInput(leaderOccupation))
+			continue;
+		for (const BlockingTimeDiagramInput& followerOccupation : follower.occupations) {
+			if (!validBlockingTimeDiagramInput(followerOccupation)
+				|| !shareBlockingTimeResource(leaderOccupation, followerOccupation))
+				continue;
+			const double leaderOffset = leaderOccupation.endOccTime - leaderProfile;
+			const double followerOffset = followerOccupation.startOccTime - followerProfile;
+			const double candidate = leaderOffset - followerOffset;
+			if (!finite(candidate))
+				continue;
+			if (!row.hasSharedConstraint || candidate > maximumCandidate + kBlockingTimeToleranceSeconds) {
+				row.governingEvidence.clear();
+				maximumCandidate = candidate;
+				row.hasSharedConstraint = true;
+			} else if (std::abs(candidate - maximumCandidate) > kBlockingTimeToleranceSeconds) {
+				continue;
+			}
+			if (row.hasSharedConstraint && std::abs(candidate - maximumCandidate) <= kBlockingTimeToleranceSeconds)
+				row.governingEvidence.push_back({leaderOccupation.blockId, followerOccupation.blockId,
+					leaderOffset, followerOffset, candidate});
+		}
+	}
+	if (row.hasSharedConstraint) {
+		row.minimumHeadway = std::max(0.0, maximumCandidate);
+		if (finite(row.scheduledHeadway))
+			row.buffer = row.scheduledHeadway - row.minimumHeadway;
+	}
+	return row;
+}
+
+bool conflicts(const std::vector<std::vector<BlockingTimeDiagramInput>>& occupations) {
+	for (std::size_t leaderIndex = 0; leaderIndex < occupations.size(); ++leaderIndex) {
+		for (std::size_t followerIndex = leaderIndex + 1; followerIndex < occupations.size(); ++followerIndex) {
+			for (const auto& leader : occupations[leaderIndex]) {
+				if (!validBlockingTimeDiagramInput(leader))
+					continue;
+				for (const auto& follower : occupations[followerIndex]) {
+					if (!validBlockingTimeDiagramInput(follower) || !shareBlockingTimeResource(leader, follower))
+						continue;
+					if (std::max(leader.startOccTime, follower.startOccTime)
+						< std::min(leader.endOccTime, follower.endOccTime) - kBlockingTimeToleranceSeconds)
+						return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+} // namespace
+
+CapacityAnalysisResult analyzeCapacity(const std::vector<CapacityAnalysisTrain>& trains,
+	 double periodSeconds, const std::string& cycleEndIdentity) {
+	CapacityAnalysisResult result;
+	result.periodSeconds = availableTime(periodSeconds) ? periodSeconds : -1.0;
+	result.trainIdentities.reserve(trains.size());
+	result.referenceLabels.reserve(trains.size());
+	result.referenceSources.reserve(trains.size());
+	for (const CapacityAnalysisTrain& train : trains) {
+		result.trainIdentities.push_back(train.runtimeId);
+		result.referenceLabels.push_back(train.referenceLabel);
+		result.referenceSources.push_back(train.referenceSource);
+	}
+	if (trains.empty())
+		return result;
+
+	std::vector<double> profileReferences;
+	std::vector<double> scheduledReferences;
+	profileReferences.reserve(trains.size());
+	scheduledReferences.reserve(trains.size());
+	for (const CapacityAnalysisTrain& train : trains) {
+		const double profile = train.profileReferenceTime;
+		profileReferences.push_back(profile);
+		scheduledReferences.push_back(scheduledReference(train, profile));
+	}
+
+	std::vector<std::vector<CapacityPairRow>> pairMatrix(trains.size());
+	for (std::size_t leaderIndex = 0; leaderIndex < trains.size(); ++leaderIndex) {
+		pairMatrix[leaderIndex].resize(trains.size());
+		for (std::size_t followerIndex = leaderIndex + 1; followerIndex < trains.size(); ++followerIndex)
+		{
+			CapacityPairRow pair = pairConstraint(trains[leaderIndex], trains[followerIndex],
+				profileReferences[leaderIndex], profileReferences[followerIndex],
+				followerIndex == leaderIndex + 1);
+			pairMatrix[leaderIndex][followerIndex] = pair;
+			if (pair.adjacent)
+				result.pairs.push_back(pair);
+			result.allPairs.push_back(std::move(pair));
+		}
+	}
+
+	std::vector<double> compressedReferences(trains.size(), -1.0);
+	result.compression.reserve(trains.size());
+	for (std::size_t index = 0; index < trains.size(); ++index) {
+		CapacityCompressionRow row;
+		row.identity = trains[index].runtimeId;
+		row.operatingCode = trains[index].operatingCode;
+		row.originalReference = profileReferences[index];
+		row.scheduledReference = scheduledReferences[index];
+		row.compressedReference = scheduledReferences[index];
+		double compressed = scheduledReferences[index];
+		if (index > 0) {
+			compressed = compressedReferences[index - 1];
+			double best = compressed;
+			for (std::size_t predecessor = 0; predecessor < index; ++predecessor) {
+				const CapacityPairRow& pair = pairMatrix[predecessor][index];
+				if (!pair.hasSharedConstraint)
+					continue;
+				const double candidate = compressedReferences[predecessor] + pair.minimumHeadway;
+				if (!finite(candidate))
+					continue;
+				if (!finite(best) || candidate > best + kBlockingTimeToleranceSeconds) {
+					best = candidate;
+					row.governingPredecessors.clear();
+				} else if (std::abs(candidate - best) > kBlockingTimeToleranceSeconds) {
+					continue;
+				}
+				if (std::abs(candidate - best) <= kBlockingTimeToleranceSeconds)
+					row.governingPredecessors.push_back({trains[predecessor].runtimeId,
+						pair.minimumHeadway, pair.governingEvidence});
+			}
+			compressed = best;
+		}
+		row.compressedReference = compressed;
+		row.shift = finite(compressed) && finite(row.scheduledReference)
+			? compressed - row.scheduledReference : 0.0;
+		compressedReferences[index] = compressed;
+		result.compression.push_back(std::move(row));
+	}
+
+	result.compressedOccupations.resize(trains.size());
+	for (std::size_t index = 0; index < trains.size(); ++index) {
+		const double shift = availableTime(compressedReferences[index]) && availableTime(profileReferences[index])
+			? compressedReferences[index] - profileReferences[index] : 0.0;
+		for (const BlockingTimeDiagramInput& source : trains[index].occupations) {
+			if (!validBlockingTimeDiagramInput(source))
+				continue;
+			BlockingTimeDiagramInput shifted = source;
+			shifted.startOccTime += shift;
+			shifted.endOccTime += shift;
+			result.compressedOccupations[index].push_back(std::move(shifted));
+		}
+	}
+
+	for (std::size_t followerIndex = 1; followerIndex < result.compressedOccupations.size(); ++followerIndex) {
+		for (const CapacityCompressionEvidence& governing : result.compression[followerIndex].governingPredecessors) {
+			const auto predecessor = std::find_if(trains.begin(), trains.end(), [&governing](const CapacityAnalysisTrain& train) {
+				return train.runtimeId == governing.predecessorIdentity;
+			});
+			if (predecessor == trains.end())
+				continue;
+			const std::size_t leaderIndex = static_cast<std::size_t>(predecessor - trains.begin());
+			for (std::size_t leaderOccupation = 0;
+				 leaderOccupation < result.compressedOccupations[leaderIndex].size(); ++leaderOccupation) {
+				auto& leader = result.compressedOccupations[leaderIndex][leaderOccupation];
+				for (std::size_t followerOccupation = 0;
+					 followerOccupation < result.compressedOccupations[followerIndex].size(); ++followerOccupation) {
+					auto& follower = result.compressedOccupations[followerIndex][followerOccupation];
+					if (!shareBlockingTimeResource(leader, follower))
+						continue;
+					const double gap = follower.startOccTime - leader.endOccTime;
+					if (std::abs(gap) > kBlockingTimeToleranceSeconds)
+						continue;
+					leader.capacityCritical = true;
+					follower.capacityCritical = true;
+					result.criticalBlocks.push_back({trains[leaderIndex].runtimeId,
+						trains[followerIndex].runtimeId, leader.blockId, follower.blockId, gap});
+				}
+			}
+		}
+	}
+
+	result.conflictFree = !conflicts(result.compressedOccupations);
+	const bool hasValidProfiles = std::all_of(profileReferences.begin(), profileReferences.end(), availableTime);
+	const bool hasAdjacentConstraints = !result.pairs.empty()
+		&& std::all_of(result.pairs.begin(), result.pairs.end(),
+			[](const CapacityPairRow& pair) { return pair.hasSharedConstraint; });
+	result.analyzable = trains.size() >= 2 && hasValidProfiles && hasAdjacentConstraints && result.conflictFree;
+	if (result.compression.empty())
+		return result;
+	result.firstIdentity = result.compression.front().identity;
+	const auto cycleEnd = std::find_if(result.compression.begin(), result.compression.end(),
+		[&cycleEndIdentity](const CapacityCompressionRow& row) { return row.identity == cycleEndIdentity; });
+	if (cycleEnd == result.compression.end() || cycleEnd == result.compression.begin())
+		return result;
+	result.cycleEndIdentity = cycleEnd->identity;
+	if (finite(result.compression.front().compressedReference) && finite(cycleEnd->compressedReference)) {
+		result.cycleTime = cycleEnd->compressedReference - result.compression.front().compressedReference;
+		if (finite(result.periodSeconds) && result.periodSeconds > 0.0)
+			result.cyclePercentage = result.cycleTime / result.periodSeconds * 100.0;
+	}
+	return result;
+}

--- a/EGTRAIN/QEGTRAIN/diagrams/CapacityAnalysis.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/CapacityAnalysis.h
@@ -1,0 +1,90 @@
+#ifndef CAPACITYANALYSIS_H
+#define CAPACITYANALYSIS_H
+
+#include "diagrams/BlockingTimeDiagram.h"
+
+#include <string>
+#include <vector>
+
+struct CapacityAnalysisTrain {
+	// Runtime occurrence identity, not a canonical service/timetable key.
+	std::string runtimeId;
+	std::string operatingCode;
+	// Profile reference is the selected section entry (normally BlockTime's
+	// StartRunTime); malformed or unavailable references make the result invalid.
+	double profileReferenceTime = -1.0;
+	double scheduledReferenceTime = -1.0;
+	std::string referenceLabel;
+	std::string referenceSource;
+	std::vector<BlockingTimeDiagramInput> occupations;
+};
+
+struct CapacityHeadwayEvidence {
+	std::string leaderBlockId;
+	std::string followerBlockId;
+	double leaderOffset = 0.0;
+	double followerOffset = 0.0;
+	double candidateHeadway = 0.0;
+};
+
+struct CapacityPairRow {
+	std::string leaderIdentity;
+	std::string followerIdentity;
+	std::string leaderOperatingCode;
+	std::string followerOperatingCode;
+	double scheduledHeadway = -1.0;
+	double minimumHeadway = -1.0;
+	double buffer = -1.0;
+	bool hasSharedConstraint = false;
+	bool adjacent = false;
+	std::vector<CapacityHeadwayEvidence> governingEvidence;
+};
+
+struct CapacityCompressionEvidence {
+	std::string predecessorIdentity;
+	double minimumHeadway = 0.0;
+	std::vector<CapacityHeadwayEvidence> governingEvidence;
+};
+
+struct CapacityCompressionRow {
+	std::string identity;
+	std::string operatingCode;
+	double originalReference = -1.0;
+	double scheduledReference = -1.0;
+	double compressedReference = -1.0;
+	double shift = 0.0;
+	std::vector<CapacityCompressionEvidence> governingPredecessors;
+};
+
+struct CapacityCriticalBlock {
+	std::string leaderIdentity;
+	std::string followerIdentity;
+	std::string leaderBlockId;
+	std::string followerBlockId;
+	double gap = 0.0;
+};
+
+struct CapacityAnalysisResult {
+	std::vector<CapacityPairRow> pairs;      // Adjacent rows in supplied order.
+	std::vector<CapacityPairRow> allPairs;   // Every earlier/later constraint.
+	std::vector<CapacityCompressionRow> compression;
+	std::vector<std::vector<BlockingTimeDiagramInput>> compressedOccupations;
+	std::vector<std::string> trainIdentities;
+	std::vector<std::string> referenceLabels;
+	std::vector<std::string> referenceSources;
+	std::vector<CapacityCriticalBlock> criticalBlocks;
+	double cycleTime = -1.0;
+	double periodSeconds = -1.0;
+	double cyclePercentage = -1.0;
+	bool conflictFree = false;
+	bool analyzable = false;
+	std::string firstIdentity;
+	std::string cycleEndIdentity;
+};
+
+// Ordered, deterministic capacity chain for one explicit sequence. Inputs are
+// copied; neither train occupations nor canonical timetable data are changed.
+CapacityAnalysisResult analyzeCapacity(const std::vector<CapacityAnalysisTrain>& trains,
+	 double periodSeconds = -1.0, const std::string& cycleEndIdentity = {});
+
+#endif // CAPACITYANALYSIS_H

--- a/EGTRAIN/QEGTRAIN/tests/test_blockingtimediagram.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_blockingtimediagram.cpp
@@ -30,8 +30,9 @@ int main() {
 			block("@13-B0@", 25.0, 40.0, 1600.0, 2200.0, "SW13", "None", true),
 		},
 		{
-			block("@12-B9@", 15.0, 25.0, 1000.0, 1500.0, "None", "StationA", true),
+			block("@12-B0@", 15.0, 25.0, 1000.0, 1500.0, "None", "StationA", true),
 			block("@40-B0@", 50.0, 45.0, 1800.0, 2100.0, "None", "None", true),
+			block("@42-B0@", 45.0, 45.0, 1900.0, 2200.0, "None", "None", true),
 			block("@41-B0@", 60.0, 70.0, 2100.0, 2300.0, "None", "None", false),
 		},
 	};
@@ -39,6 +40,10 @@ int main() {
 	std::vector<BlockingTimeDiagramSegment> segments = buildBlockingTimeDiagramSegments(trains, names);
 
 	bool ok = true;
+	ok &= expect(!shareBlockingTimeResource("2-B0", "2-B4"),
+		"distinct decorated block resources do not match");
+	ok &= expect(shareBlockingTimeResource("@2-B0@-1.0/@3-B1@-2.0", "2-B0"),
+		"composite block matches its exact component");
 	ok &= expect(segments.size() == 3, "invalid and incomplete intervals are filtered");
 	if (segments.size() >= 3) {
 		ok &= expect(segments[0].trainName == "A", "first segment train name");
@@ -55,7 +60,7 @@ int main() {
 	}
 
 	const std::vector<BlockingTimeDiagramSegment> scoped = filterBlockingTimeDiagramSegments(
-		segments, {"A"}, {"@12-B7@"}, 12.0, 18.0);
+		segments, {"A"}, {"@12-B0@"}, 12.0, 18.0);
 	ok &= expect(scoped.size() == 1, "route block and train scope filters segments");
 	if (!scoped.empty()) {
 		ok &= expect(scoped[0].startTime == 12.0 && scoped[0].endTime == 18.0,
@@ -73,6 +78,13 @@ int main() {
 		"planned scope retains both source points for a visible line crossing");
 	ok &= expect(filterBlockingTimePlannedReferences(references, 31.0, 39.0).empty(),
 		"off-window planned points do not create an empty scoped chart or export");
+	const auto nearTouch = buildBlockingTimeDiagramSegments({
+		{block("T", 0.0, 10.00000005, 0.0, 100.0, "None", "None", true)},
+		{block("T", 10.0, 20.0, 0.0, 100.0, "None", "None", true)}}, {"A", "B"});
+	ok &= expect(nearTouch.size() == 2
+		&& nearTouch[0].style == BlockingTimeSegmentStyle::Default
+		&& nearTouch[1].style == BlockingTimeSegmentStyle::Default,
+		"sub-tolerance touching is not also styled as an overlap conflict");
 
 	if (!ok)
 		return 1;

--- a/EGTRAIN/QEGTRAIN/tests/test_capacityanalysis.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_capacityanalysis.cpp
@@ -1,0 +1,138 @@
+#include "diagrams/CapacityAnalysis.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+namespace {
+
+bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+BlockingTimeDiagramInput occupation(const char* id, double start, double end) {
+	BlockingTimeDiagramInput value;
+	value.blockId = id;
+	value.startOccTime = start;
+	value.endOccTime = end;
+	value.posStart = 0.0;
+	value.posEnd = 100.0;
+	value.isComplete = true;
+	return value;
+}
+
+CapacityAnalysisTrain train(const char* id, double scheduled,
+	std::initializer_list<BlockingTimeDiagramInput> occupations) {
+	CapacityAnalysisTrain value;
+	value.runtimeId = id;
+	value.operatingCode = id;
+	value.profileReferenceTime = 0.0;
+	value.scheduledReferenceTime = scheduled;
+	value.referenceLabel = id;
+	value.referenceSource = "test";
+	value.occupations = occupations;
+	return value;
+}
+
+} // namespace
+
+int main() {
+	bool ok = true;
+	const auto leader = train("A", 0.0, {occupation("2-B0", 0.0, 20.0)});
+	const auto follower = train("B", 20.0, {occupation("2-B0", 5.0, 25.0)});
+	const auto pair = analyzeCapacity({leader, follower}, 3600.0);
+	ok &= expect(pair.pairs.size() == 1, "one adjacent pair row");
+	ok &= expect(pair.pairs[0].hasSharedConstraint, "shared pair is valid");
+	ok &= expect(pair.pairs[0].minimumHeadway == 15.0, "governing minimum headway uses offsets");
+	ok &= expect(pair.pairs[0].buffer == 5.0, "scheduled buffer is not clamped");
+	ok &= expect(pair.pairs[0].governingEvidence.size() == 1
+		&& pair.pairs[0].governingEvidence[0].leaderBlockId == "2-B0"
+		&& pair.pairs[0].governingEvidence[0].followerBlockId == "2-B0",
+		"headway retains governing block evidence");
+	const auto tied = analyzeCapacity({train("A", 0.0,
+		{occupation("AB", 0.0, 20.0), occupation("AC", 0.0, 20.0)}),
+		train("B", 20.0, {occupation("AB", 5.0, 25.0), occupation("AC", 5.0, 25.0)})});
+	ok &= expect(tied.pairs[0].governingEvidence.size() == 2,
+		"tied governing resources are all retained");
+
+	const auto negativeBuffer = analyzeCapacity({leader,
+		train("B", 10.0, {occupation("2-B0", 5.0, 25.0)})});
+	ok &= expect(negativeBuffer.pairs[0].buffer == -5.0, "negative scheduled buffer is retained");
+	ok &= expect(shareBlockingTimeResource("@2-B0@-1.0/@3-B1@-2.0", "2-B0"),
+		"composite block matches its exact component");
+	ok &= expect(!shareBlockingTimeResource("2-B0", "2-B4"),
+		"distinct decorated block resources do not match");
+	const auto noShared = analyzeCapacity({leader,
+		train("B", 20.0, {occupation("other", 5.0, 25.0)})});
+	ok &= expect(!noShared.pairs[0].hasSharedConstraint && noShared.pairs[0].minimumHeadway < 0.0,
+		"no shared resource is invalid");
+	CapacityAnalysisTrain malformed = follower;
+	malformed.profileReferenceTime = -1.0;
+	ok &= expect(!analyzeCapacity({leader, malformed}).analyzable,
+		"missing profile reference is not analyzable");
+	const auto zeroDuration = analyzeCapacity({leader,
+		train("B", 20.0, {occupation("2-B0", 5.0, 5.0)})});
+	ok &= expect(!zeroDuration.pairs[0].hasSharedConstraint,
+		"zero-duration occupations are rejected consistently with the diagram");
+	const auto nearTouch = analyzeCapacity({
+		train("A", 0.0, {occupation("G", 0.0, 20.0), occupation("X", 0.0, 20.00000005)}),
+		train("B", 20.0, {occupation("G", 5.0, 25.0), occupation("X", 5.0, 25.0)})},
+		100.0, "B");
+	ok &= expect(nearTouch.conflictFree && nearTouch.criticalBlocks.size() == 2,
+		"touch tolerance is not also classified as an overlap conflict");
+
+	const std::vector<CapacityAnalysisTrain> sequence = {
+		train("A", 0.0, {occupation("AB", 0.0, 20.0), occupation("AC", 0.0, 100.0)}),
+		train("B", 100.0, {occupation("AB", 0.0, 10.0), occupation("BC", 0.0, 5.0)}),
+		train("C", 30.0, {occupation("AC", 0.0, 50.0), occupation("BC", 0.0, 5.0),
+			occupation("CD", 0.0, 10.0)}),
+		train("D", 120.0, {occupation("CD", 0.0, 5.0)})};
+	const auto before = sequence;
+	const auto compressed = analyzeCapacity(sequence, 200.0, "C");
+	ok &= expect(sequence[0].occupations[0].startOccTime == before[0].occupations[0].startOccTime
+		&& sequence[2].scheduledReferenceTime == before[2].scheduledReferenceTime,
+		"capacity analysis does not mutate inputs");
+	ok &= expect(compressed.compression.size() == 4
+		&& compressed.compression[1].compressedReference == 20.0
+		&& compressed.compression[2].compressedReference == 100.0
+		&& compressed.compression[3].compressedReference == 110.0,
+		"compression considers every earlier train");
+	ok &= expect(compressed.compression[2].governingPredecessors.size() == 1
+		&& compressed.compression[2].governingPredecessors[0].predecessorIdentity == "A",
+		"nonadjacent predecessor governs compression");
+	ok &= expect(compressed.conflictFree, "compressed occupations have no overlaps");
+	const auto hasCritical = [&compressed](const char* leaderId, const char* followerId, const char* blockId) {
+		return std::any_of(compressed.criticalBlocks.begin(), compressed.criticalBlocks.end(),
+			[=](const CapacityCriticalBlock& critical) {
+				return critical.leaderIdentity == leaderId && critical.followerIdentity == followerId
+					&& critical.leaderBlockId == blockId && std::abs(critical.gap) < 1e-9;
+			});
+	};
+	ok &= expect(compressed.criticalBlocks.size() == 3 && hasCritical("A", "B", "AB")
+		&& hasCritical("A", "C", "AC") && hasCritical("C", "D", "CD"),
+		"adjacent and nonadjacent governing touches are retained separately");
+	const auto compressedSegments = buildBlockingTimeDiagramSegments(compressed.compressedOccupations,
+		compressed.trainIdentities);
+	const auto criticalSegment = std::find_if(compressedSegments.begin(), compressedSegments.end(),
+		[](const BlockingTimeDiagramSegment& segment) {
+			return segment.capacityCritical && segment.blockId == "AB";
+		});
+	ok &= expect(criticalSegment != compressedSegments.end()
+		&& criticalSegment->style != BlockingTimeSegmentStyle::Critical,
+		"touching capacity-critical styling stays distinct from red overlap conflict");
+	ok &= expect(compressed.cycleTime == 100.0 && compressed.cyclePercentage == 50.0,
+		"explicit cycle endpoint and transparent period percentage are exact");
+	ok &= expect(compressed.firstIdentity == "A" && compressed.cycleEndIdentity == "C"
+		&& compressed.compression.back().identity == "D",
+		"cycle endpoint is explicit and independent of the last selected train");
+	const auto missingCycleEnd = analyzeCapacity(sequence, 200.0);
+	ok &= expect(missingCycleEnd.cycleEndIdentity.empty() && missingCycleEnd.cycleTime < 0.0,
+		"cycle consumption is unavailable without an explicit closing occurrence");
+
+	if (!ok)
+		return 1;
+	std::cout << "all CapacityAnalysis tests passed\n";
+	return 0;
+}

--- a/tools/e2e/csv_export_smoke.sh
+++ b/tools/e2e/csv_export_smoke.sh
@@ -48,6 +48,29 @@ head -n1 "$OUTDIR/timetable.csv" | grep -q "^Train,Station,Journey order,Operati
 	|| { echo "timetable.csv header mismatch" >&2; exit 1; }
 head -n1 "$OUTDIR/run_summary.csv" | grep -q "^Train,Operating code,Performance \[%\],Applied maximum speed \[km/h\],Start\[s\],End\[s\],Travel time\[s\]" \
 	|| { echo "run_summary.csv header mismatch" >&2; exit 1; }
+if [[ -s "$OUTDIR/capacity_analysis.csv" ]]; then
+	head -n1 "$OUTDIR/capacity_analysis.csv" | grep -q "^Record type,Leader,Follower,Identity,Operating code,Original reference\[s\].*Cycle time\[s\],Period\[s\],Cycle / period \[%\],Section,Reference label,Reference source" \
+		|| { echo "capacity_analysis.csv header mismatch" >&2; exit 1; }
+	for record in summary pair compression critical; do
+		grep -q "^$record," "$OUTDIR/capacity_analysis.csv" \
+			|| { echo "capacity_analysis.csv missing $record records" >&2; exit 1; }
+	done
+	awk -F, '
+NR == 1 {
+	for (i = 1; i <= NF; ++i) column[$i] = i
+	next
+}
+NR == 2 {
+	if ($(column["Cycle time[s]"]) == "" || $(column["Period[s]"]) == "" ||
+		$(column["Cycle / period [%]"]) == "" || $(column["Section"]) == "")
+		exit 1
+}
+' "$OUTDIR/capacity_analysis.csv" \
+		|| { echo "capacity_analysis.csv summary lacks cycle, period, percentage, or section" >&2; exit 1; }
+else
+	grep -q "E2E_CAPACITY_EXPORT_UNAVAILABLE" "$LOG" \
+		|| { echo "capacity export was skipped without an explicit unavailable marker" >&2; exit 1; }
+fi
 
 # Trajectory and timetable must carry data rows, not just a header.
 traj_rows=$(($(wc -l < "$OUTDIR/trajectory.csv") - 1))


### PR DESCRIPTION
## Summary

- Compute ordered-pair minimum headway from retained native occupations on a selected route and block section, with governing evidence and unclamped buffer time.
- Compress a supplied occurrence order without changing the authored timetable, and mark governing touching critical blocks separately from overlap conflicts.
- Require an explicit cycle-closing occurrence and expose cycle time, analysis period, percentage, tables, CSV, and a compressed blocking-time diagram.
- Match decorated and composite block resources exactly and share one interval validity and touch tolerance with the existing diagram.

## Scientific boundary

Capacity analysis now refuses to run when retained native occupations are unavailable. It does not infer a signalling level or hard-code setup, release, or reaction values. The assignment basic-hour rehearsal remains blocked by the missing canonical signalling level and sourced corridor signalling tracked in #218 and #182.

## Verification

- Complete configured build passed.
- CTest passed 43/43.
- Focused capacity and blocking-time tests passed.
- CSV export smoke passed with 6,214 trajectory rows and 13 timetable rows, including the explicit unavailable-capacity path.
- Visual polish, DPR2, station overlay, scene render, and legacy import smokes passed.
- Six committed scenes passed native headless smoke.
- All six scenes passed validate, export, reimport, and the reimported Assignment run ended `ROUNDTRIP PASS`.

Advances #45, #46, #47, #48, and #49.
Closes #273.
Related: #218, #182, #7, #4.