### PR TITLE
Make editor mutations reference-safe

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -2786,12 +2786,12 @@ void MainWindow::newScene() {
 	updateSceneActions();
 	statusBar()->showMessage("New case study created; save it to choose a location");
 	refreshCaseSettingsPanel();
-	refreshValidationPanel();
 	refreshCompositionPanel();
 	refreshTrainUnitPanel();
 	refreshServicePanel();
 	refreshIncidentPanel();
 	refreshInfrastructurePanel();
+	refreshValidationPanel();
 	renderTrackPreview(m_sceneModel);
 	if (m_caseSettingsDock) {
 		m_caseSettingsDock->show();
@@ -2873,12 +2873,12 @@ bool MainWindow::openSceneDirectory(const QString& dir) {
 								 .arg(QString::fromStdString(m_sceneModel.name))
 								 .arg(static_cast<int>(m_sceneModel.services.size()))
 								 .arg(static_cast<int>(m_sceneModel.routes.size())));
-	refreshValidationPanel();
 	refreshCompositionPanel();
 	refreshTrainUnitPanel();
 	refreshServicePanel();
 	refreshIncidentPanel();
 	refreshInfrastructurePanel();
+	refreshValidationPanel();
 	renderTrackPreview(m_sceneModel);
 	if (m_loadedDataDock) {
 		m_loadedDataDock->show();
@@ -3180,9 +3180,7 @@ bool MainWindow::finishSceneSave(const SceneSaveResult& result) {
 bool MainWindow::saveSceneToCurrentDir() {
 	if (!m_sceneLoaded)
 		return false;
-	commitPendingCaseSettings();
-	commitPendingServiceSettings();
-	commitTrainUnitSources();
+	commitPendingEditorValues();
 	if (m_sceneDir.isEmpty())
 		return saveSceneAsToBundle();
 
@@ -3199,9 +3197,7 @@ void MainWindow::saveSceneAs() {
 bool MainWindow::saveSceneAsToBundle() {
 	if (!m_sceneLoaded)
 		return false;
-	commitPendingCaseSettings();
-	commitPendingServiceSettings();
-	commitTrainUnitSources();
+	commitPendingEditorValues();
 
 	const QString startPath = m_sceneDir.isEmpty() ? QDir::homePath()
 		: (QFileInfo(m_sceneDir).isDir() ? m_sceneDir : QFileInfo(m_sceneDir).absoluteFilePath());
@@ -3226,9 +3222,7 @@ bool MainWindow::saveSceneAsToBundle() {
 bool MainWindow::saveSceneAsToDirectory() {
 	if (!m_sceneLoaded)
 		return false;
-	commitPendingCaseSettings();
-	commitPendingServiceSettings();
-	commitTrainUnitSources();
+	commitPendingEditorValues();
 
 	const QString startDir = m_sceneDir.isEmpty() ? QDir::homePath()
 		: (QFileInfo(m_sceneDir).isDir() ? m_sceneDir : QFileInfo(m_sceneDir).absolutePath());
@@ -3303,9 +3297,7 @@ bool MainWindow::copyScenePassthroughFiles(const QString& targetDir) {
 }
 
 bool MainWindow::maybeSaveScene() {
-	commitPendingCaseSettings();
-	commitPendingServiceSettings();
-	commitTrainUnitSources();
+	commitPendingEditorValues();
 	if (!m_sceneDirty)
 		return true;
 
@@ -3323,7 +3315,7 @@ bool MainWindow::maybeSaveScene() {
 
 void MainWindow::updateSceneActions() {
 	if (m_saveSceneAction)
-		m_saveSceneAction->setEnabled(m_sceneLoaded && m_sceneDirty);
+		m_saveSceneAction->setEnabled(m_sceneLoaded);
 	if (m_saveSceneAsAction)
 		m_saveSceneAsAction->setEnabled(m_sceneLoaded);
 	if (m_saveSceneAsFolderAction)
@@ -3345,6 +3337,9 @@ void MainWindow::updateSceneActions() {
 }
 
 void MainWindow::refreshValidationPanel() {
+	if (m_committingPendingEditorValues)
+		return;
+	commitPendingEditorValues();
 	if (!m_sceneLoaded) {
 		m_sceneDiagnostics.clear();
 		if (m_validationTable)
@@ -3615,6 +3610,62 @@ void MainWindow::refreshCaseSettingsPanel() {
 	}
 }
 
+void MainWindow::commitPendingEditorValues() {
+	if (m_committingPendingEditorValues)
+		return;
+	m_committingPendingEditorValues = true;
+	const auto hasEditorFocus = [](QWidget* editor) {
+		QWidget* focus = QApplication::focusWidget();
+		return editor && (editor->hasFocus() || (focus && editor->isAncestorOf(focus)));
+	};
+
+	commitPendingCaseSettings();
+	commitTrainUnitIdEdit();
+	for (std::size_t index = 0; index < m_trainUnitPhysicalEdits.size(); ++index) {
+		QDoubleSpinBox* edit = m_trainUnitPhysicalEdits[index];
+		if (hasEditorFocus(edit)) {
+			edit->interpretText();
+			commitTrainUnitPhysical(static_cast<int>(index));
+		}
+	}
+	if (m_trainUnitTractionTable) {
+		for (int row = 0; row < m_trainUnitTractionTable->rowCount(); ++row) {
+			for (int column = 0; column < m_trainUnitTractionTable->columnCount(); ++column) {
+				auto* edit = qobject_cast<QDoubleSpinBox*>(m_trainUnitTractionTable->cellWidget(row, column));
+				if (hasEditorFocus(edit)) {
+					edit->interpretText();
+					commitTrainUnitTractionCell(row, column, edit->value());
+				}
+			}
+		}
+	}
+	commitTrainUnitSources();
+	commitCompositionIdEdit();
+	commitPendingServiceSettings();
+	if (m_stopArrivalSecondsEdit && m_stopArrivalSecondsEdit->isEnabled())
+		commitStopArrivalSeconds();
+	if (m_stopDepartureSecondsEdit && m_stopDepartureSecondsEdit->isEnabled())
+		commitStopDepartureSeconds();
+	if (m_stopDwellSecondsEdit && m_stopDwellSecondsEdit->isEnabled())
+		commitStopDwellSeconds();
+	commitScenarioIdEdit();
+	commitScenarioNameEdit();
+	commitScenarioDescriptionEdit();
+	commitIncidentIdEdit();
+	commitIncidentStartSeconds();
+	if (m_incidentHasEndSecondsCheck && m_incidentHasEndSecondsCheck->isChecked())
+		commitIncidentEndSeconds();
+	if (m_incidentHasOccurrenceCheck && m_incidentHasOccurrenceCheck->isChecked())
+		commitIncidentOccurrence();
+	if (m_incidentHasReducedSpeedCheck && m_incidentHasReducedSpeedCheck->isChecked()
+			&& m_incidentReducedSpeedKmhEdit) {
+		m_incidentReducedSpeedKmhEdit->interpretText();
+		commitIncidentReducedSpeed();
+	}
+
+	m_committingPendingEditorValues = false;
+}
+
 void MainWindow::commitPendingCaseSettings() {
 	if (m_caseDurationSecondsEdit)
 		m_caseDurationSecondsEdit->interpretText();
@@ -3705,6 +3756,153 @@ std::string MainWindow::uniqueInfrastructureId(const std::string& baseId, const 
 	while (exists(candidate))
 		candidate = baseId + "_" + std::to_string(suffix++);
 	return candidate;
+}
+
+QStringList MainWindow::directDeleteConsumers(const QString& facet, const std::string& id,
+		const std::string& scope) const {
+	QStringList consumers;
+	const auto add = [&consumers](const QString& description) {
+		if (!description.isEmpty() && !consumers.contains(description))
+			consumers << description;
+	};
+	const auto sectionUsesBlock = [&id](const SceneSectionInventory& inventory,
+			const std::string& reference) {
+		const std::vector<std::string> components = previewRouteComponents(reference);
+		if (std::find(components.begin(), components.end(), id) != components.end())
+			return true;
+		const SceneSectionDescriptor* section = inventory.resolve(reference);
+		return section && (section->sourceBlockId == id || section->firstBlockId == id
+			|| section->secondBlockId == id);
+	};
+	const auto sectionUsesConnection = [](const SceneSectionInventory& inventory,
+			const std::string& connectionId, const std::string& reference) {
+		const SceneSectionDescriptor* section = inventory.resolve(reference);
+		return section && section->sourceConnectionId == connectionId;
+	};
+
+	if (facet == "tracks") {
+		for (const auto& node : m_sceneModel.nodes)
+			if (node.trackId == id)
+				add(QString("node '%1'").arg(QString::fromStdString(node.id)));
+		for (const auto& arc : m_sceneModel.arcs)
+			if (arc.trackId == id)
+				add(QString("arc '%1'").arg(QString::fromStdString(arc.id)));
+		for (const auto& block : m_sceneModel.blocks)
+			if (block.trackId == id)
+				add(QString("block '%1'").arg(QString::fromStdString(block.id)));
+		for (const auto& area : m_sceneModel.signallingAreas)
+			if (area.trackId == id)
+				add(QString("signalling area '%1'").arg(QString::fromStdString(area.id)));
+	} else if (facet == "nodes") {
+		for (const auto& arc : m_sceneModel.arcs)
+			if (arc.fromNodeId == id || arc.toNodeId == id)
+				add(QString("arc '%1' endpoint").arg(QString::fromStdString(arc.id)));
+		for (const auto& connection : m_sceneModel.connections)
+			if (connection.fromNodeId == id || connection.toNodeId == id)
+				add(QString("connection '%1' endpoint").arg(QString::fromStdString(connection.id)));
+		for (const auto& station : m_sceneModel.stations)
+			for (const auto& platform : station.platforms)
+				if (std::find(platform.nodeIds.begin(), platform.nodeIds.end(), id) != platform.nodeIds.end())
+					add(QString("platform '%1' at station '%2'")
+						.arg(QString::fromStdString(platform.id), QString::fromStdString(station.id)));
+	} else if (facet == "blocks" || facet == "connections") {
+		const SceneSectionInventory inventory = buildSceneSectionInventory(m_sceneModel);
+		const auto usesSection = [&](const std::string& reference) {
+			return facet == "blocks" ? sectionUsesBlock(inventory, reference)
+				: sectionUsesConnection(inventory, id, reference);
+		};
+		for (const auto& route : m_sceneModel.routes)
+			for (const auto& token : route.blocks)
+				if (usesSection(token)) {
+					add(QString("route '%1' section '%2'")
+						.arg(QString::fromStdString(route.id), QString::fromStdString(token)));
+					break;
+				}
+		for (const auto& signal : sceneSignals(m_sceneModel))
+			if (usesSection(signal.protectedSection))
+				add(QString("signal '%1' protected section '%2'")
+					.arg(QString::fromStdString(signal.id), QString::fromStdString(signal.protectedSection)));
+		for (const auto& scenario : m_sceneModel.scenarios)
+			for (const auto& incident : scenario.incidents)
+				if (incident.type == "signal_failure" && usesSection(incident.target))
+					add(QString("signal-failure incident '%1' in scenario '%2'")
+						.arg(QString::fromStdString(incident.id), QString::fromStdString(scenario.id)));
+		for (const auto& dependency : m_sceneModel.blockDependencies)
+			if (usesSection(dependency.block) || usesSection(dependency.dependsOn))
+				add(QString("block dependency '%1' -> '%2'")
+					.arg(QString::fromStdString(dependency.block), QString::fromStdString(dependency.dependsOn)));
+		for (const auto& restriction : m_sceneModel.singleTrackRestrictions)
+			if (usesSection(restriction.startBlock) || usesSection(restriction.endBlock)
+				|| usesSection(restriction.protectedStartBlock) || usesSection(restriction.protectedEndBlock))
+				add(QString("single-track restriction '%1' -> '%2'")
+					.arg(QString::fromStdString(restriction.startBlock), QString::fromStdString(restriction.endBlock)));
+		for (const auto& boundary : m_sceneModel.stationBoundaries)
+			if (usesSection(boundary.entranceBlock)
+				|| (boundary.hasExitBlock && usesSection(boundary.exitBlock)))
+				add(QString("station boundary '%1' -> '%2'")
+					.arg(QString::fromStdString(boundary.entranceBlock), QString::fromStdString(boundary.exitBlock)));
+	} else if (facet == "stations") {
+		for (const auto& service : m_sceneModel.services)
+			for (const auto& stop : service.stops)
+				if (stop.stationId == id)
+					add(QString("service '%1' stop").arg(QString::fromStdString(service.id)));
+		for (const auto& scenario : m_sceneModel.scenarios)
+			for (const auto& delay : scenario.entranceDelays)
+				if (delay.stationId == id)
+					add(QString("entrance delay for service '%1' in scenario '%2'")
+						.arg(QString::fromStdString(delay.serviceId), QString::fromStdString(scenario.id)));
+		for (const auto& passenger : m_sceneModel.passengers)
+			for (const auto& journey : passenger.journeys) {
+				if (journey.originStationId == id || journey.destinationStationId == id)
+					add(QString("passenger '%1' journey '%2'")
+						.arg(QString::fromStdString(passenger.id), QString::fromStdString(journey.id)));
+				for (const auto& leg : journey.legs)
+					if (leg.originStationId == id || leg.destinationStationId == id)
+						add(QString("passenger '%1' leg '%2'")
+							.arg(QString::fromStdString(passenger.id), QString::fromStdString(leg.id)));
+			}
+	} else if (facet == "platforms") {
+		for (const auto& service : m_sceneModel.services)
+			for (const auto& stop : service.stops)
+				if (stop.stationId == scope && stop.platformId == id)
+					add(QString("service '%1' stop at station '%2'")
+						.arg(QString::fromStdString(service.id), QString::fromStdString(scope)));
+	} else if (facet == "signals") {
+		for (const auto& scenario : m_sceneModel.scenarios)
+			for (const auto& incident : scenario.incidents)
+				if (incident.type == "signal_failure" && incident.target == id)
+					add(QString("signal-failure incident '%1' in scenario '%2'")
+						.arg(QString::fromStdString(incident.id), QString::fromStdString(scenario.id)));
+	} else if (facet == "routes") {
+		for (const auto& service : m_sceneModel.services)
+			if (service.route == id)
+				add(QString("service '%1'").arg(QString::fromStdString(service.id)));
+	} else if (facet == "train_unit") {
+		for (const auto& composition : m_sceneModel.compositions)
+			if (std::find(composition.units.begin(), composition.units.end(), id) != composition.units.end())
+				add(QString("composition '%1'").arg(QString::fromStdString(composition.id)));
+	} else if (facet == "composition") {
+		for (const auto& service : m_sceneModel.services)
+			if (service.composition == id)
+				add(QString("service '%1'").arg(QString::fromStdString(service.id)));
+	} else if (facet == "service") {
+		for (const auto& scenario : m_sceneModel.scenarios) {
+			for (const auto& incident : scenario.incidents)
+				if (incident.type == "train_breakdown" && incident.target == id)
+					add(QString("breakdown incident '%1' in scenario '%2'")
+						.arg(QString::fromStdString(incident.id), QString::fromStdString(scenario.id)));
+			for (const auto& delay : scenario.entranceDelays)
+				if (delay.serviceId == id)
+					add(QString("entrance delay in scenario '%1'").arg(QString::fromStdString(scenario.id)));
+		}
+		for (const auto& passenger : m_sceneModel.passengers)
+			for (const auto& journey : passenger.journeys)
+				for (const auto& leg : journey.legs)
+					if (leg.serviceId == id)
+						add(QString("passenger '%1' leg '%2'")
+							.arg(QString::fromStdString(passenger.id), QString::fromStdString(leg.id)));
+	}
+	return consumers;
 }
 
 void MainWindow::refreshBlockTrackFilter() {
@@ -4903,7 +5101,7 @@ void MainWindow::deleteInfrastructureEntity() {
 		|| facet == QStringLiteral("station_boundaries");
 	if (id.isEmpty() && !anonymousRow)
 		return;
-	const QString displayId = id.isEmpty() ? QStringLiteral("incomplete row") : id;
+	QString displayId = id.isEmpty() ? QStringLiteral("incomplete row") : id;
 	int stationIndex = -1;
 	int platformIndex = -1;
 	if (facet == "platforms") {
@@ -4918,60 +5116,41 @@ void MainWindow::deleteInfrastructureEntity() {
 			flattened += static_cast<int>(platforms.size());
 		}
 	}
-	QString referenceSummary;
-	if (facet == "tracks" && row < static_cast<int>(m_sceneModel.tracks.size())) {
-		const std::string trackId = m_sceneModel.tracks[static_cast<std::size_t>(row)].id;
-		int areaCount = 0;
-		for (const auto& area : m_sceneModel.signallingAreas)
-			if (area.trackId == trackId)
-				++areaCount;
-		referenceSummary = areaCount == 0
-			? QStringLiteral("No signalling-area references")
-			: QStringLiteral("Referencing signalling areas: %1").arg(areaCount);
-	} else if (facet == "stations" && row < static_cast<int>(m_sceneModel.stations.size())) {
-		const std::string stationId = m_sceneModel.stations[static_cast<std::size_t>(row)].id;
-		QMap<QString, int> serviceCounts;
-		for (const auto& service : m_sceneModel.services)
-			for (const auto& stop : service.stops)
-				if (stop.stationId == stationId)
-					++serviceCounts[QString::fromStdString(service.id)];
-		QStringList refs;
-		for (auto it = serviceCounts.cbegin(); it != serviceCounts.cend(); ++it)
-			refs << QString("%1 (%2 stop(s))").arg(it.key()).arg(it.value());
-		referenceSummary = refs.isEmpty() ? QStringLiteral("No service references")
-										  : QStringLiteral("Referencing services: %1").arg(refs.join(", "));
-	} else if (facet == "platforms" && stationIndex >= 0 && platformIndex >= 0) {
-		const std::string stationId = m_sceneModel.stations[static_cast<std::size_t>(stationIndex)].id;
-		QMap<QString, int> serviceCounts;
-		for (const auto& service : m_sceneModel.services)
-			for (const auto& stop : service.stops)
-				if (stop.stationId == stationId && stop.platformId == id.toStdString())
-					++serviceCounts[QString::fromStdString(service.id)];
-		QStringList refs;
-		for (auto it = serviceCounts.cbegin(); it != serviceCounts.cend(); ++it)
-			refs << QString("%1 (%2 stop(s))").arg(it.key()).arg(it.value());
-		referenceSummary = refs.isEmpty() ? QStringLiteral("No service references")
-										  : QStringLiteral("Referencing services: %1").arg(refs.join(", "));
-	} else if (facet == "routes") {
-		QStringList refs;
-		for (const auto& service : m_sceneModel.services)
-			if (service.route == id.toStdString())
-				refs << QString::fromStdString(service.id);
-		referenceSummary = refs.isEmpty() ? QStringLiteral("No dependent services")
-										  : QStringLiteral("Dependent services: %1").arg(refs.join(", "));
-	} else if (facet == "signals") {
-		QStringList refs;
-		for (const auto& scenario : m_sceneModel.scenarios)
-			for (const auto& incident : scenario.incidents)
-				if (incident.type == "signal_failure" && incident.target == id.toStdString())
-					refs << QString::fromStdString(incident.id);
-		referenceSummary = refs.isEmpty() ? QStringLiteral("No dependent signal-failure incidents")
-										  : QStringLiteral("Dependent incidents: %1").arg(refs.join(", "));
+	if (facet == "tracks" && row < static_cast<int>(m_sceneModel.tracks.size()))
+		id = QString::fromStdString(m_sceneModel.tracks[static_cast<std::size_t>(row)].id);
+	else if (facet == "nodes" && row < static_cast<int>(m_sceneModel.nodes.size()))
+		id = QString::fromStdString(m_sceneModel.nodes[static_cast<std::size_t>(row)].id);
+	else if (facet == "arcs" && row < static_cast<int>(m_sceneModel.arcs.size()))
+		id = QString::fromStdString(m_sceneModel.arcs[static_cast<std::size_t>(row)].id);
+	else if (facet == "blocks" && modelRow < static_cast<int>(m_sceneModel.blocks.size()))
+		id = QString::fromStdString(m_sceneModel.blocks[static_cast<std::size_t>(modelRow)].id);
+	else if (facet == "connections" && row < static_cast<int>(m_sceneModel.connections.size()))
+		id = QString::fromStdString(m_sceneModel.connections[static_cast<std::size_t>(row)].id);
+	else if (facet == "stations" && row < static_cast<int>(m_sceneModel.stations.size()))
+		id = QString::fromStdString(m_sceneModel.stations[static_cast<std::size_t>(row)].id);
+	else if (facet == "platforms" && stationIndex >= 0 && platformIndex >= 0)
+		id = QString::fromStdString(m_sceneModel.stations[static_cast<std::size_t>(stationIndex)]
+			.platforms[static_cast<std::size_t>(platformIndex)].id);
+	else if (facet == "signals" && row < static_cast<int>(sceneSignals(m_sceneModel).size()))
+		id = QString::fromStdString(sceneSignals(m_sceneModel)[static_cast<std::size_t>(row)].id);
+	else if (facet == "signalling_areas" && row < static_cast<int>(m_sceneModel.signallingAreas.size()))
+		id = QString::fromStdString(m_sceneModel.signallingAreas[static_cast<std::size_t>(row)].id);
+	else if (facet == "routes" && row < static_cast<int>(m_sceneModel.routes.size()))
+		id = QString::fromStdString(m_sceneModel.routes[static_cast<std::size_t>(row)].id);
+	displayId = id.isEmpty() ? QStringLiteral("incomplete row") : id;
+	const std::string platformScope = stationIndex >= 0
+		? m_sceneModel.stations[static_cast<std::size_t>(stationIndex)].id : std::string();
+	const QStringList consumers = directDeleteConsumers(facet, id.toStdString(), platformScope);
+	if (!consumers.isEmpty()) {
+		showBlockingError(this, "Cannot Delete Infrastructure Entity",
+			QString("Cannot delete %1 '%2' because it is still referenced by:\n• %3\nRemove or rebind those consumers first.")
+				.arg(m_infrastructureFacetCombo->currentText().toLower(), displayId, consumers.join("\n• ")),
+			true);
+		return;
 	}
 	const QMessageBox::StandardButton answer = QMessageBox::question(
 		this, "Delete infrastructure entity",
-		QString("Delete %1 '%2'? %3 Referenced entities will remain and validation will show any fallout.")
-			.arg(m_infrastructureFacetCombo->currentText().toLower(), displayId, referenceSummary),
+		QString("Delete %1 '%2'?").arg(m_infrastructureFacetCombo->currentText().toLower(), displayId),
 		QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 	if (answer != QMessageBox::Yes)
 		return;
@@ -5185,26 +5364,24 @@ void MainWindow::deleteTrainUnit() {
 	if (row < 0 || row >= static_cast<int>(m_sceneModel.trainUnits.size()))
 		return;
 	const std::string id = m_sceneModel.trainUnits[row].id;
-	bool referenced = false;
-	for (const auto& composition : m_sceneModel.compositions) {
-		if (std::find(composition.units.begin(), composition.units.end(), id) != composition.units.end()) {
-			referenced = true;
-			break;
-		}
+	const QStringList consumers = directDeleteConsumers(QStringLiteral("train_unit"), id);
+	if (!consumers.isEmpty()) {
+		showBlockingError(this, "Cannot Delete Train Unit",
+			QString("Cannot delete train unit '%1' because it is still referenced by:\n• %2\nRemove it from those compositions first.")
+				.arg(QString::fromStdString(id), consumers.join("\n• ")), true);
+		return;
 	}
-	const QString message = referenced
-		? QString("Train unit '%1' is referenced by a composition. Delete it and leave the reference for validation to diagnose?").arg(QString::fromStdString(id))
-		: QString("Delete train unit '%1'?").arg(QString::fromStdString(id));
-	if (QMessageBox::question(this, "Delete Train Unit", message,
+	if (QMessageBox::question(this, "Delete Train Unit",
+			QString("Delete train unit '%1'?").arg(QString::fromStdString(id)),
 			QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
 		return;
 	m_sceneModel.trainUnits.erase(m_sceneModel.trainUnits.begin() + row);
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshTrainUnitPanel();
 	refreshCompositionPanel();
+	refreshValidationPanel();
 }
 
 void MainWindow::commitTrainUnitIdEdit() {
@@ -5558,10 +5735,17 @@ void MainWindow::deleteComposition() {
 	if (row < 0 || row >= static_cast<int>(m_sceneModel.compositions.size()))
 		return;
 
-	QString id = QString::fromStdString(m_sceneModel.compositions[row].id);
+	const std::string id = m_sceneModel.compositions[row].id;
+	const QStringList consumers = directDeleteConsumers(QStringLiteral("composition"), id);
+	if (!consumers.isEmpty()) {
+		showBlockingError(this, "Cannot Delete Composition",
+			QString("Cannot delete composition '%1' because it is still referenced by:\n• %2\nReassign those services first.")
+				.arg(QString::fromStdString(id), consumers.join("\n• ")), true);
+		return;
+	}
 	auto response = QMessageBox::question(this,
-										  "Delete Composition",
-										  QString("Delete composition '%1'?").arg(id),
+											  "Delete Composition",
+											  QString("Delete composition '%1'?").arg(QString::fromStdString(id)),
 										  QMessageBox::Yes | QMessageBox::No,
 										  QMessageBox::No);
 	if (response != QMessageBox::Yes)
@@ -5572,8 +5756,8 @@ void MainWindow::deleteComposition() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshCompositionPanel();
+	refreshValidationPanel();
 }
 
 void MainWindow::commitCompositionIdEdit() {
@@ -6130,8 +6314,8 @@ void MainWindow::addService() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshServicePanel();
+	refreshValidationPanel();
 
 	if (m_serviceListWidget)
 		m_serviceListWidget->setCurrentRow(static_cast<int>(m_sceneModel.services.size()) - 1);
@@ -6165,16 +6349,29 @@ void MainWindow::deleteService() {
 	if (row < 0 || row >= static_cast<int>(m_sceneModel.services.size()))
 		return;
 
-	QString id = QString::fromStdString(m_sceneModel.services[row].id);
+	const std::string id = m_sceneModel.services[row].id;
+	const QStringList consumers = directDeleteConsumers(QStringLiteral("service"), id);
+	if (!consumers.isEmpty()) {
+		showBlockingError(this, "Cannot Delete Service",
+			QString("Cannot delete service '%1' because it is still referenced by:\n• %2\nRemove those operation references first.")
+				.arg(QString::fromStdString(id), consumers.join("\n• ")), true);
+		return;
+	}
 	auto response = QMessageBox::question(this,
-										  "Delete Service",
-										  QString("Delete service '%1'?").arg(id),
+											  "Delete Service",
+											  QString("Delete service '%1'?").arg(QString::fromStdString(id)),
 										  QMessageBox::Yes | QMessageBox::No,
 										  QMessageBox::No);
 	if (response != QMessageBox::Yes)
 		return;
 
 	m_sceneModel.services.erase(m_sceneModel.services.begin() + row);
+	for (auto it = m_excludedSceneOccurrences.begin(); it != m_excludedSceneOccurrences.end();) {
+		if (it->serviceId == id)
+			it = m_excludedSceneOccurrences.erase(it);
+		else
+			++it;
+	}
 
 	markSceneDirty();
 	updateSceneWindowTitle();
@@ -6190,11 +6387,24 @@ void MainWindow::commitServiceIdEdit() {
 	if (row < 0 || row >= static_cast<int>(m_sceneModel.services.size()))
 		return;
 
-	std::string newId = m_serviceIdEdit->text().trimmed().toStdString();
-	if (newId == m_sceneModel.services[row].id)
-		return;
-
 	const std::string oldId = m_sceneModel.services[row].id;
+	const std::string newId = m_serviceIdEdit->text().trimmed().toStdString();
+	if (newId.empty()) {
+		const QSignalBlocker blocker(m_serviceIdEdit);
+		m_serviceIdEdit->setText(QString::fromStdString(oldId));
+		showBlockingError(this, "Invalid Service ID", "Service IDs must not be empty.", true);
+		return;
+	}
+	if (newId == oldId)
+		return;
+	for (int index = 0; index < static_cast<int>(m_sceneModel.services.size()); ++index) {
+		if (index != row && m_sceneModel.services[static_cast<std::size_t>(index)].id == newId) {
+			const QSignalBlocker blocker(m_serviceIdEdit);
+			m_serviceIdEdit->setText(QString::fromStdString(oldId));
+			showBlockingError(this, "Service ID already exists", "Choose a unique service ID.", true);
+			return;
+		}
+	}
 	for (auto& scenario : m_sceneModel.scenarios) {
 		for (auto& delay : scenario.entranceDelays)
 			if (delay.serviceId == oldId)
@@ -6223,6 +6433,7 @@ void MainWindow::commitServiceIdEdit() {
 	updateSceneActions();
 	refreshValidationPanel();
 	refreshServiceOccurrencePreview();
+	updateIncidentDetailPanel();
 }
 
 void MainWindow::commitServiceOperatingCode() {
@@ -6727,11 +6938,11 @@ void MainWindow::addStop() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshStopList();
 
 	if (m_stopListWidget)
 		m_stopListWidget->setCurrentRow(static_cast<int>(m_sceneModel.services[serviceRow].stops.size()) - 1);
+	refreshValidationPanel();
 }
 
 void MainWindow::removeStop() {
@@ -6751,7 +6962,6 @@ void MainWindow::removeStop() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshStopList();
 
 	if (m_stopListWidget) {
@@ -6759,6 +6969,7 @@ void MainWindow::removeStop() {
 		if (remaining > 0)
 			m_stopListWidget->setCurrentRow(stopRow < remaining ? stopRow : remaining - 1);
 	}
+	refreshValidationPanel();
 }
 
 void MainWindow::moveStopUp() {
@@ -6780,11 +6991,11 @@ void MainWindow::moveStopUp() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshStopList();
 
 	if (m_stopListWidget)
 		m_stopListWidget->setCurrentRow(stopRow - 1);
+	refreshValidationPanel();
 }
 
 void MainWindow::moveStopDown() {
@@ -6806,11 +7017,11 @@ void MainWindow::moveStopDown() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshStopList();
 
 	if (m_stopListWidget)
 		m_stopListWidget->setCurrentRow(stopRow + 1);
+	refreshValidationPanel();
 }
 
 void MainWindow::commitStopStation(const QString& text) {
@@ -7254,8 +7465,8 @@ void MainWindow::addBlankScenario() {
 	m_sceneModel.scenarios.push_back(std::move(scenario));
 	m_selectedScenarioId = m_sceneModel.scenarios.back().id;
 	markScenarioModified();
-	refreshValidationPanel();
 	refreshIncidentPanel();
+	refreshValidationPanel();
 }
 
 void MainWindow::duplicateScenario() {
@@ -7270,8 +7481,8 @@ void MainWindow::duplicateScenario() {
 	m_sceneModel.scenarios.push_back(std::move(copy));
 	m_selectedScenarioId = m_sceneModel.scenarios.back().id;
 	markScenarioModified();
-	refreshValidationPanel();
 	refreshIncidentPanel();
+	refreshValidationPanel();
 }
 
 void MainWindow::exportScenario() {
@@ -7335,8 +7546,8 @@ void MainWindow::importScenario() {
 	m_sceneModel.scenarios.push_back(std::move(imported));
 	m_selectedScenarioId = m_sceneModel.scenarios.back().id;
 	markScenarioModified();
-	refreshValidationPanel();
 	refreshIncidentPanel();
+	refreshValidationPanel();
 	QString message = QString("Imported scenario %1").arg(QString::fromStdString(m_selectedScenarioId));
 	if (scenarioConflict)
 		message += QString(" (ID %1 already existed; imported as %2)")
@@ -7354,9 +7565,10 @@ void MainWindow::commitScenarioIdEdit() {
 	if (!scenario || !m_scenarioIdEdit)
 		return;
 	const std::string newId = m_scenarioIdEdit->text().trimmed().toStdString();
-	if (newId.empty() || newId == scenario->id) {
-		if (newId.empty())
-			showBlockingError(this, "Invalid Scenario ID", "Scenario IDs must not be empty.", true);
+	if (newId == scenario->id)
+		return;
+	if (newId.empty()) {
+		showBlockingError(this, "Invalid Scenario ID", "Scenario IDs must not be empty.", true);
 		updateScenarioDetailPanel();
 		return;
 	}
@@ -7604,8 +7816,8 @@ void MainWindow::deleteIncident() {
 	incidents.erase(incidents.begin() + row);
 
 	markScenarioModified();
-	refreshValidationPanel();
 	refreshIncidentPanel();
+	refreshValidationPanel();
 }
 
 void MainWindow::commitIncidentIdEdit() {
@@ -7617,9 +7829,10 @@ void MainWindow::commitIncidentIdEdit() {
 		return;
 
 	std::string newId = m_incidentIdEdit->text().trimmed().toStdString();
-	if (newId.empty() || newId == incidents[row].id) {
-		if (newId.empty())
-			showBlockingError(this, "Invalid Incident ID", "Incident IDs must not be empty.", true);
+	if (newId == incidents[row].id)
+		return;
+	if (newId.empty()) {
+		showBlockingError(this, "Invalid Incident ID", "Incident IDs must not be empty.", true);
 		updateIncidentDetailPanel();
 		return;
 	}
@@ -10174,6 +10387,20 @@ void MainWindow::runEditorSmokeE2E() {
 			}
 		});
 	};
+	auto discardConfirmation = [this]() {
+		QTimer::singleShot(25, this, []() {
+			for (QWidget* widget : QApplication::topLevelWidgets()) {
+				auto* dialog = qobject_cast<QMessageBox*>(widget);
+				if (!dialog || !dialog->isVisible())
+					continue;
+				if (auto* button = dialog->button(QMessageBox::Discard))
+					button->click();
+				else
+					dialog->done(QMessageBox::Discard);
+				break;
+			}
+		});
+	};
 	auto acceptUnitChoice = [this](const QString& unitId) {
 		QTimer::singleShot(25, this, [unitId]() {
 			for (QWidget* widget : QApplication::topLevelWidgets()) {
@@ -10378,6 +10605,7 @@ void MainWindow::runEditorSmokeE2E() {
 		if (!m_sceneLoaded || originalScenePath.isEmpty()) {
 			facetFailure(facetOk, "new case", "the original scene was not available to restore");
 		} else {
+			discardConfirmation();
 			newScene();
 			QApplication::processEvents();
 			if (!m_sceneLoaded || !m_sceneDirty || !m_sceneDir.isEmpty() || m_sceneIsBundle || !m_saveSceneAction || !m_saveSceneAction->isEnabled() || !m_saveSceneAsAction || !m_saveSceneAsAction->isEnabled() || !m_saveSceneAsFolderAction || !m_saveSceneAsFolderAction->isEnabled())
@@ -10857,6 +11085,47 @@ void MainWindow::runEditorSmokeE2E() {
 				} else {
 					facetFailure(facetOk, "stations/signalling", "incident controls unavailable for signal coverage");
 				}
+					auto refuseInfrastructureDelete = [&](const char* facet, int row, int column,
+						std::size_t expectedSize, const char* label) {
+					if (!chooseInfrastructureFacet(facet) || row < 0 || row >= infrastructureTable->rowCount()) {
+						facetFailure(facetOk, "delete integrity", QString("%1 facet row unavailable").arg(label));
+						return;
+					}
+					infrastructureTable->setCurrentCell(row, column);
+					QApplication::processEvents();
+					infrastructureDelete->click();
+					QApplication::processEvents();
+					const QString facetName = QString::fromLatin1(facet);
+					std::size_t actualSize = expectedSize;
+					if (facetName == "tracks") actualSize = m_sceneModel.tracks.size();
+					else if (facetName == "nodes") actualSize = m_sceneModel.nodes.size();
+					else if (facetName == "arcs") actualSize = m_sceneModel.arcs.size();
+					else if (facetName == "blocks") actualSize = m_sceneModel.blocks.size();
+					else if (facetName == "connections") actualSize = m_sceneModel.connections.size();
+					else if (facetName == "stations") actualSize = m_sceneModel.stations.size();
+					else if (facetName == "platforms") {
+						actualSize = 0;
+						for (const auto& station : m_sceneModel.stations)
+							actualSize += station.platforms.size();
+					} else if (facetName == "signals") actualSize = sceneSignals(m_sceneModel).size();
+					else if (facetName == "routes") actualSize = m_sceneModel.routes.size();
+					if (actualSize != expectedSize)
+						facetFailure(facetOk, "delete integrity", QString("referenced %1 delete was not refused").arg(label));
+				};
+				refuseInfrastructureDelete("tracks", 0, 0, m_sceneModel.tracks.size(), "track");
+				refuseInfrastructureDelete("nodes", 0, 0, m_sceneModel.nodes.size(), "node");
+				if (chooseBlockTrack("e2e-main"))
+					refuseInfrastructureDelete("blocks", 0, 0, m_sceneModel.blocks.size(), "block");
+				else
+					facetFailure(facetOk, "delete integrity", "block facet filter unavailable");
+				refuseInfrastructureDelete("connections", 0, 0, m_sceneModel.connections.size(), "connection");
+				refuseInfrastructureDelete("stations", 0, 0, m_sceneModel.stations.size(), "station");
+				std::size_t platformCount = 0;
+				for (const auto& station : m_sceneModel.stations)
+					platformCount += station.platforms.size();
+				refuseInfrastructureDelete("platforms", 0, 1, platformCount, "platform");
+				refuseInfrastructureDelete("signals", 0, 0, sceneSignals(m_sceneModel).size(), "signal");
+				refuseInfrastructureDelete("routes", 0, 0, m_sceneModel.routes.size(), "route");
 				expectedTracks = m_sceneModel.tracks;
 				expectedNodes = m_sceneModel.nodes;
 				expectedArcs = m_sceneModel.arcs;
@@ -11284,18 +11553,12 @@ void MainWindow::runEditorSmokeE2E() {
 				acceptUnitChoice(QString::fromStdString(duplicateId));
 				addUnitToComposition();
 				QApplication::processEvents();
-				acceptConfirmation();
+				const int referencedCount = m_trainUnitListWidget->count();
 				deleteTrainUnit();
-				if (m_trainUnitListWidget->count() != originalCount + 1)
-					facetFailure(facetOk, "train unit", "delete did not apply");
-				refreshValidationPanel();
-				bool danglingReference = false;
-				for (const auto& diagnostic : m_sceneDiagnostics) {
-					if (diagnostic.code == "scene.ref.unresolved" && diagnostic.relatedId == duplicateId)
-						danglingReference = true;
-				}
-				if (!danglingReference)
-					facetFailure(facetOk, "train unit", "referenced-unit delete did not leave a validator reference diagnostic");
+				const bool duplicateStillPresent = std::any_of(m_sceneModel.trainUnits.begin(),
+					m_sceneModel.trainUnits.end(), [&](const SceneTrainUnit& unit) { return unit.id == duplicateId; });
+				if (m_trainUnitListWidget->count() != referencedCount || !duplicateStillPresent)
+					facetFailure(facetOk, "train unit", "referenced-unit delete was not refused");
 				m_compositionListWidget->setCurrentRow(0);
 				for (int unitRow = 0; unitRow < m_compositionUnitsListWidget->count(); ++unitRow) {
 					if (m_compositionUnitsListWidget->item(unitRow)->text().toStdString() == duplicateId) {
@@ -11304,6 +11567,12 @@ void MainWindow::runEditorSmokeE2E() {
 						break;
 					}
 				}
+				acceptConfirmation();
+				deleteTrainUnit();
+				if (m_trainUnitListWidget->count() != originalCount + 1
+						|| std::any_of(m_sceneModel.trainUnits.begin(), m_sceneModel.trainUnits.end(),
+							[&](const SceneTrainUnit& unit) { return unit.id == duplicateId; }))
+					facetFailure(facetOk, "train unit", "unreferenced-unit delete did not apply");
 			}
 		}
 		if (!m_sceneModel.trainUnits.empty()) {
@@ -11400,6 +11669,15 @@ void MainWindow::runEditorSmokeE2E() {
 						facetFailure(facetOk, "composition", "id edit did not apply");
 				}
 			}
+			const int referencedCompositionCount = m_compositionListWidget->count();
+			m_compositionListWidget->setCurrentRow(assignedCompositionRow);
+			deleteComposition();
+			if (m_compositionListWidget->count() != referencedCompositionCount
+					|| !std::any_of(m_sceneModel.compositions.begin(), m_sceneModel.compositions.end(),
+						[&](const SceneComposition& composition) {
+							return composition.id == editedCompositionId;
+						}))
+				facetFailure(facetOk, "composition", "service-referenced composition delete was not refused");
 			addComposition();
 			if (m_compositionListWidget->count() != originalCount + 2) {
 				facetFailure(facetOk, "composition", "add did not apply");
@@ -11471,6 +11749,31 @@ void MainWindow::runEditorSmokeE2E() {
 			if (!m_serviceIdEdit) {
 				facetFailure(facetOk, "service", "id editor unavailable");
 			} else {
+				const std::string duplicateServiceId = m_sceneModel.services.front().id;
+				const auto referencesStillOld = [&]() {
+					if (referenceScenarioRow < 0)
+						return true;
+					const SceneScenario& scenario = m_sceneModel.scenarios[static_cast<std::size_t>(referenceScenarioRow)];
+					const bool delayStillOld = temporaryDelayCount == 0 || (!scenario.entranceDelays.empty()
+						&& scenario.entranceDelays.back().serviceId == oldServiceId);
+					const bool incidentStillOld = temporaryIncidentCount == 0 || (!scenario.incidents.empty()
+						&& scenario.incidents.back().target == oldServiceId);
+					return delayStillOld && incidentStillOld
+						&& m_excludedSceneOccurrences.find(SceneServiceOccurrence{oldServiceId, 1})
+							!= m_excludedSceneOccurrences.end();
+				};
+				m_serviceIdEdit->setText(QString());
+				commitServiceIdEdit();
+				const bool emptyRejected = m_sceneModel.services[1].id == oldServiceId
+					&& m_serviceIdEdit->text() == QString::fromStdString(oldServiceId)
+					&& referencesStillOld();
+				m_serviceIdEdit->setText(QString::fromStdString(duplicateServiceId));
+				commitServiceIdEdit();
+				const bool duplicateRejected = m_sceneModel.services[1].id == oldServiceId
+					&& m_serviceIdEdit->text() == QString::fromStdString(oldServiceId)
+					&& referencesStillOld();
+				if (!emptyRejected || !duplicateRejected)
+					facetFailure(facetOk, "service", "empty or duplicate ID rename changed canonical references");
 				m_serviceIdEdit->setText(QString::fromStdString(editedServiceId));
 				commitServiceIdEdit();
 				if (m_sceneModel.services.size() <= 1 || m_sceneModel.services[1].id != editedServiceId)
@@ -11491,6 +11794,13 @@ void MainWindow::runEditorSmokeE2E() {
 				referencesUpdated = false;
 			if (!referencesUpdated)
 				facetFailure(facetOk, "service", "service ID rename did not update canonical references or occurrence exclusions");
+			m_serviceListWidget->setCurrentRow(1);
+			const int referencedServiceCount = m_serviceListWidget->count();
+			deleteService();
+			if (m_serviceListWidget->count() != referencedServiceCount
+					|| !std::any_of(m_sceneModel.services.begin(), m_sceneModel.services.end(),
+						[&](const SceneService& service) { return service.id == editedServiceId; }))
+				facetFailure(facetOk, "service", "operation-referenced service delete was not refused");
 			if (referenceScenarioRow >= 0) {
 				SceneScenario& referenceScenario = m_sceneModel.scenarios[static_cast<std::size_t>(referenceScenarioRow)];
 				if (temporaryDelayCount > 0 && !referenceScenario.entranceDelays.empty())
@@ -11591,10 +11901,21 @@ void MainWindow::runEditorSmokeE2E() {
 		if (m_serviceListWidget->count() != originalCount + 2) {
 			facetFailure(facetOk, "service", "add did not apply");
 		} else {
+			const std::string unreferencedServiceId = m_sceneModel.services.back().id;
+			if (m_selectNoneOccurrencesButton) {
+				m_selectNoneOccurrencesButton->click();
+				QApplication::processEvents();
+			}
+			const bool occurrenceExclusionCreated = m_excludedSceneOccurrences.find(
+				SceneServiceOccurrence{unreferencedServiceId, 1}) != m_excludedSceneOccurrences.end();
 			acceptConfirmation();
 			deleteService();
-			if (m_serviceListWidget->count() != originalCount + 1)
-				facetFailure(facetOk, "service", "delete did not apply");
+			if (m_serviceListWidget->count() != originalCount + 1
+					|| std::any_of(m_sceneModel.services.begin(), m_sceneModel.services.end(),
+						[&](const SceneService& service) { return service.id == unreferencedServiceId; })
+					|| (occurrenceExclusionCreated && m_excludedSceneOccurrences.find(
+						SceneServiceOccurrence{unreferencedServiceId, 1}) != m_excludedSceneOccurrences.end()))
+				facetFailure(facetOk, "service", "unreferenced service delete did not prune occurrence exclusions");
 		}
 		int editedRow = -1;
 		for (int row = 0; row < static_cast<int>(m_sceneModel.services.size()); ++row) {
@@ -11862,44 +12183,204 @@ void MainWindow::runEditorSmokeE2E() {
 			} else if (m_sceneDirty || hasErrors(m_sceneDiagnostics)) {
 				facetFailure(facetOk, "save/reload", "reloaded scene is dirty or invalid");
 			} else {
-				bool selectionRoundtripOk = m_excludedSceneOccurrences.empty();
-				if (m_serviceOccurrenceTable) {
-					for (int row = 0; row < m_serviceOccurrenceTable->rowCount(); ++row) {
-						QTableWidgetItem* include = m_serviceOccurrenceTable->item(row, 0);
-						selectionRoundtripOk = selectionRoundtripOk && include
-							&& include->checkState() == Qt::Checked;
-					}
-				}
-				if (!selectionRoundtripOk)
-					facetFailure(facetOk, "save/reload", "temporary occurrence selection was serialized or not reset on reopen");
-
-				const auto editedUnit = std::find_if(m_sceneModel.trainUnits.begin(), m_sceneModel.trainUnits.end(),
-					[&editedTrainUnitId](const SceneTrainUnit& unit) { return unit.id == editedTrainUnitId; });
-				if (editedUnit == m_sceneModel.trainUnits.end() || !m_trainUnitSourceDataEdit) {
-					facetFailure(facetOk, "save/reload", "edited train unit or source editor unavailable");
+				const auto triggerPendingSave = [&]() {
+					if (!m_saveSceneAction || !m_saveSceneAction->isEnabled())
+						return false;
+					m_saveSceneAction->trigger();
+					QApplication::processEvents();
+					return !m_sceneDirty;
+				};
+				const auto spinTextEdit = [](QDoubleSpinBox* spin) {
+					return spin ? spin->findChild<QLineEdit*>() : nullptr;
+				};
+				const auto modelRowFor = [](const auto& values, const std::string& id) {
+					for (int row = 0; row < static_cast<int>(values.size()); ++row)
+						if (values[static_cast<std::size_t>(row)].id == id)
+							return row;
+					return -1;
+				};
+				const int trainUnitRow = modelRowFor(m_sceneModel.trainUnits, editedTrainUnitId);
+				const int compositionRow = modelRowFor(m_sceneModel.compositions, editedCompositionId);
+				const int serviceRow = modelRowFor(m_sceneModel.services, editedServiceId);
+				if (trainUnitRow < 0 || compositionRow < 0 || serviceRow < 0
+						|| !m_compositionIdEdit || !m_trainUnitPhysicalEdits[0]
+						|| !spinTextEdit(m_trainUnitPhysicalEdits[0])) {
+					facetFailure(facetOk, "save/reload", "pending editor controls were unavailable after reload");
 				} else {
-					const int trainUnitRow = static_cast<int>(std::distance(m_sceneModel.trainUnits.begin(), editedUnit));
+					activateWindow();
+					if (m_trainUnitDock) {
+						m_trainUnitDock->show();
+						m_trainUnitDock->raise();
+					}
+					QApplication::processEvents();
 					m_trainUnitListWidget->setCurrentRow(trainUnitRow);
-					const std::string pendingSource = "e2e/source-data-pending-save.txt";
-					m_trainUnitSourceDataEdit->setFocus();
-					m_trainUnitSourceDataEdit->setText(QString::fromStdString(pendingSource));
-					if (m_sceneModel.trainUnits[static_cast<std::size_t>(trainUnitRow)].sourceDataFile == pendingSource) {
-						facetFailure(facetOk, "save/reload", "pending source edit committed before the save path");
-					} else if (!saveSceneToCurrentDir()) {
-						facetFailure(facetOk, "save/reload", "save path rejected a pending source edit");
-					} else if (!openSceneDirectory(outScenePath)) {
-						facetFailure(facetOk, "save/reload", "scene with a pending source edit did not reload");
+					m_serviceListWidget->setCurrentRow(serviceRow);
+					const double pendingPhysicalMass = std::max(
+						123.0, m_trainUnitPhysicalEdits[0]->value() + 1.25);
+					QLineEdit* pendingPhysicalEdit = spinTextEdit(m_trainUnitPhysicalEdits[0]);
+					pendingPhysicalEdit->setText(QString::number(pendingPhysicalMass, 'g', 16));
+					pendingPhysicalEdit->setFocus();
+					QApplication::processEvents();
+					if (!triggerPendingSave()) {
+						facetFailure(facetOk, "save/reload", "Save action did not flush focused train-unit text");
 					} else {
-						const auto reloadedUnit = std::find_if(m_sceneModel.trainUnits.begin(), m_sceneModel.trainUnits.end(),
-							[&editedTrainUnitId](const SceneTrainUnit& unit) { return unit.id == editedTrainUnitId; });
-						if (reloadedUnit == m_sceneModel.trainUnits.end() || reloadedUnit->sourceDataFile != pendingSource)
-							facetFailure(facetOk, "save/reload", "pending source edit was not saved and reloaded");
+						const int committedTrainRow = modelRowFor(m_sceneModel.trainUnits, editedTrainUnitId);
+						if (committedTrainRow < 0
+								|| !m_sceneModel.trainUnits[static_cast<std::size_t>(committedTrainRow)].hasPhysical
+								|| m_sceneModel.trainUnits[static_cast<std::size_t>(committedTrainRow)]
+									   .physical.mass_of_traction_unit_kg != pendingPhysicalMass)
+							facetFailure(facetOk, "save/reload", "focused train-unit text was not committed before Save");
+					}
+
+					const std::string pendingCompositionId = uniqueCompositionId("e2e_pending_composition");
+					if (m_compositionDock) {
+						m_compositionDock->show();
+						m_compositionDock->raise();
+					}
+					m_compositionListWidget->setCurrentRow(compositionRow);
+					m_serviceListWidget->setCurrentRow(serviceRow);
+					m_compositionIdEdit->setText(QString::fromStdString(pendingCompositionId));
+					m_compositionIdEdit->setFocus();
+					if (!triggerPendingSave()) {
+						facetFailure(facetOk, "save/reload", "Save action did not flush focused composition text");
+					} else {
+						const int committedCompositionRow = modelRowFor(m_sceneModel.compositions, pendingCompositionId);
+						if (committedCompositionRow < 0
+								|| !std::any_of(m_sceneModel.services.begin(), m_sceneModel.services.end(),
+									[&](const SceneService& service) {
+										return service.composition == pendingCompositionId;
+									}))
+							facetFailure(facetOk, "save/reload", "focused composition text was not committed before Save");
+						else
+							editedCompositionId = pendingCompositionId;
+					}
+
+					const int pendingServiceRow = modelRowFor(m_sceneModel.services, editedServiceId);
+					int pendingStopRow = -1;
+					if (pendingServiceRow >= 0) {
+						const auto& stops = m_sceneModel.services[static_cast<std::size_t>(pendingServiceRow)].stops;
+						for (int row = 0; row < static_cast<int>(stops.size()); ++row) {
+							if (stops[static_cast<std::size_t>(row)].hasPlannedArrival && stops[static_cast<std::size_t>(row)].hasPlannedDeparture) {
+								pendingStopRow = row;
+								break;
+							}
+						}
+						if (pendingStopRow < 0 && !stops.empty())
+							pendingStopRow = 0;
+					}
+					const int scenarioRow = [&]() {
+						for (int row = 0; row < static_cast<int>(m_sceneModel.scenarios.size()); ++row)
+							if (m_sceneModel.scenarios[static_cast<std::size_t>(row)].id == m_selectedScenarioId)
+								return row;
+						return -1;
+					}();
+					if (pendingServiceRow < 0 || pendingStopRow < 0 || scenarioRow < 0
+							|| !m_stopListWidget || !m_stopDwellSecondsEdit
+							|| !m_scenarioListWidget || !m_scenarioDescriptionEdit
+							|| !m_incidentListWidget || !m_incidentStartSecondsEdit) {
+						facetFailure(facetOk, "save/reload", "pending stop, scenario, or incident controls were unavailable");
+					} else {
+						m_serviceListWidget->setCurrentRow(pendingServiceRow);
+						m_stopListWidget->setCurrentRow(pendingStopRow);
+						QApplication::processEvents();
+						const int pendingDwell = static_cast<int>(m_sceneModel.services[
+							static_cast<std::size_t>(pendingServiceRow)]
+							.stops[static_cast<std::size_t>(pendingStopRow)].dwellSeconds) + 1;
+						m_stopDwellSecondsEdit->setText(QString::number(pendingDwell));
+						m_stopDwellSecondsEdit->setFocus();
+						if (!triggerPendingSave() || m_sceneModel.services[static_cast<std::size_t>(pendingServiceRow)]
+															 .stops[static_cast<std::size_t>(pendingStopRow)]
+															 .dwellSeconds != pendingDwell)
+							facetFailure(facetOk, "save/reload", "focused stop dwell text was not committed before Save");
+
+						if (m_incidentDock) {
+							m_incidentDock->show();
+							m_incidentDock->raise();
+						}
+						m_scenarioListWidget->setCurrentRow(scenarioRow);
+						QApplication::processEvents();
+						m_scenarioDescriptionEdit->setText("pending scenario values");
+						m_scenarioDescriptionEdit->setFocus();
+						QApplication::processEvents();
+						if (!triggerPendingSave() || !selectedScenario() || selectedScenario()->description != "pending scenario values")
+							facetFailure(facetOk, "save/reload", "focused scenario description was not committed before Save");
+
+						const auto& incidents = selectedScenarioIncidents();
+						const auto pendingIncident = std::find_if(incidents.begin(), incidents.end(),
+							[&](const SceneIncident& incident) { return incident.id == editedIncidentId; });
+						if (pendingIncident == incidents.end()) {
+							facetFailure(facetOk, "save/reload", "edited incident was unavailable for pending Save coverage");
+						} else {
+							const int incidentRow = static_cast<int>(std::distance(incidents.begin(), pendingIncident));
+							m_incidentListWidget->setCurrentRow(incidentRow);
+							QApplication::processEvents();
+							const int pendingIncidentStart = static_cast<int>(pendingIncident->startSeconds) + 1;
+							m_incidentStartSecondsEdit->setText(QString::number(pendingIncidentStart));
+							m_incidentStartSecondsEdit->setFocus();
+							QApplication::processEvents();
+							if (m_sceneModel.routes.empty()) {
+								facetFailure(facetOk, "save/reload", "route unavailable for blocked Run coverage");
+							} else {
+								const std::vector<std::string> validRoute = m_sceneModel.routes.front().blocks;
+								m_sceneModel.routes.front().blocks.clear();
+								m_runSceneAction->trigger();
+								QApplication::processEvents();
+								if (m_worker || !selectedIncident()
+										|| selectedIncident()->startSeconds != pendingIncidentStart)
+									facetFailure(facetOk, "save/reload", "Run did not flush focused incident text before validation");
+								m_sceneModel.routes.front().blocks = validRoute;
+								refreshValidationPanel();
+							}
+						}
+					}
+					expectedTrainUnits = m_sceneModel.trainUnits;
+					expectedCompositions = m_sceneModel.compositions;
+					expectedServices = m_sceneModel.services;
+					expectedIncidents = selectedScenarioIncidents();
+					if (!saveSceneToCurrentDir() || !openSceneDirectory(outScenePath)
+							|| !sameTrainUnits(expectedTrainUnits, m_sceneModel.trainUnits)
+							|| !sameCompositions(expectedCompositions, m_sceneModel.compositions)
+							|| !sameServices(expectedServices, m_sceneModel.services)
+							|| !sameIncidents(expectedIncidents, selectedScenarioIncidents()))
+						facetFailure(facetOk, "save/reload", "pending editor values did not survive Save and reopen");
+					bool selectionRoundtripOk = m_excludedSceneOccurrences.empty();
+					if (m_serviceOccurrenceTable) {
+						for (int row = 0; row < m_serviceOccurrenceTable->rowCount(); ++row) {
+							QTableWidgetItem* include = m_serviceOccurrenceTable->item(row, 0);
+							selectionRoundtripOk = selectionRoundtripOk && include && include->checkState() == Qt::Checked;
+						}
+					}
+					if (!selectionRoundtripOk)
+						facetFailure(facetOk, "save/reload", "temporary occurrence selection was serialized or not reset on reopen");
+
+					const auto editedUnit = std::find_if(m_sceneModel.trainUnits.begin(), m_sceneModel.trainUnits.end(),
+														 [&editedTrainUnitId](const SceneTrainUnit& unit) { return unit.id == editedTrainUnitId; });
+					if (editedUnit == m_sceneModel.trainUnits.end() || !m_trainUnitSourceDataEdit) {
+						facetFailure(facetOk, "save/reload", "edited train unit or source editor unavailable");
+					} else {
+						const int trainUnitRow = static_cast<int>(std::distance(m_sceneModel.trainUnits.begin(), editedUnit));
+						m_trainUnitListWidget->setCurrentRow(trainUnitRow);
+						const std::string pendingSource = "e2e/source-data-pending-save.txt";
+						m_trainUnitSourceDataEdit->setFocus();
+						m_trainUnitSourceDataEdit->setText(QString::fromStdString(pendingSource));
+						if (m_sceneModel.trainUnits[static_cast<std::size_t>(trainUnitRow)].sourceDataFile == pendingSource) {
+							facetFailure(facetOk, "save/reload", "pending source edit committed before the save path");
+						} else if (!saveSceneToCurrentDir()) {
+							facetFailure(facetOk, "save/reload", "save path rejected a pending source edit");
+						} else if (!openSceneDirectory(outScenePath)) {
+							facetFailure(facetOk, "save/reload", "scene with a pending source edit did not reload");
+						} else {
+							const auto reloadedUnit = std::find_if(m_sceneModel.trainUnits.begin(), m_sceneModel.trainUnits.end(),
+																   [&editedTrainUnitId](const SceneTrainUnit& unit) { return unit.id == editedTrainUnitId; });
+							if (reloadedUnit == m_sceneModel.trainUnits.end() || reloadedUnit->sourceDataFile != pendingSource)
+								facetFailure(facetOk, "save/reload", "pending source edit was not saved and reloaded");
+						}
 					}
 				}
 			}
+			if (facetOk)
+				std::fprintf(stdout, "E2E_EDITOR_SAVE_RELOAD_OK\n");
 		}
-		if (facetOk)
-			std::fprintf(stdout, "E2E_EDITOR_SAVE_RELOAD_OK\n");
 	}
 
 	if (ok) {
@@ -13312,9 +13793,7 @@ void MainWindow::runScene() {
 	if (!m_sceneLoaded)
 		return;
 
-	commitPendingCaseSettings();
-	commitPendingServiceSettings();
-	commitTrainUnitSources();
+	commitPendingEditorValues();
 	refreshValidationPanel();
 	if (hasErrors(m_sceneDiagnostics)) {
 		int errorCount = countDiagnostics(m_sceneDiagnostics).errors;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -5423,7 +5423,6 @@ void MainWindow::commitTrainUnitIdEdit() {
 	updateSceneWindowTitle();
 	updateSceneActions();
 	refreshCompositionPanel();
-	updateServiceDetailPanel();
 	refreshValidationPanel();
 }
 
@@ -6374,12 +6373,7 @@ void MainWindow::deleteService() {
 		return;
 
 	m_sceneModel.services.erase(m_sceneModel.services.begin() + row);
-	for (auto it = m_excludedSceneOccurrences.begin(); it != m_excludedSceneOccurrences.end();) {
-		if (it->serviceId == id)
-			it = m_excludedSceneOccurrences.erase(it);
-		else
-			++it;
-	}
+	pruneExcludedServiceOccurrences();
 
 	markSceneDirty();
 	updateSceneWindowTitle();
@@ -6406,13 +6400,11 @@ void MainWindow::commitServiceIdEdit() {
 	}
 	if (newId == oldId)
 		return;
-	for (int index = 0; index < static_cast<int>(m_sceneModel.services.size()); ++index) {
-		if (index != row && m_sceneModel.services[static_cast<std::size_t>(index)].id == newId) {
-			const QSignalBlocker blocker(m_serviceIdEdit);
-			m_serviceIdEdit->setText(QString::fromStdString(oldId));
-			showBlockingError(this, "Service ID already exists", "Choose a unique service ID.", true);
-			return;
-		}
+	if (uniqueServiceId(newId) != newId) {
+		const QSignalBlocker blocker(m_serviceIdEdit);
+		m_serviceIdEdit->setText(QString::fromStdString(oldId));
+		showBlockingError(this, "Service ID already exists", "Choose a unique service ID.", true);
+		return;
 	}
 	for (auto& scenario : m_sceneModel.scenarios) {
 		for (auto& delay : scenario.entranceDelays)
@@ -12232,7 +12224,8 @@ void MainWindow::runEditorSmokeE2E() {
 				const int compositionRow = modelRowFor(m_sceneModel.compositions, editedCompositionId);
 				const int serviceRow = modelRowFor(m_sceneModel.services, editedServiceId);
 				if (trainUnitRow < 0 || compositionRow < 0 || serviceRow < 0
-						|| !m_compositionIdEdit || !m_trainUnitPhysicalEdits[0]
+						|| !m_compositionIdEdit || !m_trainUnitSourceDataEdit
+						|| !m_trainUnitPhysicalEdits[0]
 						|| !spinTextEdit(m_trainUnitPhysicalEdits[0])) {
 					facetFailure(facetOk, "save/reload", "pending editor controls were unavailable after reload");
 				} else {
@@ -12364,19 +12357,30 @@ void MainWindow::runEditorSmokeE2E() {
 								m_sceneModel.routes.front().blocks = validRoute;
 								refreshValidationPanel();
 							}
+							}
 						}
-					}
-					expectedTrainUnits = m_sceneModel.trainUnits;
-					expectedCompositions = m_sceneModel.compositions;
-					expectedServices = m_sceneModel.services;
-					expectedIncidents = selectedScenarioIncidents();
-					if (!saveSceneToCurrentDir() || !openSceneDirectory(outScenePath)
-							|| !sameTrainUnits(expectedTrainUnits, m_sceneModel.trainUnits)
-							|| !sameCompositions(expectedCompositions, m_sceneModel.compositions)
-							|| !sameServices(expectedServices, m_sceneModel.services)
-							|| !sameIncidents(expectedIncidents, selectedScenarioIncidents()))
-						facetFailure(facetOk, "save/reload", "pending editor values did not survive Save and reopen");
-					bool selectionRoundtripOk = m_excludedSceneOccurrences.empty();
+						const std::string pendingSource = "e2e/source-data-pending-save.txt";
+						m_trainUnitListWidget->setCurrentRow(trainUnitRow);
+						m_trainUnitSourceDataEdit->setText(QString::fromStdString(pendingSource));
+						m_trainUnitSourceDataEdit->setFocus();
+						if (m_sceneModel.trainUnits[static_cast<std::size_t>(trainUnitRow)].sourceDataFile
+								== pendingSource) {
+							facetFailure(facetOk, "save/reload", "pending source edit committed before Save");
+						} else if (!saveSceneToCurrentDir()) {
+							facetFailure(facetOk, "save/reload", "pending editor values were not saved");
+						} else {
+							expectedTrainUnits = m_sceneModel.trainUnits;
+							expectedCompositions = m_sceneModel.compositions;
+							expectedServices = m_sceneModel.services;
+							expectedIncidents = selectedScenarioIncidents();
+							if (!openSceneDirectory(outScenePath)
+									|| !sameTrainUnits(expectedTrainUnits, m_sceneModel.trainUnits)
+									|| !sameCompositions(expectedCompositions, m_sceneModel.compositions)
+									|| !sameServices(expectedServices, m_sceneModel.services)
+									|| !sameIncidents(expectedIncidents, selectedScenarioIncidents()))
+								facetFailure(facetOk, "save/reload", "pending editor values did not survive Save and reopen");
+						}
+						bool selectionRoundtripOk = m_excludedSceneOccurrences.empty();
 					if (m_serviceOccurrenceTable) {
 						for (int row = 0; row < m_serviceOccurrenceTable->rowCount(); ++row) {
 							QTableWidgetItem* include = m_serviceOccurrenceTable->item(row, 0);
@@ -12385,31 +12389,7 @@ void MainWindow::runEditorSmokeE2E() {
 					}
 					if (!selectionRoundtripOk)
 						facetFailure(facetOk, "save/reload", "temporary occurrence selection was serialized or not reset on reopen");
-
-					const auto editedUnit = std::find_if(m_sceneModel.trainUnits.begin(), m_sceneModel.trainUnits.end(),
-														 [&editedTrainUnitId](const SceneTrainUnit& unit) { return unit.id == editedTrainUnitId; });
-					if (editedUnit == m_sceneModel.trainUnits.end() || !m_trainUnitSourceDataEdit) {
-						facetFailure(facetOk, "save/reload", "edited train unit or source editor unavailable");
-					} else {
-						const int trainUnitRow = static_cast<int>(std::distance(m_sceneModel.trainUnits.begin(), editedUnit));
-						m_trainUnitListWidget->setCurrentRow(trainUnitRow);
-						const std::string pendingSource = "e2e/source-data-pending-save.txt";
-						m_trainUnitSourceDataEdit->setFocus();
-						m_trainUnitSourceDataEdit->setText(QString::fromStdString(pendingSource));
-						if (m_sceneModel.trainUnits[static_cast<std::size_t>(trainUnitRow)].sourceDataFile == pendingSource) {
-							facetFailure(facetOk, "save/reload", "pending source edit committed before the save path");
-						} else if (!saveSceneToCurrentDir()) {
-							facetFailure(facetOk, "save/reload", "save path rejected a pending source edit");
-						} else if (!openSceneDirectory(outScenePath)) {
-							facetFailure(facetOk, "save/reload", "scene with a pending source edit did not reload");
-						} else {
-							const auto reloadedUnit = std::find_if(m_sceneModel.trainUnits.begin(), m_sceneModel.trainUnits.end(),
-																   [&editedTrainUnitId](const SceneTrainUnit& unit) { return unit.id == editedTrainUnitId; });
-							if (reloadedUnit == m_sceneModel.trainUnits.end() || reloadedUnit->sourceDataFile != pendingSource)
-								facetFailure(facetOk, "save/reload", "pending source edit was not saved and reloaded");
-						}
 					}
-				}
 			}
 			if (facetOk)
 				std::fprintf(stdout, "E2E_EDITOR_SAVE_RELOAD_OK\n");
@@ -13826,7 +13806,6 @@ void MainWindow::runScene() {
 	if (!m_sceneLoaded)
 		return;
 
-	commitPendingEditorValues();
 	refreshValidationPanel();
 	if (hasErrors(m_sceneDiagnostics)) {
 		int errorCount = countDiagnostics(m_sceneDiagnostics).errors;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3653,7 +3653,9 @@ void MainWindow::commitPendingEditorValues() {
 	commitScenarioDescriptionEdit();
 	commitIncidentIdEdit();
 	commitIncidentStartSeconds();
-	if (m_incidentHasEndSecondsCheck && m_incidentHasEndSecondsCheck->isChecked())
+	if (m_incidentEndSecondsEdit && ((m_incidentHasEndSecondsCheck
+			&& m_incidentHasEndSecondsCheck->isChecked())
+			|| hasEditorFocus(m_incidentEndSecondsEdit)))
 		commitIncidentEndSeconds();
 	if (m_incidentHasOccurrenceCheck && m_incidentHasOccurrenceCheck->isChecked())
 		commitIncidentOccurrence();
@@ -5420,8 +5422,9 @@ void MainWindow::commitTrainUnitIdEdit() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshCompositionPanel();
+	updateServiceDetailPanel();
+	refreshValidationPanel();
 }
 
 void MainWindow::commitTrainUnitSources() {
@@ -5700,8 +5703,9 @@ void MainWindow::addComposition() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshCompositionPanel();
+	updateServiceDetailPanel();
+	refreshValidationPanel();
 
 	if (m_compositionListWidget)
 		m_compositionListWidget->setCurrentRow(static_cast<int>(m_sceneModel.compositions.size()) - 1);
@@ -5721,8 +5725,9 @@ void MainWindow::duplicateComposition() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshCompositionPanel();
+	updateServiceDetailPanel();
+	refreshValidationPanel();
 
 	if (m_compositionListWidget)
 		m_compositionListWidget->setCurrentRow(row + 1);
@@ -5757,6 +5762,7 @@ void MainWindow::deleteComposition() {
 	updateSceneWindowTitle();
 	updateSceneActions();
 	refreshCompositionPanel();
+	updateServiceDetailPanel();
 	refreshValidationPanel();
 }
 
@@ -6315,6 +6321,7 @@ void MainWindow::addService() {
 	updateSceneWindowTitle();
 	updateSceneActions();
 	refreshServicePanel();
+	refreshIncidentTargetCombo();
 	refreshValidationPanel();
 
 	if (m_serviceListWidget)
@@ -6335,8 +6342,9 @@ void MainWindow::duplicateService() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshServicePanel();
+	refreshIncidentTargetCombo();
+	refreshValidationPanel();
 
 	if (m_serviceListWidget)
 		m_serviceListWidget->setCurrentRow(row + 1);
@@ -6376,8 +6384,9 @@ void MainWindow::deleteService() {
 	markSceneDirty();
 	updateSceneWindowTitle();
 	updateSceneActions();
-	refreshValidationPanel();
 	refreshServicePanel();
+	refreshIncidentTargetCombo();
+	refreshValidationPanel();
 }
 
 void MainWindow::commitServiceIdEdit() {
@@ -11679,13 +11688,19 @@ void MainWindow::runEditorSmokeE2E() {
 						}))
 				facetFailure(facetOk, "composition", "service-referenced composition delete was not refused");
 			addComposition();
-			if (m_compositionListWidget->count() != originalCount + 2) {
-				facetFailure(facetOk, "composition", "add did not apply");
+			const std::string temporaryCompositionId = m_sceneModel.compositions.back().id;
+			if (m_compositionListWidget->count() != originalCount + 2
+					|| !m_serviceCompositionCombo
+					|| m_serviceCompositionCombo->findText(
+						QString::fromStdString(temporaryCompositionId)) < 0) {
+				facetFailure(facetOk, "composition", "add did not refresh the service selector");
 			} else {
 				acceptConfirmation();
 				deleteComposition();
-				if (m_compositionListWidget->count() != originalCount + 1)
-					facetFailure(facetOk, "composition", "delete did not apply");
+				if (m_compositionListWidget->count() != originalCount + 1
+						|| m_serviceCompositionCombo->findText(
+							QString::fromStdString(temporaryCompositionId)) >= 0)
+					facetFailure(facetOk, "composition", "delete did not refresh the service selector");
 			}
 			int editedRow = -1;
 			for (int row = 0; row < static_cast<int>(m_sceneModel.compositions.size()); ++row) {
@@ -12125,6 +12140,20 @@ void MainWindow::runEditorSmokeE2E() {
 				|| incidents[editedRow].hasEndSeconds
 				|| !incidents[editedRow].terminateAtDestination)
 			facetFailure(facetOk, "incident", "edited incident was not retained");
+		if (!m_serviceListWidget || !m_incidentTargetCombo) {
+			facetFailure(facetOk, "incident", "service target controls unavailable");
+		} else {
+			const int serviceCount = m_serviceListWidget->count();
+			addService();
+			const std::string temporaryServiceId = m_sceneModel.services.back().id;
+			if (m_incidentTargetCombo->findText(QString::fromStdString(temporaryServiceId)) < 0)
+				facetFailure(facetOk, "incident", "service add did not refresh breakdown targets");
+			acceptConfirmation();
+			deleteService();
+			if (m_serviceListWidget->count() != serviceCount
+					|| m_incidentTargetCombo->findText(QString::fromStdString(temporaryServiceId)) >= 0)
+				facetFailure(facetOk, "incident", "service delete did not refresh breakdown targets");
+		}
 		if (facetOk)
 			std::fprintf(stdout, "E2E_EDITOR_INCIDENT_OK\n");
 	}
@@ -12277,7 +12306,8 @@ void MainWindow::runEditorSmokeE2E() {
 					if (pendingServiceRow < 0 || pendingStopRow < 0 || scenarioRow < 0
 							|| !m_stopListWidget || !m_stopDwellSecondsEdit
 							|| !m_scenarioListWidget || !m_scenarioDescriptionEdit
-							|| !m_incidentListWidget || !m_incidentStartSecondsEdit) {
+							|| !m_incidentListWidget || !m_incidentEndSecondsEdit
+							|| !m_incidentHasEndSecondsCheck) {
 						facetFailure(facetOk, "save/reload", "pending stop, scenario, or incident controls were unavailable");
 					} else {
 						m_serviceListWidget->setCurrentRow(pendingServiceRow);
@@ -12314,9 +12344,11 @@ void MainWindow::runEditorSmokeE2E() {
 							const int incidentRow = static_cast<int>(std::distance(incidents.begin(), pendingIncident));
 							m_incidentListWidget->setCurrentRow(incidentRow);
 							QApplication::processEvents();
-							const int pendingIncidentStart = static_cast<int>(pendingIncident->startSeconds) + 1;
-							m_incidentStartSecondsEdit->setText(QString::number(pendingIncidentStart));
-							m_incidentStartSecondsEdit->setFocus();
+							if (m_incidentHasEndSecondsCheck->isChecked())
+								m_incidentHasEndSecondsCheck->setChecked(false);
+							const int pendingIncidentEnd = static_cast<int>(pendingIncident->endSeconds) + 200;
+							m_incidentEndSecondsEdit->setText(QString::number(pendingIncidentEnd));
+							m_incidentEndSecondsEdit->setFocus();
 							QApplication::processEvents();
 							if (m_sceneModel.routes.empty()) {
 								facetFailure(facetOk, "save/reload", "route unavailable for blocked Run coverage");
@@ -12326,7 +12358,8 @@ void MainWindow::runEditorSmokeE2E() {
 								m_runSceneAction->trigger();
 								QApplication::processEvents();
 								if (m_worker || !selectedIncident()
-										|| selectedIncident()->startSeconds != pendingIncidentStart)
+										|| !selectedIncident()->hasEndSeconds
+										|| selectedIncident()->endSeconds != pendingIncidentEnd)
 									facetFailure(facetOk, "save/reload", "Run did not flush focused incident text before validation");
 								m_sceneModel.routes.front().blocks = validRoute;
 								refreshValidationPanel();

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -384,6 +384,7 @@ private:
 	bool m_sceneLoaded = false;
 	bool m_sceneIsBundle = false;
 	bool m_sceneDirty = false;
+	bool m_committingPendingEditorValues = false;
 	QAction* m_saveSceneAction = nullptr;
 	QAction* m_saveSceneAsAction = nullptr;
 	QAction* m_saveSceneAsFolderAction = nullptr;
@@ -589,6 +590,7 @@ private:
 	void updateSceneWindowTitle();
 	void updateCaseLayersPanel();
 	void refreshCaseSettingsPanel();
+	void commitPendingEditorValues();
 	void commitPendingCaseSettings();
 	void commitCaseSettings();
 	void refreshInfrastructurePanel();
@@ -606,6 +608,8 @@ private:
 	void deleteInfrastructureEntity();
 	void updateInfrastructureSelection();
 	std::string uniqueInfrastructureId(const std::string& baseId, const QString& facet) const;
+	QStringList directDeleteConsumers(const QString& facet, const std::string& id,
+		const std::string& scope = {}) const;
 	void refreshValidationPanel();
 	void refreshLoadedDataTree();
 	void activateLoadedDataItem(QTreeWidgetItem* item);

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -11,7 +11,7 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - Current milestone: PR 3, safe editor commits, IDs, references, rename, and deletion
 - Current worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/editor-reference-integrity`
 - Current branch: `fix/editor-reference-integrity`
-- Current PR: not opened
+- Current PR: #292, `Make editor mutations reference-safe`
 - Completed milestones and PRs:
   - PR #290, `Bind signals to canonical track sections`, merged as
     `d90eb24de0f6f72e33b5206d1ffecec7ab64f7a2`;
@@ -547,5 +547,5 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 
 ## Next action
 
-Commit and open PR 3 from the verified `fix/editor-reference-integrity` worktree, then run the fresh correctness
-and Ponytail reviews against the complete PR diff before merge.
+Run the fresh correctness review against PR #292's complete diff, correct every confirmed finding, rerun the
+affected gates, and then run the independent Ponytail simplicity review.

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -351,6 +351,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - After correcting the first PR 3 review findings, the full build passed, all 7 scene tests passed in 0.69
   seconds, `tools/e2e/editor_smoke.sh` passed, and `git diff --check` passed.
 - The post-correction `graphify update .` rebuilt 6,053 nodes, 9,943 edges, and 1,633 communities.
+- The clean post-correction CTest run passed all 43 tests in 120.31 seconds. The sequential visual-polish smoke
+  passed DPR 1 and DPR 2 visuals, station overlays, scene rendering, and legacy import.
+- After applying the PR 3 Ponytail reductions, the full build passed, all 7 scene tests passed in 0.70 seconds,
+  editor smoke passed, and `git diff --check` passed.
+- The post-simplification graph update rebuilt 6,053 nodes, 9,943 edges, and 1,628 communities.
 
 ## Review record
 
@@ -369,6 +374,8 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   3. a focused breakdown end-time edit was skipped when the optional end-time checkbox was initially clear.
   The same review independently passed the build, 43 of 43 CTest cases, the focused scene gate, editor smoke, and
   `git diff --check`.
+- The fresh corrected-diff review found no P0, P1, or P2 issue at `8c1a957`. It independently passed the full
+  build, CTest 43 of 43, editor smoke with every required marker, and `git diff --check`.
 
 - The first fresh review of PR #290 found no P0 issue and four merge blockers:
   1. overlapping connection-derived sections could be accepted through a shared block without matching the
@@ -540,6 +547,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - The PR 2 Ponytail review identified three practical reductions: use the existing filtered block-row map for
   neighbor moves, remove text-cell commit branches made unreachable by section combos, and share the repeated
   anonymous-row add/delete smoke sequence.
+- The PR 3 Ponytail review found no simpler production design and five localized reductions: reuse occurrence
+  pruning and unique-service-ID helpers, remove two redundant refresh/commit calls, and fold the pending train-unit
+  source check into the existing save/reopen round trip.
 
 ### Simplifications made
 
@@ -547,6 +557,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   No further production simplification was justified after the clean correctness review.
 - PR 2 now uses one direction-parameterized block-move path, deletes the two unreachable linked-topology text
   commit paths, and uses one local smoke helper for dependency, restriction, and boundary row deletion checks.
+- PR 3 now uses `pruneExcludedServiceOccurrences` and `uniqueServiceId` instead of local loops, removes a service
+  refresh that cannot depend on train-unit IDs, lets Run rely on validation's pending commit, and saves/reopens
+  once for the final focused-source persistence check.
 
 ## Blockers
 

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -19,7 +19,7 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
     `14b242cc8829c06358f74be8c2717e85f9238b05`.
 - Open milestone dependencies: PR 3 depends on merged PR #291. Issues #85 and #86 remain parity gates.
 
-## Confirmed creator gaps
+## Planning-baseline creator gaps
 
 1. Switch routes and linked signalling structures expose generated section strings.
 2. Block placement follows hidden vector order without insert, reorder, or placement inspection.
@@ -30,7 +30,7 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 7. Passenger journeys and legs lack public import, inspection, and CRUD.
 8. Passenger platform geometry uses hidden fixed values.
 9. General result exports lack a saved-input snapshot and complete run provenance.
-10. The current creator smoke bypasses public operations and does not prove a seventh case.
+10. The current creator smoke does not prove a complete UI-only seventh-case workflow.
 
 ## Disproven or outdated findings
 
@@ -77,8 +77,8 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - PR 3 uses one MainWindow-local direct-consumer query for infrastructure, rolling-stock, composition, route,
   and service deletes. Referenced deletes are rejected. No remap, cascade, database-style index, or command
   framework is needed. An accepted service delete prunes only its transient occurrence-selection entries.
-- The PR 2 selector refresh boundary already rebuilds route and incident choices after block mutations. The
-  selector-refresh sentence in #287 is outdated and will not be implemented again in PR 3.
+- PR 2 already refreshes route and incident choices after block mutations. PR 3 adds refreshes for composition
+  and service mutations.
 
 ## Compatibility decisions
 
@@ -356,6 +356,8 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - After applying the PR 3 Ponytail reductions, the full build passed, all 7 scene tests passed in 0.70 seconds,
   editor smoke passed, and `git diff --check` passed.
 - The post-simplification graph update rebuilt 6,053 nodes, 9,943 edges, and 1,628 communities.
+- The fresh post-simplification correctness reviewer passed the focused five-test scene gate, the editor smoke
+  with every required marker, and `git diff --check` at `4a5daa3`.
 
 ## Review record
 
@@ -376,6 +378,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   `git diff --check`.
 - The fresh corrected-diff review found no P0, P1, or P2 issue at `8c1a957`. It independently passed the full
   build, CTest 43 of 43, editor smoke with every required marker, and `git diff --check`.
+- The fresh post-simplification review found no P0, P1, or P2 issue at `4a5daa3`. It rechecked the simplified
+  pending-Run, service-ID, occurrence-pruning, selector-refresh, unchecked incident end-time, and final
+  save/reopen paths against the complete diff.
 
 - The first fresh review of PR #290 found no P0 issue and four merge blockers:
   1. overlapping connection-derived sections could be accepted through a shared block without matching the
@@ -573,5 +578,4 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 
 ## Next action
 
-Run the fresh correctness review against PR #292's complete diff, correct every confirmed finding, rerun the
-affected gates, and then run the independent Ponytail simplicity review.
+Wait for PR #292's required build and sanitizer checks, then record the merge decision.

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -348,6 +348,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - `graphify update .` ran against the PR 3 worktree through the canonical checkout's maintained graph directory.
   It rebuilt 6,053 nodes, 9,936 edges, and 1,633 communities, retaining 46 fail-closed nodes whose source files
   still exist but left the current scan corpus.
+- After correcting the first PR 3 review findings, the full build passed, all 7 scene tests passed in 0.69
+  seconds, `tools/e2e/editor_smoke.sh` passed, and `git diff --check` passed.
+- The post-correction `graphify update .` rebuilt 6,053 nodes, 9,943 edges, and 1,633 communities.
 
 ## Review record
 
@@ -360,6 +363,12 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   changing the selected scenario.
 - A separate read-only pre-commit trace found no remaining P0, P1, or P2 issue in the pending-commit, save/run,
   delete-consumer, service-rename, or public-smoke paths.
+- The first fresh review of PR #292 found no P0 or P1 issue and three P2 gaps:
+  1. composition add, duplicate, and delete did not rebuild the service composition selector;
+  2. service add, duplicate, and delete did not rebuild train-breakdown target choices;
+  3. a focused breakdown end-time edit was skipped when the optional end-time checkbox was initially clear.
+  The same review independently passed the build, 43 of 43 CTest cases, the focused scene gate, editor smoke, and
+  `git diff --check`.
 
 - The first fresh review of PR #290 found no P0 issue and four merge blockers:
   1. overlapping connection-derived sections could be accepted through a shared block without matching the
@@ -515,6 +524,10 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - Route-detail refresh now runs once at the common infrastructure-selection boundary. The existing helper hides
   the pane on every non-Route facet, and the smoke asserts both its initial hidden state and the Routes-to-Blocks
   transition so stale route controls cannot remain visible.
+- PR 3 now refreshes service composition choices after every accepted composition mutation and breakdown targets
+  after every accepted service mutation. Pending incident end-time text commits when the editor has focus even if
+  its checkbox was previously clear. Focused smoke checks cover both selector add/delete paths and the unchecked
+  end-time Run handoff.
 
 ### Ponytail findings
 

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -7,14 +7,17 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 ## Current state
 
 - Planning baseline: `59128cea7a50b2fbc83e147f2e6d9dd6f451c2cf`
-- Current `origin/main`: `d90eb24de0f6f72e33b5206d1ffecec7ab64f7a2`
-- Current milestone: PR 2, structured topology authoring and explicit block order
-- Current worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/structured-topology-authoring`
-- Current branch: `feature/structured-topology-authoring`
-- Current PR: #291, `Add structured topology authoring`
-- Completed milestones and PRs: PR #290, `Bind signals to canonical track sections`, merged as
-  `d90eb24de0f6f72e33b5206d1ffecec7ab64f7a2`
-- Open milestone dependencies: PR 2 depends on merged PR #290. Issues #85 and #86 remain parity gates.
+- Current `origin/main`: `14b242cc8829c06358f74be8c2717e85f9238b05`
+- Current milestone: PR 3, safe editor commits, IDs, references, rename, and deletion
+- Current worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/editor-reference-integrity`
+- Current branch: `fix/editor-reference-integrity`
+- Current PR: not opened
+- Completed milestones and PRs:
+  - PR #290, `Bind signals to canonical track sections`, merged as
+    `d90eb24de0f6f72e33b5206d1ffecec7ab64f7a2`;
+  - PR #291, `Add structured topology authoring`, merged as
+    `14b242cc8829c06358f74be8c2717e85f9238b05`.
+- Open milestone dependencies: PR 3 depends on merged PR #291. Issues #85 and #86 remain parity gates.
 
 ## Confirmed creator gaps
 
@@ -67,6 +70,15 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - PR 2 uses the existing section inventory for route, dependency, restriction, and boundary choices. Route order
   is edited through one small ordered list; no schema field, second topology model, or generic editor framework is
   added. Invalid legacy references remain visible and unchanged until the creator replaces or removes them.
+- PR 3 remains local to `MainWindow.{h,cpp}` and the existing editor smoke. One guarded
+  `commitPendingEditorValues` path calls current commit slots before validation, Save, Save As, close/new/open
+  handoff, and Run. It interprets only focused deferred spin-box text so an untouched unit does not acquire
+  physical data merely because it was saved.
+- PR 3 uses one MainWindow-local direct-consumer query for infrastructure, rolling-stock, composition, route,
+  and service deletes. Referenced deletes are rejected. No remap, cascade, database-style index, or command
+  framework is needed. An accepted service delete prunes only its transient occurrence-selection entries.
+- The PR 2 selector refresh boundary already rebuilds route and incident choices after block mutations. The
+  selector-refresh sentence in #287 is outdated and will not be implemented again in PR 3.
 
 ## Compatibility decisions
 
@@ -76,11 +88,14 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - Invalid or ambiguous legacy targets must receive actionable diagnostics before native allocation.
 - The legacy exporter retains its exact block-map handling for slash-bearing stored references as a recovery and
   conversion path. That exporter behavior does not make `/` a valid canonical runtime block-ID character.
+- PR 3 changes no schema, reader, writer, bundle, or native runtime behavior. Existing invalid scenes remain
+  loadable and saveable; normal public deletes stop creating new dangling references.
 
 ## GitHub issue state
 
 - Closed by PR #290: #50 and #58.
-- Reopened and reused for current work: #57.
+- Closed by PR #291: #57 and #286.
+- Current milestone: #287.
 - Updated and reused: #126.
 - Reused: #85, #86, #129, #164.
 - Created during planning: #286, #287, #288, #289.
@@ -106,6 +121,13 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   route entirely through public widgets. It exercises block insertion and reordering, route add/remove/reorder,
   typed linked references, folder and bundle round trips, a reference-preserving block rename, and direct native
   construction retaining the exact authored route order. The smoke never types a generated section identity.
+- PR 3 adds one guarded pending-editor commit path before validation, persistence, close/new/open handoff, and
+  Run. It blocks referenced infrastructure, train-unit, composition, and service deletes; validates service IDs
+  before reference migration; prunes transient run exclusions after an accepted service delete; and refreshes
+  shifted detail panels before validation can read them.
+- The editor smoke covers focused train-unit, composition, stop, scenario, and incident values through public
+  Save or Run actions, persistence after reopen, rejected empty and duplicate service renames, referenced-delete
+  refusal, accepted unreferenced deletes, and transient occurrence-selection cleanup.
 
 ## Verification record
 
@@ -308,10 +330,36 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - The fresh post-simplification correctness review found no P0, P1, or P2 issue at `5f1599a`. The root full
   CTest suite passed 43 of 43 in 120.70 seconds; the reviewer independently passed 43 of 43 in 120.24 seconds.
 - `git diff --check` passed after the final PR 2 source change.
+- PR #291 CI passed both jobs at final head `1531614`. The build job completed in 16 minutes 17 seconds and
+  included CTest plus the headless, editor, round-trip, bundle, Assignment, incident, render, track-preview, and
+  visual smokes. The sanitizer job completed in 14 minutes 51 seconds.
+- PR #291 merged as `14b242cc8829c06358f74be8c2717e85f9238b05`; issues #57 and #286 closed with the merge.
+- PR 3 baseline configured and built successfully from merged main `14b242c`. The baseline editor smoke passed
+  after all 7 scene tests passed in 2.40 seconds.
+- After the bounded PR 3 implementation and lead simplification, the full build passed and
+  `tools/e2e/editor_smoke.sh` passed after all 7 scene tests. The smoke exercises still-focused Save and blocked
+  Run handoffs without first changing focus.
+- `tools/e2e/visual_polish_smoke.sh` passed its DPR 1 and DPR 2 visual, station-overlay, scene-render, and
+  legacy-import checks.
+- A first full CTest run executed alongside visual smoke passed 42 of 43 tests; `test_gui_autostart_smoke` saw a
+  shared-output train-row mismatch. The failed test passed alone in 78.87 seconds. A clean sequential rerun then
+  passed all 43 tests in 119.89 seconds.
+- `git diff --check` passed after the final pre-review source changes.
+- `graphify update .` ran against the PR 3 worktree through the canonical checkout's maintained graph directory.
+  It rebuilt 6,053 nodes, 9,936 edges, and 1,633 communities, retaining 46 fail-closed nodes whose source files
+  still exist but left the current scan corpus.
 
 ## Review record
 
 ### Independent correctness findings
+
+- The PR 3 lead diff review found one stale-widget lifecycle defect before commit: deleting a non-final train
+  unit, composition, service, or incident refreshed validation before the corresponding detail panel, allowing
+  pending-commit logic to overwrite the item shifted into the deleted row. The panel refresh now precedes
+  validation for those destructive paths. Scenario add, duplicate, and import use the same safe order after
+  changing the selected scenario.
+- A separate read-only pre-commit trace found no remaining P0, P1, or P2 issue in the pending-commit, save/run,
+  delete-consumer, service-rename, or public-smoke paths.
 
 - The first fresh review of PR #290 found no P0 issue and four merge blockers:
   1. overlapping connection-derived sections could be accepted through a shared block without matching the
@@ -495,8 +543,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 
 ### Unresolved application blockers
 
-- PR 1 is complete. PRs 2 through 6 remain open.
+- PRs 1 and 2 are complete. PRs 3 through 6 remain open.
 
 ## Next action
 
-Monitor PR #291 CI, then merge if both build and sanitizer checks pass.
+Commit and open PR 3 from the verified `fix/editor-reference-integrity` worktree, then run the fresh correctness
+and Ponytail reviews against the complete PR diff before merge.


### PR DESCRIPTION
Closes #287

## Problem

- Focused editor values could be omitted when Save, Save As, close/new/open handoff, validation, or Run read SceneModel.
- Service rename could migrate references before rejecting an empty or duplicate ID.
- Referenced deletes could leave dangling scene data, and accepted composition or service changes could leave dependent selectors stale.

## Solution

- Commit pending values through one guarded path before persistence, validation, close handoff, and Run.
- Validate service IDs before changing the service or its consumers.
- Reject deletes that still have direct canonical consumers.
- Refresh service composition choices after composition changes and train-breakdown targets after service changes.
- Refresh shifted detail panels before validation and prune transient occurrence exclusions after an accepted service delete.

## Compatibility

No scene schema, reader, writer, bundle, or runtime format changed. Existing invalid scenes remain loadable and saveable.

## Verification

- Local full build passed.
- Local CTest passed 43 of 43 tests.
- Local editor smoke passed, including focused Save and Run coverage.
- Local visual polish smoke passed.
- Local git diff --check passed.
- Required current-head build and sanitizer checks passed.