### PR TITLE
Add canonical signalling areas and assignment workflow guidance

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -1898,6 +1898,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_infrastructureFacetCombo->addItem("Stations", "stations");
 	m_infrastructureFacetCombo->addItem("Platforms", "platforms");
 	m_infrastructureFacetCombo->addItem("Signals", "signals");
+	m_infrastructureFacetCombo->addItem("Signalling area", "signalling_areas");
 	m_infrastructureFacetCombo->addItem("Routes", "routes");
 	m_infrastructureFacetCombo->addItem("Block dependencies", "block_dependencies");
 	m_infrastructureFacetCombo->addItem("Single-track restrictions", "single_track_restrictions");
@@ -3517,6 +3518,9 @@ std::string MainWindow::uniqueInfrastructureId(const std::string& baseId, const 
 		if (facet == "signals")
 			return std::any_of(sceneSignals(m_sceneModel).begin(), sceneSignals(m_sceneModel).end(),
 							   [&id](const SceneSignal& item) { return item.id == id; });
+		if (facet == "signalling_areas")
+			return std::any_of(m_sceneModel.signallingAreas.begin(), m_sceneModel.signallingAreas.end(),
+							   [&id](const SceneSignallingArea& item) { return item.id == id; });
 		return std::any_of(m_sceneModel.routes.begin(), m_sceneModel.routes.end(),
 						   [&id](const SceneRoute& item) { return item.id == id; });
 	};
@@ -3576,6 +3580,8 @@ void MainWindow::refreshInfrastructureTable() {
 		headers << "Station ID" << "ID" << "Nodes";
 	else if (facet == "signals")
 		headers << "ID";
+	else if (facet == "signalling_areas")
+		headers << "ID" << "Start km" << "End km" << "Level" << "Track ID";
 	else if (facet == "routes")
 		headers << "ID" << "Blocks" << "Has corridor" << "Corridor" << "Reversed";
 	else if (facet == "block_dependencies")
@@ -3664,6 +3670,16 @@ void MainWindow::refreshInfrastructureTable() {
 		m_infrastructureTable->setRowCount(static_cast<int>(signalsList.size()));
 		for (int row = 0; row < m_infrastructureTable->rowCount(); ++row)
 			setCell(row, 0, QString::fromStdString(signalsList[static_cast<std::size_t>(row)].id));
+	} else if (facet == "signalling_areas") {
+		m_infrastructureTable->setRowCount(static_cast<int>(m_sceneModel.signallingAreas.size()));
+		for (int row = 0; row < m_infrastructureTable->rowCount(); ++row) {
+			const SceneSignallingArea& area = m_sceneModel.signallingAreas[static_cast<std::size_t>(row)];
+			setCell(row, 0, QString::fromStdString(area.id));
+			setCell(row, 1, QString::number(area.startKm, 'g', precision));
+			setCell(row, 2, QString::number(area.endKm, 'g', precision));
+			setCell(row, 3, QString::number(area.level));
+			setCell(row, 4, QString::fromStdString(area.trackId));
+		}
 	} else if (facet == "routes") {
 		m_infrastructureTable->setRowCount(static_cast<int>(m_sceneModel.routes.size()));
 		for (int row = 0; row < m_infrastructureTable->rowCount(); ++row) {
@@ -3830,6 +3846,9 @@ void MainWindow::commitInfrastructureCell(int row, int column) {
 			for (auto& block : m_sceneModel.blocks)
 				if (block.trackId == oldId)
 					block.trackId = newId;
+			for (auto& area : m_sceneModel.signallingAreas)
+				if (area.trackId == oldId)
+					area.trackId = newId;
 			m_infrastructureSelectionId = value;
 			changed = true;
 		}
@@ -4090,6 +4109,39 @@ void MainWindow::commitInfrastructureCell(int row, int column) {
 			m_infrastructureSelectionId = value;
 			changed = true;
 		}
+	} else if (facet == "signalling_areas" && row < static_cast<int>(m_sceneModel.signallingAreas.size())) {
+		SceneSignallingArea& area = m_sceneModel.signallingAreas[static_cast<std::size_t>(row)];
+		if (column == 0) {
+			const std::string oldId = area.id;
+			const std::string newId = value.toStdString();
+			if (oldId != newId) {
+				if (!idCanReplaceRow(m_sceneModel.signallingAreas, newId)) {
+					rejectUnsafeId();
+					return;
+				}
+				area.id = newId;
+				m_infrastructureSelectionId = value;
+				changed = true;
+			}
+		} else if (column == 1) {
+			parseNumber(area.startKm);
+		} else if (column == 2) {
+			parseNumber(area.endKm);
+		} else if (column == 3) {
+			bool parsed = false;
+			const int level = value.toInt(&parsed);
+			if (!parsed) {
+				refreshInfrastructureTable();
+				return;
+			}
+			if (area.level != level) {
+				area.level = level;
+				changed = true;
+			}
+		} else if (column == 4 && area.trackId != value.toStdString()) {
+			area.trackId = value.toStdString();
+			changed = true;
+		}
 	} else if (facet == "routes" && row < static_cast<int>(m_sceneModel.routes.size())) {
 		SceneRoute& route = m_sceneModel.routes[static_cast<std::size_t>(row)];
 		if (column == 0) {
@@ -4241,6 +4293,10 @@ void MainWindow::addInfrastructureEntity() {
 		id = uniqueInfrastructureId("signal", facet);
 		sceneSignals(m_sceneModel).push_back({id});
 		newRow = static_cast<int>(sceneSignals(m_sceneModel).size()) - 1;
+	} else if (facet == "signalling_areas") {
+		id = uniqueInfrastructureId("signalling-area", facet);
+		m_sceneModel.signallingAreas.push_back({id, 0.0, 0.0, 0, {}});
+		newRow = static_cast<int>(m_sceneModel.signallingAreas.size()) - 1;
 	} else if (facet == "routes") {
 		id = uniqueInfrastructureId("route", facet);
 		m_sceneModel.routes.push_back({id, {}, false, {}, false});
@@ -4295,7 +4351,16 @@ void MainWindow::deleteInfrastructureEntity() {
 		}
 	}
 	QString referenceSummary;
-	if (facet == "stations" && row < static_cast<int>(m_sceneModel.stations.size())) {
+	if (facet == "tracks" && row < static_cast<int>(m_sceneModel.tracks.size())) {
+		const std::string trackId = m_sceneModel.tracks[static_cast<std::size_t>(row)].id;
+		int areaCount = 0;
+		for (const auto& area : m_sceneModel.signallingAreas)
+			if (area.trackId == trackId)
+				++areaCount;
+		referenceSummary = areaCount == 0
+			? QStringLiteral("No signalling-area references")
+			: QStringLiteral("Referencing signalling areas: %1").arg(areaCount);
+	} else if (facet == "stations" && row < static_cast<int>(m_sceneModel.stations.size())) {
 		const std::string stationId = m_sceneModel.stations[static_cast<std::size_t>(row)].id;
 		QMap<QString, int> serviceCounts;
 		for (const auto& service : m_sceneModel.services)
@@ -4358,6 +4423,8 @@ void MainWindow::deleteInfrastructureEntity() {
 			m_sceneModel.stations[static_cast<std::size_t>(stationIndex)].platforms.begin() + platformIndex);
 	else if (facet == "signals" && row < static_cast<int>(sceneSignals(m_sceneModel).size()))
 		sceneSignals(m_sceneModel).erase(sceneSignals(m_sceneModel).begin() + row);
+	else if (facet == "signalling_areas" && row < static_cast<int>(m_sceneModel.signallingAreas.size()))
+		m_sceneModel.signallingAreas.erase(m_sceneModel.signallingAreas.begin() + row);
 	else if (facet == "routes" && row < static_cast<int>(m_sceneModel.routes.size()))
 		m_sceneModel.routes.erase(m_sceneModel.routes.begin() + row);
 	else if (facet == "block_dependencies" && row < static_cast<int>(m_sceneModel.blockDependencies.size()))
@@ -9489,6 +9556,7 @@ void MainWindow::runEditorSmokeE2E() {
 	std::vector<SceneBlockDependency> expectedBlockDependencies;
 	std::vector<SceneSingleTrackRestriction> expectedSingleTrackRestrictions;
 	std::vector<SceneStationBoundary> expectedStationBoundaries;
+	std::vector<SceneSignallingArea> expectedSignallingAreas;
 	std::vector<SceneStation> expectedStations;
 	std::vector<SceneSignal> expectedSignals;
 	std::vector<SceneService> expectedNewCaseServices;
@@ -9602,6 +9670,16 @@ void MainWindow::runEditorSmokeE2E() {
 			return false;
 		return std::equal(left.begin(), left.end(), right.begin(), [](const SceneSignal& a, const SceneSignal& b) {
 			return a.id == b.id;
+		});
+	};
+	auto sameSignallingAreas = [](const std::vector<SceneSignallingArea>& left,
+			const std::vector<SceneSignallingArea>& right) {
+		if (left.size() != right.size())
+			return false;
+		return std::equal(left.begin(), left.end(), right.begin(), [](const SceneSignallingArea& a,
+				const SceneSignallingArea& b) {
+			return a.id == b.id && a.startKm == b.startKm && a.endKm == b.endKm
+				&& a.level == b.level && a.trackId == b.trackId;
 		});
 	};
 	auto sameInfrastructure = [](const SceneModel& left, const std::vector<SceneTrack>& tracks,
@@ -9813,6 +9891,35 @@ void MainWindow::runEditorSmokeE2E() {
 					facetFailure(facetOk, "stations/signalling", "platform table authoring or station move did not apply");
 				if (!addInfrastructureRow("signals") || !setInfrastructureCell("signals", 0, 0, "e2e-signal"))
 					facetFailure(facetOk, "stations/signalling", "signal table authoring did not apply");
+				if (!addInfrastructureRow("signalling_areas"))
+					facetFailure(facetOk, "stations/signalling", "signalling area row could not be added");
+				const bool signallingAreaStartsInvalid = m_sceneModel.signallingAreas.size() == 1
+						&& m_sceneModel.signallingAreas.front().startKm == 0.0
+						&& m_sceneModel.signallingAreas.front().endKm == 0.0
+						&& m_sceneModel.signallingAreas.front().level == 0
+						&& m_sceneModel.signallingAreas.front().trackId.empty();
+				if (!signallingAreaStartsInvalid)
+					facetFailure(facetOk, "stations/signalling", "Add did not create an inert signalling area row");
+				if (!setInfrastructureCell("signalling_areas", 0, 0, "e2e-signalling-area")
+						|| !setInfrastructureCell("signalling_areas", 0, 1, "0.25")
+						|| !setInfrastructureCell("signalling_areas", 0, 2, "1.75")
+						|| !setInfrastructureCell("signalling_areas", 0, 3, "4"))
+					facetFailure(facetOk, "stations/signalling", "network-wide signalling area authoring did not apply");
+				const bool networkAreaAuthored = m_sceneModel.signallingAreas.size() == 1
+						&& m_sceneModel.signallingAreas.front().id == "e2e-signalling-area"
+						&& m_sceneModel.signallingAreas.front().level == 4
+						&& m_sceneModel.signallingAreas.front().trackId.empty();
+				if (!networkAreaAuthored)
+					facetFailure(facetOk, "stations/signalling", "network-wide signalling area was not canonical");
+				if (!setInfrastructureCell("signalling_areas", 0, 4, "e2e-main")
+						|| m_sceneModel.signallingAreas.front().trackId != "e2e-main")
+					facetFailure(facetOk, "stations/signalling", "signalling area track-scope edit did not apply");
+				const bool areaTrackRenameUpdated = setInfrastructureCell("tracks", 0, 0, "e2e-main-renamed")
+						&& m_sceneModel.signallingAreas.front().trackId == "e2e-main-renamed"
+						&& setInfrastructureCell("tracks", 0, 0, "e2e-main")
+						&& m_sceneModel.signallingAreas.front().trackId == "e2e-main";
+				if (!areaTrackRenameUpdated)
+					facetFailure(facetOk, "stations/signalling", "track rename did not preserve signalling-area scope");
 				if (!addInfrastructureRow("routes") || !setInfrastructureCell("routes", 0, 0, "e2e-block-route") || !setInfrastructureCell("routes", 0, 1, QString::fromStdString("@" + oldBlockId + "@-0.25/@" + secondBlockId + "@-0.50")) || !setInfrastructureCell("routes", 0, 2, "true") || !setInfrastructureCell("routes", 0, 3, "e2e-corridor") || !setInfrastructureCell("routes", 0, 4, "true"))
 					facetFailure(facetOk, "stations/signalling", "route table authoring did not apply");
 				if (!addInfrastructureRow("block_dependencies") || !setInfrastructureCell("block_dependencies", 0, 0, QString::fromStdString("@" + oldBlockId + "@-1.0")) || !setInfrastructureCell("block_dependencies", 0, 1, QString::fromStdString(secondBlockId)) || !addInfrastructureRow("single_track_restrictions") || !setInfrastructureCell("single_track_restrictions", 0, 0, QString::fromStdString(oldBlockId)) || !setInfrastructureCell("single_track_restrictions", 0, 1, QString::fromStdString(secondBlockId)) || !setInfrastructureCell("single_track_restrictions", 0, 2, QString::fromStdString("@" + oldBlockId + "@-1.0/@" + secondBlockId + "@-2.0")) || !setInfrastructureCell("single_track_restrictions", 0, 3, QString::fromStdString(secondBlockId)) || !addInfrastructureRow("station_boundaries") || !setInfrastructureCell("station_boundaries", 0, 0, QString::fromStdString("@" + oldBlockId + "@-3.0")) || !setInfrastructureCell("station_boundaries", 0, 1, "true") || !setInfrastructureCell("station_boundaries", 0, 2, QString::fromStdString(secondBlockId)) || !setInfrastructureCell("station_boundaries", 0, 3, "false"))
@@ -9893,6 +10000,7 @@ void MainWindow::runEditorSmokeE2E() {
 				expectedBlockDependencies = m_sceneModel.blockDependencies;
 				expectedSingleTrackRestrictions = m_sceneModel.singleTrackRestrictions;
 				expectedStationBoundaries = m_sceneModel.stationBoundaries;
+				expectedSignallingAreas = m_sceneModel.signallingAreas;
 				expectedStations = m_sceneModel.stations;
 				expectedSignals = sceneSignals(m_sceneModel);
 				expectedNewCaseServices = m_sceneModel.services;
@@ -9923,7 +10031,7 @@ void MainWindow::runEditorSmokeE2E() {
 			std::string expectedDescription = "new case editor smoke";
 			const auto verifyNewCase = [&]() {
 				const SceneScenario* scenario = defaultScenario(static_cast<const SceneModel&>(m_sceneModel));
-				return m_sceneLoaded && !m_sceneDirty && m_sceneModel.schemaVersion == 1 && m_sceneModel.name == expectedName && m_sceneModel.description == expectedDescription && m_sceneModel.baseTime == "09:15:30" && m_sceneModel.settings.hasDuration && m_sceneModel.settings.durationSeconds == 7200.0 && m_sceneModel.settings.hasBufferTime && m_sceneModel.settings.bufferTimeSeconds == 30.0 && m_sceneModel.settings.hasRecoveryTime && m_sceneModel.settings.recoveryTimePercent == 7.5 && m_sceneModel.defaultScenarioId == "baseline" && scenario && scenario->id == "baseline" && scenario->name == "Baseline" && sameIncidents(scenario->incidents, expectedNewCaseIncidents) && scenario->entranceDelays.empty() && (expectedTracks.empty() || sameInfrastructure(m_sceneModel, expectedTracks, expectedNodes, expectedArcs, expectedBlocks, expectedConnections)) && (expectedRoutes.empty() || sameBlockReferences(m_sceneModel, expectedRoutes, expectedBlockDependencies, expectedSingleTrackRestrictions, expectedStationBoundaries)) && (expectedStations.empty() || sameStations(m_sceneModel.stations, expectedStations)) && (expectedSignals.empty() || sameSignals(sceneSignals(m_sceneModel), expectedSignals)) && (expectedNewCaseServices.empty() || sameServices(m_sceneModel.services, expectedNewCaseServices));
+				return m_sceneLoaded && !m_sceneDirty && m_sceneModel.schemaVersion == 1 && m_sceneModel.name == expectedName && m_sceneModel.description == expectedDescription && m_sceneModel.baseTime == "09:15:30" && m_sceneModel.settings.hasDuration && m_sceneModel.settings.durationSeconds == 7200.0 && m_sceneModel.settings.hasBufferTime && m_sceneModel.settings.bufferTimeSeconds == 30.0 && m_sceneModel.settings.hasRecoveryTime && m_sceneModel.settings.recoveryTimePercent == 7.5 && m_sceneModel.defaultScenarioId == "baseline" && scenario && scenario->id == "baseline" && scenario->name == "Baseline" && sameIncidents(scenario->incidents, expectedNewCaseIncidents) && scenario->entranceDelays.empty() && (expectedTracks.empty() || sameInfrastructure(m_sceneModel, expectedTracks, expectedNodes, expectedArcs, expectedBlocks, expectedConnections)) && (expectedRoutes.empty() || sameBlockReferences(m_sceneModel, expectedRoutes, expectedBlockDependencies, expectedSingleTrackRestrictions, expectedStationBoundaries)) && (expectedSignallingAreas.empty() || sameSignallingAreas(m_sceneModel.signallingAreas, expectedSignallingAreas)) && (expectedStations.empty() || sameStations(m_sceneModel.stations, expectedStations)) && (expectedSignals.empty() || sameSignals(sceneSignals(m_sceneModel), expectedSignals)) && (expectedNewCaseServices.empty() || sameServices(m_sceneModel.services, expectedNewCaseServices));
 			};
 			if (!openSceneDirectory(newCaseFolder) || !verifyNewCase())
 				facetFailure(facetOk, "new case", "folder save did not reopen with the edited settings");

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
@@ -407,13 +407,14 @@ void refreshLoadedDataSummary(SceneModel& scene) {
 	for (const auto& composition : scene.compositions)
 		addTarget(compositions, composition.id, "rolling_stock.json", "composition");
 
-	int signallingCount = static_cast<int>(scene.signals.size() + scene.routes.size()
+	int signallingCount = static_cast<int>(scene.signals.size() + scene.signallingAreas.size() + scene.routes.size()
 			+ scene.blockDependencies.size() + scene.singleTrackRestrictions.size()
 			+ scene.stationBoundaries.size());
 	add("signalling", "signalling.json", signallingCount);
 	scene.loadedData.back().targetType = "network";
 	const std::string signallingStatus = scene.loadedData.back().status;
 	addChild("signals", "signalling.json", static_cast<int>(scene.signals.size()), signallingStatus).targetType = "network";
+	addChild("signalling_areas", "signalling.json", static_cast<int>(scene.signallingAreas.size()), signallingStatus).targetType = "network";
 	addChild("routes", "signalling.json", static_cast<int>(scene.routes.size()), signallingStatus).targetType = "network";
 	addChild("dependencies", "signalling.json", static_cast<int>(scene.blockDependencies.size()), signallingStatus).targetType = "network";
 	addChild("restrictions", "signalling.json", static_cast<int>(scene.singleTrackRestrictions.size()
@@ -863,6 +864,19 @@ SceneLoadResult loadScene(const std::string& sceneDir) {
 				SceneSignal signal;
 				stringField(signallingJson["signals"][index], "id", "signalling.json", path, signal.id);
 				result.scene.signals.push_back(signal);
+			}
+		}
+		if (arraySection(signallingJson, "signalling_areas", "signalling.json", "", false)) {
+			for (std::size_t index = 0; index < signallingJson["signalling_areas"].size(); ++index) {
+				const std::string path = "signalling_areas[" + std::to_string(index) + "]";
+				const json& value = signallingJson["signalling_areas"][index];
+				SceneSignallingArea area;
+				stringField(value, "id", "signalling.json", path, area.id);
+				numberField(value, "start_km", "signalling.json", path, area.startKm);
+				numberField(value, "end_km", "signalling.json", path, area.endKm);
+				integerField(value, "level", "signalling.json", path, area.level);
+				stringField(value, "track", "signalling.json", path, area.trackId, false);
+				result.scene.signallingAreas.push_back(std::move(area));
 			}
 		}
 		if (arraySection(signallingJson, "routes", "signalling.json", "", true)) {

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.h
@@ -64,6 +64,14 @@ struct SceneStation {
 
 struct SceneSignal { std::string id; };
 
+struct SceneSignallingArea {
+	std::string id;
+	double startKm = 0.0;
+	double endKm = 0.0;
+	int level = 0;
+	std::string trackId; // Empty means network-wide.
+};
+
 struct SceneRoute {
 	std::string id;
 	std::vector<std::string> blocks;
@@ -265,6 +273,7 @@ struct SceneModel {
 	std::vector<SceneConnection> connections;
 	std::vector<SceneStation> stations;
 	std::vector<SceneSignal> signals;
+	std::vector<SceneSignallingArea> signallingAreas;
 	std::vector<SceneRoute> routes;
 	std::vector<SceneBlockDependency> blockDependencies;
 	std::vector<SceneSingleTrackRestriction> singleTrackRestrictions;

--- a/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
@@ -563,6 +563,27 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 
 	std::unordered_set<std::string> signalIds;
 	collectIds(scene.signals, "signalling.json", "signal", "signals", diagnostics, signalIds);
+	std::unordered_set<std::string> signallingAreaIds;
+	collectIds(scene.signallingAreas, "signalling.json", "signalling area", "signalling_areas",
+			diagnostics, signallingAreaIds);
+	for (std::size_t index = 0; index < scene.signallingAreas.size(); ++index) {
+		const SceneSignallingArea& area = scene.signallingAreas[index];
+		const std::string path = "signalling_areas[" + std::to_string(index) + "]";
+		if (!std::isfinite(area.startKm) || !std::isfinite(area.endKm)
+				|| !(area.startKm < area.endKm))
+			diagnostics.error("scene.signalling_area.range",
+				"Signalling area start_km and end_km must be finite with start_km below end_km",
+				"signalling.json", "signalling_area", area.id, path, area.id,
+				"Use a finite increasing coordinate range");
+		if (area.level < 0 || area.level > 5)
+			diagnostics.error("scene.signalling_area.level", "Signalling area level must be between 0 and 5",
+				"signalling.json", "signalling_area", area.id, path + ".level", area.trackId,
+				"Use a signalling level from 0 through 5");
+		if (!area.trackId.empty() && !hasId(trackIds, area.trackId))
+			diagnostics.error("scene.ref.unresolved", "Signalling area refers to unknown track",
+				"signalling.json", "signalling_area", area.id, path + ".track", area.trackId,
+				"Add the track or leave track blank for a network-wide area");
+	}
 	std::unordered_set<std::string> routeIds;
 	collectIds(scene.routes, "signalling.json", "route", "routes", diagnostics, routeIds);
 	std::unordered_set<std::string> routeBlockIds;
@@ -1107,7 +1128,15 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 				double startX = 0.0;
 				double endX = 0.0;
 			};
+			struct PlannedSignallingSection {
+				std::string id;
+				double startX = 0.0;
+				double endX = 0.0;
+				std::string firstTrackId;
+				std::string secondTrackId;
+			};
 			std::vector<NativeBlockPlan> blockPlans;
+			std::vector<PlannedSignallingSection> plannedSignallingSections;
 			std::vector<const SceneTrack*> orderedTracks;
 			orderedTracks.reserve(scene.tracks.size());
 			for (const auto& track : scene.tracks)
@@ -1187,6 +1216,8 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 					runtimeCapacity("Canonical block IDs normalize to the same native runtime section ID",
 							"infrastructure.json", "block", plan.source->id, "blocks", runtimeId,
 							"Give each block a distinct native runtime section ID");
+				plannedSignallingSections.push_back(
+						{runtimeId, plan.startX, plan.endX, plan.trackId, {}});
 			}
 			auto plannedRuntimeId = [&](const std::string& reference) {
 				if (plannedSectionIds.find(reference) != plannedSectionIds.end())
@@ -1228,6 +1259,8 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 							runtimeCapacity("Connections produce the same native runtime switch section ID",
 									"infrastructure.json", "connection", connection.id, "connections", derivedId,
 									"Give each switch connection a distinct runtime section ID");
+						plannedSignallingSections.push_back({derivedId, firstPlan.startX, secondPlan.endX,
+								firstPlan.trackId, secondPlan.trackId});
 						int derivedArcCount = 1;
 						for (const SceneArc* arc : nativeChainArcs[firstPlan.trackId]) {
 							const auto fromNode = nodesById.find(arc->fromNodeId);
@@ -1255,6 +1288,36 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 							runtimeCapacity("Derived switch section exceeds the runtime arc capacity",
 									"infrastructure.json", "connection", connection.id, "connections",
 									std::to_string(kNativeMaxSectionArcs), "Reduce the connected block spans");
+					}
+				}
+			}
+			for (const PlannedSignallingSection& section : plannedSignallingSections) {
+				for (const bool trackScoped : {false, true}) {
+					const SceneSignallingArea* matched = nullptr;
+					for (std::size_t areaIndex = 0; areaIndex < scene.signallingAreas.size(); ++areaIndex) {
+						const SceneSignallingArea& area = scene.signallingAreas[areaIndex];
+						if (!std::isfinite(area.startKm) || !std::isfinite(area.endKm)
+								|| !(area.startKm < area.endKm) || area.level < 0 || area.level > 5
+								|| area.trackId.empty() != !trackScoped
+								|| section.startX < area.startKm - kNativeCoordinateTolerance
+								|| section.endX > area.endKm + kNativeCoordinateTolerance)
+							continue;
+						if (trackScoped && area.trackId != section.firstTrackId
+								&& area.trackId != section.secondTrackId)
+							continue;
+						if (!matched) {
+							matched = &area;
+							continue;
+						}
+						if (matched->level != area.level) {
+							diagnostics.error("scene.signalling_area.conflict",
+									"Multiple signalling areas assign different levels to one runtime section",
+									"signalling.json", "signalling_area", area.id,
+									"signalling_areas[" + std::to_string(areaIndex) + "]",
+									matched->id + " -> " + section.id,
+									"Adjust area ranges, levels, or track scope");
+							break;
+						}
 					}
 				}
 			}

--- a/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
@@ -518,6 +518,20 @@ SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) 
 	};
 	for (const auto& signal : scene.signals)
 		signalling["signals"].push_back({{"id", signal.id}});
+	if (!scene.signallingAreas.empty()) {
+		signalling["signalling_areas"] = json::array();
+		for (const auto& area : scene.signallingAreas) {
+			json value = {
+				{"id", area.id},
+				{"start_km", area.startKm},
+				{"end_km", area.endKm},
+				{"level", area.level},
+			};
+			if (!area.trackId.empty())
+				value["track"] = area.trackId;
+			signalling["signalling_areas"].push_back(std::move(value));
+		}
+	}
 	for (const auto& route : scene.routes) {
 		json value = {{"id", route.id}, {"blocks", route.blocks}};
 		if (route.hasCorridor || !route.corridor.empty())

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -2183,6 +2183,14 @@ struct NativeBlockPlan {
 	double endX = 0.0;
 };
 
+struct NativeSectionPlan {
+	std::string id;
+	double startX = 0.0;
+	double endX = 0.0;
+	std::string firstTrackId;
+	std::string secondTrackId;
+};
+
 struct NativeStationBinding {
 	const SceneStation* station = nullptr;
 	const ScenePlatform* platform = nullptr;
@@ -2522,12 +2530,18 @@ std::vector<SceneDiagnostic> buildInfrastructureAndSignallingFromScene(const Sce
 		}
 	}
 	std::unordered_set<std::string> plannedSectionIds;
+	std::vector<NativeSectionPlan> signallingSectionPlans;
+	signallingSectionPlans.reserve(blockPlans.size() + scene.connections.size());
 	for (const auto& plan : blockPlans) {
 		const std::string runtimeId = nativeRuntimeBlockId(plan.source->id);
-		if (!plannedSectionIds.insert(runtimeId).second)
+		if (!plannedSectionIds.insert(runtimeId).second) {
 			add(SceneSeverity::Error, "scene.native.id.duplicate",
 				"Blocks produce the same runtime section ID", "infrastructure.json",
 				"block", plan.source->id, "blocks", runtimeId);
+		} else {
+			signallingSectionPlans.push_back(
+					{runtimeId, plan.startX, plan.endX, plan.source->trackId, {}});
+		}
 	}
 	auto plannedRuntimeId = [&](const std::string& reference) {
 		if (plannedSectionIds.find(reference) != plannedSectionIds.end())
@@ -2570,10 +2584,14 @@ std::vector<SceneDiagnostic> buildInfrastructureAndSignallingFromScene(const Sce
 						&& second->xKm <= secondPlan.endX + kNativeCoordinateTolerance) {
 					const std::string derivedId = nativeRuntimeBlockId(firstPlan.source->id) + "-" + firstX
 							+ "/" + nativeRuntimeBlockId(secondPlan.source->id) + "-" + secondX;
-					if (!plannedSectionIds.insert(derivedId).second)
+					if (!plannedSectionIds.insert(derivedId).second) {
 						add(SceneSeverity::Error, "scene.native.id.duplicate",
 							"Connections produce the same runtime switch section",
 							"infrastructure.json", "connection", connection.id, "connections", derivedId);
+					} else {
+						signallingSectionPlans.push_back({derivedId, firstPlan.startX, secondPlan.endX,
+							firstPlan.source->trackId, secondPlan.source->trackId});
+					}
 					int derivedArcCount = 1;
 					for (const SceneArc* arc : nativeTracks[firstPlan.trackSlot].chainArcs) {
 						const double beginX = std::max(firstPlan.startX, nodesById[arc->fromNodeId]->xKm);
@@ -2686,6 +2704,66 @@ std::vector<SceneDiagnostic> buildInfrastructureAndSignallingFromScene(const Sce
 							"signalling.json", "station_boundary", boundary.entranceBlock, "station_boundaries", component);
 			}
 		}
+	}
+	std::unordered_set<std::string> signallingAreaIds;
+	for (std::size_t index = 0; index < scene.signallingAreas.size(); ++index) {
+		const SceneSignallingArea& area = scene.signallingAreas[index];
+		const std::string path = "signalling_areas[" + std::to_string(index) + "]";
+		if (area.id.empty())
+			add(SceneSeverity::Error, "scene.native.id.empty", "Signalling area id is empty",
+				"signalling.json", "signalling_area", area.id, path + ".id");
+		else if (!signallingAreaIds.insert(area.id).second)
+			add(SceneSeverity::Error, "scene.native.id.duplicate", "Duplicate signalling area id",
+				"signalling.json", "signalling_area", area.id, path + ".id");
+		if (!std::isfinite(area.startKm) || !std::isfinite(area.endKm)
+				|| !(area.startKm < area.endKm))
+			add(SceneSeverity::Error, "scene.native.signalling_area.range",
+				"Signalling area coordinates must be finite with start below end",
+				"signalling.json", "signalling_area", area.id, path);
+		if (area.level < 0 || area.level > 5)
+			add(SceneSeverity::Error, "scene.native.signalling_area.level",
+				"Signalling area level must be between 0 and 5",
+				"signalling.json", "signalling_area", area.id, path + ".level");
+		if (!area.trackId.empty() && tracksById.find(area.trackId) == tracksById.end())
+			add(SceneSeverity::Error, "scene.native.ref.unresolved",
+				"Signalling area refers to an unknown track", "signalling.json", "signalling_area",
+				area.id, path + ".track", area.trackId);
+	}
+	auto sectionSpanInsideArea = [](const NativeSectionPlan& section, const SceneSignallingArea& area) {
+		return section.startX >= area.startKm - kNativeCoordinateTolerance
+				&& section.endX <= area.endKm + kNativeCoordinateTolerance;
+	};
+	std::unordered_map<std::string, int> plannedSignallingLevels;
+	for (const auto& section : signallingSectionPlans) {
+		int selectedLevel = -1;
+		for (const bool trackScoped : {false, true}) {
+			bool matched = false;
+			bool conflict = false;
+			int level = -1;
+			std::string firstAreaId;
+			for (const auto& area : scene.signallingAreas) {
+				if (area.trackId.empty() != !trackScoped
+						|| !sectionSpanInsideArea(section, area)
+						|| (trackScoped && area.trackId != section.firstTrackId
+								&& area.trackId != section.secondTrackId))
+					continue;
+				if (!matched) {
+					matched = true;
+					level = area.level;
+					firstAreaId = area.id;
+				} else if (level != area.level) {
+					conflict = true;
+					add(SceneSeverity::Error, "scene.native.signalling_area.conflict",
+						"Multiple signalling areas assign different levels to one runtime section",
+						"signalling.json", "signalling_area", area.id, "signalling_areas",
+						firstAreaId + " -> " + section.id);
+				}
+			}
+			if (matched && !conflict)
+				selectedLevel = level;
+		}
+		if (selectedLevel >= 0)
+			plannedSignallingLevels[section.id] = selectedLevel;
 	}
 
 	if (nativeHasErrors(diagnostics))
@@ -2929,6 +3007,13 @@ std::vector<SceneDiagnostic> buildInfrastructureAndSignallingFromScene(const Sce
 			"infrastructure.json", "block", "", "connections", std::to_string(kNativeMaxBlocks));
 		return diagnostics;
 	}
+	for (int sectionIndex = 0; sectionIndex < Blocks; ++sectionIndex) {
+		const auto plannedLevel = plannedSignallingLevels.find(signalling_block_sections[sectionIndex].ID);
+		if (plannedLevel != plannedSignallingLevels.end())
+			signalling_block_sections[sectionIndex].SignallingLevel = plannedLevel->second;
+	}
+	if (nativeHasErrors(diagnostics))
+		return diagnostics;
 	setDependenciesBetweenBlocksInternal(false);
 
 	std::unordered_map<std::string, int> sectionAliases;

--- a/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
@@ -58,6 +58,16 @@ static SceneModel stableConnectionScene() {
 	return scene;
 }
 
+static SceneModel signallingAreasScene() {
+	SceneModel scene = stableConnectionScene();
+	scene.routes.push_back({"route.switch", {"@alpha.block@-1.000000/@beta.block@-2.000000"}, false, {}, false});
+	scene.signallingAreas = {
+		{"network-area", 0.0, 3.0, 1, {}},
+		{"alpha-area", 0.0, 3.0, 3, "alpha"},
+	};
+	return scene;
+}
+
 static SceneModel twoRegionRouteScene() {
 	SceneModel scene;
 	scene.tracks = {{"region.a"}, {"region.b"}};
@@ -147,6 +157,38 @@ static bool runTinyBuilderChecks() {
 					|| signalling_block_sections[2].arcs_in_signalling_block_section[index].speedLimit == 7.5;
 		ok &= expect(hasCanonicalSwitchSpeed, "connection speed is retained independently of endpoint order");
 	}
+	diagnostics = buildInfrastructureAndSignallingFromScene(signallingAreasScene());
+	ok &= expect(!hasErrors(diagnostics) && Blocks == 3,
+			"signalling areas apply before route construction");
+	if (!hasErrors(diagnostics) && Blocks == 3) {
+		const Section& alpha = signalling_block_sections[0];
+		const Section& beta = signalling_block_sections[1];
+		const Section& derived = signalling_block_sections[2];
+		ok &= expect(alpha.SignallingLevel == 3 && beta.SignallingLevel == 1
+				&& derived.SignallingLevel == 3,
+				"network and track-scoped levels reach base and derived switch sections");
+		ok &= expect(!train_route.empty() && train_route.front().N_Block_Sections == 1
+				&& train_route.front().sequence_of_block_sections[0].SignallingLevel == 3,
+				"signalling level is copied into the derived route section");
+	}
+	const int blocksBeforeConflict = Blocks;
+	std::vector<std::string> sectionIdsBeforeConflict;
+	for (int index = 0; index < Blocks; ++index)
+		sectionIdsBeforeConflict.push_back(signalling_block_sections[index].ID);
+	SceneModel conflictingAreas = signallingAreasScene();
+	conflictingAreas.signallingAreas.push_back({"beta-area", 0.0, 3.0, 4, "beta"});
+	conflictingAreas.tracks.push_back({"gamma"});
+	conflictingAreas.nodes.push_back({"gamma.start", "gamma", 4.0, 0.0});
+	conflictingAreas.nodes.push_back({"gamma.end", "gamma", 5.0, 0.0});
+	conflictingAreas.arcs.push_back({"gamma.arc", "gamma", "gamma.start", "gamma.end", 0.0, 0.0, 10.0});
+	conflictingAreas.blocks.push_back({"gamma.block", "gamma", 1.0});
+	diagnostics = buildInfrastructureAndSignallingFromScene(conflictingAreas);
+	bool sectionIdsUnchanged = Blocks == blocksBeforeConflict;
+	for (std::size_t index = 0; sectionIdsUnchanged && index < sectionIdsBeforeConflict.size(); ++index)
+		sectionIdsUnchanged = signalling_block_sections[index].ID == sectionIdsBeforeConflict[index];
+	ok &= expect(hasDiagnostic(diagnostics, SceneSeverity::Error, "signalling.json", "signalling_area.conflict")
+				&& sectionIdsUnchanged,
+			"same-tier conflicting track areas are rejected before replacing the prior runtime");
 	SceneModel invalidSwitchReference = stableConnectionScene();
 	invalidSwitchReference.blockDependencies.push_back(
 			{"alpha.block", "@alpha.block@-9.000000/@beta.block@-10.000000"});

--- a/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
@@ -121,6 +121,64 @@ int main(int argc, char** argv) {
 			"semantic validation does not reject complete topology");
 	ok &= expect(validateScene(clean).empty(), "complete scene passes semantic validation");
 	ok &= expect(validateRunnableScene(clean).empty(), "complete scene passes runnable validation");
+	SceneModel validAreas = clean;
+	validAreas.signallingAreas = {
+		{"network-area", 0.0, 2.0, 2, {}},
+		{"track-area", 0.25, 1.75, 4, "track-1"},
+	};
+	ok &= expect(validateScene(validAreas).empty(),
+			"network-wide and track-scoped signalling areas validate");
+	SceneModel duplicateArea = clean;
+	duplicateArea.signallingAreas = {{"area", 0.0, 1.0, 2, {}}, {"area", 1.0, 2.0, 2, {}}};
+	ok &= expect(hasCode(validateScene(duplicateArea), "scene.id.duplicate"),
+			"signalling area IDs must be unique");
+	SceneModel invalidAreaRange = clean;
+	invalidAreaRange.signallingAreas = {{"area", 1.0, 1.0, 2, {}}};
+	ok &= expect(hasCode(validateScene(invalidAreaRange), "scene.signalling_area.range"),
+			"signalling area ranges must increase");
+	invalidAreaRange.signallingAreas[0].startKm = std::numeric_limits<double>::quiet_NaN();
+	ok &= expect(hasCode(validateScene(invalidAreaRange), "scene.signalling_area.range"),
+			"signalling area coordinates must be finite");
+	SceneModel invalidAreaLevel = clean;
+	invalidAreaLevel.signallingAreas = {{"area", 0.0, 1.0, 6, {}}};
+	ok &= expect(hasCode(validateScene(invalidAreaLevel), "scene.signalling_area.level"),
+			"signalling area levels must be between zero and five");
+	SceneModel unknownAreaTrack = clean;
+	unknownAreaTrack.signallingAreas = {{"area", 0.0, 1.0, 2, "missing-track"}};
+	ok &= expect(hasCodeAndPath(validateScene(unknownAreaTrack), "scene.ref.unresolved",
+			"signalling_areas[0].track"), "signalling area track references must resolve");
+	SceneModel overlapWithoutSharedSection = clean;
+	overlapWithoutSharedSection.signallingAreas = {
+		{"first", 0.0, 1.5, 2, {}}, {"second", 1.0, 2.0, 3, {}}};
+	ok &= expect(!hasCode(validateRunnableScene(overlapWithoutSharedSection),
+			"scene.signalling_area.conflict"),
+			"coordinate overlap is allowed when no complete section receives both levels");
+	SceneModel conflictingNetworkAreas = clean;
+	conflictingNetworkAreas.signallingAreas = {
+		{"first", 0.0, 2.0, 2, {}}, {"second", 0.0, 2.0, 3, {}}};
+	ok &= expect(hasCode(validateRunnableScene(conflictingNetworkAreas),
+			"scene.signalling_area.conflict"),
+			"network-wide areas cannot assign different levels to one runtime section");
+	SceneModel conflictingTrackAreas = clean;
+	conflictingTrackAreas.signallingAreas = {
+		{"first", 0.0, 2.0, 2, "track-1"}, {"second", 0.0, 2.0, 3, "track-1"}};
+	ok &= expect(hasCode(validateRunnableScene(conflictingTrackAreas),
+			"scene.signalling_area.conflict"),
+			"same-track areas cannot assign different levels to one runtime section");
+	SceneModel conflictingDerivedAreas = clean;
+	conflictingDerivedAreas.tracks.push_back({"track-2"});
+	conflictingDerivedAreas.nodes.push_back({"node-4", "track-2", 3.0, 0.0});
+	conflictingDerivedAreas.nodes.push_back({"node-5", "track-2", 4.0, 0.0});
+	conflictingDerivedAreas.arcs.push_back(
+			{"arc-3", "track-2", "node-4", "node-5", 0.0, 0.0, 35.0});
+	conflictingDerivedAreas.blocks.push_back({"block-3", "track-2", 1.0});
+	conflictingDerivedAreas.connections = {
+		{"connection-1", "node-3", "node-4", false, 0.0}};
+	conflictingDerivedAreas.signallingAreas = {
+		{"first", 0.0, 4.0, 2, "track-1"}, {"second", 0.0, 4.0, 3, "track-2"}};
+	ok &= expect(hasCode(validateRunnableScene(conflictingDerivedAreas),
+			"scene.signalling_area.conflict"),
+			"different track scopes cannot conflict on one derived switch section");
 
 	struct FailureCase {
 		const char* name;

--- a/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
@@ -73,6 +73,7 @@ static SceneModel completeScene() {
 	scene.stations.push_back(second);
 
 	scene.signals.push_back({"signal-1"});
+	scene.signallingAreas.push_back({"area-1", 0.25, 0.75, 4, "track-1"});
 	SceneRoute route;
 	route.id = "route-1";
 	route.blocks = {"block-1", "block-2"};
@@ -182,6 +183,34 @@ int main() {
 			"rolling_stock.json", "services.json", "scenarios.json", "passengers.json"})
 		ok &= expect(fs::exists(temp.path / file), "all canonical files are written");
 	ok &= expect(!fs::exists(temp.path / "incidents.json"), "writer does not emit flat incidents.json");
+	json signalling;
+	{
+		std::ifstream input(temp.path / "signalling.json");
+		input >> signalling;
+	}
+	ok &= expect(signalling["signalling_areas"].size() == 1
+			&& signalling["signalling_areas"][0]["id"] == "area-1"
+			&& signalling["signalling_areas"][0]["start_km"] == 0.25
+			&& signalling["signalling_areas"][0]["end_km"] == 0.75
+			&& signalling["signalling_areas"][0]["level"] == 4
+			&& signalling["signalling_areas"][0]["track"] == "track-1",
+			"writer emits signalling area fields");
+	SceneModel absentAreas = completeScene();
+	absentAreas.signallingAreas.clear();
+	const fs::path absentAreasPath = temp.path / "absent-signalling-areas";
+	ok &= expect(saveScene(absentAreas, absentAreasPath.string()).success(),
+			"scene without signalling areas saves");
+	json absentSignalling;
+	{
+		std::ifstream input(absentAreasPath / "signalling.json");
+		input >> absentSignalling;
+	}
+	ok &= expect(!absentSignalling.contains("signalling_areas"),
+			"writer preserves an absent signalling area array");
+	SceneModel absentAreasReloaded;
+	ok &= expect(loadHasNoErrors(absentAreasPath, absentAreasReloaded)
+			&& absentAreasReloaded.signallingAreas.empty(),
+			"scene without signalling areas reloads with no inferred defaults");
 
 	json services;
 	{
@@ -274,6 +303,13 @@ int main() {
 			"topology round-trips");
 	ok &= expect(reloaded.routes[0].corridor == "corridor-1" && reloaded.routes[0].reversed,
 			"route corridor and direction round-trip");
+	ok &= expect(reloaded.signallingAreas.size() == 1
+			&& reloaded.signallingAreas[0].id == "area-1"
+			&& reloaded.signallingAreas[0].startKm == 0.25
+			&& reloaded.signallingAreas[0].endKm == 0.75
+			&& reloaded.signallingAreas[0].level == 4
+			&& reloaded.signallingAreas[0].trackId == "track-1",
+			"signalling area fields round-trip");
 	ok &= expect(reloaded.services[0].stops[0].hasPlannedDeparture
 				&& reloaded.services[0].stops[0].plannedDepartureSeconds == 100.0,
 			"planned departure round-trips");

--- a/docs/architecture/scene-model.md
+++ b/docs/architecture/scene-model.md
@@ -22,7 +22,7 @@ or consults an `Input/` tree.
 | `scene.json` | schema version, identity, units, base time, simulation settings, and optional import report | required |
 | `infrastructure.json` | tracks, nodes, arcs, blocks, and connections | required |
 | `stations.json` | stations, positions, platforms, and platform nodes | required |
-| `signalling.json` | signals, routes, dependencies, single-track restrictions, and station boundaries | required |
+| `signalling.json` | signals, routes, signalling areas, dependencies, single-track restrictions, and station boundaries | required |
 | `rolling_stock.json` | train units, physical data, traction curves, and compositions | required |
 | `services.json` | services, explicit route/composition links, stops, planned times, dwell, and repetition | required |
 | `scenarios.json` | default scenario, named scenarios, incidents, and entrance delays | optional on load; always written by `SceneWriter` |
@@ -162,3 +162,11 @@ rows and operating code/service identity to timetable rows. `TrackPreview`
 resolves connections and station markers through the same canonical node IDs.
 GUI Run, `--scene`, and the numeric case shortcuts all enter this shared native
 path; there is no legacy-runtime fallback.
+
+Canonical signalling areas assign levels to the base and derived switch
+sections before route construction copies those sections. An area has a
+complete chainage span, a level from 0 through 5, and optional canonical track
+scope. Track-scoped areas override a network-wide area; conflicting values for
+one section are rejected. Missing coverage keeps the native unset value. Normal
+runtime does not read `TrackLines/AreasCaseStudy.txt` and does not synthesize a
+conventional or ETCS default.

--- a/docs/architecture/scene-schema.md
+++ b/docs/architecture/scene-schema.md
@@ -84,12 +84,24 @@ Required root arrays are `signals` and `routes`.
 - `signals[]`: `{ "id": string }`.
 - `routes[]`: required `id` and string-array `blocks`; optional string
   `corridor` and boolean `reversed`.
+- `signalling_areas[]`: required `id`, numeric `start_km`, numeric `end_km`,
+  and integer `level` from 0 through 5; optional `track` refers to a canonical
+  track ID. The array is optional.
 - `block_dependencies[]`: `{ "block": string, "depends_on": string }`.
 - `single_track_restrictions[]`: preferred explicit
   `start_block`, `end_block`, `protected_start_block`, and
   `protected_end_block`.
 - `station_boundaries[]`: required `entrance_block`, optional `exit_block`,
   and optional boolean `direction`.
+
+A signalling area covers a native section only when the section's complete
+coordinate span lies inside the area. Network-wide areas are applied before
+track-scoped areas; a track-scoped value overrides the network-wide value.
+Either connected track matches a derived switch section. Different values at
+the same precedence tier that cover one section are invalid. The builder
+applies areas after base and switch sections exist and before routes copy them.
+A section with no matching area retains the unset signalling value. The loader
+and writer never create a default level.
 
 ## `rolling_stock.json`
 

--- a/docs/guides/v1-scene-properties.md
+++ b/docs/guides/v1-scene-properties.md
@@ -56,6 +56,10 @@ A route has `id`, a string-array `blocks`, and optional `corridor` and
 
 Use these optional arrays for explicit signalling relationships:
 
+- `signalling_areas`: `id`, numeric `start_km`, numeric `end_km`, integer
+  `level` from 0 through 5, and optional canonical `track`. A section must fit
+  completely inside the area. Track-scoped areas override network-wide areas;
+  missing coverage remains unset.
 - `block_dependencies`: `{ "block": "...", "depends_on": "..." }`.
 - `single_track_restrictions`: `start_block`, `end_block`,
   `protected_start_block`, and `protected_end_block`.

--- a/docs/product/assignment-corridor.md
+++ b/docs/product/assignment-corridor.md
@@ -1,25 +1,46 @@
-# Assignment Corridor
+# Assignment corridor
 
-## Decision
+## Target case
 
-Use Den Haag Centraal (`Gvc`) to Utrecht (`Ut`) via Gouda (`Gd` and `Gdg`) as
-the assignment corridor. `Assignment_Gvc_Gdg_Ut` is the current runnable
-baseline.
+The TU Delft assignment runs from Den Haag Centraal (`Gvc`) to Utrecht (`Ut`)
+via Gouda (`Gd` and `Gdg`). EGTRAIN uses this as its acceptance case for
+authoring, timetable, capacity, rolling-stock, and disruption work.
 
-## Current gaps
+## Repository status
 
-The committed scene has only `Gvc`, `Gdg`, and `Ut`. Issue #182 adds the missing
-intermediate stations, keeps `Gd` and `Gdg` distinct, and applies the source
-stopping patterns.
+`Assignment_Gvc_Gdg_Ut` currently contains a synthetic two-track fixture with
+three stations (`Gvc`, `Gdg`, and `Ut`), no signals, one placeholder
+`SLT_Sprinter` composition, and four services that all use that placeholder.
+The historical generator built uniform 2 km blocks with fixed geometry and did
+not convert the OpenTrack case. The fixture can validate, run, round trip, and be
+packed as `.egscene`, but those checks do not make its railway data authoritative.
 
-The scene defines only `SLT_Sprinter`, and all four services use that placeholder
-composition. Issue #228 obtains traceable ICM3, ICM4, IRM3, and SGM3 parameters.
-Issue #181 uses those records to build the source compositions. Do not guess
-train physics while #228 is open.
+Do not use the fixture for model answers or publish it as the completed
+assignment. The expected course archive, `OpenTrack data 2016.zip`, is not in
+the workspace or repository. The model-answer PDF gives the educational tasks,
+named services, timetable exercises, and selected composition information. It
+does not supply the complete corridor geometry, signalling records, S451
+mapping, or train physics.
 
-## Data policy
+## Source blockers
 
-- Keep the full canonical Netherlands scene intact as a reference.
-- Use source-backed station, timetable, and train data in the assignment scene.
-- Update the assignment generator, committed scene, and focused checks together.
-- Use legacy import and export only for explicit compatibility work.
+- [Issue #182](https://github.com/Ancientkingg/EGTRAIN/issues/182) owns the
+  corridor, intermediate stations, stopping patterns, detailed signalling, and
+  historical S451 mapping.
+- [Issue #228](https://github.com/Ancientkingg/EGTRAIN/issues/228) owns sourced
+  ICM3, ICM4, IRM3, SGM3, and Plan V physical and traction records.
+- [Issue #181](https://github.com/Ancientkingg/EGTRAIN/issues/181) builds the
+  assignment compositions and service assignments after those records exist.
+
+Screenshots and OpenTrack result plots are not substitutes for missing input
+records. Current ProRail data also cannot establish the historical teaching
+model.
+
+## Completion rule
+
+The case is complete only after the source records have been converted into
+canonical scene data, inspected through the normal editor, rehearsed through
+all 25 operations in the [assignment workflow](assignment-workflow.md), saved
+as `.egscene`, reopened, and rerun. Normal runtime must remain canonical
+`SceneModel` data through native builders, with legacy import and export used
+only for explicit compatibility work.

--- a/docs/product/assignment-workflow.md
+++ b/docs/product/assignment-workflow.md
@@ -1,58 +1,101 @@
-# Assignment Workflow
+# TU Delft assignment workflow in EGTRAIN
 
-EGTRAIN should replace the OpenTrack workflow used in the railway traffic management assignment. The target corridor is Den Haag Centraal (`Gvc`) to Utrecht (`Ut`) via Gouda (`Gd` and `Gdg`), with Sprinter and Intercity services.
+EGTRAIN implements the railway authoring, simulation, capacity, and disruption
+work behind the TU Delft OpenTrack assignment. The controls and result views are
+EGTRAIN-native. Students should reproduce the method and explain their modelling
+choices, not copy OpenTrack menus or target the model-answer timestamps.
 
-## Users
+The committed `Assignment_Gvc_Gdg_Ut` scene is an incomplete synthetic fixture.
+It is useful for product smoke tests, but it is not the distributable assignment
+case. The course archive named `OpenTrack data 2016.zip` is not in the repository,
+and the model-answer PDF does not contain enough infrastructure, signalling, or
+rolling-stock data to reconstruct it. [Issue #182](https://github.com/Ancientkingg/EGTRAIN/issues/182)
+tracks the corridor and signalling source. [Issue #228](https://github.com/Ancientkingg/EGTRAIN/issues/228)
+and [issue #181](https://github.com/Ancientkingg/EGTRAIN/issues/181) track the train
+sources and compositions. Do not distribute the fixture as the completed course
+case or fill those gaps from screenshots.
 
-- Students configure trains, build timetables, run simulations, inspect diagrams, and export results.
-- Instructors need repeatable scenes and clear validation errors.
-- Researchers need readable input data and reproducible runs.
+## Instructor preparation
 
-## V1 Student Stories
+Once the source records are available, an instructor can build the case through
+the normal application workflow:
 
-- As a student, I can load the assignment scene from the app start screen.
-- As a student, I can edit train material, service stops, dwell times, platforms, and per-service performance.
-- As a student, I can create a basic half-hour timetable without editing text files.
-- As a student, I can run one train to get minimum running time.
-- As a student, I can add running-time supplements and timetable rounding.
-- As a student, I can run the full timetable and compare planned and simulated output.
-- As a student, I can inspect speed-distance, speed-time, time-distance, delay, and blocking-time diagrams.
-- As a student, I can toggle trains in diagrams and export tables and figures for a report.
-- As a student, I can add assignment incidents such as a signal failure or train breakdown.
-- As a student, I can duplicate and select named incident scenarios, run the selected scenario, and review its results.
+1. Choose **File > New Case Study...** and enter the case name, base time,
+   duration, buffer, and recovery settings in **Case Settings**.
+2. Use the **Infrastructure** table and network preview to add tracks, nodes,
+   arcs, blocks, connections, stations, platforms, signals, routes, dependencies,
+   restrictions, boundaries, and signalling areas.
+3. Add sourced train units, their physical fields and traction curves, then build
+   ordered compositions from those units.
+4. Add the four services, route and platform stops, planned arrival and departure
+   times, dwell, per-service performance, and repeat rules.
+5. Add named scenarios for the signal failure and occurrence-specific train
+   breakdown.
+6. Resolve validation errors, run representative services, and save both the
+   canonical folder and a `.egscene` bundle. Reopen the bundle before release.
 
-## V1 Editor Scope
+The assignment defines these base services and compositions. Their physical
+train-unit records still require the sources tracked in issues #228 and #181.
 
-The first editor should cover assignment-level data:
+| Service | Assignment composition |
+| --- | --- |
+| IC 1723 | 2xICM3 + 2xICM4 |
+| S 19825 | 1xSGM3 |
+| IC 2025 | 2xIRM3 |
+| S 9827 | 1xSGM3 |
 
-- train compositions
-- train services
-- stopping patterns
-- dwell times
-- platform choices
-- scheduled times
-- repeated services
-- per-service performance values
-- signal and train incidents
+The alternative-composition exercise uses 1xICM3 for IC 1723. The
+rolling-stock comparison replaces SGM with sourced Plan V data without changing
+the service pattern.
 
-The editor should show infrastructure context for selection. It should not support full track drawing in V1.
+An incomplete scene remains editable and saveable. **Run** remains unavailable
+when validation reports an error. Missing signalling coverage is never replaced
+with an implicit conventional or ETCS setting.
 
-## Later Editor Scope
+## Exercise sequence
 
-Full infrastructure editing is a later milestone:
+| # | Assignment operation | EGTRAIN action | Student work |
+| --- | --- | --- | --- |
+| 1 | Define train-unit compositions | Author sourced train units and ordered compositions. Inspect the static traction input separately from results. | Check the unit order and record the composition used. |
+| 2 | Define four base services | Author services with an operating code, composition, route, and stops. | Check each stopping pattern. |
+| 3 | Define routes, platforms, and stops | Use the Infrastructure table and preview, then select those records in the service editor. | Explain the chosen route and platform pattern. |
+| 4 | Simulate trains individually | Select one service occurrence and run it without changing the canonical timetable. | Record and interpret minimum running times. |
+| 5 | Tune per-service performance | Edit `performance_percent` and rerun the same occurrence. | Test values and explain the nonlinear running-time response. |
+| 6 | Create the planned timetable | Edit planned arrival and departure independently at each stop. | Apply the course scheduling and rounding method. |
+| 7 | Repeat half-hour services | Set a 1,800 second interval, an explicit count, and the operating-code step. Preview generated occurrences. | Check sequences such as 1723, 1725, and 1727. |
+| 8 | Model overtaking at Gdg | Use ordinary route, platform, dwell, and timetable fields. | Choose and justify the overtaking pattern. |
+| 9 | Inspect blocking times | Open **Blocking time**, select the route, block range, time range, and trains. | Compare planned timing, actual occupations, and conflicts. |
+| 10 | Inspect speed versus distance | Open the existing speed-distance result and filter the trains. | Explain acceleration, braking, and line-speed effects. |
+| 11 | Inspect actual tractive effort | Open the applied tractive-effort distance result or export its CSV. | Distinguish positive traction, coasting or balance, and braking from the static traction curve. |
+| 12 | Compare an alternative composition | Duplicate or edit a composition assignment and rerun. | Explain the change in performance and feasibility. |
+| 13 | Compare SGM and Plan V | Select the sourced alternatives and rerun the same service. | Explain the observed differences. This exercise remains blocked until #228 and #181 supply both records. |
+| 14 | Compute minimum headways | Open **Capacity**, choose an ordered pair and explicit route section. | Interpret the minimum headway and governing block. |
+| 15 | Compress the timetable | Use the same ordered occurrence sequence in **Capacity** and open the compressed diagram. | Check that order is preserved and occupations do not conflict. |
+| 16 | Identify critical blocks | Inspect the reported touching constraints in the compressed result. | Explain why a critical touch is not an overlap conflict. |
+| 17 | Obtain buffer times | Read scheduled headway, minimum headway, and their unclamped difference. | Interpret positive or negative buffer. |
+| 18 | Assess capacity consumption | Select the analysis period and explicit cycle-closing occurrence. | Reproduce the displayed numerator, denominator, and percentage, then compare it with the course recommendation. |
+| 19 | Generate a multi-hour timetable | Increase repeat count while retaining the interval and code step. | Check occurrence identities and planned offsets. |
+| 20 | Simulate signal failure | Select the 08:30 to 09:00 signal-failure scenario and run the same occurrence set as the baseline. | Inspect the affected traffic and blocking-time change. The historical S451 mapping remains blocked by #182. |
+| 21 | Simulate rolling-stock breakdown | Target IC 1727 at 08:25, set the 40 km/h cap, and request destination termination at Utrecht. | Check that sibling repeats are unchanged and the target continues under signalling. |
+| 22 | Distinguish delay effects | Freeze an incident-free baseline, run the incident scenario, and open delay comparison. | Interpret direct primary rows, propagated secondary rows, and the reconciled total arrival delay. |
+| 23 | Add the extra train | Create a normal through service with the 3xPlanV composition and a 100 km/h service cap. | Experiment with departure time to limit propagated delay. This exercise remains blocked until sourced Plan V data is available. |
+| 24 | Export results | Use CSV from result tables and PNG from diagrams. | Keep the input settings and selected occurrences with submitted evidence. |
+| 25 | Save and distribute | Save the canonical folder, use **Save As** for `.egscene`, reopen it, and rerun representative exercises. | Work from a copy of the distributed bundle. |
 
-- nodes and arcs
-- tracks and switches
-- gradients and curves
-- speed limits
-- stations and platforms
-- signals and block sections
-- routes and corridors
+## Calculation boundaries
 
-## Data Policy
+Capacity analysis uses complete native block occupations from the selected run.
+If the scene has no sourced signalling coverage or the run produced no complete
+occupations, EGTRAIN reports the analysis as unavailable. It does not create
+blocking times from a default signalling system.
 
-Students should work through the application. Hand editing should remain possible for review, debugging, and research, but it should not be the normal assignment workflow.
+Minimum headway, compression, critical blocks, buffer, and capacity consumption
+are section-scoped results. The Gdg overtaking exercise therefore uses separate
+ordered sections before and after Gdg where the train order changes. Compression
+is analysis output and does not rewrite the authored timetable.
 
-The completed loop is open, validate, select or edit a scenario, save a case
-copy when needed, review the run summary, run the selected scenario, and use
-the existing results views for timetable and delay analysis.
+Delay comparison requires equivalent run settings and the same selected
+occurrences. A positive arrival difference is primary only when the runtime
+recorded direct incident evidence for that occurrence. Other positive rows are
+secondary. EGTRAIN leaves the causal interpretation and railway explanation to
+the student.


### PR DESCRIPTION
## Summary

- add optional canonical signalling areas with network and track scope, explicit precedence, validation, and native section propagation
- expose signalling-area authoring through the existing Infrastructure table and preserve track references across rename, save, and reopen
- document the EGTRAIN-native 25-operation assignment workflow and the current corridor, S451, and rolling-stock source blockers

No canonical Assignment railway values are changed. Missing signalling coverage remains unset. Normal runtime stays on `SceneModel` and native builders.

## Verification

- complete build
- CTest 43/43
- editor, Assignment, incident, bundle, CSV, visual, headless, and round-trip smokes
- `git diff --check`

Advances #218 and #4. Authoritative case completion remains blocked by #182, #228, and #181.