### PR TITLE
Close remaining scene authoring gaps

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -1311,6 +1311,23 @@ std::vector<SceneSignal>& sceneSignals(SceneModel& sceneModel) {
 #endif
 	return result;
 }
+
+std::vector<std::string> signalFailureTargets(const SceneModel& sceneModel) {
+	std::vector<std::string> targets;
+	std::set<std::string> seen;
+	const auto add = [&targets, &seen](const std::string& target) {
+		if (!target.empty() && seen.insert(target).second)
+			targets.push_back(target);
+	};
+	for (const auto& signal : sceneSignals(sceneModel))
+		add(signal.id);
+	for (const auto& block : sceneModel.blocks)
+		add(block.id);
+	for (const auto& route : sceneModel.routes)
+		for (const auto& blockToken : route.blocks)
+			add(blockToken);
+	return targets;
+}
 } // namespace
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
@@ -2033,14 +2050,14 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	}
 	trainUnitDetailLayout->addLayout(trainPhysicalLayout);
 
-	trainUnitDetailLayout->addWidget(new QLabel("Original parameter source", trainUnitDetailPane));
-	m_trainUnitSourceDataLabel = new QLabel(trainUnitDetailPane);
-	m_trainUnitSourceDataLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-	trainUnitDetailLayout->addWidget(m_trainUnitSourceDataLabel);
-	trainUnitDetailLayout->addWidget(new QLabel("Original tractive-effort source", trainUnitDetailPane));
-	m_trainUnitSourceTractionLabel = new QLabel(trainUnitDetailPane);
-	m_trainUnitSourceTractionLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-	trainUnitDetailLayout->addWidget(m_trainUnitSourceTractionLabel);
+	trainUnitDetailLayout->addWidget(new QLabel("Parameter source reference", trainUnitDetailPane));
+	m_trainUnitSourceDataEdit = new QLineEdit(trainUnitDetailPane);
+	m_trainUnitSourceDataEdit->setPlaceholderText("Optional");
+	trainUnitDetailLayout->addWidget(m_trainUnitSourceDataEdit);
+	trainUnitDetailLayout->addWidget(new QLabel("Tractive-effort source reference", trainUnitDetailPane));
+	m_trainUnitSourceTractionEdit = new QLineEdit(trainUnitDetailPane);
+	m_trainUnitSourceTractionEdit->setPlaceholderText("Optional");
+	trainUnitDetailLayout->addWidget(m_trainUnitSourceTractionEdit);
 	m_plotTrainUnitTractionButton = new QPushButton("Plot input traction characteristic", trainUnitDetailPane);
 	trainUnitDetailLayout->addWidget(m_plotTrainUnitTractionButton);
 
@@ -2075,6 +2092,8 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 		updateTrainUnitDetailPanel();
 	});
 	connect(m_trainUnitIdEdit, &QLineEdit::editingFinished, this, &MainWindow::commitTrainUnitIdEdit);
+	connect(m_trainUnitSourceDataEdit, &QLineEdit::editingFinished, this, &MainWindow::commitTrainUnitSources);
+	connect(m_trainUnitSourceTractionEdit, &QLineEdit::editingFinished, this, &MainWindow::commitTrainUnitSources);
 	for (int i = 0; i < 9; ++i) {
 		connect(m_trainUnitPhysicalEdits[static_cast<size_t>(i)], QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 				this, [this, i](double) { commitTrainUnitPhysical(i); });
@@ -3064,6 +3083,7 @@ bool MainWindow::saveSceneToCurrentDir() {
 		return false;
 	commitPendingCaseSettings();
 	commitPendingServiceSettings();
+	commitTrainUnitSources();
 	if (m_sceneDir.isEmpty())
 		return saveSceneAsToBundle();
 
@@ -3082,6 +3102,7 @@ bool MainWindow::saveSceneAsToBundle() {
 		return false;
 	commitPendingCaseSettings();
 	commitPendingServiceSettings();
+	commitTrainUnitSources();
 
 	const QString startPath = m_sceneDir.isEmpty() ? QDir::homePath()
 		: (QFileInfo(m_sceneDir).isDir() ? m_sceneDir : QFileInfo(m_sceneDir).absoluteFilePath());
@@ -3108,6 +3129,7 @@ bool MainWindow::saveSceneAsToDirectory() {
 		return false;
 	commitPendingCaseSettings();
 	commitPendingServiceSettings();
+	commitTrainUnitSources();
 
 	const QString startDir = m_sceneDir.isEmpty() ? QDir::homePath()
 		: (QFileInfo(m_sceneDir).isDir() ? m_sceneDir : QFileInfo(m_sceneDir).absolutePath());
@@ -3184,6 +3206,7 @@ bool MainWindow::copyScenePassthroughFiles(const QString& targetDir) {
 bool MainWindow::maybeSaveScene() {
 	commitPendingCaseSettings();
 	commitPendingServiceSettings();
+	commitTrainUnitSources();
 	if (!m_sceneDirty)
 		return true;
 
@@ -4538,13 +4561,13 @@ void MainWindow::updateTrainUnitDetailPanel() {
 		m_trainUnitPhysicalEdits[index]->setValue(values[index]);
 		m_trainUnitPhysicalEdits[index]->setEnabled(hasSelection);
 	}
-	if (m_trainUnitSourceDataLabel) {
-		m_trainUnitSourceDataLabel->setText(unit && !unit->sourceDataFile.empty()
-			? QString::fromStdString(unit->sourceDataFile) : QString("(none)"));
+	if (m_trainUnitSourceDataEdit) {
+		m_trainUnitSourceDataEdit->setText(unit ? QString::fromStdString(unit->sourceDataFile) : QString());
+		m_trainUnitSourceDataEdit->setEnabled(hasSelection);
 	}
-	if (m_trainUnitSourceTractionLabel) {
-		m_trainUnitSourceTractionLabel->setText(unit && !unit->sourceTractionFile.empty()
-			? QString::fromStdString(unit->sourceTractionFile) : QString("(none)"));
+	if (m_trainUnitSourceTractionEdit) {
+		m_trainUnitSourceTractionEdit->setText(unit ? QString::fromStdString(unit->sourceTractionFile) : QString());
+		m_trainUnitSourceTractionEdit->setEnabled(hasSelection);
 	}
 	if (m_plotTrainUnitTractionButton)
 		m_plotTrainUnitTractionButton->setEnabled(unit && !unit->tractionCurve.empty());
@@ -4720,6 +4743,27 @@ void MainWindow::commitTrainUnitIdEdit() {
 	updateSceneActions();
 	refreshValidationPanel();
 	refreshCompositionPanel();
+}
+
+void MainWindow::commitTrainUnitSources() {
+	if (!m_sceneLoaded || !m_trainUnitListWidget || !m_trainUnitSourceDataEdit
+			|| !m_trainUnitSourceTractionEdit)
+		return;
+	const int row = m_trainUnitListWidget->currentRow();
+	if (row < 0 || row >= static_cast<int>(m_sceneModel.trainUnits.size()))
+		return;
+	SceneTrainUnit& unit = m_sceneModel.trainUnits[static_cast<std::size_t>(row)];
+	const std::string sourceDataFile = m_trainUnitSourceDataEdit->text().toStdString();
+	const std::string sourceTractionFile = m_trainUnitSourceTractionEdit->text().toStdString();
+	if (unit.sourceDataFile == sourceDataFile && unit.sourceTractionFile == sourceTractionFile)
+		return;
+	unit.sourceDataFile = sourceDataFile;
+	unit.sourceTractionFile = sourceTractionFile;
+	markSceneDirty();
+	updateSceneWindowTitle();
+	updateSceneActions();
+	refreshValidationPanel();
+	updateCompositionUnitButtons();
 }
 
 void MainWindow::commitTrainUnitPhysical(int fieldIndex) {
@@ -5033,15 +5077,26 @@ void MainWindow::deleteComposition() {
 void MainWindow::commitCompositionIdEdit() {
 	if (!m_sceneLoaded || !m_compositionListWidget || !m_compositionIdEdit)
 		return;
-	int row = m_compositionListWidget->currentRow();
+	const int row = m_compositionListWidget->currentRow();
 	if (row < 0 || row >= static_cast<int>(m_sceneModel.compositions.size()))
 		return;
 
-	std::string newId = m_compositionIdEdit->text().trimmed().toStdString();
-	if (newId == m_sceneModel.compositions[row].id)
+	const std::string oldId = m_sceneModel.compositions[row].id;
+	const std::string newId = m_compositionIdEdit->text().trimmed().toStdString();
+	if (newId == oldId)
 		return;
+	const bool duplicate = newId.empty() || uniqueCompositionId(newId) != newId;
+	if (duplicate) {
+		m_compositionIdEdit->setText(QString::fromStdString(oldId));
+		return;
+	}
 
 	m_sceneModel.compositions[row].id = newId;
+	for (auto& service : m_sceneModel.services) {
+		if (service.composition == oldId)
+			service.composition = newId;
+	}
+	updateServiceDetailPanel();
 
 	// update the list row label in place instead of rebuilding the panel, so a
 	// focus-out that lands on another control keeps that pending click intact
@@ -6953,17 +7008,8 @@ void MainWindow::refreshIncidentTargetCombo() {
 		// which pool of ids to offer depends on the current type
 		QString typeText = m_incidentTypeCombo ? m_incidentTypeCombo->currentText() : QString();
 		if (typeText == "signal_failure") {
-#ifdef signals
-#define EGTRAIN_INCIDENT_RESTORE_SIGNALS
-#undef signals
-#endif
-			const auto& signalList = m_sceneModel.signals;
-#ifdef EGTRAIN_INCIDENT_RESTORE_SIGNALS
-#define signals Q_SIGNALS
-#undef EGTRAIN_INCIDENT_RESTORE_SIGNALS
-#endif
-			for (int i = 0; i < static_cast<int>(signalList.size()); ++i)
-				m_incidentTargetCombo->addItem(QString::fromStdString(signalList[i].id));
+			for (const auto& target : signalFailureTargets(m_sceneModel))
+				m_incidentTargetCombo->addItem(QString::fromStdString(target));
 		} else {
 			// train_breakdown or any unrecognised type: offer service ids
 			for (const auto& service : m_sceneModel.services)
@@ -7122,21 +7168,8 @@ void MainWindow::commitIncidentType(const QString& text) {
 	bool targetValid = incidents[row].target.empty();
 	if (!targetValid) {
 		if (newType == "signal_failure") {
-#ifdef signals
-#define EGTRAIN_INCIDENT_RESTORE_SIGNALS
-#undef signals
-#endif
-			const auto& signalList = m_sceneModel.signals;
-#ifdef EGTRAIN_INCIDENT_RESTORE_SIGNALS
-#define signals Q_SIGNALS
-#undef EGTRAIN_INCIDENT_RESTORE_SIGNALS
-#endif
-			for (int i = 0; i < static_cast<int>(signalList.size()); ++i) {
-				if (signalList[i].id == incidents[row].target) {
-					targetValid = true;
-					break;
-				}
-			}
+			const auto targets = signalFailureTargets(m_sceneModel);
+			targetValid = std::find(targets.begin(), targets.end(), incidents[row].target) != targets.end();
 		} else {
 			for (const auto& service : m_sceneModel.services) {
 				if (service.id == incidents[row].target) {
@@ -10032,6 +10065,23 @@ void MainWindow::runEditorSmokeE2E() {
 							commitIncidentEndSeconds();
 						}
 					}
+					const std::vector<SceneSignal> savedSignals = sceneSignals(m_sceneModel);
+					sceneSignals(m_sceneModel).clear();
+					refreshIncidentPanel();
+					const bool blockTargetOffered = m_incidentTargetCombo
+						&& m_incidentTargetCombo->findText(QString::fromStdString(renamedBlockId)) >= 0;
+					if (!blockTargetOffered) {
+						facetFailure(facetOk, "stations/signalling", "block target was not offered with an empty signal list");
+					} else {
+						m_incidentTargetCombo->setCurrentText(QString::fromStdString(renamedBlockId));
+						commitIncidentTarget(QString::fromStdString(renamedBlockId));
+						const SceneIncident* blockIncident = selectedIncident();
+						if (!blockIncident || blockIncident->target != renamedBlockId)
+							facetFailure(facetOk, "stations/signalling", "block signal_failure target did not persist canonically");
+					}
+					sceneSignals(m_sceneModel) = savedSignals;
+					refreshIncidentPanel();
+					refreshValidationPanel();
 				} else {
 					facetFailure(facetOk, "stations/signalling", "incident controls unavailable for signal coverage");
 				}
@@ -10254,12 +10304,13 @@ void MainWindow::runEditorSmokeE2E() {
 		bool hasParameterSource = false;
 		bool hasTractionSource = false;
 		for (QLabel* label : findChildren<QLabel*>()) {
-			hasParameterSource = hasParameterSource || label->text() == "Original parameter source";
-			hasTractionSource = hasTractionSource || label->text() == "Original tractive-effort source";
+			hasParameterSource = hasParameterSource || label->text() == "Parameter source reference";
+			hasTractionSource = hasTractionSource || label->text() == "Tractive-effort source reference";
 		}
 		bool hasPlotButton = false;
 		for (QPushButton* button : findChildren<QPushButton*>())
 				hasPlotButton = hasPlotButton || button->text() == "Plot input traction characteristic";
+		const bool hasEditableTrainSources = m_trainUnitSourceDataEdit && m_trainUnitSourceTractionEdit;
 		bool hasPlannedArrival = false;
 		bool hasPlannedDeparture = false;
 		for (QCheckBox* check : findChildren<QCheckBox*>()) {
@@ -10287,7 +10338,7 @@ void MainWindow::runEditorSmokeE2E() {
 				}
 			}
 		}
-		if (!explorerOk || !hasParameterSource || !hasTractionSource || !hasPlotButton
+		if (!explorerOk || !hasParameterSource || !hasTractionSource || !hasPlotButton || !hasEditableTrainSources
 				|| !hasPlannedArrival || !hasPlannedDeparture || !axesOk) {
 			ok = false;
 			failures << "explorer: load review, activation, generic provenance, plot axes, or timetable labels missing";
@@ -10359,6 +10410,26 @@ void MainWindow::runEditorSmokeE2E() {
 			}
 			if (oldReferencePresent || !newReferencePresent)
 				facetFailure(facetOk, "train unit", "rename did not update composition references");
+
+			m_trainUnitListWidget->setCurrentRow(originalCount);
+			const QString initialSourceData = QStringLiteral("e2e/source-data-initial.txt");
+			const QString initialSourceTraction = QStringLiteral("e2e/source-traction-initial.txt");
+			const QString editedSourceData = QStringLiteral("e2e/source-data-final.txt");
+			const QString editedSourceTraction = QStringLiteral("e2e/source-traction-final.txt");
+			if (!m_trainUnitSourceDataEdit || !m_trainUnitSourceTractionEdit) {
+				facetFailure(facetOk, "train unit", "source reference editors unavailable");
+			} else {
+				m_trainUnitSourceDataEdit->setText(initialSourceData);
+				m_trainUnitSourceTractionEdit->setText(initialSourceTraction);
+				QMetaObject::invokeMethod(m_trainUnitSourceDataEdit, "editingFinished", Qt::DirectConnection);
+				m_trainUnitSourceDataEdit->setText(editedSourceData);
+				m_trainUnitSourceTractionEdit->setText(editedSourceTraction);
+				QMetaObject::invokeMethod(m_trainUnitSourceTractionEdit, "editingFinished", Qt::DirectConnection);
+				const SceneTrainUnit& editedUnit = m_sceneModel.trainUnits[originalCount];
+				if (editedUnit.sourceDataFile != editedSourceData.toStdString()
+						|| editedUnit.sourceTractionFile != editedSourceTraction.toStdString())
+					facetFailure(facetOk, "train unit", "source reference edits did not commit both fields");
+			}
 
 			const double physicalValues[] = {
 				101.1234567890123, 51.0000000012345, 2.0, 40.1234567890123,
@@ -10462,15 +10533,13 @@ void MainWindow::runEditorSmokeE2E() {
 				}
 			}
 		}
-		if (!m_sceneModel.trainUnits.empty() && !m_sceneModel.trainUnits.front().sourceDataFile.empty()) {
+		if (!m_sceneModel.trainUnits.empty()) {
 			m_trainUnitListWidget->setCurrentRow(0);
-			if (!m_trainUnitSourceDataLabel || m_trainUnitSourceDataLabel->text().toStdString() != m_sceneModel.trainUnits.front().sourceDataFile)
-				facetFailure(facetOk, "train unit", "source data filename is not visible and unchanged");
-		}
-		if (!m_sceneModel.trainUnits.empty() && !m_sceneModel.trainUnits.front().sourceTractionFile.empty()) {
-			m_trainUnitListWidget->setCurrentRow(0);
-			if (!m_trainUnitSourceTractionLabel || m_trainUnitSourceTractionLabel->text().toStdString() != m_sceneModel.trainUnits.front().sourceTractionFile)
-				facetFailure(facetOk, "train unit", "source traction filename is not visible and unchanged");
+			if (!m_trainUnitSourceDataEdit || m_trainUnitSourceDataEdit->text().toStdString()
+					!= m_sceneModel.trainUnits.front().sourceDataFile
+				|| !m_trainUnitSourceTractionEdit || m_trainUnitSourceTractionEdit->text().toStdString()
+					!= m_sceneModel.trainUnits.front().sourceTractionFile)
+				facetFailure(facetOk, "train unit", "source references are not visible and unchanged");
 		}
 		expectedCompositions = m_sceneModel.compositions;
 		if (facetOk)
@@ -10484,57 +10553,102 @@ void MainWindow::runEditorSmokeE2E() {
 	} else {
 		bool facetOk = true;
 		const int originalCount = m_compositionListWidget->count();
-		m_compositionListWidget->setCurrentRow(0);
-		// the selected unit surfaces its source files and a plottable traction curve
-		if (m_compositionUnitsListWidget && m_compositionUnitsListWidget->count() > 0 &&
-			m_compositionUnitsListWidget->item(0)) {
-			m_compositionUnitsListWidget->setCurrentRow(0);
-			const SceneTrainUnit* tractionUnit =
-				trainUnitById(m_compositionUnitsListWidget->item(0)->text().toStdString());
-			if (tractionUnit && !tractionUnit->tractionCurve.empty()) {
-				if (!m_plotTractionButton || !m_plotTractionButton->isEnabled())
-					facetFailure(facetOk, "composition", "traction plot disabled for a unit with a curve");
-				if (sampleTractionCurve(tractionUnit->tractionCurve).empty())
-					facetFailure(facetOk, "composition", "traction curve produced no plot samples");
-				if (m_compositionUnitSourceDataLabel && m_compositionUnitSourceDataLabel->text().isEmpty())
-					facetFailure(facetOk, "composition", "unit source data label empty");
-			}
-		}
-		duplicateComposition();
-		if (m_compositionListWidget->count() != originalCount + 1) {
-			facetFailure(facetOk, "composition", "duplicate did not apply");
-		} else {
-			m_compositionListWidget->setCurrentRow(1);
-			editedCompositionId = uniqueCompositionId("e2e_composition");
-			if (!m_compositionIdEdit) {
-				facetFailure(facetOk, "composition", "id editor unavailable");
-			} else {
-				m_compositionIdEdit->setText(QString::fromStdString(editedCompositionId));
-				commitCompositionIdEdit();
-				if (m_sceneModel.compositions.size() <= 1 || m_sceneModel.compositions[1].id != editedCompositionId)
-					facetFailure(facetOk, "composition", "id edit did not apply");
-			}
-		}
-		addComposition();
-		if (m_compositionListWidget->count() != originalCount + 2) {
-			facetFailure(facetOk, "composition", "add did not apply");
-		} else {
-			acceptConfirmation();
-			deleteComposition();
-			if (m_compositionListWidget->count() != originalCount + 1)
-				facetFailure(facetOk, "composition", "delete did not apply");
-		}
-		int editedRow = -1;
+		int assignedCompositionRow = -1;
 		for (int row = 0; row < static_cast<int>(m_sceneModel.compositions.size()); ++row) {
-			if (m_sceneModel.compositions[row].id == editedCompositionId) {
-				editedRow = row;
+			const std::string& compositionId = m_sceneModel.compositions[static_cast<std::size_t>(row)].id;
+			if (std::any_of(m_sceneModel.services.begin(), m_sceneModel.services.end(),
+					[&compositionId](const SceneService& service) { return service.composition == compositionId; })) {
+				assignedCompositionRow = row;
 				break;
 			}
 		}
-		if (editedRow < 0 || m_sceneModel.compositions[editedRow].units != expectedCompositions[0].units)
-			facetFailure(facetOk, "composition", "edited composition was not retained");
-		if (facetOk)
-			std::fprintf(stdout, "E2E_EDITOR_COMPOSITION_OK\n");
+		if (assignedCompositionRow < 0) {
+			facetFailure(facetOk, "composition", "no service-assigned composition available for rename coverage");
+		} else {
+			m_compositionListWidget->setCurrentRow(assignedCompositionRow);
+			// the selected unit surfaces its source files and a plottable traction curve
+			if (m_compositionUnitsListWidget && m_compositionUnitsListWidget->count() > 0 &&
+				m_compositionUnitsListWidget->item(0)) {
+				m_compositionUnitsListWidget->setCurrentRow(0);
+				const SceneTrainUnit* tractionUnit =
+					trainUnitById(m_compositionUnitsListWidget->item(0)->text().toStdString());
+				if (tractionUnit && !tractionUnit->tractionCurve.empty()) {
+					if (!m_plotTractionButton || !m_plotTractionButton->isEnabled())
+						facetFailure(facetOk, "composition", "traction plot disabled for a unit with a curve");
+					if (sampleTractionCurve(tractionUnit->tractionCurve).empty())
+						facetFailure(facetOk, "composition", "traction curve produced no plot samples");
+					if (m_compositionUnitSourceDataLabel && m_compositionUnitSourceDataLabel->text().isEmpty())
+						facetFailure(facetOk, "composition", "unit source data label empty");
+				}
+			}
+			duplicateComposition();
+			if (m_compositionListWidget->count() != originalCount + 1) {
+				facetFailure(facetOk, "composition", "duplicate did not apply");
+			} else {
+				const std::string originalAssignedCompositionId =
+					m_sceneModel.compositions[static_cast<std::size_t>(assignedCompositionRow)].id;
+				const std::string duplicateCompositionId =
+					m_sceneModel.compositions[static_cast<std::size_t>(assignedCompositionRow + 1)].id;
+				m_compositionListWidget->setCurrentRow(assignedCompositionRow);
+				if (!m_compositionIdEdit) {
+					facetFailure(facetOk, "composition", "id editor unavailable");
+				} else {
+					m_compositionIdEdit->setText(QString());
+					commitCompositionIdEdit();
+					const bool emptyRejected = m_sceneModel.compositions[static_cast<std::size_t>(assignedCompositionRow)].id
+							== originalAssignedCompositionId
+						&& m_compositionIdEdit->text() == QString::fromStdString(originalAssignedCompositionId)
+						&& m_compositionListWidget->currentRow() == assignedCompositionRow;
+					m_compositionIdEdit->setText(QString::fromStdString(duplicateCompositionId));
+					commitCompositionIdEdit();
+					const bool duplicateRejected = m_sceneModel.compositions[static_cast<std::size_t>(assignedCompositionRow)].id
+							== originalAssignedCompositionId
+						&& m_compositionIdEdit->text() == QString::fromStdString(originalAssignedCompositionId)
+						&& m_compositionListWidget->currentRow() == assignedCompositionRow;
+					if (!emptyRejected || !duplicateRejected)
+						facetFailure(facetOk, "composition", "empty or duplicate ID was not rejected with the prior text restored");
+
+					editedCompositionId = uniqueCompositionId("e2e_composition");
+					m_compositionIdEdit->setText(QString::fromStdString(editedCompositionId));
+					commitCompositionIdEdit();
+					int migratedServiceCount = 0;
+					int staleServiceCount = 0;
+					for (const auto& service : m_sceneModel.services) {
+						if (service.composition == editedCompositionId)
+							++migratedServiceCount;
+						if (service.composition == originalAssignedCompositionId)
+							++staleServiceCount;
+					}
+					if (m_sceneModel.compositions[static_cast<std::size_t>(assignedCompositionRow)].id != editedCompositionId
+							|| migratedServiceCount <= 0 || staleServiceCount != 0
+							|| m_compositionListWidget->currentRow() != assignedCompositionRow
+							|| !m_serviceCompositionCombo
+							|| m_serviceCompositionCombo->findText(QString::fromStdString(editedCompositionId)) < 0)
+						facetFailure(facetOk, "composition", "id edit did not apply");
+				}
+			}
+			addComposition();
+			if (m_compositionListWidget->count() != originalCount + 2) {
+				facetFailure(facetOk, "composition", "add did not apply");
+			} else {
+				acceptConfirmation();
+				deleteComposition();
+				if (m_compositionListWidget->count() != originalCount + 1)
+					facetFailure(facetOk, "composition", "delete did not apply");
+			}
+			int editedRow = -1;
+			for (int row = 0; row < static_cast<int>(m_sceneModel.compositions.size()); ++row) {
+				if (m_sceneModel.compositions[row].id == editedCompositionId) {
+					editedRow = row;
+					break;
+				}
+			}
+			if (editedRow < 0 || m_sceneModel.compositions[editedRow].units
+					!= expectedCompositions[static_cast<std::size_t>(assignedCompositionRow)].units)
+				facetFailure(facetOk, "composition", "edited composition was not retained");
+			if (facetOk)
+				std::fprintf(stdout, "E2E_EDITOR_COMPOSITION_OK\n");
+		}
 	}
 
 	std::string editedServiceId;
@@ -10985,8 +11099,31 @@ void MainWindow::runEditorSmokeE2E() {
 				}
 				if (!selectionRoundtripOk)
 					facetFailure(facetOk, "save/reload", "temporary occurrence selection was serialized or not reset on reopen");
+
+				const auto editedUnit = std::find_if(m_sceneModel.trainUnits.begin(), m_sceneModel.trainUnits.end(),
+					[&editedTrainUnitId](const SceneTrainUnit& unit) { return unit.id == editedTrainUnitId; });
+				if (editedUnit == m_sceneModel.trainUnits.end() || !m_trainUnitSourceDataEdit) {
+					facetFailure(facetOk, "save/reload", "edited train unit or source editor unavailable");
+				} else {
+					const int trainUnitRow = static_cast<int>(std::distance(m_sceneModel.trainUnits.begin(), editedUnit));
+					m_trainUnitListWidget->setCurrentRow(trainUnitRow);
+					const std::string pendingSource = "e2e/source-data-pending-save.txt";
+					m_trainUnitSourceDataEdit->setFocus();
+					m_trainUnitSourceDataEdit->setText(QString::fromStdString(pendingSource));
+					if (m_sceneModel.trainUnits[static_cast<std::size_t>(trainUnitRow)].sourceDataFile == pendingSource) {
+						facetFailure(facetOk, "save/reload", "pending source edit committed before the save path");
+					} else if (!saveSceneToCurrentDir()) {
+						facetFailure(facetOk, "save/reload", "save path rejected a pending source edit");
+					} else if (!openSceneDirectory(outScenePath)) {
+						facetFailure(facetOk, "save/reload", "scene with a pending source edit did not reload");
+					} else {
+						const auto reloadedUnit = std::find_if(m_sceneModel.trainUnits.begin(), m_sceneModel.trainUnits.end(),
+							[&editedTrainUnitId](const SceneTrainUnit& unit) { return unit.id == editedTrainUnitId; });
+						if (reloadedUnit == m_sceneModel.trainUnits.end() || reloadedUnit->sourceDataFile != pendingSource)
+							facetFailure(facetOk, "save/reload", "pending source edit was not saved and reloaded");
+					}
+				}
 			}
-		}
 		if (facetOk)
 			std::fprintf(stdout, "E2E_EDITOR_SAVE_RELOAD_OK\n");
 	}
@@ -12401,6 +12538,7 @@ void MainWindow::runScene() {
 
 	commitPendingCaseSettings();
 	commitPendingServiceSettings();
+	commitTrainUnitSources();
 	refreshValidationPanel();
 	if (hasErrors(m_sceneDiagnostics)) {
 		int errorCount = countDiagnostics(m_sceneDiagnostics).errors;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -11124,6 +11124,7 @@ void MainWindow::runEditorSmokeE2E() {
 					}
 				}
 			}
+		}
 		if (facetOk)
 			std::fprintf(stdout, "E2E_EDITOR_SAVE_RELOAD_OK\n");
 	}

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -428,8 +428,8 @@ private:
 	QListWidget* m_trainUnitListWidget = nullptr;
 	QLineEdit* m_trainUnitIdEdit = nullptr;
 	std::array<QDoubleSpinBox*, 9> m_trainUnitPhysicalEdits{};
-	QLabel* m_trainUnitSourceDataLabel = nullptr;
-	QLabel* m_trainUnitSourceTractionLabel = nullptr;
+	QLineEdit* m_trainUnitSourceDataEdit = nullptr;
+	QLineEdit* m_trainUnitSourceTractionEdit = nullptr;
 	QTableWidget* m_trainUnitTractionTable = nullptr;
 	QPushButton* m_addTrainUnitButton = nullptr;
 	QPushButton* m_duplicateTrainUnitButton = nullptr;
@@ -617,6 +617,7 @@ private:
 	void duplicateTrainUnit();
 	void deleteTrainUnit();
 	void commitTrainUnitIdEdit();
+	void commitTrainUnitSources();
 	void commitTrainUnitPhysical(int fieldIndex);
 	void addTrainUnitTractionRow();
 	void removeTrainUnitTractionRow();

--- a/docs/architecture/scene-editor-flow.md
+++ b/docs/architecture/scene-editor-flow.md
@@ -2,17 +2,22 @@
 
 ## Purpose and users
 
-The scene editor gives students one window flow for opening an assignment scene, editing timetable and incident data, running EGTRAIN, and inspecting the existing diagrams. Instructors need portable bundles, editable scene directories, and clear validation errors. Researchers need readable JSON inputs and reproducible runs without direct legacy-file editing.
+The scene editor gives instructors one window flow for creating a railway case,
+authoring its canonical data, running EGTRAIN, and packaging the result. Students
+can edit the supplied timetable and scenarios and inspect the same result views.
+Researchers retain readable JSON inputs and reproducible native runs without
+using legacy files.
 
 ## Window flow
 
-- Start state: the main window opens with no scene selected. `Open Case Study...`, `Open Scene Folder...`, recent scenes, `Load Legacy Case...`, and `Quit` are available. Save, scene edit panes, and scene Run are disabled until a scene opens.
+- Start state: the main window opens with no scene selected. `New Case Study...`, `Open Case Study...`, `Open Scene Folder...`, recent scenes, `Load Legacy Case...`, and `Quit` are available. Save, scene edit panes, and scene Run are disabled until a scene opens.
+- New scene: `New Case Study...` creates the smallest structurally valid `SceneModel`. It remains editable and saveable while semantic diagnostics identify the railway data still required for Run.
 - Open scene: `Open Case Study...` selects an `.egscene` bundle; `Open Scene Folder...` selects an editable canonical directory. Both load the same canonical JSON into `SceneModel`, add the selected path to the recent-scenes list in `QSettings`, and raise the non-modal Loaded Data review.
 - Validation: opening a scene populates the validation panel with `SceneDiagnostic` entries. Structural errors are shown first. Semantic validation runs only when structural loading has no errors; the panel remains available from the View menu and Loaded Data diagnostics.
 - Edit panes: after a valid enough model loads, the editor panes show scene data from `SceneModel`. V1 edits update `SceneModel`; they do not edit legacy files directly.
 - Save: `Save Scene` writes back to the opened bundle or directory. `Save Case Study As...` writes a portable `.egscene`; `Save Scene As Folder...` writes canonical JSON to a directory.
 - Run handoff: Run revalidates the current model. Error diagnostics block Run. If validation passes, the shared native setup builds the existing runtime globals directly from that model.
-- Back to diagrams: after the run, students return to the normal EGTRAIN diagram tools: speed-distance, speed-time, time-distance, delay, train path, and blocking-time diagrams.
+- Back to results: after the run, students can inspect speed, time, applied tractive effort, blocking-time, timetable, delay, and capacity results. Existing tables and diagrams provide CSV or PNG export where applicable.
 
 `Load Legacy Case...` is an explicit conversion action. It reads a selected
 external legacy directory into a new canonical scene; the source files are not
@@ -25,7 +30,7 @@ an editable or runtime fallback.
 | File menu | `Open Case Study...`, `Open Scene Folder...`, `Save Scene`, `Save Case Study As...`, `Save Scene As Folder...`, recent scenes, `Load Legacy Case...`, `Quit` | Open, recent scenes, legacy case picker, and Quit are always enabled. Save is enabled when a scene is loaded and dirty. Both Save As actions are enabled when a scene is loaded. |
 | Simulation menu and toolbar | `Run`, `Pause`, `Stop`, speed control | Run is enabled when a runnable scene is loaded and no scene error diagnostics are current. Pause and Stop are enabled only while simulation is running. |
 | Central view | Existing network view and progress bar | Empty at startup. Shows canonical scene infrastructure after open and simulation state after setup and run. |
-| Scene editor dock | Overview, infrastructure context, compositions, services and timetable, incidents | Enabled for an opened bundle or directory. A legacy case must first be imported and opened as a scene. |
+| Editor docks | Case settings, infrastructure, train units, compositions, services and timetable, incidents | Enabled for a new or opened canonical scene. A legacy case must first be imported as a scene. |
 | Validation panel | Dockable table of diagnostics | Visible after scene open. Updated on open, edit, save, and pre-run validation. |
 | Loaded Data panel | Case/source metadata, parsed category counts, scenarios, provenance, validation status, editor links, runtime and result readiness | Raised after scene open. Item activation reuses the existing network view, validation table, and domain editors. |
 | Existing info dock | Read-only selected item details for nodes, stations, arcs, connections, signals, trains | Enabled when the network view has selectable items. It stays read-only outside explicit editor controls. |
@@ -35,7 +40,7 @@ an editable or runtime fallback.
 
 Validation runs when a bundle or directory opens, after each committed editor change, after Save or Save As, and immediately before Run. The pre-run validation is mandatory even when the panel already shows no errors.
 
-Structural diagnostics come from the bundle reader or directory loader and the required JSON files. If structural loading has errors, semantic validation is skipped to avoid duplicate noise from a partial model. Semantic diagnostics check references, empty trains or routes, timetable values, dwell times, platform references, incident targets, incident windows, base time, and repeated-service headways.
+Structural diagnostics come from the bundle reader or directory loader and the required JSON files. If structural loading has errors, semantic validation is skipped to avoid duplicate noise from a partial model. Semantic diagnostics check topology, identifiers and references, rolling-stock values and traction intervals, timetable values, signalling coverage, incidents, base time, and repeated-service rules.
 
 Save is allowed with semantic errors so students can preserve work in progress. Run is not allowed with any `SceneSeverity::Error`. Warnings and info diagnostics stay visible but do not block Run. Native builder diagnostics appear under **Runtime and results** in Loaded Data, and builder errors block Run.
 
@@ -72,43 +77,29 @@ available, but remains outside canonical input.
 
 ## V1 edit panes
 
-Tables are read-only first. Editing happens through explicit row, cell, add, duplicate, and delete controls inside the editor panes.
+Editing uses explicit fields, table cells, and add, duplicate, move, and delete
+controls. The network view previews canonical infrastructure; it is not a CAD
+surface.
 
-| Pane | Editable in V1 | Read-only in V1 |
+| Pane | Editable in V1 | Derived or read-only |
 |---|---|---|
-| Overview | None for scene JSON metadata | Scene name, scene path, schema version, base time, units, derived run parameters, validation summary |
-| Infrastructure context | None | Stations, platforms, signals, routes, block ids, imported infrastructure context |
-| Compositions | Train compositions and unit membership | Full train-unit source files and traction curve structure |
-| Services and timetable | Services, composition choice, route choice, stopping patterns, station stops, platform choices, arrival times, departure times, dwell times, entry time, repeated-service headway, per-service performance values | Station definitions, route block definitions, signal definitions |
-| Incidents | Signal failure incidents and train breakdown incidents: id, type, target, start time, end time | Target lists derived from signals and services |
+| Case settings | Name, description, base time, duration, buffer, recovery | Schema version, units, scene path, validation summary |
+| Infrastructure | Tracks, nodes, arcs, blocks, connections, stations, platforms, signals, signalling areas, routes, dependencies, single-track restrictions, station boundaries | Network geometry preview and runtime diagnostics |
+| Train units | ID, nine native physical fields, traction rows, parameter source reference, traction source reference | Static traction plot; composition usage |
+| Compositions | ID and ordered train-unit membership | Selected-unit source references and traction plot |
+| Services and timetable | ID, operating code, composition, route, through state, entry time, performance, optional speed cap, repeat count/headway/code step, run selection, ordered stops, platforms, planned arrival/departure, dwell | Generated occurrence identities and offsets |
+| Incidents | Scenario metadata; signal failures and train breakdowns; targets, windows, occurrence, reduced speed, recovery, destination termination | Target choices derived from signals, blocks, routes, and services |
 
-Per-service performance values still need new fields in `services.json` and `SceneModel`. Incident edits are part of the native run handoff and require no generated legacy file.
+Canonical entrance delays can be loaded and run but do not yet have an editor;
+issue #126 tracks that optional scenario extension. The assignment workflow uses
+signal-failure and train-breakdown incidents.
 
 ## Explicit out-of-scope list
 
-- Full infrastructure editing in V1.
-- Drawing or editing nodes, arcs, tracks, switches, gradients, curves, speed limits, station topology, platform topology, signals, block sections, routes, or corridors.
+- Drag-and-drop railway CAD, route painting, or automatic signal placement.
+- Automatic timetable optimization or performance sweeps.
+- A generic scenario scripting language.
 - Treating legacy files as the editable source of truth.
 - Editing legacy source files from the UI.
 - Treating an explicit interoperability export as a scene directory.
-- Replacing existing diagram windows or diagram export behavior as part of the scene editor flow.
 - General-purpose JSON text editing inside the application.
-
-## Consequences for #23 and #24
-
-#23 implements the scene load and save UI:
-
-- File menu actions for opening bundles or folders, saving bundles or folders, recent scenes, and legacy import.
-- Main-window scene state: current scene path, current `SceneModel`, dirty flag, recent-scenes `QSettings`, and action enabled state.
-- Open dialogs for `.egscene` files and canonical directories.
-- Save and Save As behavior for bundles and canonical JSON directories.
-- Unsaved-change prompts when opening another scene, loading a legacy case, or quitting.
-
-#24 implements the validation panel:
-
-- Dockable `Scene Validation` panel.
-- Table columns for severity, code, message, file, path, and suggested fix.
-- Population from `SceneDiagnostic` entries on open, edit, save, and pre-run validation.
-- Error summary in the status bar.
-- Run gating when any diagnostic has error severity.
-- Selection behavior that opens or focuses the related editor row when the diagnostic identifies an item.

--- a/docs/guides/lebanon-case-study.md
+++ b/docs/guides/lebanon-case-study.md
@@ -48,7 +48,7 @@ Open the Train Units dock.
 2. Give the unit an id.
 3. Fill the physical fields: mass, length, and the other values for the stock you are modelling.
 4. Enter the traction curve rows. Each row is a speed interval with a lower speed, an upper speed, and the three coefficients C0, C1, and C2. Tractive effort at a speed follows C0 plus C1 times speed plus C2 times speed squared, in newtons, with speed in metres per second.
-5. When import provenance exists, **Original parameter source** and **Original tractive-effort source** show the source filenames. Provenance is optional and is not reopened by the runtime.
+5. **Parameter source reference** and **Tractive-effort source reference** retain imported filenames and accept references for newly authored units. Provenance is optional and is not reopened by the runtime.
 
 Repeat for every unit the presentation needs, then remove the teaching unit if
 no composition uses it.

--- a/docs/product/assignment-workflow.md
+++ b/docs/product/assignment-workflow.md
@@ -5,37 +5,36 @@ work behind the TU Delft OpenTrack assignment. The controls and result views are
 EGTRAIN-native. Students should reproduce the method and explain their modelling
 choices, not copy OpenTrack menus or target the model-answer timestamps.
 
-The committed `Assignment_Gvc_Gdg_Ut` scene is an incomplete synthetic fixture.
-It is useful for product smoke tests, but it is not the distributable assignment
-case. The course archive named `OpenTrack data 2016.zip` is not in the repository,
-and the model-answer PDF does not contain enough infrastructure, signalling, or
-rolling-stock data to reconstruct it. [Issue #182](https://github.com/Ancientkingg/EGTRAIN/issues/182)
-tracks the corridor and signalling source. [Issue #228](https://github.com/Ancientkingg/EGTRAIN/issues/228)
-and [issue #181](https://github.com/Ancientkingg/EGTRAIN/issues/181) track the train
-sources and compositions. Do not distribute the fixture as the completed course
-case or fill those gaps from screenshots.
+The application provides the complete authoring and analysis path. It does not
+invent the railway records. An instructor supplies authoritative infrastructure,
+signalling, and rolling-stock values and records the train-unit source references
+in the editor. The committed `Assignment_Gvc_Gdg_Ut` scene is a synthetic smoke
+fixture, not a distributable TU Delft case. Issues
+[#182](https://github.com/Ancientkingg/EGTRAIN/issues/182),
+[#228](https://github.com/Ancientkingg/EGTRAIN/issues/228), and
+[#181](https://github.com/Ancientkingg/EGTRAIN/issues/181) track optional project
+work to add a source-backed example dataset.
 
 ## Instructor preparation
 
-Once the source records are available, an instructor can build the case through
-the normal application workflow:
+An instructor can build the case through the normal application workflow:
 
 1. Choose **File > New Case Study...** and enter the case name, base time,
    duration, buffer, and recovery settings in **Case Settings**.
 2. Use the **Infrastructure** table and network preview to add tracks, nodes,
    arcs, blocks, connections, stations, platforms, signals, routes, dependencies,
    restrictions, boundaries, and signalling areas.
-3. Add sourced train units, their physical fields and traction curves, then build
-   ordered compositions from those units.
+3. Add sourced train units, their physical fields, traction curves, and source
+   references, then build ordered compositions from those units.
 4. Add the four services, route and platform stops, planned arrival and departure
    times, dwell, per-service performance, and repeat rules.
-5. Add named scenarios for the signal failure and occurrence-specific train
-   breakdown.
+5. Add named scenarios. A signal failure can target the corresponding canonical
+   signal or block. A breakdown can target one generated service occurrence.
 6. Resolve validation errors, run representative services, and save both the
    canonical folder and a `.egscene` bundle. Reopen the bundle before release.
 
-The assignment defines these base services and compositions. Their physical
-train-unit records still require the sources tracked in issues #228 and #181.
+The assignment defines these base services and compositions. The instructor
+enters their sourced physical and traction records through the train-unit editor.
 
 | Service | Assignment composition |
 | --- | --- |
@@ -68,17 +67,17 @@ with an implicit conventional or ETCS setting.
 | 10 | Inspect speed versus distance | Open the existing speed-distance result and filter the trains. | Explain acceleration, braking, and line-speed effects. |
 | 11 | Inspect actual tractive effort | Open the applied tractive-effort distance result or export its CSV. | Distinguish positive traction, coasting or balance, and braking from the static traction curve. |
 | 12 | Compare an alternative composition | Duplicate or edit a composition assignment and rerun. | Explain the change in performance and feasibility. |
-| 13 | Compare SGM and Plan V | Select the sourced alternatives and rerun the same service. | Explain the observed differences. This exercise remains blocked until #228 and #181 supply both records. |
+| 13 | Compare SGM and Plan V | Author or select the sourced alternatives and rerun the same service. | Explain the observed differences. |
 | 14 | Compute minimum headways | Open **Capacity**, choose an ordered pair and explicit route section. | Interpret the minimum headway and governing block. |
 | 15 | Compress the timetable | Use the same ordered occurrence sequence in **Capacity** and open the compressed diagram. | Check that order is preserved and occupations do not conflict. |
 | 16 | Identify critical blocks | Inspect the reported touching constraints in the compressed result. | Explain why a critical touch is not an overlap conflict. |
 | 17 | Obtain buffer times | Read scheduled headway, minimum headway, and their unclamped difference. | Interpret positive or negative buffer. |
 | 18 | Assess capacity consumption | Select the analysis period and explicit cycle-closing occurrence. | Reproduce the displayed numerator, denominator, and percentage, then compare it with the course recommendation. |
 | 19 | Generate a multi-hour timetable | Increase repeat count while retaining the interval and code step. | Check occurrence identities and planned offsets. |
-| 20 | Simulate signal failure | Select the 08:30 to 09:00 signal-failure scenario and run the same occurrence set as the baseline. | Inspect the affected traffic and blocking-time change. The historical S451 mapping remains blocked by #182. |
+| 20 | Simulate signal failure | Map S451 to the corresponding canonical signal or block, set the 08:30 to 09:00 window, and run the same occurrence set as the baseline. | Inspect the affected traffic and blocking-time change. |
 | 21 | Simulate rolling-stock breakdown | Target IC 1727 at 08:25, set the 40 km/h cap, and request destination termination at Utrecht. | Check that sibling repeats are unchanged and the target continues under signalling. |
 | 22 | Distinguish delay effects | Freeze an incident-free baseline, run the incident scenario, and open delay comparison. | Interpret direct primary rows, propagated secondary rows, and the reconciled total arrival delay. |
-| 23 | Add the extra train | Create a normal through service with the 3xPlanV composition and a 100 km/h service cap. | Experiment with departure time to limit propagated delay. This exercise remains blocked until sourced Plan V data is available. |
+| 23 | Add the extra train | Create a normal through service with the instructor-supplied 3xPlanV composition and a 100 km/h service cap. | Experiment with departure time to limit propagated delay. |
 | 24 | Export results | Use CSV from result tables and PNG from diagrams. | Keep the input settings and selected occurrences with submitted evidence. |
 | 25 | Save and distribute | Save the canonical folder, use **Save As** for `.egscene`, reopen it, and rerun representative exercises. | Work from a copy of the distributed bundle. |
 


### PR DESCRIPTION
## Summary

- make train-unit parameter and traction source references editable and flush focused values before save, close, and Run
- reject empty or duplicate composition IDs and migrate assigned service references on rename
- offer canonical signals, blocks, and route block tokens as signal-failure targets
- update the authoring guides to describe the complete human-authored workflow

Optional entrance-delay editing remains tracked in #126 and is not required by the 25 assignment operations.

## Verification

- QEGTRAIN build
- CTest: 43/43 passed
- editor_smoke.sh
- incident_smoke.py
- visual_polish_smoke.sh
- graph update
- diff whitespace check

Closes #50
Closes #283
Closes #284
