### PR TITLE
Add disruption and delay analysis

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -2459,8 +2459,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_incidentEndSecondsEdit->setValidator(
 		new QIntValidator(0, std::numeric_limits<int>::max(), m_incidentEndSecondsEdit));
 	incidentDetailLayout->addWidget(m_incidentEndSecondsEdit);
-	m_incidentHasEndSecondsCheck = new QCheckBox("Use recovery end (otherwise until destination)", incidentDetailPane);
+	m_incidentHasEndSecondsCheck = new QCheckBox("Use recovery end", incidentDetailPane);
 	m_incidentHasEndSecondsCheck->setObjectName("incidentHasEndSecondsCheck");
+	m_incidentHasEndSecondsCheck->setToolTip("When disabled, a reduced-speed breakdown continues until the destination.");
 	incidentDetailLayout->addWidget(m_incidentHasEndSecondsCheck);
 	m_incidentHasOccurrenceCheck = new QCheckBox("Occurrence (1-based)", incidentDetailPane);
 	m_incidentHasOccurrenceCheck->setObjectName("incidentHasOccurrenceCheck");

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -433,10 +433,25 @@ bool chooseBlockingTimeScope(QWidget* parent, BlockingTimeScope& scope) {
 	return true;
 }
 
+std::string joinIncidentIds(const std::vector<std::string>& ids) {
+	std::string result;
+	for (const std::string& id : ids) {
+		if (!result.empty())
+			result += ";";
+		result += id;
+	}
+	return result;
+}
+
+std::string terminationOutcome(bool requested, bool terminated) {
+	if (!requested)
+		return "not requested";
+	return terminated ? "terminated at destination" : "not terminated at destination";
+}
+
 // Run summary: per-train start, end, travel time, and energy totals, plus a
 // network totals row.
-std::string buildRunSummaryCsv() {
-	const RunResults results = buildRunResults(runResultTrainPointers(), timestep);
+std::string buildRunSummaryCsv(const RunResults& results) {
 	std::vector<std::vector<std::string>> rows;
 	for (const TrainRunResult& t : results.trains) {
 		rows.push_back({
@@ -450,7 +465,11 @@ std::string buildRunSummaryCsv() {
 			csvValue(t.energyConsumedKWh),
 			csvValue(t.energyWithRegenKWh),
 			csvValue(t.substationKWh),
-			csvValue(t.substationWithRegenKWh)});
+			csvValue(t.substationWithRegenKWh),
+			joinIncidentIds(t.directIncidentIds),
+			csvValue(t.firstDirectIncidentTime),
+			csvValue(t.firstDirectIncidentLocation),
+			terminationOutcome(t.destinationTerminationRequested, t.destinationTerminated)});
 	}
 	rows.push_back({
 		"Network total",
@@ -463,12 +482,43 @@ std::string buildRunSummaryCsv() {
 		csvValue(results.energyConsumedKWh),
 		csvValue(results.energyWithRegenKWh),
 		csvValue(results.substationKWh),
-		csvValue(results.substationWithRegenKWh)});
+		csvValue(results.substationWithRegenKWh),
+		std::string(csv::kMissingValue),
+		std::string(csv::kMissingValue),
+		std::string(csv::kMissingValue),
+		std::string(csv::kMissingValue)});
 	if (results.trains.empty())
 		return std::string();
 	return csv::makeDocument(
 		{"Train", "Operating code", "Performance [%]", "Applied maximum speed [km/h]", "Start[s]", "End[s]", "Travel time[s]", "Energy consumed[kWh]",
-			"Energy with regen[kWh]", "Substation[kWh]", "Substation with regen[kWh]"},
+			"Energy with regen[kWh]", "Substation[kWh]", "Substation with regen[kWh]", "Incident IDs",
+			"First direct time[s]", "First direct location[m]", "Termination outcome"},
+		rows);
+}
+std::string delayComparisonCsv(const DelayRunSnapshot& baseline,
+		const DelayRunSnapshot& scenario, const DelayComparisonResult& comparison) {
+	std::vector<std::vector<std::string>> rows;
+	for (const DelayComparisonRow& row : comparison.rows) {
+		rows.push_back({
+			baseline.scenarioId,
+			scenario.scenarioId,
+			baseline.caseRevision,
+			row.serviceId,
+			std::to_string(row.occurrence),
+			row.operatingCode,
+			csvValue(row.baselineFinalArrival),
+			csvValue(row.scenarioFinalArrival),
+			csvValue(row.positiveContribution),
+			row.attribution,
+			joinIncidentIds(row.incidentIds),
+			csvValue(row.firstDirectTime),
+			csvValue(row.firstDirectLocation),
+			terminationOutcome(row.destinationTerminationRequested, row.destinationTerminated)});
+	}
+	return csv::makeDocument(
+		{"Baseline scenario", "Scenario", "Case revision", "Service", "Occurrence", "Operating code",
+			"Baseline final arrival[s]", "Scenario final arrival[s]", "Positive contribution[s]",
+			"Attribution", "Incident IDs", "First direct time[s]", "First direct location[m]", "Termination outcome"},
 		rows);
 }
 
@@ -2403,11 +2453,34 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_incidentStartSecondsEdit->setValidator(
 		new QIntValidator(0, std::numeric_limits<int>::max(), m_incidentStartSecondsEdit));
 	incidentDetailLayout->addWidget(m_incidentStartSecondsEdit);
-	incidentDetailLayout->addWidget(new QLabel("End (s)", incidentDetailPane));
+	incidentDetailLayout->addWidget(new QLabel("Recovery end (s)", incidentDetailPane));
 	m_incidentEndSecondsEdit = new QLineEdit(incidentDetailPane);
+	m_incidentEndSecondsEdit->setObjectName("incidentEndSecondsEdit");
 	m_incidentEndSecondsEdit->setValidator(
 		new QIntValidator(0, std::numeric_limits<int>::max(), m_incidentEndSecondsEdit));
 	incidentDetailLayout->addWidget(m_incidentEndSecondsEdit);
+	m_incidentHasEndSecondsCheck = new QCheckBox("Use recovery end (otherwise until destination)", incidentDetailPane);
+	m_incidentHasEndSecondsCheck->setObjectName("incidentHasEndSecondsCheck");
+	incidentDetailLayout->addWidget(m_incidentHasEndSecondsCheck);
+	m_incidentHasOccurrenceCheck = new QCheckBox("Occurrence (1-based)", incidentDetailPane);
+	m_incidentHasOccurrenceCheck->setObjectName("incidentHasOccurrenceCheck");
+	m_incidentOccurrenceEdit = new QLineEdit(incidentDetailPane);
+	m_incidentOccurrenceEdit->setObjectName("incidentOccurrenceEdit");
+	m_incidentOccurrenceEdit->setValidator(new QIntValidator(1, std::numeric_limits<int>::max(), m_incidentOccurrenceEdit));
+	incidentDetailLayout->addWidget(m_incidentHasOccurrenceCheck);
+	incidentDetailLayout->addWidget(m_incidentOccurrenceEdit);
+	m_incidentHasReducedSpeedCheck = new QCheckBox("Reduced speed cap", incidentDetailPane);
+	m_incidentHasReducedSpeedCheck->setObjectName("incidentHasReducedSpeedCheck");
+	m_incidentReducedSpeedKmhEdit = new CompactDoubleSpinBox(incidentDetailPane);
+	m_incidentReducedSpeedKmhEdit->setObjectName("incidentReducedSpeedKmhEdit");
+	m_incidentReducedSpeedKmhEdit->setRange(0.01, 1000.0);
+	m_incidentReducedSpeedKmhEdit->setDecimals(std::numeric_limits<double>::max_digits10);
+	m_incidentReducedSpeedKmhEdit->setSuffix(" km/h");
+	incidentDetailLayout->addWidget(m_incidentHasReducedSpeedCheck);
+	incidentDetailLayout->addWidget(m_incidentReducedSpeedKmhEdit);
+	m_incidentTerminateAtDestinationCheck = new QCheckBox("Terminate at destination", incidentDetailPane);
+	m_incidentTerminateAtDestinationCheck->setObjectName("incidentTerminateAtDestinationCheck");
+	incidentDetailLayout->addWidget(m_incidentTerminateAtDestinationCheck);
 	incidentDetailLayout->addStretch();
 
 	// the detail pane may become taller than the dock, so let it scroll rather
@@ -2441,6 +2514,12 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	connect(m_incidentTargetCombo, &QComboBox::currentTextChanged, this, &MainWindow::commitIncidentTarget);
 	connect(m_incidentStartSecondsEdit, &QLineEdit::editingFinished, this, &MainWindow::commitIncidentStartSeconds);
 	connect(m_incidentEndSecondsEdit, &QLineEdit::editingFinished, this, &MainWindow::commitIncidentEndSeconds);
+	connect(m_incidentHasOccurrenceCheck, &QCheckBox::toggled, this, &MainWindow::commitIncidentHasOccurrence);
+	connect(m_incidentOccurrenceEdit, &QLineEdit::editingFinished, this, &MainWindow::commitIncidentOccurrence);
+	connect(m_incidentHasReducedSpeedCheck, &QCheckBox::toggled, this, &MainWindow::commitIncidentHasReducedSpeed);
+	connect(m_incidentReducedSpeedKmhEdit, &QAbstractSpinBox::editingFinished, this, &MainWindow::commitIncidentReducedSpeed);
+	connect(m_incidentHasEndSecondsCheck, &QCheckBox::toggled, this, &MainWindow::commitIncidentHasEndSeconds);
+	connect(m_incidentTerminateAtDestinationCheck, &QCheckBox::toggled, this, &MainWindow::commitIncidentTerminateAtDestination);
 	connect(m_addIncidentButton, &QPushButton::clicked, this, &MainWindow::addIncident);
 	connect(m_duplicateIncidentButton, &QPushButton::clicked, this, &MainWindow::duplicateIncident);
 	connect(m_deleteIncidentButton, &QPushButton::clicked, this, &MainWindow::deleteIncident);
@@ -2528,6 +2607,8 @@ void MainWindow::newScene() {
 	simulation.resetState();
 	m_sceneDir.clear();
 	m_sceneModel = makeNewSceneModel();
+	++m_sceneRevision;
+	m_delayBaseline.reset();
 	m_sceneLoaded = true;
 	m_sceneIsBundle = false;
 	m_sceneDirty = true;
@@ -2604,6 +2685,8 @@ bool MainWindow::openSceneDirectory(const QString& dir) {
 	m_lastRunTotalOccurrences = 0;
 	m_sceneDir = scenePath;
 	m_sceneModel = result.scene;
+	++m_sceneRevision;
+	m_delayBaseline.reset();
 	m_sceneLoaded = true;
 	m_sceneIsBundle = QFileInfo(scenePath).isFile();
 	m_sceneDirty = false;
@@ -3293,6 +3376,8 @@ void MainWindow::activateLoadedDataItem(QTreeWidgetItem* item) {
 }
 
 void MainWindow::markSceneDirty() {
+	++m_sceneRevision;
+	m_delayBaseline.reset();
 	m_sceneDirty = true;
 	if (m_worker) {
 		m_sceneChangedDuringRun = true;
@@ -3312,6 +3397,8 @@ void MainWindow::invalidateRunResults() {
 	m_resultsAvailable = false;
 	m_sceneChangedDuringRun = false;
 	m_appliedScenarioId.clear();
+	m_completedRunResults = RunResults();
+	m_completedTimetableResults.clear();
 	if (m_runResultsTable)
 		m_runResultsTable->setRowCount(0);
 	if (m_runResultsSummaryLabel)
@@ -6310,6 +6397,14 @@ std::vector<SceneIncident>& MainWindow::selectedScenarioIncidents() {
 	return scenario ? scenario->incidents : empty;
 }
 
+SceneIncident* MainWindow::selectedIncident() {
+	if (!m_incidentListWidget)
+		return nullptr;
+	auto& incidents = selectedScenarioIncidents();
+	const int row = m_incidentListWidget->currentRow();
+	return row >= 0 && row < static_cast<int>(incidents.size()) ? &incidents[row] : nullptr;
+}
+
 const std::vector<SceneIncident>& MainWindow::selectedScenarioIncidents() const {
 	static const std::vector<SceneIncident> empty;
 	const SceneScenario* scenario = selectedScenario();
@@ -6454,6 +6549,10 @@ void MainWindow::refreshIncidentPanel() {
 		if (hasScene) {
 			for (const auto& incident : incidents) {
 				QString label = QString::fromStdString(incident.id) + " (" + QString::fromStdString(incident.type) + ")";
+				if (incident.hasOccurrence || incident.occurrence != 1)
+					label += QString(" #%1").arg(incident.occurrence);
+				if (incident.hasReducedSpeed || incident.reducedSpeedKmh != 0.0)
+					label += QString(" / %1 km/h").arg(incident.reducedSpeedKmh);
 				m_incidentListWidget->addItem(label);
 			}
 		}
@@ -6636,6 +6735,7 @@ void MainWindow::updateIncidentDetailPanel() {
 	int row = m_incidentListWidget ? m_incidentListWidget->currentRow() : -1;
 	bool hasSelection = m_sceneLoaded && !m_worker && row >= 0
 		&& row < static_cast<int>(incidents.size());
+	const bool isBreakdown = hasSelection && incidents[static_cast<std::size_t>(row)].type == "train_breakdown";
 
 	if (m_incidentIdEdit) {
 		const QSignalBlocker blocker(m_incidentIdEdit);
@@ -6672,6 +6772,49 @@ void MainWindow::updateIncidentDetailPanel() {
 		int seconds = hasSelection ? static_cast<int>(incidents[row].endSeconds) : 0;
 		m_incidentEndSecondsEdit->setText(QString::number(seconds));
 		m_incidentEndSecondsEdit->setEnabled(hasSelection);
+	}
+	if (m_incidentHasEndSecondsCheck) {
+		const QSignalBlocker blocker(m_incidentHasEndSecondsCheck);
+		const bool hasEnd = hasSelection && (incidents[static_cast<std::size_t>(row)].hasEndSeconds
+			|| incidents[static_cast<std::size_t>(row)].endSeconds != 0.0);
+		m_incidentHasEndSecondsCheck->setChecked(hasEnd);
+		m_incidentHasEndSecondsCheck->setEnabled(hasSelection);
+	}
+	if (m_incidentHasOccurrenceCheck) {
+		const QSignalBlocker blocker(m_incidentHasOccurrenceCheck);
+		const bool hasOccurrence = isBreakdown && (incidents[static_cast<std::size_t>(row)].hasOccurrence
+			|| incidents[static_cast<std::size_t>(row)].occurrence != 1);
+		m_incidentHasOccurrenceCheck->setChecked(hasOccurrence);
+		m_incidentHasOccurrenceCheck->setEnabled(isBreakdown);
+	}
+	if (m_incidentOccurrenceEdit) {
+		const QSignalBlocker blocker(m_incidentOccurrenceEdit);
+		const int occurrence = hasSelection ? std::max(1, incidents[static_cast<std::size_t>(row)].occurrence) : 1;
+		m_incidentOccurrenceEdit->setText(QString::number(occurrence));
+		m_incidentOccurrenceEdit->setEnabled(isBreakdown
+			&& m_incidentHasOccurrenceCheck && m_incidentHasOccurrenceCheck->isChecked());
+	}
+	if (m_incidentHasReducedSpeedCheck) {
+		const QSignalBlocker blocker(m_incidentHasReducedSpeedCheck);
+		const bool hasCap = isBreakdown && (incidents[static_cast<std::size_t>(row)].hasReducedSpeed
+			|| incidents[static_cast<std::size_t>(row)].reducedSpeedKmh != 0.0);
+		m_incidentHasReducedSpeedCheck->setChecked(hasCap);
+		m_incidentHasReducedSpeedCheck->setEnabled(isBreakdown);
+	}
+	if (m_incidentReducedSpeedKmhEdit) {
+		const QSignalBlocker blocker(m_incidentReducedSpeedKmhEdit);
+		const double cap = hasSelection && std::isfinite(incidents[static_cast<std::size_t>(row)].reducedSpeedKmh)
+			&& incidents[static_cast<std::size_t>(row)].reducedSpeedKmh > 0.0
+			? incidents[static_cast<std::size_t>(row)].reducedSpeedKmh : 40.0;
+		m_incidentReducedSpeedKmhEdit->setValue(cap);
+		m_incidentReducedSpeedKmhEdit->setEnabled(isBreakdown
+			&& m_incidentHasReducedSpeedCheck && m_incidentHasReducedSpeedCheck->isChecked());
+	}
+	if (m_incidentTerminateAtDestinationCheck) {
+		const QSignalBlocker blocker(m_incidentTerminateAtDestinationCheck);
+		m_incidentTerminateAtDestinationCheck->setChecked(isBreakdown && hasSelection
+			&& incidents[static_cast<std::size_t>(row)].terminateAtDestination);
+		m_incidentTerminateAtDestinationCheck->setEnabled(isBreakdown);
 	}
 
 	if (m_duplicateIncidentButton)
@@ -6750,6 +6893,7 @@ void MainWindow::addIncident() {
 	SceneIncident incident;
 	incident.id = uniqueIncidentId("new_incident");
 	incident.type = "signal_failure";
+	incident.hasEndSeconds = true;
 	incidents.push_back(incident);
 
 	markScenarioModified();
@@ -6853,6 +6997,13 @@ void MainWindow::commitIncidentType(const QString& text) {
 		return;
 
 	incidents[row].type = newType;
+	if (newType == "signal_failure") {
+		incidents[row].hasOccurrence = false;
+		incidents[row].occurrence = 1;
+		incidents[row].hasReducedSpeed = false;
+		incidents[row].reducedSpeedKmh = 0.0;
+		incidents[row].terminateAtDestination = false;
+	}
 
 	// when the type changes the valid target pool also changes; drop a target
 	// that is no longer valid for the new type
@@ -6896,9 +7047,8 @@ void MainWindow::commitIncidentType(const QString& text) {
 	markScenarioModified();
 	refreshValidationPanel();
 
-	// rebuild only the target combo; the type combo already shows the new value
-	// so rebuilding it from inside its own signal is unnecessary and harmful
-	refreshIncidentTargetCombo();
+	// The target choices and breakdown-only controls both depend on the type.
+	updateIncidentDetailPanel();
 }
 
 void MainWindow::commitIncidentTarget(const QString& text) {
@@ -6969,11 +7119,114 @@ void MainWindow::commitIncidentEndSeconds() {
 	}
 
 	double newValue = static_cast<double>(seconds);
-	if (newValue == incidents[row].endSeconds)
+	if (newValue == incidents[row].endSeconds && incidents[row].hasEndSeconds)
 		return;
 
 	incidents[row].endSeconds = newValue;
+	incidents[row].hasEndSeconds = true;
 
+	markScenarioModified();
+	refreshValidationPanel();
+}
+
+void MainWindow::commitIncidentOccurrence() {
+	if (!m_sceneLoaded || !m_incidentOccurrenceEdit)
+		return;
+	SceneIncident* incident = selectedIncident();
+	if (!incident)
+		return;
+	bool ok = false;
+	int occurrence = m_incidentOccurrenceEdit->text().toInt(&ok);
+	if (!ok || occurrence < 1)
+		occurrence = 1;
+	{
+		const QSignalBlocker blocker(m_incidentOccurrenceEdit);
+		m_incidentOccurrenceEdit->setText(QString::number(occurrence));
+	}
+	if (incident->occurrence == occurrence && incident->hasOccurrence)
+		return;
+	incident->occurrence = occurrence;
+	incident->hasOccurrence = true;
+	markScenarioModified();
+	refreshValidationPanel();
+	refreshIncidentPanel();
+}
+
+void MainWindow::commitIncidentHasOccurrence(bool checked) {
+	if (!m_sceneLoaded)
+		return;
+	SceneIncident* incident = selectedIncident();
+	if (!incident)
+		return;
+	if (incident->hasOccurrence == checked)
+		return;
+	incident->hasOccurrence = checked;
+	if (!checked)
+		incident->occurrence = 1;
+	markScenarioModified();
+	refreshValidationPanel();
+	updateIncidentDetailPanel();
+}
+
+void MainWindow::commitIncidentReducedSpeed() {
+	if (!m_sceneLoaded || !m_incidentReducedSpeedKmhEdit)
+		return;
+	SceneIncident* incident = selectedIncident();
+	if (!incident)
+		return;
+	const double speed = m_incidentReducedSpeedKmhEdit->value();
+	if (incident->reducedSpeedKmh == speed && incident->hasReducedSpeed)
+		return;
+	incident->reducedSpeedKmh = speed;
+	incident->hasReducedSpeed = true;
+	markScenarioModified();
+	refreshValidationPanel();
+	refreshIncidentPanel();
+}
+
+void MainWindow::commitIncidentHasReducedSpeed(bool checked) {
+	if (!m_sceneLoaded)
+		return;
+	SceneIncident* incident = selectedIncident();
+	if (!incident)
+		return;
+	if (incident->hasReducedSpeed == checked)
+		return;
+	incident->hasReducedSpeed = checked;
+	if (checked && m_incidentReducedSpeedKmhEdit)
+		incident->reducedSpeedKmh = m_incidentReducedSpeedKmhEdit->value();
+	else if (!checked)
+		incident->reducedSpeedKmh = 0.0;
+	markScenarioModified();
+	refreshValidationPanel();
+	updateIncidentDetailPanel();
+}
+
+void MainWindow::commitIncidentHasEndSeconds(bool checked) {
+	if (!m_sceneLoaded)
+		return;
+	SceneIncident* incident = selectedIncident();
+	if (!incident)
+		return;
+	if (incident->hasEndSeconds == checked)
+		return;
+	incident->hasEndSeconds = checked;
+	if (!checked)
+		incident->endSeconds = 0.0;
+	markScenarioModified();
+	refreshValidationPanel();
+	updateIncidentDetailPanel();
+}
+
+void MainWindow::commitIncidentTerminateAtDestination(bool checked) {
+	if (!m_sceneLoaded)
+		return;
+	SceneIncident* incident = selectedIncident();
+	if (!incident)
+		return;
+	if (incident->terminateAtDestination == checked)
+		return;
+	incident->terminateAtDestination = checked;
 	markScenarioModified();
 	refreshValidationPanel();
 }
@@ -9322,7 +9575,13 @@ void MainWindow::runEditorSmokeE2E() {
 		if (left.size() != right.size())
 			return false;
 		return std::equal(left.begin(), left.end(), right.begin(), [](const SceneIncident& a, const SceneIncident& b) {
-			return a.id == b.id && a.type == b.type && a.target == b.target && a.startSeconds == b.startSeconds && a.endSeconds == b.endSeconds;
+			return a.id == b.id && a.type == b.type && a.target == b.target
+				&& a.startSeconds == b.startSeconds && a.endSeconds == b.endSeconds
+				&& a.hasOccurrence == b.hasOccurrence && a.occurrence == b.occurrence
+				&& a.hasReducedSpeed == b.hasReducedSpeed
+				&& a.reducedSpeedKmh == b.reducedSpeedKmh
+				&& a.terminateAtDestination == b.terminateAtDestination
+				&& a.hasEndSeconds == b.hasEndSeconds;
 		});
 	};
 	auto sameStations = [](const std::vector<SceneStation>& left, const std::vector<SceneStation>& right) {
@@ -10438,6 +10697,7 @@ void MainWindow::runEditorSmokeE2E() {
 		facetFailure(facetOk, "incident", "scene or edited service unavailable");
 	} else {
 		bool facetOk = true;
+		const double preciseBreakdownSpeed = 40.125;
 		const int originalCount = m_incidentListWidget->count();
 		editedIncidentId = uniqueIncidentId("e2e_incident");
 		addIncident();
@@ -10447,7 +10707,10 @@ void MainWindow::runEditorSmokeE2E() {
 			if (m_incidentIdEdit)
 				m_incidentIdEdit->setText(QString::fromStdString(editedIncidentId));
 			commitIncidentIdEdit();
-			commitIncidentType("train_breakdown");
+			if (m_incidentTypeCombo)
+				m_incidentTypeCombo->setCurrentText("train_breakdown");
+			if (!m_incidentHasReducedSpeedCheck || !m_incidentHasReducedSpeedCheck->isEnabled())
+				facetFailure(facetOk, "incident", "breakdown controls stayed disabled after the type change");
 			commitIncidentTarget(QString::fromStdString(editedServiceId));
 			if (m_incidentStartSecondsEdit)
 				m_incidentStartSecondsEdit->setText("100");
@@ -10455,6 +10718,24 @@ void MainWindow::runEditorSmokeE2E() {
 			if (m_incidentEndSecondsEdit)
 				m_incidentEndSecondsEdit->setText("200");
 			commitIncidentEndSeconds();
+			if (m_incidentHasOccurrenceCheck)
+				m_incidentHasOccurrenceCheck->setChecked(true);
+			if (m_incidentOccurrenceEdit)
+				m_incidentOccurrenceEdit->setText("2");
+			commitIncidentOccurrence();
+			if (m_incidentHasReducedSpeedCheck)
+				m_incidentHasReducedSpeedCheck->setChecked(true);
+			if (SceneIncident* incident = selectedIncident(); !incident
+					|| !incident->hasReducedSpeed || !m_incidentReducedSpeedKmhEdit
+					|| incident->reducedSpeedKmh != m_incidentReducedSpeedKmhEdit->value())
+				facetFailure(facetOk, "incident", "enabling the speed cap did not commit its displayed value");
+			if (m_incidentReducedSpeedKmhEdit)
+				m_incidentReducedSpeedKmhEdit->setValue(preciseBreakdownSpeed);
+			commitIncidentReducedSpeed();
+			if (m_incidentHasEndSecondsCheck)
+				m_incidentHasEndSecondsCheck->setChecked(false);
+			if (m_incidentTerminateAtDestinationCheck)
+				m_incidentTerminateAtDestinationCheck->setChecked(true);
 		}
 		duplicateIncident();
 		if (m_incidentListWidget->count() != originalCount + 2) {
@@ -10476,7 +10757,12 @@ void MainWindow::runEditorSmokeE2E() {
 		if (editedRow < 0 || incidents[editedRow].type != "train_breakdown"
 				|| incidents[editedRow].target != editedServiceId
 				|| incidents[editedRow].startSeconds != 100.0
-				|| incidents[editedRow].endSeconds != 200.0)
+				|| incidents[editedRow].endSeconds != 0.0
+				|| !incidents[editedRow].hasOccurrence || incidents[editedRow].occurrence != 2
+				|| !incidents[editedRow].hasReducedSpeed
+				|| incidents[editedRow].reducedSpeedKmh != preciseBreakdownSpeed
+				|| incidents[editedRow].hasEndSeconds
+				|| !incidents[editedRow].terminateAtDestination)
 			facetFailure(facetOk, "incident", "edited incident was not retained");
 		if (facetOk)
 			std::fprintf(stdout, "E2E_EDITOR_INCIDENT_OK\n");
@@ -11462,6 +11748,14 @@ void MainWindow::updateDiagramActions() {
 				button->setEnabled(available);
 		}
 	}
+	const DelayRunSnapshot current = completedDelaySnapshot();
+	const bool canSetBaseline = available && !current.scenarioId.empty()
+		&& !current.hasIncidents && !current.hasEntranceDelays;
+	if (m_setDelayBaselineButton)
+		m_setDelayBaselineButton->setEnabled(canSetBaseline);
+	if (m_compareDelayButton)
+		m_compareDelayButton->setEnabled(available && m_delayBaseline.has_value()
+			&& current.hasIncidents && !current.hasEntranceDelays);
 }
 
 // Lazily created so the menu only appears once an editor dock registers.
@@ -11597,7 +11891,24 @@ bool MainWindow::showRunReview() {
 	if (e2eDialogsSuppressed())
 		return true;
 	const SceneDiagnosticCounts counts = countDiagnostics(m_sceneDiagnostics);
-	const QString summary = QString("Case study: %1\nScenario: %2\nServices: %3\nOccurrences: %4/%5 selected\nCompositions: %6\nIncidents: %7\nValidation: %8 error(s), %9 warning(s)")
+	QString incidentDetails;
+	for (const SceneIncident& incident : selectedScenarioIncidents()) {
+		QString detail = QString::fromStdString(incident.id) + " [" + QString::fromStdString(incident.type) + "]";
+		if (incident.hasOccurrence || incident.occurrence != 1)
+			detail += QString(" occurrence=%1").arg(incident.occurrence);
+		if (incident.hasReducedSpeed)
+			detail += QString(" cap=%1 km/h").arg(incident.reducedSpeedKmh);
+		if (incident.hasEndSeconds || incident.endSeconds != 0.0)
+			detail += QString(" recovery=%1 s").arg(incident.endSeconds);
+		else if (incident.type == "train_breakdown" && incident.hasReducedSpeed)
+			detail += " until destination";
+		if (incident.terminateAtDestination)
+			detail += " terminate at destination";
+		if (!incidentDetails.isEmpty())
+			incidentDetails += "; ";
+		incidentDetails += detail;
+	}
+	QString summary = QString("Case study: %1\nScenario: %2\nServices: %3\nOccurrences: %4/%5 selected\nCompositions: %6\nIncidents: %7\nValidation: %8 error(s), %9 warning(s)")
 		.arg(QString::fromStdString(m_sceneModel.name))
 		.arg(scenarioContext())
 		.arg(static_cast<int>(m_sceneModel.services.size()))
@@ -11607,6 +11918,8 @@ bool MainWindow::showRunReview() {
 		.arg(static_cast<int>(selectedScenarioIncidents().size()))
 		.arg(counts.errors)
 		.arg(counts.warnings);
+	if (!incidentDetails.isEmpty())
+		summary += "\nIncident configuration: " + incidentDetails;
 	QMessageBox review(QMessageBox::Question, "Review run", summary, QMessageBox::NoButton, this);
 	QAbstractButton* runButton = review.addButton("Run", QMessageBox::AcceptRole);
 	QAbstractButton* loadedButton = review.addButton("Loaded Data", QMessageBox::ActionRole);
@@ -11623,6 +11936,113 @@ bool MainWindow::showRunReview() {
 		m_validationDock->raise();
 	}
 	return false;
+}
+
+DelayRunSnapshot MainWindow::completedDelaySnapshot() const {
+	DelayRunSnapshot snapshot;
+	if (!m_resultsAvailable || m_completedRunResults.trains.empty())
+		return snapshot;
+	snapshot.caseRevision = std::to_string(m_sceneRevision);
+	snapshot.scenarioId = m_appliedScenarioId;
+	snapshot.baseTimeSeconds = static_cast<double>(baseTimeToSeconds(m_sceneModel.baseTime));
+	snapshot.durationSeconds = std::isfinite(initial_variables.times)
+		? initial_variables.times : 0.0;
+	snapshot.timestep = timestep;
+	for (const SceneScenario& scenario : m_sceneModel.scenarios) {
+		if (scenario.id != snapshot.scenarioId)
+			continue;
+		snapshot.hasIncidents = !scenario.incidents.empty();
+		snapshot.hasEntranceDelays = !scenario.entranceDelays.empty();
+		break;
+	}
+	snapshot.run = m_completedRunResults;
+	snapshot.timetable = m_completedTimetableResults;
+	return snapshot;
+}
+
+void MainWindow::setDelayBaseline() {
+	const DelayRunSnapshot snapshot = completedDelaySnapshot();
+	if (snapshot.scenarioId.empty() || snapshot.run.trains.empty()) {
+		QMessageBox::warning(this, "Delay baseline unavailable", "Complete an incident-free run first.");
+		return;
+	}
+	if (snapshot.hasIncidents || snapshot.hasEntranceDelays) {
+		QMessageBox::warning(this, "Delay baseline rejected",
+			"The delay baseline must have no incidents and no entrance delays.");
+		return;
+	}
+	m_delayBaseline = snapshot;
+	statusBar()->showMessage(QString("Delay baseline set to scenario %1").arg(QString::fromStdString(snapshot.scenarioId)), 5000);
+	refreshRunResults();
+	updateDiagramActions();
+}
+
+void MainWindow::showDelayComparison() {
+	if (!m_delayBaseline) {
+		QMessageBox::warning(this, "Delay comparison unavailable", "Set an incident-free delay baseline first.");
+		return;
+	}
+	const DelayRunSnapshot scenario = completedDelaySnapshot();
+	const DelayComparisonResult comparison = compareDelayRuns(*m_delayBaseline, scenario);
+	if (!comparison.valid) {
+		QMessageBox::warning(this, "Delay comparison rejected", QString::fromStdString(comparison.diagnostic));
+		return;
+	}
+
+	QDialog dialog(this);
+	dialog.setWindowTitle("Incident delay comparison");
+	dialog.resize(1180, 520);
+	QVBoxLayout* layout = new QVBoxLayout(&dialog);
+	QLabel* context = new QLabel(QString("Baseline: %1 | Scenario: %2 | Total positive arrival delay: %3 s")
+		.arg(QString::fromStdString(m_delayBaseline->scenarioId), QString::fromStdString(scenario.scenarioId))
+		.arg(comparison.totalArrivalDelay.available ? QString::number(comparison.totalArrivalDelay.value, 'g', 12) : QStringLiteral("-")), &dialog);
+	context->setWordWrap(true);
+	layout->addWidget(context);
+	QTableWidget* table = new QTableWidget(&dialog);
+	table->setObjectName("delayComparisonTable");
+	table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+	table->setSelectionBehavior(QAbstractItemView::SelectRows);
+	table->setColumnCount(13);
+	table->setHorizontalHeaderLabels({
+		"Service", "Occurrence", "Operating code", "Baseline final arrival", "Scenario final arrival",
+		"Positive delay", "Attribution", "Incident IDs", "First direct time", "First direct location",
+		"Termination requested", "Terminated", "Baseline / scenario"});
+	table->setRowCount(static_cast<int>(comparison.rows.size()));
+	const auto valueText = [](const RunResultValue& value) {
+		return value.available ? QString::number(value.value, 'g', 12) : QStringLiteral("-");
+	};
+	for (int index = 0; index < static_cast<int>(comparison.rows.size()); ++index) {
+		const DelayComparisonRow& row = comparison.rows[static_cast<std::size_t>(index)];
+		table->setItem(index, 0, new QTableWidgetItem(QString::fromStdString(row.serviceId)));
+		table->setItem(index, 1, new QTableWidgetItem(QString::number(row.occurrence)));
+		table->setItem(index, 2, new QTableWidgetItem(QString::fromStdString(row.operatingCode)));
+		table->setItem(index, 3, new QTableWidgetItem(valueText(row.baselineFinalArrival)));
+		table->setItem(index, 4, new QTableWidgetItem(valueText(row.scenarioFinalArrival)));
+		table->setItem(index, 5, new QTableWidgetItem(valueText(row.positiveContribution)));
+		table->setItem(index, 6, new QTableWidgetItem(QString::fromStdString(row.attribution)));
+		table->setItem(index, 7, new QTableWidgetItem(QString::fromStdString(joinIncidentIds(row.incidentIds))));
+		table->setItem(index, 8, new QTableWidgetItem(valueText(row.firstDirectTime)));
+		table->setItem(index, 9, new QTableWidgetItem(valueText(row.firstDirectLocation)));
+		table->setItem(index, 10, new QTableWidgetItem(row.destinationTerminationRequested ? "yes" : "no"));
+		table->setItem(index, 11, new QTableWidgetItem(row.destinationTerminated ? "yes" : "no"));
+		table->setItem(index, 12, new QTableWidgetItem(QString("%1 / %2")
+			.arg(QString::fromStdString(m_delayBaseline->scenarioId), QString::fromStdString(scenario.scenarioId))));
+	}
+	table->resizeColumnsToContents();
+	layout->addWidget(table, 1);
+	QHBoxLayout* actions = new QHBoxLayout();
+	QPushButton* exportButton = new QPushButton("Export CSV...", &dialog);
+	exportButton->setObjectName("delayComparisonExportCsvButton");
+	connect(exportButton, &QPushButton::clicked, &dialog, [this, scenario, comparison]() {
+		saveCsvInteractive(this, "delay_comparison.csv", delayComparisonCsv(*m_delayBaseline, scenario, comparison));
+	});
+	actions->addWidget(exportButton);
+	actions->addStretch();
+	QDialogButtonBox* closeButtons = new QDialogButtonBox(QDialogButtonBox::Close, &dialog);
+	connect(closeButtons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+	actions->addWidget(closeButtons);
+	layout->addLayout(actions);
+	dialog.exec();
 }
 
 // starts EGTRAIN simulation on a worker thread
@@ -11663,6 +12083,10 @@ void MainWindow::onSimulationFinished() {
 	m_resultsAvailable = !sceneChangedDuringRun && hasRawRunResults();
 	m_runtimeStatus = m_resultsAvailable ? QStringLiteral("Completed") : QStringLiteral("Failed");
 	if (m_resultsAvailable) {
+		const auto trains = runResultTrainPointers();
+		// Freeze result values before a subsequent run replaces the runtime trains.
+		m_completedRunResults = buildRunResults(trains, timestep);
+		m_completedTimetableResults = buildTimetableResults(trains);
 		refreshRunResults();
 	} else {
 		if (m_runResultsTable)
@@ -11691,7 +12115,7 @@ void MainWindow::onSimulationFinished() {
 			ok &= dump("trajectory.csv", buildTrajectoryCsv(ids));
 			ok &= dump("timetable.csv", buildTimetableCsv(ids));
 			ok &= dump("blocking_time.csv", buildBlockingTimeCsv(ids));
-			ok &= dump("run_summary.csv", buildRunSummaryCsv());
+			ok &= dump("run_summary.csv", buildRunSummaryCsv(m_completedRunResults));
 			const CapacityAnalysisScope capacityScope = firstCapacityScopeWithPair();
 			std::string capacityCsv;
 			if (capacityScope.routeIndex >= 0) {
@@ -12565,7 +12989,7 @@ void MainWindow::setupRunResultsDock() {
 	exportCsvBtn->setObjectName("resultView_ExportCSV");
 	exportCsvBtn->setToolTip("Write travel time and energy per train to a CSV file");
 	connect(exportCsvBtn, &QPushButton::clicked, this, [this]() {
-		saveCsvInteractive(this, "run_summary.csv", buildRunSummaryCsv());
+		saveCsvInteractive(this, "run_summary.csv", buildRunSummaryCsv(m_completedRunResults));
 	});
 	QPushButton* exportPngBtn = new QPushButton("Export PNG...", container);
 	exportPngBtn->setObjectName("resultView_ExportPNG");
@@ -12582,6 +13006,16 @@ void MainWindow::setupRunResultsDock() {
 	QHBoxLayout* toolRow = new QHBoxLayout();
 	toolRow->addWidget(exportCsvBtn);
 	toolRow->addWidget(exportPngBtn);
+	m_setDelayBaselineButton = new QPushButton("Set delay baseline", container);
+	m_setDelayBaselineButton->setObjectName("setDelayBaselineButton");
+	m_setDelayBaselineButton->setToolTip("Freeze this completed incident-free run as the delay baseline");
+	connect(m_setDelayBaselineButton, &QPushButton::clicked, this, &MainWindow::setDelayBaseline);
+	toolRow->addWidget(m_setDelayBaselineButton);
+	m_compareDelayButton = new QPushButton("Compare delays", container);
+	m_compareDelayButton->setObjectName("compareDelayButton");
+	m_compareDelayButton->setToolTip("Compare the completed incident run with the frozen delay baseline");
+	connect(m_compareDelayButton, &QPushButton::clicked, this, &MainWindow::showDelayComparison);
+	toolRow->addWidget(m_compareDelayButton);
 	toolRow->addStretch();
 	containerLayout->addLayout(toolRow);
 	containerLayout->addWidget(m_runResultsTable);
@@ -12591,16 +13025,28 @@ void MainWindow::setupRunResultsDock() {
 }
 
 void MainWindow::refreshRunResults() {
-	if (!m_runResultsDock || !m_runResultsTable || numRegions <= 0)
+	if (!m_runResultsDock || !m_runResultsTable || m_completedRunResults.trains.empty())
 		return;
-	if (m_runResultsSummaryLabel)
-		m_runResultsSummaryLabel->setText(QString("Case: %1 | Scenario: %2 | Occurrences: %3/%4 selected | Status: Completed")
+	int directEvidenceCount = 0;
+	int destinationTerminationCount = 0;
+	for (const TrainRunResult& result : m_completedRunResults.trains) {
+		if (!result.directIncidentIds.empty())
+			++directEvidenceCount;
+		if (result.destinationTerminated)
+			++destinationTerminationCount;
+	}
+	if (m_runResultsSummaryLabel) {
+		QString summary = QString("Case: %1 | Scenario: %2 | Occurrences: %3/%4 selected | Status: Completed | Direct incident evidence: %5 | Destination terminations: %6")
 			.arg(QString::fromStdString(m_sceneModel.name), scenarioContext())
-			.arg(m_lastRunSelectedOccurrences).arg(m_lastRunTotalOccurrences));
+			.arg(m_lastRunSelectedOccurrences).arg(m_lastRunTotalOccurrences)
+			.arg(directEvidenceCount).arg(destinationTerminationCount);
+		if (m_delayBaseline)
+			summary += QString(" | Delay baseline: %1").arg(QString::fromStdString(m_delayBaseline->scenarioId));
+		m_runResultsSummaryLabel->setText(summary);
+	}
 	m_runResultsDock->setWindowTitle(QString("Run Results — %1").arg(scenarioContext()));
 
-	const auto trains = runResultTrainPointers();
-	const RunResults results = buildRunResults(trains, timestep);
+	const RunResults& results = m_completedRunResults;
 	const int totalColumns = 11;
 	m_runResultsTable->clear();
 	m_runResultsTable->setColumnCount(totalColumns);
@@ -14468,8 +14914,8 @@ void MainWindow::showTimetableTable() {
 		return;
 	}
 
-	auto* window = new TimetableTableWindow(buildTimetableResults(runResultTrainPointers()),
-										m_startOffsetSeconds, snapshotCsv(&buildTimetableCsv), this);
+	auto* window = new TimetableTableWindow(m_completedTimetableResults,
+									m_startOffsetSeconds, snapshotCsv(&buildTimetableCsv), this);
 	window->setWindowTitle(QString("Timetable: planned vs simulated [%1]").arg(scenarioContext()));
 	window->setAttribute(Qt::WA_DeleteOnClose);
 	window->show();
@@ -14484,7 +14930,7 @@ void MainWindow::showDelayDiagram() {
 	QChart* chart = new QChart();
 	const QString title = QString("Arrival delay along journey (minutes) [%1]").arg(scenarioContext());
 	chart->setTitle(title);
-	const auto rows = buildTimetableResults(runResultTrainPointers());
+	const auto& rows = m_completedTimetableResults;
 
 	for (int i = 0; i < numRegions; i++) {
 		QLineSeries* series = new QLineSeries();

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -68,6 +68,7 @@
 #include <utility>
 #include <unordered_map>
 #include <tuple>
+#include <optional>
 #include <QStatusBar>
 #include <QSlider>
 #include <QHBoxLayout>
@@ -129,6 +130,7 @@ class ConsoleWidget; // forward declaration for m_logPane
 
 #include "simulation/SimulationWorker.h"
 #include "diagrams/CapacityAnalysis.h"
+#include "diagrams/RunResults.h"
 
 // boolean to define if GUI is used or not
 extern bool GUI;
@@ -294,6 +296,8 @@ private:
 	InfoDockWidget* infoDockWidget;
 	QDockWidget* m_runResultsDock = nullptr;
 	QTableWidget* m_runResultsTable = nullptr;
+	QPushButton* m_setDelayBaselineButton = nullptr;
+	QPushButton* m_compareDelayButton = nullptr;
 	QWidget* arcInfoWidget;
 	QLineEdit* arcIDText;
 	QLineEdit* arcFirstNodeIDText;
@@ -411,6 +415,10 @@ private:
 	std::string m_selectedScenarioId;
 	std::string m_appliedScenarioId;
 	std::set<std::string> m_modifiedScenarioIds;
+	RunResults m_completedRunResults;
+	std::vector<TimetableResultRow> m_completedTimetableResults;
+	std::optional<DelayRunSnapshot> m_delayBaseline;
+	quint64 m_sceneRevision = 0;
 	QLabel* m_runResultsSummaryLabel = nullptr;
 	int m_lastRunSelectedOccurrences = 0;
 	int m_lastRunTotalOccurrences = 0;
@@ -506,6 +514,12 @@ private:
 	QComboBox* m_incidentTargetCombo = nullptr;		 // signal id or service id depending on type
 	QLineEdit* m_incidentStartSecondsEdit = nullptr; // whole seconds
 	QLineEdit* m_incidentEndSecondsEdit = nullptr;	 // whole seconds
+	QCheckBox* m_incidentHasOccurrenceCheck = nullptr;
+	QLineEdit* m_incidentOccurrenceEdit = nullptr;
+	QCheckBox* m_incidentHasReducedSpeedCheck = nullptr;
+	QDoubleSpinBox* m_incidentReducedSpeedKmhEdit = nullptr;
+	QCheckBox* m_incidentHasEndSecondsCheck = nullptr;
+	QCheckBox* m_incidentTerminateAtDestinationCheck = nullptr;
 	QPushButton* m_addIncidentButton = nullptr;
 	QPushButton* m_duplicateIncidentButton = nullptr;
 	QPushButton* m_deleteIncidentButton = nullptr;
@@ -682,15 +696,25 @@ private:
 	void commitIncidentTarget(const QString& text);
 	void commitIncidentStartSeconds();
 	void commitIncidentEndSeconds();
+	void commitIncidentOccurrence();
+	void commitIncidentHasOccurrence(bool checked);
+	void commitIncidentReducedSpeed();
+	void commitIncidentHasReducedSpeed(bool checked);
+	void commitIncidentHasEndSeconds(bool checked);
+	void commitIncidentTerminateAtDestination(bool checked);
 	std::string uniqueIncidentId(const std::string& baseId) const;
 	std::string uniqueScenarioId(const std::string& baseId) const;
 	SceneScenario* selectedScenario();
 	const SceneScenario* selectedScenario() const;
+	SceneIncident* selectedIncident();
 	std::vector<SceneIncident>& selectedScenarioIncidents();
 	const std::vector<SceneIncident>& selectedScenarioIncidents() const;
 	void markScenarioModified();
 	QString scenarioContext() const;
 	bool showRunReview();
+	void setDelayBaseline();
+	void showDelayComparison();
+	DelayRunSnapshot completedDelaySnapshot() const;
 
 	void runVisualPolishE2E();
 	void runStationOverlayE2E();

--- a/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
@@ -6,6 +6,8 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <map>
+#include <set>
 #include <utility>
 
 namespace {
@@ -34,6 +36,44 @@ RunResultValue delayValue(const RunResultValue& planned, const RunResultValue& s
 	if (!planned.available || !simulated.available)
 		return {};
 	return availableValue(simulated.value - planned.value);
+}
+
+using OccurrenceKey = std::pair<std::string, int>;
+
+OccurrenceKey occurrenceKey(const std::string& serviceId, int occurrence,
+		const std::string& trainId = {}) {
+	return {serviceId.empty() ? trainId : serviceId, occurrence};
+}
+
+std::set<OccurrenceKey> selectedOccurrences(const RunResults& results) {
+	std::set<OccurrenceKey> keys;
+	for (const TrainRunResult& train : results.trains)
+		keys.insert(occurrenceKey(train.serviceId, train.occurrence, train.trainId));
+	return keys;
+}
+
+struct FinalArrival {
+	std::string stationId;
+	int journeyIndex = 0;
+	int callIndex = 0;
+	RunResultValue arrival;
+};
+
+std::map<OccurrenceKey, FinalArrival> finalArrivals(
+		const std::vector<TimetableResultRow>& rows) {
+	std::map<OccurrenceKey, FinalArrival> result;
+	for (const TimetableResultRow& row : rows) {
+		result[occurrenceKey(row.serviceId, row.occurrence, row.trainId)] =
+				{row.stationId, row.journeyIndex, row.callIndex, row.simulatedArrivalSeconds};
+	}
+	return result;
+}
+
+const TrainRunResult* runResultFor(const RunResults& results, const OccurrenceKey& key) {
+	for (const TrainRunResult& train : results.trains)
+		if (occurrenceKey(train.serviceId, train.occurrence, train.trainId) == key)
+			return &train;
+	return nullptr;
 }
 
 bool coveredAndFinite(const std::vector<double>& values, int first, int last) {
@@ -121,6 +161,14 @@ RunResults buildRunResults(const std::vector<const Train*>& trains, double times
 		row.compositionMaximumSpeedMs = train.compositionMaximumSpeedMs;
 		row.appliedMaximumSpeedMs = train.appliedMaximumSpeedMs;
 		row.appliedMaximumSpeedKmh = train.appliedMaximumSpeedKmh;
+		row.directIncidentIds = train.directIncidentIds;
+		if (!row.directIncidentIds.empty() && std::isfinite(train.firstDirectIncidentTime)
+				&& train.firstDirectIncidentTime >= 0.0) {
+			row.firstDirectIncidentTime = availableValue(train.firstDirectIncidentTime);
+			row.firstDirectIncidentLocation = availableValue(train.firstDirectIncidentLocation);
+		}
+		row.destinationTerminationRequested = train.destinationTerminationRequested;
+		row.destinationTerminated = train.destinationTerminated;
 
 		const bool boundsInPositionSeries = train.earliestActiveTrajectoryIndex >= 0 &&
 			train.End_Time >= train.earliestActiveTrajectoryIndex &&
@@ -190,4 +238,77 @@ RunResults buildRunResults(const std::vector<const Train*>& trains, double times
 	if (substationWithRegenComplete)
 		results.substationWithRegenKWh = availableValue(substationWithRegen);
 	return results;
+}
+
+DelayComparisonResult compareDelayRuns(const DelayRunSnapshot& baseline,
+		const DelayRunSnapshot& scenario) {
+	DelayComparisonResult result;
+	const auto reject = [&result](const std::string& message) {
+		result.valid = false;
+		result.diagnostic = message;
+		return result;
+	};
+	if (baseline.scenarioId.empty() || scenario.scenarioId.empty()
+			|| baseline.scenarioId == scenario.scenarioId)
+		return reject("Baseline and scenario IDs must be present and different");
+	if (baseline.caseRevision != scenario.caseRevision)
+		return reject("Baseline and scenario runs use different scene revisions");
+	if (baseline.baseTimeSeconds != scenario.baseTimeSeconds
+			|| baseline.durationSeconds != scenario.durationSeconds
+			|| baseline.timestep != scenario.timestep)
+		return reject("Baseline and scenario time settings do not match");
+	if (baseline.hasIncidents || baseline.hasEntranceDelays)
+		return reject("Delay baseline must be incident-free and have no entrance delays");
+	if (!scenario.hasIncidents || scenario.hasEntranceDelays)
+		return reject("Delay comparison scenario must have incidents and no entrance delays");
+	if (selectedOccurrences(baseline.run) != selectedOccurrences(scenario.run))
+		return reject("Baseline and scenario selected occurrence identities do not match");
+
+	bool hasDirectEvidence = false;
+	for (const TrainRunResult& train : scenario.run.trains)
+		hasDirectEvidence = hasDirectEvidence || !train.directIncidentIds.empty();
+	if (!hasDirectEvidence)
+		return reject("Incident run has no direct incident evidence for attribution");
+
+	const auto baselineArrivals = finalArrivals(baseline.timetable);
+	const auto scenarioArrivals = finalArrivals(scenario.timetable);
+	double total = 0.0;
+	for (const OccurrenceKey& key : selectedOccurrences(scenario.run)) {
+		const auto baselineIt = baselineArrivals.find(key);
+		const auto scenarioIt = scenarioArrivals.find(key);
+		if (baselineIt == baselineArrivals.end() || scenarioIt == scenarioArrivals.end())
+			return reject("A selected occurrence has no final timetable endpoint");
+		const FinalArrival& baselineFinal = baselineIt->second;
+		const FinalArrival& scenarioFinal = scenarioIt->second;
+		if (baselineFinal.stationId != scenarioFinal.stationId
+				|| baselineFinal.journeyIndex != scenarioFinal.journeyIndex
+				|| baselineFinal.callIndex != scenarioFinal.callIndex)
+			return reject("Baseline and scenario final timetable endpoints do not match");
+		if (!baselineFinal.arrival.available || !scenarioFinal.arrival.available)
+			return reject("Baseline and scenario require a simulated arrival at every final timetable endpoint");
+		const double contribution = scenarioFinal.arrival.value - baselineFinal.arrival.value;
+		if (!std::isfinite(contribution) || contribution <= 0.0)
+			continue;
+		const TrainRunResult* train = runResultFor(scenario.run, key);
+		if (!train)
+			continue;
+		DelayComparisonRow row;
+		row.serviceId = key.first;
+		row.occurrence = key.second;
+		row.operatingCode = train->operatingCode;
+		row.baselineFinalArrival = baselineFinal.arrival;
+		row.scenarioFinalArrival = scenarioFinal.arrival;
+		row.positiveContribution = availableValue(contribution);
+		row.attribution = train->directIncidentIds.empty() ? "secondary" : "primary";
+		row.incidentIds = train->directIncidentIds;
+		row.firstDirectTime = train->firstDirectIncidentTime;
+		row.firstDirectLocation = train->firstDirectIncidentLocation;
+		row.destinationTerminationRequested = train->destinationTerminationRequested;
+		row.destinationTerminated = train->destinationTerminated;
+		result.rows.push_back(std::move(row));
+		total += contribution;
+	}
+	result.valid = true;
+	result.totalArrivalDelay = availableValue(total);
+	return result;
 }

--- a/EGTRAIN/QEGTRAIN/diagrams/RunResults.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/RunResults.h
@@ -29,6 +29,11 @@ struct TrainRunResult {
 	RunResultValue energyWithRegenKWh;
 	RunResultValue substationKWh;
 	RunResultValue substationWithRegenKWh;
+	std::vector<std::string> directIncidentIds;
+	RunResultValue firstDirectIncidentTime;
+	RunResultValue firstDirectIncidentLocation;
+	bool destinationTerminationRequested = false;
+	bool destinationTerminated = false;
 };
 
 struct TimetableResultRow {
@@ -58,6 +63,42 @@ struct RunResults {
 	RunResultValue substationWithRegenKWh;
 };
 
+// A frozen pair of completed runs.  It owns values only; no runtime Train
+// pointers survive completion.
+struct DelayRunSnapshot {
+	std::string caseRevision;
+	std::string scenarioId;
+	double baseTimeSeconds = 0.0;
+	double durationSeconds = 0.0;
+	double timestep = 0.0;
+	bool hasIncidents = false;
+	bool hasEntranceDelays = false;
+	RunResults run;
+	std::vector<TimetableResultRow> timetable;
+};
+
+struct DelayComparisonRow {
+	std::string serviceId;
+	int occurrence = 1;
+	std::string operatingCode;
+	RunResultValue baselineFinalArrival;
+	RunResultValue scenarioFinalArrival;
+	RunResultValue positiveContribution;
+	std::string attribution; // "primary" or "secondary"
+	std::vector<std::string> incidentIds;
+	RunResultValue firstDirectTime;
+	RunResultValue firstDirectLocation;
+	bool destinationTerminationRequested = false;
+	bool destinationTerminated = false;
+};
+
+struct DelayComparisonResult {
+	bool valid = false;
+	std::string diagnostic;
+	std::vector<DelayComparisonRow> rows;
+	RunResultValue totalArrivalDelay;
+};
+
 // Preserve the legacy MJ-to-kWh conversion used by text outputs.
 constexpr double kEnergyMJToKWh = 0.27778;
 constexpr double energyMJKWh(double energyMJ) {
@@ -66,5 +107,7 @@ constexpr double energyMJKWh(double energyMJ) {
 
 RunResults buildRunResults(const std::vector<const Train*>& trains, double timestep);
 std::vector<TimetableResultRow> buildTimetableResults(const std::vector<const Train*>& trains);
+DelayComparisonResult compareDelayRuns(const DelayRunSnapshot& baseline,
+		const DelayRunSnapshot& scenario);
 
 #endif // RUNRESULTS_H

--- a/EGTRAIN/QEGTRAIN/scene/SceneExporter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneExporter.cpp
@@ -1144,6 +1144,16 @@ SceneExportResult exportLegacyScene(const std::string& sceneDir, const std::stri
 							"Incident type " + inc.type + " is not supported and was skipped", inc.id);
 					continue;
 				}
+				if (inc.type == "train_breakdown"
+						&& (inc.hasOccurrence || inc.occurrence != 1
+							|| inc.hasReducedSpeed || inc.reducedSpeedKmh != 0.0
+							|| inc.terminateAtDestination
+							|| (!inc.hasEndSeconds && inc.endSeconds == 0.0))) {
+					addDiag(SceneSeverity::Warning, "scene.export.compatibility",
+							"Enhanced breakdown " + inc.id + " was skipped because the legacy four-column exporter cannot represent its occurrence, speed, recovery, or destination semantics",
+							inc.id);
+					continue;
+				}
 				if (inc.type == "signal_failure" && routeBlockTokens.find(inc.target) == routeBlockTokens.end()) {
 					addDiag(SceneSeverity::Warning, "scene.export.adjusted",
 							"Signal id " + inc.target + " matches no route block so the failure will have no effect", inc.id);

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
@@ -1127,7 +1127,20 @@ SceneLoadResult loadScene(const std::string& sceneDir) {
 			stringField(value, "type", file, incidentPath, incident.type);
 			stringField(value, "target", file, incidentPath, incident.target);
 			numberField(value, "start_seconds", file, incidentPath, incident.startSeconds);
-			numberField(value, "end_seconds", file, incidentPath, incident.endSeconds);
+			incident.hasEndSeconds = numberField(value, "end_seconds", file, incidentPath,
+					incident.endSeconds, false);
+			incident.hasOccurrence = integerField(value, "occurrence", file, incidentPath,
+					incident.occurrence, false);
+			incident.hasReducedSpeed = numberField(value, "reduced_speed_kmh", file, incidentPath,
+					incident.reducedSpeedKmh, false);
+			if (value.contains("terminate_at_destination")) {
+				if (!value["terminate_at_destination"].is_boolean()) {
+					addError("scene.field.missing", file, "Invalid terminate_at_destination",
+							joinPath(incidentPath, "terminate_at_destination"));
+				} else {
+					incident.terminateAtDestination = value["terminate_at_destination"].get<bool>();
+				}
+			}
 			output.push_back(incident);
 		}
 	};

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.h
@@ -179,6 +179,15 @@ struct SceneIncident {
 	std::string target;
 	double startSeconds = 0.0;
 	double endSeconds = 0.0;
+	// Optional breakdown targeting/configuration.  These members deliberately
+	// follow the original five fields so existing aggregate initializers keep
+	// their legacy full-hold behavior.
+	bool hasOccurrence = false;
+	int occurrence = 1;
+	bool hasReducedSpeed = false;
+	double reducedSpeedKmh = 0.0;
+	bool terminateAtDestination = false;
+	bool hasEndSeconds = false;
 };
 
 struct SceneEntranceDelay {

--- a/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
@@ -848,6 +848,9 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 		for (std::size_t incidentIndex = 0; incidentIndex < scenario.incidents.size(); ++incidentIndex) {
 			const SceneIncident& incident = scenario.incidents[incidentIndex];
 			const std::string path = scenarioPath + ".incidents[" + std::to_string(incidentIndex) + "]";
+			const bool hasOccurrence = incident.hasOccurrence || incident.occurrence != 1;
+			const bool hasReducedSpeed = incident.hasReducedSpeed || incident.reducedSpeedKmh != 0.0;
+			const bool hasEnd = incident.hasEndSeconds || incident.endSeconds != 0.0;
 			if (!incidentIds.insert(incident.id).second)
 				diagnostics.error("scene.id.duplicate", "Duplicate incident id", "scenarios.json", "incident",
 						incident.id, path + ".id", incident.id);
@@ -862,16 +865,44 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 				if (!hasId(serviceIds, incident.target))
 					diagnostics.error("scene.ref.unresolved", "Train breakdown refers to unknown service",
 							"scenarios.json", "incident", incident.id, path + ".target", incident.target);
+				if (hasOccurrence) {
+					if (incident.occurrence <= 0)
+						diagnostics.error("scene.occurrence.invalid", "Breakdown occurrence must be positive",
+								"scenarios.json", "incident", incident.id, path + ".occurrence");
+					else if (hasId(serviceIds, incident.target)
+							&& incident.occurrence > serviceOccurrences[incident.target])
+						diagnostics.error("scene.occurrence.invalid", "Breakdown occurrence is outside the configured service pattern",
+								"scenarios.json", "incident", incident.id, path + ".occurrence",
+								incident.target + "-" + std::to_string(incident.occurrence));
+				}
+				if (hasReducedSpeed
+						&& (!std::isfinite(incident.reducedSpeedKmh) || incident.reducedSpeedKmh <= 0.0))
+					diagnostics.error("scene.incident.speed", "Reduced breakdown speed must be positive and finite",
+							"scenarios.json", "incident", incident.id, path + ".reduced_speed_kmh");
+				if (!hasReducedSpeed && !hasEnd)
+					diagnostics.error("scene.incident.window", "A full-hold breakdown requires end_seconds",
+							"scenarios.json", "incident", incident.id, path + ".end_seconds");
 			} else {
 				diagnostics.error("scene.incident.type", "Unknown incident type", "scenarios.json", "incident",
 						incident.id, path + ".type", incident.type,
 						"Use signal_failure or train_breakdown");
 			}
-			if (incident.endSeconds <= incident.startSeconds || incident.startSeconds < 0.0
-					|| incident.endSeconds < 0.0)
-				diagnostics.error("scene.incident.window", "Invalid incident time window", "scenarios.json",
-						"incident", incident.id, path, "",
-						"Set end_seconds after start_seconds, both 0 or more");
+			if (!std::isfinite(incident.startSeconds) || incident.startSeconds < 0.0)
+				diagnostics.error("scene.incident.window", "Incident start_seconds must be finite and non-negative",
+						"scenarios.json", "incident", incident.id, path + ".start_seconds");
+			if (incident.type == "signal_failure") {
+				if (hasOccurrence || hasReducedSpeed || incident.terminateAtDestination)
+					diagnostics.error("scene.incident.fields", "Signal failures do not accept breakdown-only fields",
+							"scenarios.json", "incident", incident.id, path);
+				if (!hasEnd || !std::isfinite(incident.endSeconds)
+						|| incident.endSeconds <= incident.startSeconds)
+					diagnostics.error("scene.incident.window", "Signal failure requires end_seconds after start_seconds",
+							"scenarios.json", "incident", incident.id, path + ".end_seconds");
+			} else if (hasEnd && (!std::isfinite(incident.endSeconds)
+					|| incident.endSeconds <= incident.startSeconds)) {
+				diagnostics.error("scene.incident.window", "Incident end_seconds must be after start_seconds",
+						"scenarios.json", "incident", incident.id, path + ".end_seconds");
+			}
 		}
 		for (std::size_t delayIndex = 0; delayIndex < scenario.entranceDelays.size(); ++delayIndex) {
 			const SceneEntranceDelay& delay = scenario.entranceDelays[delayIndex];

--- a/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
@@ -147,13 +147,24 @@ static json writeScenarioValue(const SceneScenario& scenario) {
 	if (!scenario.description.empty())
 		value["description"] = scenario.description;
 	for (const auto& incident : scenario.incidents) {
-		value["incidents"].push_back({
+		const bool hasReducedSpeed = incident.hasReducedSpeed || incident.reducedSpeedKmh != 0.0;
+		json incidentValue = {
 			{"id", incident.id},
 			{"type", incident.type},
 			{"target", incident.target},
 			{"start_seconds", incident.startSeconds},
-			{"end_seconds", incident.endSeconds},
-		});
+		};
+		// Keep the historical five-field shape byte-for-byte in behavior while
+		// allowing reduced-speed incidents to run until the destination.
+		if (!hasReducedSpeed || incident.hasEndSeconds || incident.endSeconds != 0.0)
+			incidentValue["end_seconds"] = incident.endSeconds;
+		if (incident.hasOccurrence || incident.occurrence != 1)
+			incidentValue["occurrence"] = incident.occurrence;
+		if (hasReducedSpeed)
+			incidentValue["reduced_speed_kmh"] = incident.reducedSpeedKmh;
+		if (incident.terminateAtDestination)
+			incidentValue["terminate_at_destination"] = true;
+		value["incidents"].push_back(std::move(incidentValue));
 	}
 	for (const auto& delay : scenario.entranceDelays) {
 		value["entrance_delays"].push_back({
@@ -270,7 +281,20 @@ static void parseScenarioIncident(const json& value, std::size_t index,
 	scenarioString(value, "type", result, incident.type, true, path);
 	scenarioString(value, "target", result, incident.target, true, path);
 	scenarioNumber(value, "start_seconds", result, incident.startSeconds, path);
-	scenarioNumber(value, "end_seconds", result, incident.endSeconds, path);
+	if (value.contains("end_seconds"))
+		incident.hasEndSeconds = scenarioNumber(value, "end_seconds", result, incident.endSeconds, path);
+	incident.hasOccurrence = value.contains("occurrence")
+		&& scenarioInteger(value, "occurrence", result, incident.occurrence, path);
+	if (value.contains("reduced_speed_kmh"))
+		incident.hasReducedSpeed = scenarioNumber(value, "reduced_speed_kmh", result,
+				incident.reducedSpeedKmh, path);
+	if (value.contains("terminate_at_destination")) {
+		if (!value["terminate_at_destination"].is_boolean())
+			addScenarioDiagnostic(result, SceneSeverity::Error, "scene.scenario.field.type",
+					"Invalid terminate_at_destination", path + ".terminate_at_destination");
+		else
+			incident.terminateAtDestination = value["terminate_at_destination"].get<bool>();
+	}
 	result.scenario.incidents.push_back(std::move(incident));
 }
 

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
@@ -308,6 +308,7 @@ struct NativeTrainPlan {
 	double compositionMaximumSpeedMs = 0.0;
 	double appliedMaximumSpeedMs = 0.0;
 	double appliedMaximumSpeedKmh = 0.0;
+	bool destinationTerminationRequested = false;
 	double scheduledDeparture = 0.0;
 	double entranceDelay = 0.0;
 };
@@ -467,6 +468,11 @@ void nativeCopyTrainPlan(const NativeTrainPlan& plan, Regional& train, int vecto
 	train.compositionMaximumSpeedMs = plan.compositionMaximumSpeedMs;
 	train.appliedMaximumSpeedMs = plan.appliedMaximumSpeedMs;
 	train.appliedMaximumSpeedKmh = plan.appliedMaximumSpeedKmh;
+	train.destinationTerminationRequested = plan.destinationTerminationRequested;
+	train.destinationTerminated = false;
+	train.directIncidentIds.clear();
+	train.firstDirectIncidentTime = -1.0;
+	train.firstDirectIncidentLocation = -1.0;
 	train.TrainRouteID = plan.routeId;
 	train.indexOfRoute = plan.routeIndex;
 	train.trainDescription = plan.trainDescription;
@@ -911,15 +917,69 @@ std::vector<SceneDiagnostic> buildOperationsFromScene(const SceneModel& scene,
 						"scenarios.json", "incident", incident.id, "incidents[" + incident.id + "].type");
 				continue;
 			}
-			if (!nativeFinite(incident.startSeconds) || !nativeFinite(incident.endSeconds)
-					|| incident.startSeconds < 0.0 || incident.endSeconds <= incident.startSeconds) {
-				addNativeDiagnostic(diagnostics, "scene.native.incident.time", "Incident start/end must be finite with end after start",
-						"scenarios.json", "incident", incident.id, "incidents[" + incident.id + "]");
+			const bool hasOccurrence = incident.hasOccurrence || incident.occurrence != 1;
+			const bool hasReducedSpeed = incident.hasReducedSpeed || incident.reducedSpeedKmh != 0.0;
+			const bool hasEnd = incident.hasEndSeconds || incident.endSeconds != 0.0;
+			if (!nativeFinite(incident.startSeconds) || incident.startSeconds < 0.0) {
+				addNativeDiagnostic(diagnostics, "scene.native.incident.time",
+						"Incident start must be finite and non-negative", "scenarios.json", "incident",
+						incident.id, "incidents[" + incident.id + "].start_seconds");
 				valid = false;
 			}
+			if (incident.type == "signal_failure") {
+				if (hasOccurrence || hasReducedSpeed || incident.terminateAtDestination) {
+					addNativeDiagnostic(diagnostics, "scene.native.incident.fields",
+							"Signal failures do not accept breakdown-only fields", "scenarios.json", "incident",
+							incident.id, "incidents[" + incident.id + "]");
+					valid = false;
+				}
+				if (!hasEnd || !nativeFinite(incident.endSeconds)
+						|| incident.endSeconds <= incident.startSeconds) {
+					addNativeDiagnostic(diagnostics, "scene.native.incident.time",
+							"Signal failure requires end after start", "scenarios.json", "incident", incident.id,
+							"incidents[" + incident.id + "].end_seconds");
+					valid = false;
+				}
+			} else {
+				if (hasOccurrence && (incident.occurrence < 1
+						|| repeatCounts.find(incident.target) == repeatCounts.end()
+						|| incident.occurrence > repeatCounts[incident.target])) {
+					addNativeDiagnostic(diagnostics, "scene.native.incident.occurrence",
+							"Breakdown occurrence is outside the configured service pattern", "scenarios.json",
+							"incident", incident.id, "incidents[" + incident.id + "].occurrence");
+					valid = false;
+				}
+				if (hasReducedSpeed && (!nativeFinite(incident.reducedSpeedKmh)
+						|| incident.reducedSpeedKmh <= 0.0)) {
+					addNativeDiagnostic(diagnostics, "scene.native.incident.speed",
+							"Reduced breakdown speed must be positive and finite", "scenarios.json", "incident",
+							incident.id, "incidents[" + incident.id + "].reduced_speed_kmh");
+					valid = false;
+				}
+				if (!hasReducedSpeed && !hasEnd) {
+					addNativeDiagnostic(diagnostics, "scene.native.incident.time",
+							"A full-hold breakdown requires end_seconds", "scenarios.json", "incident",
+							incident.id, "incidents[" + incident.id + "].end_seconds");
+					valid = false;
+				}
+				if (hasEnd && (!nativeFinite(incident.endSeconds)
+						|| incident.endSeconds <= incident.startSeconds)) {
+					addNativeDiagnostic(diagnostics, "scene.native.incident.time",
+							"Incident end must be after start", "scenarios.json", "incident", incident.id,
+							"incidents[" + incident.id + "].end_seconds");
+					valid = false;
+				}
+			}
 			SimulationIncident runtimeIncident;
+			runtimeIncident.id = incident.id;
 			runtimeIncident.type = incident.type;
 			runtimeIncident.target = incident.target;
+			runtimeIncident.hasOccurrence = hasOccurrence;
+			runtimeIncident.occurrence = incident.occurrence;
+			runtimeIncident.hasReducedSpeed = hasReducedSpeed;
+			runtimeIncident.reducedSpeedKmh = incident.reducedSpeedKmh;
+			runtimeIncident.terminateAtDestination = incident.terminateAtDestination;
+			runtimeIncident.hasEndSeconds = hasEnd;
 			runtimeIncident.startSeconds = incident.startSeconds;
 			runtimeIncident.endSeconds = incident.endSeconds;
 			if (incident.type == "signal_failure") {
@@ -988,6 +1048,16 @@ std::vector<SceneDiagnostic> buildOperationsFromScene(const SceneModel& scene,
 			for (NativeStopPlan& trainStop : train.stops) {
 				if (trainStop.stationId == delay.stationId) {
 					trainStop.plannedDeparture += delay.delaySeconds;
+					break;
+				}
+			}
+		}
+		for (NativeTrainPlan& train : trains) {
+			for (const SimulationIncident& incident : stagedIncidents) {
+				if (incident.type == "train_breakdown" && incident.terminateAtDestination
+						&& incident.target == train.serviceId
+						&& (!incident.hasOccurrence || incident.occurrence == train.occurrence)) {
+					train.destinationTerminationRequested = true;
 					break;
 				}
 			}

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -590,6 +590,11 @@ public:
 	double compositionMaximumSpeedMs = 0.0;
 	double appliedMaximumSpeedMs = 0.0;
 	double appliedMaximumSpeedKmh = 0.0;
+	std::vector<std::string> directIncidentIds;
+	double firstDirectIncidentTime = -1.0;
+	double firstDirectIncidentLocation = -1.0;
+	bool destinationTerminationRequested = false;
+	bool destinationTerminated = false;
 	Arc As;							 // Temporary Arc object representing the Arc occupied by the train in a determined time instant
 	Section Bs;						 // Temporary Block Section Object representing the Block Section occupied by the Train in a certain time instant
 	double Start_Node_X = 0.0;		 // It represents the X of the Node from which the train starts its run
@@ -2869,6 +2874,8 @@ public:
 			// window; entrance processing is also suspended, so a train whose
 			// window covers its entry time simply enters after the window.
 			if (i > 0 && Incident_Holds_Train(trainDescription, i)) {
+				if (const SimulationIncident* incident = Active_Train_Breakdown(trainDescription, i))
+					recordDirectIncident(*incident, i * timestep, instant_spatial_position[i - 1]);
 				instant_train_speed[i] = 0;
 				instant_spatial_position[i] = instant_spatial_position[i - 1];
 				instant_train_power_consumption[i] = 0;
@@ -2914,6 +2921,7 @@ public:
 					if (Speeds[k] <= V_lim)
 						V_lim = Speeds[k];
 				}
+				V_lim = effectiveIncidentSpeedLimit(V_lim, i);
 				// Imposing Station Nodes via cached indices
 				for (int s = 0; s < numStations; s++) {
 					int h = stationBlockSection[s];
@@ -3053,6 +3061,8 @@ public:
 				// Release of signalling system when the train exits simulation
 				if (instant_spatial_position[i - 1] >= train_route[indexOfRoute].x_of_end_node * 1000) {
 					End_Time = i - 1;
+					if (destinationTerminationRequested)
+						destinationTerminated = true;
 					instant_train_speed[i] = 0;
 					instant_spatial_position[i] = -9999;
 					instant_train_power_consumption[i] = -9999;
@@ -3168,6 +3178,48 @@ public:
 		}
 	}
 
+	void recordDirectIncidentId(const std::string& incidentId, double timeSeconds,
+			double locationMeters) {
+		if (incidentId.empty())
+			return;
+		if (std::find(directIncidentIds.begin(), directIncidentIds.end(), incidentId)
+				== directIncidentIds.end())
+			directIncidentIds.push_back(incidentId);
+		if (firstDirectIncidentTime < 0.0) {
+			firstDirectIncidentTime = timeSeconds;
+			firstDirectIncidentLocation = locationMeters;
+		}
+	}
+
+	void recordDirectIncident(const SimulationIncident& incident, double timeSeconds,
+			double locationMeters) {
+		recordDirectIncidentId(incident.id.empty() ? incident.target : incident.id,
+			timeSeconds, locationMeters);
+	}
+
+	void recordDirectSignalFailure(const MovementAuthority& authority, double timeSeconds) {
+		if (authority.type != "SignalFailure")
+			return;
+		const std::string prefix = "signal_failure:";
+		const std::string& encoded = authority.TrainInfo.trainDescription;
+		if (encoded.rfind(prefix, 0) != 0)
+			return;
+		const std::string incidentId = encoded.substr(prefix.size());
+		recordDirectIncidentId(incidentId, timeSeconds, authority.AbsPosEoA);
+	}
+
+	double effectiveIncidentSpeedLimit(double candidate, int timestepIndex) {
+		const SimulationIncident* incident = Active_Train_Breakdown(trainDescription, timestepIndex);
+		const double cap = incident ? incident->reducedSpeedKmh / 3.6 : 0.0;
+		if (incident && incident->hasReducedSpeed && cap > 0.0 && std::isfinite(cap)
+				&& cap < candidate) {
+			recordDirectIncident(*incident, timestepIndex * timestep, instant_spatial_position.empty()
+					? 0.0 : instant_spatial_position[std::max(0, timestepIndex - 1)]);
+			return cap;
+		}
+		return candidate;
+	}
+
 	// Function to Replicate a train repeated regularly over the time
 	void ReplicateTrainTrajectory(Train T_2_Replicate) {
 		// Offset (i.e. time headway) between the two trains
@@ -3201,6 +3253,8 @@ public:
 		if (OutOfSimulation == 0) {
 			// same breakdown hold as Trajectory_Block_Section
 			if (i > 0 && Incident_Holds_Train(trainDescription, i)) {
+				if (const SimulationIncident* incident = Active_Train_Breakdown(trainDescription, i))
+					recordDirectIncident(*incident, i * timestep, instant_spatial_position[i - 1]);
 				instant_train_speed[i] = 0;
 				instant_spatial_position[i] = instant_spatial_position[i - 1];
 				instant_train_power_consumption[i] = 0;
@@ -3255,6 +3309,7 @@ public:
 					if (Speeds[k] <= V_lim)
 						V_lim = Speeds[k];
 				}
+				V_lim = effectiveIncidentSpeedLimit(V_lim, i);
 				cout << "Right speed limit " << to_string(V_lim * 3.6) << endl;
 				// Imposing Station Nodes via cached indices
 				for (int s = 0; s < numStations; s++) {
@@ -3275,6 +3330,7 @@ public:
 					(this->Last_Received_MA.RelativePosEoA - instant_spatial_position[i - 1] < 4)) {
 					Last_MA_StoppedAt = Last_Received_MA;
 					IsTrainStoppedForEoA = true;
+					recordDirectSignalFailure(Last_MA_StoppedAt, i * timestep);
 					cout << "IsTrainStoppedForEoA" << endl;
 				}
 
@@ -3439,6 +3495,8 @@ public:
 				// Release of signalling system when the train exits simulation
 				if (instant_spatial_position[i - 1] >= train_route[indexOfRoute].x_of_end_node * 1000) {
 					End_Time = i - 1;
+					if (destinationTerminationRequested)
+						destinationTerminated = true;
 					instant_train_speed[i] = 0;
 					instant_spatial_position[i] = -9999;
 					instant_train_power_consumption[i] = -9999;
@@ -3606,6 +3664,8 @@ public:
 			// window; entrance processing is also suspended, so a train whose
 			// window covers its entry time simply enters after the window.
 			if (time_seconds > 0 && Incident_Holds_Train(trainDescription, time_seconds)) {
+				if (const SimulationIncident* incident = Active_Train_Breakdown(trainDescription, time_seconds))
+					recordDirectIncident(*incident, time_seconds * timestep, instant_spatial_position[time_seconds - 1]);
 				instant_train_speed[time_seconds] = 0;
 				instant_spatial_position[time_seconds] = instant_spatial_position[time_seconds - 1];
 				instant_train_power_consumption[time_seconds] = 0;
@@ -3662,6 +3722,7 @@ public:
 					if (Speeds[k] <= V_lim)
 						V_lim = Speeds[k];
 				}
+				V_lim = effectiveIncidentSpeedLimit(V_lim, time_seconds);
 
 				// Imposing Station Nodes via cached indices
 				for (int s = 0; s < numStations; s++) {
@@ -3685,6 +3746,7 @@ public:
 
 					Last_MA_StoppedAt = Last_Received_MA;
 					IsTrainStoppedForEoA = true;
+					recordDirectSignalFailure(Last_MA_StoppedAt, time_seconds * timestep);
 				}
 
 				// Calculating the most severe value of Train Braking Distance at time instant i
@@ -4045,6 +4107,8 @@ public:
 				// Release of signalling system when the train exits simulation
 				if (instant_spatial_position[time_seconds - 1] >= train_route[indexOfRoute].x_of_end_node * 1000) {
 					End_Time = time_seconds - 1;
+					if (destinationTerminationRequested)
+						destinationTerminated = true;
 					instant_train_speed[time_seconds] = 0;
 					instant_spatial_position[time_seconds] = -9999;
 					instant_train_power_consumption[time_seconds] = -9999;
@@ -7949,6 +8013,11 @@ public:
 		compositionMaximumSpeedMs = ob2.compositionMaximumSpeedMs;
 		appliedMaximumSpeedMs = ob2.appliedMaximumSpeedMs;
 		appliedMaximumSpeedKmh = ob2.appliedMaximumSpeedKmh;
+		directIncidentIds = ob2.directIncidentIds;
+		firstDirectIncidentTime = ob2.firstDirectIncidentTime;
+		firstDirectIncidentLocation = ob2.firstDirectIncidentLocation;
+		destinationTerminationRequested = ob2.destinationTerminationRequested;
+		destinationTerminated = ob2.destinationTerminated;
 		return *this;
 	}
 };

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -1,5 +1,6 @@
 #include "simulation/Signalling.h"
 #include "scene/SceneModel.h"
+#include <algorithm>
 #include <cmath>
 #include <unordered_map>
 #include <unordered_set>
@@ -5691,15 +5692,60 @@ void saveSignalAspectChanges(int t, std::string FolderName) {
 
 std::vector<SimulationIncident> simulationIncidents;
 
+namespace {
+bool runtimeIncidentHasEnd(const SimulationIncident& incident) {
+	return incident.hasEndSeconds || incident.endSeconds != 0.0;
+}
+
+bool trainOccurrence(const std::string& trainDesc, std::string& serviceId, int& occurrence) {
+	const std::size_t separator = trainDesc.rfind('-');
+	if (separator == std::string::npos || separator == 0 || separator + 1 >= trainDesc.size())
+		return false;
+	try {
+		std::size_t parsed = 0;
+		occurrence = std::stoi(trainDesc.substr(separator + 1), &parsed);
+		if (parsed != trainDesc.size() - separator - 1 || occurrence < 1)
+			return false;
+	} catch (const std::exception&) {
+		return false;
+	}
+	serviceId = trainDesc.substr(0, separator);
+	return true;
+}
+
+bool breakdownMatchesTrain(const SimulationIncident& incident, const std::string& trainDesc) {
+	std::string serviceId;
+	int occurrence = 0;
+	if (!trainOccurrence(trainDesc, serviceId, occurrence) || serviceId != incident.target)
+		return false;
+	return !incident.hasOccurrence || occurrence == incident.occurrence;
+}
+
+bool breakdownActive(const SimulationIncident& incident, const std::string& trainDesc,
+		int timestepIndex) {
+	if (incident.type != "train_breakdown" || !breakdownMatchesTrain(incident, trainDesc)
+			|| timestepIndex < incident.startSeconds)
+		return false;
+	return !runtimeIncidentHasEnd(incident) || timestepIndex < incident.endSeconds;
+}
+} // namespace
+
+const SimulationIncident* Active_Train_Breakdown(const std::string& trainDesc, int timestepIndex) {
+	const SimulationIncident* strictestCap = nullptr;
+	for (const auto& incident : simulationIncidents) {
+		if (!breakdownActive(incident, trainDesc, timestepIndex))
+			continue;
+		if (!incident.hasReducedSpeed)
+			return &incident;
+		if (!strictestCap || incident.reducedSpeedKmh < strictestCap->reducedSpeedKmh)
+			strictestCap = &incident;
+	}
+	return strictestCap;
+}
 
 bool Incident_Holds_Train(const std::string& trainDesc, int timestepIndex) {
-	for (const auto& inc : simulationIncidents) {
-		// trainDescription is "<service>-<n>", so a service target holds every repeat
-		if (inc.type == "train_breakdown" && timestepIndex >= inc.startSeconds && timestepIndex < inc.endSeconds && trainDesc.rfind(inc.target + "-", 0) == 0) {
-			return true;
-		}
-	}
-	return false;
+	const SimulationIncident* incident = Active_Train_Breakdown(trainDesc, timestepIndex);
+	return incident != nullptr && !incident->hasReducedSpeed;
 }
 
 // Apply active signal_failure incidents to the mixed signalling state. The
@@ -5708,7 +5754,8 @@ bool Incident_Holds_Train(const std::string& trainDesc, int timestepIndex) {
 // for it; occupancy alone never reaches the EVC of ETCS level 3 and 4 trains.
 void Apply_Signal_Failures_Mixed_Signalling(int timestepIndex) {
 	for (const auto& inc : simulationIncidents) {
-		if (inc.type != "signal_failure" || timestepIndex < inc.startSeconds || timestepIndex > inc.endSeconds)
+		if (inc.type != "signal_failure" || timestepIndex < inc.startSeconds
+				|| (runtimeIncidentHasEnd(inc) && timestepIndex > inc.endSeconds))
 			continue;
 		for (const auto& secID : inc.resolvedSectionIDs) {
 			bool occupied = false;
@@ -5746,7 +5793,8 @@ void Apply_Signal_Failures_Mixed_Signalling(int timestepIndex) {
 					MA.AbsPosEoA = train_route[r].reversed_direction
 						? anchor.GeoXBegNode - anchorDist
 						: anchor.start_node.X * 1000 + anchorDist;
-					MA.TrainInfo.trainDescription = "signal_failure:" + inc.target;
+					MA.TrainInfo.trainDescription = "signal_failure:"
+							+ (inc.id.empty() ? inc.target : inc.id);
 					MA.TrainInfo.Position = MA.AbsPosEoA;
 					MA.TrainInfo.TrainSpeed = 0;
 					MA.TrainInfo.Acceleration = 0;

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.h
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.h
@@ -22,13 +22,21 @@ void resetNativeInfrastructureState();
 struct SimulationIncident {
 	std::string type;
 	std::string target;
-	double startSeconds;
-	double endSeconds;
+	double startSeconds = 0.0;
+	double endSeconds = 0.0;
 	std::vector<std::string> resolvedSectionIDs; // Resolved section IDs for signal_failure
+	std::string id;
+	bool hasOccurrence = false;
+	int occurrence = 1;
+	bool hasReducedSpeed = false;
+	double reducedSpeedKmh = 0.0;
+	bool terminateAtDestination = false;
+	bool hasEndSeconds = false;
 };
 
 extern std::vector<SimulationIncident> simulationIncidents;
 bool Incident_Holds_Train(const std::string& trainDesc, int timestepIndex);
+const SimulationIncident* Active_Train_Breakdown(const std::string& trainDesc, int timestepIndex);
 void Apply_Signal_Failures_Mixed_Signalling(int timestepIndex);
 
 // --- TrainEvent: ordered train events (departures, arrivals, etc.) ---

--- a/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
@@ -186,8 +186,61 @@ int main() {
 	ok &= expect(simulationIncidents.size() == 2
 			&& simulationIncidents[0].target == "signal.0"
 			&& simulationIncidents[1].target == "service.native", "only the selected scenario reaches runtime incidents");
+	ok &= expect(simulationIncidents[1].id == "incident.breakdown"
+			&& simulationIncidents[1].hasEndSeconds
+			&& !simulationIncidents[1].hasOccurrence
+			&& !simulationIncidents[1].hasReducedSpeed,
+			"legacy breakdown incidents retain full-hold runtime defaults");
 	if (!simulationIncidents.empty())
 		ok &= expect(!simulationIncidents.front().resolvedSectionIDs.empty(), "signal failure resolves its exact runtime section");
+	SceneModel occurrenceSpecific = completeScene();
+	SceneIncident& occurrenceBreakdown = occurrenceSpecific.scenarios[1].incidents[1];
+	occurrenceBreakdown.hasOccurrence = true;
+	occurrenceBreakdown.occurrence = 2;
+	occurrenceBreakdown.hasReducedSpeed = true;
+	occurrenceBreakdown.reducedSpeedKmh = 40.0;
+	occurrenceBreakdown.hasEndSeconds = false;
+	occurrenceBreakdown.endSeconds = 0.0;
+	occurrenceBreakdown.terminateAtDestination = true;
+	const auto occurrenceInfrastructure = buildInfrastructureAndSignallingFromScene(occurrenceSpecific);
+	const auto occurrenceOperations = buildOperationsFromScene(occurrenceSpecific, "scenario.selected");
+	ok &= expect(!hasErrors(occurrenceInfrastructure) && !hasErrors(occurrenceOperations)
+			&& simulationIncidents.size() == 2
+			&& simulationIncidents[1].hasOccurrence && simulationIncidents[1].occurrence == 2
+			&& simulationIncidents[1].hasReducedSpeed
+			&& std::fabs(simulationIncidents[1].reducedSpeedKmh - 40.0) < 1e-9
+			&& Incident_Holds_Train("service.native-2", 50) == false
+			&& regional_train[1].destinationTerminationRequested
+			&& !regional_train[0].destinationTerminationRequested
+			&& !regional_train[2].destinationTerminationRequested,
+			"reduced breakdown staging targets one occurrence and continues without recovery");
+	regional_train[1].directIncidentIds.clear();
+	ok &= expect(std::fabs(regional_train[1].effectiveIncidentSpeedLimit(10.0, 50) - 10.0) < 1e-9
+			&& regional_train[1].directIncidentIds.empty(),
+			"a nonbinding breakdown cap is not recorded as direct evidence");
+	ok &= expect(std::fabs(regional_train[1].effectiveIncidentSpeedLimit(25.0, 50) - 40.0 / 3.6) < 1e-9
+			&& regional_train[1].directIncidentIds == std::vector<std::string>{"incident.breakdown"}
+			&& std::fabs(regional_train[0].effectiveIncidentSpeedLimit(25.0, 50) - 25.0) < 1e-9,
+			"a binding cap records direct evidence only on the targeted occurrence");
+	SimulationIncident overlappingHold = simulationIncidents[1];
+	overlappingHold.id = "incident.hold";
+	overlappingHold.hasReducedSpeed = false;
+	overlappingHold.reducedSpeedKmh = 0.0;
+	overlappingHold.hasEndSeconds = true;
+	overlappingHold.startSeconds = 45.0;
+	overlappingHold.endSeconds = 55.0;
+	simulationIncidents.push_back(overlappingHold);
+	ok &= expect(Incident_Holds_Train("service.native-2", 50)
+			&& Active_Train_Breakdown("service.native-2", 50)->id == "incident.hold",
+			"an overlapping full hold dominates an earlier reduced-speed incident");
+	SimulationIncident strictCap = simulationIncidents[1];
+	strictCap.id = "incident.strict-cap";
+	strictCap.reducedSpeedKmh = 30.0;
+	simulationIncidents.push_back(strictCap);
+	regional_train[1].directIncidentIds.clear();
+	ok &= expect(std::fabs(regional_train[1].effectiveIncidentSpeedLimit(25.0, 60) - 30.0 / 3.6) < 1e-9
+			&& regional_train[1].directIncidentIds == std::vector<std::string>{"incident.strict-cap"},
+			"the strictest concurrent cap supplies the governing direct evidence");
 	ok &= expect(AllStationPlatforms.size() == 3, "native operations reuses the M2 platform list");
 	if (!AllStationPlatforms.empty())
 		ok &= expect(AllStationPlatforms.front().List_Trains_Stopping_At_Platform.front() == "service.native-1",

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -322,6 +322,10 @@ int main() {
 	const std::vector<const Train*> delayedTrains{delayed.get()};
 	const auto delayedResults = buildRunResults(delayedTrains, 0.5);
 	ok &= expect(delayedResults.trains.size() == 1, "one train result");
+	ok &= expect(delayedResults.trains[0].directIncidentIds.empty()
+				 && !delayedResults.trains[0].firstDirectIncidentTime.available
+				 && !delayedResults.trains[0].firstDirectIncidentLocation.available,
+				 "missing direct incident evidence stays unavailable");
 	ok &= expect(delayedResults.trains[0].operatingCode == "1725"
 				 && delayedResults.trains[0].serviceId == "service.native"
 				 && delayedResults.trains[0].occurrence == 2
@@ -341,6 +345,15 @@ int main() {
 	ok &= expect(delayedResults.trains[0].travelSeconds.available &&
 					 closeTo(delayedResults.trains[0].travelSeconds.value, 2.0),
 					 "travel time spans active bounds");
+	delayed->directIncidentIds = {"incident.breakdown"};
+	delayed->firstDirectIncidentTime = 2.0;
+	delayed->firstDirectIncidentLocation = 30.0;
+	const auto directResults = buildRunResults(delayedTrains, 0.5);
+	ok &= expect(directResults.trains[0].firstDirectIncidentTime.available
+				 && closeTo(directResults.trains[0].firstDirectIncidentTime.value, 2.0)
+				 && directResults.trains[0].firstDirectIncidentLocation.available
+				 && closeTo(directResults.trains[0].firstDirectIncidentLocation.value, 30.0),
+				 "recorded direct incident evidence remains available");
 
 	auto gap = makeTrain("gap", 1, 5, 11.0, 21.0, 31.0, 41.0);
 	gap->instant_spatial_position[3] = -9999.0;
@@ -496,6 +509,92 @@ int main() {
 					 regionalRunResults.trains[0].trainId == "regional-first" &&
 					 regionalRunResults.trains[1].trainId == "regional-second",
 					"safe Regional collection keeps both run result rows");
+	}
+
+	{
+		DelayRunSnapshot baseline;
+		baseline.caseRevision = "revision-7";
+		baseline.scenarioId = "baseline";
+		baseline.baseTimeSeconds = 8 * 3600;
+		baseline.durationSeconds = 3600.0;
+		baseline.timestep = 1.0;
+		baseline.hasIncidents = false;
+		baseline.hasEntranceDelays = false;
+		DelayRunSnapshot scenario = baseline;
+		scenario.scenarioId = "incident-run";
+		scenario.hasIncidents = true;
+
+		const auto addIdentity = [](RunResults& results, const std::string& service, int occurrence,
+				const std::string& code, const std::vector<std::string>& incidentIds = {}) {
+			TrainRunResult train;
+			train.trainId = service + "-" + std::to_string(occurrence);
+			train.serviceId = service;
+			train.occurrence = occurrence;
+			train.operatingCode = code;
+			train.directIncidentIds = incidentIds;
+			results.trains.push_back(train);
+		};
+		addIdentity(baseline.run, "service-a", 1, "A1");
+		addIdentity(baseline.run, "service-a", 2, "A2");
+		addIdentity(baseline.run, "service-a", 3, "A3");
+		addIdentity(scenario.run, "service-a", 1, "A1", {"signal-failure-1"});
+		addIdentity(scenario.run, "service-a", 2, "A2");
+		addIdentity(scenario.run, "service-a", 3, "A3");
+		const auto addArrival = [](std::vector<TimetableResultRow>& rows, int occurrence, double arrival) {
+			TimetableResultRow row;
+			row.serviceId = "service-a";
+			row.occurrence = occurrence;
+			row.stationId = "destination";
+			row.simulatedArrivalSeconds = {true, arrival};
+			rows.push_back(row);
+		};
+		addArrival(baseline.timetable, 1, 100.0);
+		addArrival(baseline.timetable, 2, 150.0);
+		addArrival(baseline.timetable, 3, 200.0);
+		addArrival(scenario.timetable, 1, 112.0);
+		addArrival(scenario.timetable, 2, 155.0);
+		addArrival(scenario.timetable, 3, 190.0);
+		scenario.run.trains[0].firstDirectIncidentTime = {true, 80.0};
+		scenario.run.trains[0].firstDirectIncidentLocation = {true, 1234.0};
+		scenario.run.trains[0].destinationTerminationRequested = true;
+		scenario.run.trains[0].destinationTerminated = true;
+
+		const DelayComparisonResult comparison = compareDelayRuns(baseline, scenario);
+		ok &= expect(comparison.valid && comparison.rows.size() == 2
+				&& comparison.rows[0].attribution == "primary"
+				&& comparison.rows[1].attribution == "secondary"
+				&& closeTo(comparison.totalArrivalDelay.value, 17.0),
+				"delay comparison keeps primary plus following-secondary rows and exact total");
+		ok &= expect(comparison.rows[0].incidentIds == std::vector<std::string>{"signal-failure-1"}
+				&& comparison.rows[0].firstDirectTime.available
+				&& closeTo(comparison.rows[0].firstDirectTime.value, 80.0)
+				&& comparison.rows[0].destinationTerminationRequested
+				&& comparison.rows[0].destinationTerminated,
+				"signal-failure direct evidence and destination outcome reach comparison rows");
+
+		DelayRunSnapshot mismatched = scenario;
+		mismatched.run.trains.pop_back();
+		const DelayComparisonResult mismatchResult = compareDelayRuns(baseline, mismatched);
+		ok &= expect(!mismatchResult.valid, "delay comparison rejects selected occurrence identity mismatch");
+		DelayRunSnapshot noEvidence = scenario;
+		for (TrainRunResult& train : noEvidence.run.trains)
+			train.directIncidentIds.clear();
+		const DelayComparisonResult noEvidenceResult = compareDelayRuns(baseline, noEvidence);
+		ok &= expect(!noEvidenceResult.valid, "delay comparison rejects incident runs without direct evidence");
+		DelayRunSnapshot incompleteBaseline = baseline;
+		DelayRunSnapshot incompleteScenario = scenario;
+		TimetableResultRow baselineDestination;
+		baselineDestination.serviceId = "service-a";
+		baselineDestination.occurrence = 1;
+		baselineDestination.stationId = "later-destination";
+		baselineDestination.simulatedArrivalSeconds = {true, 220.0};
+		incompleteBaseline.timetable.push_back(baselineDestination);
+		TimetableResultRow missingScenarioDestination = baselineDestination;
+		missingScenarioDestination.simulatedArrivalSeconds = {};
+		incompleteScenario.timetable.push_back(missingScenarioDestination);
+		const DelayComparisonResult incompleteResult = compareDelayRuns(incompleteBaseline, incompleteScenario);
+		ok &= expect(!incompleteResult.valid,
+				"delay comparison rejects an unavailable final destination arrival");
 	}
 
 	if (!ok)

--- a/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
@@ -280,6 +280,53 @@ int main(int argc, char** argv) {
 			passed = passed && hasCodeAndPath(diagnostics, test.code, test.path);
 		ok &= expect(passed, test.name);
 	}
+	SceneModel reducedBreakdown = clean;
+	SceneIncident& reducedIncident = reducedBreakdown.scenarios[0].incidents[0];
+	reducedIncident.type = "train_breakdown";
+	reducedIncident.target = "service-1";
+	reducedIncident.startSeconds = 300.0;
+	reducedIncident.endSeconds = 0.0;
+	reducedIncident.hasEndSeconds = false;
+	reducedIncident.hasReducedSpeed = true;
+	reducedIncident.reducedSpeedKmh = 40.0;
+	reducedIncident.hasOccurrence = true;
+	reducedIncident.occurrence = 1;
+	ok &= expect(validateRunnableScene(reducedBreakdown).empty(),
+			"reduced-speed breakdown may omit recovery end");
+
+	SceneModel fullHoldWithoutEnd = reducedBreakdown;
+	fullHoldWithoutEnd.scenarios[0].incidents[0].hasReducedSpeed = false;
+	fullHoldWithoutEnd.scenarios[0].incidents[0].reducedSpeedKmh = 0.0;
+	ok &= expect(hasCode(validateRunnableScene(fullHoldWithoutEnd), "scene.incident.window"),
+			"legacy full-hold breakdown requires an end");
+
+	SceneModel invalidBreakdown = reducedBreakdown;
+	invalidBreakdown.scenarios[0].incidents[0].occurrence = 0;
+	ok &= expect(hasCode(validateRunnableScene(invalidBreakdown), "scene.occurrence.invalid"),
+			"breakdown occurrence must be positive");
+	invalidBreakdown = reducedBreakdown;
+	invalidBreakdown.services[0].hasRepeat = true;
+	invalidBreakdown.services[0].headwaySeconds = 30.0;
+	invalidBreakdown.services[0].hasRepeatCount = true;
+	invalidBreakdown.services[0].repeatCount = 1;
+	invalidBreakdown.scenarios[0].incidents[0].occurrence = 2;
+	ok &= expect(hasCode(validateRunnableScene(invalidBreakdown), "scene.occurrence.invalid"),
+			"breakdown occurrence must be inside the configured repeat range");
+	invalidBreakdown = reducedBreakdown;
+	invalidBreakdown.scenarios[0].incidents[0].reducedSpeedKmh = 0.0;
+	ok &= expect(hasCode(validateRunnableScene(invalidBreakdown), "scene.incident.speed"),
+			"reduced breakdown speed must be positive");
+	invalidBreakdown = reducedBreakdown;
+	invalidBreakdown.scenarios[0].incidents[0].hasEndSeconds = true;
+	invalidBreakdown.scenarios[0].incidents[0].endSeconds = 300.0;
+	ok &= expect(hasCode(validateRunnableScene(invalidBreakdown), "scene.incident.window"),
+			"breakdown recovery end must be after start");
+	invalidBreakdown = reducedBreakdown;
+	invalidBreakdown.scenarios[0].incidents[0].terminateAtDestination = true;
+	invalidBreakdown.scenarios[0].incidents[0].type = "signal_failure";
+	invalidBreakdown.scenarios[0].incidents[0].target = "signal-1";
+	ok &= expect(hasCode(validateRunnableScene(invalidBreakdown), "scene.incident.fields"),
+			"signal failures reject breakdown-only fields");
 	SceneService repeated = clean.services[0];
 	repeated.operatingCode = "1723";
 	repeated.hasRepeat = true;

--- a/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
@@ -126,6 +126,13 @@ static SceneModel completeScene() {
 	SceneScenario alternate;
 	alternate.id = "alternate";
 	alternate.name = "Alternate";
+	SceneIncident enhancedBreakdown{"breakdown-2", "train_breakdown", "service-1", 900.0, 0.0};
+	enhancedBreakdown.hasOccurrence = true;
+	enhancedBreakdown.occurrence = 2;
+	enhancedBreakdown.hasReducedSpeed = true;
+	enhancedBreakdown.reducedSpeedKmh = 40.0;
+	enhancedBreakdown.terminateAtDestination = true;
+	alternate.incidents.push_back(enhancedBreakdown);
 	scene.scenarios.push_back(alternate);
 	scene.defaultScenarioId = "baseline";
 
@@ -203,6 +210,12 @@ int main() {
 	}
 	ok &= expect(scenarios["default_scenario_id"] == "baseline", "writer emits default_scenario_id");
 	ok &= expect(scenarios["scenarios"].size() == 2, "writer emits named scenarios");
+	const json& enhancedJson = scenarios["scenarios"][1]["incidents"][0];
+	ok &= expect(enhancedJson["occurrence"] == 2
+			&& enhancedJson["reduced_speed_kmh"] == 40.0
+			&& enhancedJson["terminate_at_destination"] == true
+			&& !enhancedJson.contains("end_seconds"),
+			"writer preserves occurrence-specific reduced breakdown without recovery end");
 
 	const fs::path standaloneScenarioPath = temp.path / "baseline-scenario.json";
 	const SceneSaveResult standaloneSave = saveScenarioJson(source.scenarios[0], standaloneScenarioPath.string());
@@ -272,8 +285,18 @@ int main() {
 				&& reloaded.services[0].hasOperatingCodeStep
 				&& reloaded.services[0].operatingCodeStep == 2,
 				"optional service runtime properties round-trip");
+	ok &= expect(reloaded.scenarios[1].incidents.size() == 1
+				&& reloaded.scenarios[1].incidents[0].hasOccurrence
+				&& reloaded.scenarios[1].incidents[0].occurrence == 2
+				&& reloaded.scenarios[1].incidents[0].hasReducedSpeed
+				&& reloaded.scenarios[1].incidents[0].reducedSpeedKmh == 40.0
+				&& !reloaded.scenarios[1].incidents[0].hasEndSeconds
+				&& reloaded.scenarios[1].incidents[0].terminateAtDestination,
+				"enhanced breakdown fields round-trip through canonical scene files");
 
 	SceneModel legacyDefaults = completeScene();
+	legacyDefaults.scenarios[1].incidents[0].hasReducedSpeed = false;
+	legacyDefaults.scenarios[1].incidents[0].reducedSpeedKmh = 40.125;
 	const fs::path legacyDefaultsPath = temp.path / "legacy-defaults";
 	ok &= expect(saveScene(legacyDefaults, legacyDefaultsPath.string()).success(),
 			"legacy-default service still saves");
@@ -282,6 +305,14 @@ int main() {
 		std::ifstream input(legacyDefaultsPath / "services.json");
 		input >> legacyServices;
 	}
+	json normalizedScenarios;
+	{
+		std::ifstream input(legacyDefaultsPath / "scenarios.json");
+		input >> normalizedScenarios;
+	}
+	ok &= expect(normalizedScenarios["scenarios"][1]["incidents"][0]["reduced_speed_kmh"] == 40.125
+			&& !normalizedScenarios["scenarios"][1]["incidents"][0].contains("end_seconds"),
+			"writer preserves a nonzero reduced speed when its presence flag is stale");
 	ok &= expect(!legacyServices["services"][0].contains("performance_percent")
 				&& !legacyServices["services"][0].contains("maximum_speed_kmh")
 				&& !legacyServices["services"][0].contains("repeat"),

--- a/docs/architecture/scene-schema.md
+++ b/docs/architecture/scene-schema.md
@@ -169,9 +169,30 @@ ID selects one named scenario. Each scenario has required `id`, `name`, and
 `incidents` array; it may have `description` and `entrance_delays`.
 
 Each incident is concrete input with `id`, `type` (`signal_failure` or
-`train_breakdown`), `target`, `start_seconds`, and `end_seconds`. An entrance
-delay has `service`, optional integer `occurrence`, `station`, and numeric
+`train_breakdown`), `target`, and finite non-negative `start_seconds`.
+`end_seconds` is explicitly optional in the JSON shape, but is required for
+signal failures and legacy full-hold breakdowns. A breakdown with
+`reduced_speed_kmh` may omit `end_seconds`; its positive finite speed cap then
+continues until the target reaches its normal route end. When present, an end
+is recovery time and the breakdown interval is `[start_seconds, end_seconds)`.
+The optional breakdown fields are:
+
+- `occurrence`: positive 1-based service occurrence. When omitted, the
+  breakdown targets every occurrence of the canonical `target` service.
+- `reduced_speed_kmh`: positive finite effective-trajectory speed cap. It
+  changes neither composition data nor the canonical service maximum.
+- `terminate_at_destination`: boolean request retained after recovery; the
+  result is marked when that occurrence reaches its authored route end.
+
+The occurrence must be inside the service's configured repeat range. Signal
+failures accept only the legacy target/start/end fields. An entrance delay has
+`service`, optional integer `occurrence`, `station`, and numeric
 `delay_seconds`.
+
+The four-column legacy `Incidents.txt` exporter cannot represent an enhanced
+breakdown (occurrence, reduced speed, destination termination, or an omitted
+end), so it skips that row with a compatibility diagnostic instead of
+exporting full-hold semantics.
 
 If `scenarios.json` is absent, loading creates a baseline scenario. A legacy
 `incidents.json` is read into that baseline for compatibility. Saving writes
@@ -206,6 +227,36 @@ not diverge between the two forms. The editor checks incident types/targets
 and entrance-delay references against the open scene before importing. A
 conflicting scenario or incident ID is never used as-is; the imported object
 is added with a reported unique ID.
+
+An occurrence-specific reduced-speed breakdown can instead be authored as:
+
+```json
+{"id": "breakdown-2", "type": "train_breakdown", "target": "service-1",
+ "start_seconds": 900, "occurrence": 2, "reduced_speed_kmh": 40,
+ "terminate_at_destination": true}
+```
+
+### Delay comparison provenance
+
+The results UI can freeze a completed incident-free, no-entrance-delay run as
+the delay baseline. A comparison run must contain incidents, no entrance
+delays, and the same scene revision, base time, duration, timestep, and full
+selected `(service_id, occurrence)` identity set; its scenario ID must differ
+from the baseline. Baseline and scenario results are value snapshots, not
+runtime train pointers.
+
+For each occurrence, final arrival is the simulated arrival at its last
+authored timetable station and call. Baseline and scenario must use the same
+endpoint and both arrivals must be available; otherwise comparison is rejected.
+Only positive `scenario - baseline` values are rows, and their exact sum is
+the total arrival delay. A positive row is `primary` only when the scenario
+occurrence has direct runtime evidence (incident ID plus first direct time and
+location); otherwise it is `secondary`. No attribution is inferred from a
+timetable difference alone. A comparison is rejected when the incident run
+has no direct evidence anywhere. Signal-failure evidence is direct only when
+the train stops at an active `SignalFailure` EoA; a breakdown hold or applied
+speed cap is direct evidence. Destination request and termination outcome are
+reported with each row.
 
 ## `passengers.json`
 

--- a/docs/guides/scenes-and-application.md
+++ b/docs/guides/scenes-and-application.md
@@ -85,6 +85,21 @@ are cleared when the case or scenario changes and are rebuilt only by a new
 run, so a result window is never presented as belonging to a newly selected
 scenario.
 
+The incident editor exposes occurrence, reduced-speed cap, recovery end (or
+until-destination), and destination termination directly; these are not hidden
+JSON-only settings. A completed incident-free run can be frozen with **Set
+delay baseline**. Selecting another scenario retains that baseline, while a
+canonical scene edit, **New**, or **Open** clears it and advances the local
+scene revision. **Compare delays** requires an incident run with no entrance
+delays and matching scene revision, base time, duration, timestep, and full
+selected `(service_id, occurrence)` identity set. The compact table and CSV
+show baseline/scenario identities, matching final authored timetable arrivals,
+positive contribution, primary/secondary attribution, incident IDs, first
+direct time/location, and destination-termination outcome. Primary means direct runtime evidence exists
+for that occurrence; secondary means it does not. Timetable differences alone
+are never treated as causal, and a comparison with no direct evidence anywhere
+is rejected. Positive contribution rows sum exactly to total arrival delay.
+
 ## Portable bundles
 
 V2 `.egscene` files package canonical V1 JSON in a deterministic ZIP archive.

--- a/docs/guides/v1-scene-properties.md
+++ b/docs/guides/v1-scene-properties.md
@@ -171,11 +171,46 @@ stops may be marked `through: true`; a repeated service uses a positive
 }
 ```
 
-An incident is concrete input with `id`, `type`, `target`, `start_seconds`,
-and `end_seconds`. Valid types are `signal_failure` and `train_breakdown`.
-An entrance delay has `service`, optional `occurrence`, `station`, and
-`delay_seconds`. If no scenario file is supplied, the loader creates a
-baseline; the historical flat incident file is read into that baseline.
+An incident is concrete input with `id`, `type`, `target`, and finite
+non-negative `start_seconds`. Valid types are `signal_failure` and
+`train_breakdown`. Signal failures require `end_seconds`; the interval is
+start-inclusive and end-inclusive for compatibility. Legacy full-hold
+breakdowns also require an end, with `[start_seconds, end_seconds)` semantics.
+A reduced-speed breakdown may omit `end_seconds`, in which case its cap lasts
+until the targeted occurrence reaches its normal route end. When present,
+`end_seconds` is recovery time.
+
+Breakdown-only optional fields are:
+
+- `occurrence`: positive 1-based occurrence of the target service. Omit it to
+  target every occurrence; a configured occurrence must be within the service
+  repeat range.
+- `reduced_speed_kmh`: positive finite cap on the matched occurrence's
+  effective trajectory speed. It does not mutate composition or service
+  maximum-speed data.
+- `terminate_at_destination`: retain a destination-termination request after
+  recovery and report whether the occurrence reached its normal route end.
+
+Signal failures reject these breakdown-only fields. The four-column legacy
+`Incidents.txt` export skips enhanced breakdowns and emits a compatibility
+diagnostic because it cannot encode occurrence, cap, recovery omission, or
+termination semantics.
+
+If no scenario file is supplied, the loader creates a baseline; the historical
+flat incident file is read into that baseline.
+
+The current results UI can freeze an incident-free, no-entrance-delay run with
+**Set delay baseline**. An incident comparison must have incidents and no
+entrance delays, different scenario IDs, and matching scene revision, base
+time, duration, timestep, and selected `(service_id, occurrence)` identities.
+Final arrival is the simulated arrival at the last authored timetable station
+and call. The endpoint must match and be available in both runs. Only positive
+scenario-minus-baseline contributions are included, and their exact sum is the
+total delay. A positive row is `primary` only when that occurrence has direct
+runtime incident evidence; otherwise it is `secondary`. Timetable differences
+alone never establish causality, and comparison is rejected if the incident
+run has no direct evidence anywhere. The table/CSV includes incident IDs,
+first direct time/location, and destination termination outcome.
 
 ## Passengers
 


### PR DESCRIPTION
## Summary

- target one repeated service occurrence with a reduced-speed breakdown and destination termination
- retain direct incident evidence and compare frozen baseline and scenario runs at matching final timetable endpoints
- expose incident controls, delay attribution, totals, and CSV output through the existing editor and result paths
- preserve legacy full-hold behavior and skip enhanced breakdowns during explicit legacy export

## Verification

- complete build passed
- CTest passed 43/43
- editor, incident, CSV, visual, native, and round-trip smokes passed
- independent correctness review and affected-area re-reviews are clean
- Review removed redundant cap, export, selection, and evidence paths

Closes #51
Closes #52
Advances #7
Advances #4

Exact S451 and IC 1727 assignment rehearsal still depends on sourced corridor and signalling work in #182 and #218. No railway values were inferred.