### PR TITLE
Add reproducible creator acceptance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,6 +689,9 @@ if(EGTRAIN_BUILD_TESTS)
 	add_test(NAME test_lebanon_scene_smoke
 		COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/lebanon_scene_smoke.sh)
 	set_tests_properties(test_lebanon_scene_smoke PROPERTIES TIMEOUT 360)
+	add_test(NAME test_creator_acceptance_smoke
+		COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/creator_acceptance_smoke.sh)
+	set_tests_properties(test_creator_acceptance_smoke PROPERTIES TIMEOUT 240)
 	if(APPLE)
 		add_test(NAME test_package_contents_smoke
 			COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/package_contents_smoke.sh)

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -104,6 +104,23 @@ QString sceneSectionDisplayLabel(const SceneSectionDescriptor& section) {
 			QString::fromStdString(section.firstTrackId));
 }
 
+QString completedRunContext(const RunProvenance& provenance) {
+	const QString caseName = QString::fromStdString(provenance.caseName);
+	const QString scenario = QString::fromStdString(provenance.appliedScenario);
+	if (caseName.isEmpty())
+		return scenario.isEmpty() ? QStringLiteral("(none)") : scenario;
+	if (scenario.isEmpty())
+		return caseName;
+	return QStringLiteral("%1 / %2").arg(caseName, scenario);
+}
+
+void attachRunProvenance(DiagramWindow* window, RunProvenance provenance) {
+	window->setProvenanceWriter([provenance = std::move(provenance)](
+			const QString& path, const char* kind) {
+		return writeRunProvenanceSidecar(path.toStdString(), kind, provenance);
+	});
+}
+
 void populateSceneSectionCombo(QComboBox* combo, const SceneSectionInventory& inventory,
 		const std::string& current, bool allowNone, const QString& noneLabel) {
 	if (!combo)
@@ -1093,9 +1110,16 @@ bool writeCsvFile(const QString& path, const std::string& content) {
 	return file.write(bytes) == bytes.size() && file.commit();
 }
 
+bool writeCsvFileWithProvenance(const QString& path, const std::string& content,
+		const RunProvenance& provenance) {
+	return writeCsvFile(path, content)
+		&& writeRunProvenanceSidecar(path.toStdString(), "csv", provenance);
+}
+
 // Prompt for a path and write CSV text atomically. A cancelled dialog or a write
 // failure never leaves a partial file behind.
-void saveCsvInteractive(QWidget* parent, const QString& suggestedName, const std::string& content) {
+void saveCsvInteractive(QWidget* parent, const QString& suggestedName, const std::string& content,
+		const std::function<bool(const QString&)>& sidecarWriter = {}) {
 	if (content.empty()) {
 		QMessageBox::information(parent, "Nothing to export", "There is no data to export.");
 		return;
@@ -1115,6 +1139,10 @@ void saveCsvInteractive(QWidget* parent, const QString& suggestedName, const std
 	if (file.write(bytes) != bytes.size() || !file.commit()) {
 		QMessageBox::warning(parent, "Export failed",
 							 QString("Could not write the data to:\n%1").arg(path));
+	} else if (sidecarWriter && !sidecarWriter(path)) {
+		QMessageBox::warning(parent, "Export warning",
+							 QString("The CSV was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+								.arg(path));
 	}
 }
 
@@ -3875,6 +3903,8 @@ void MainWindow::invalidateRunResults() {
 	m_appliedScenarioId.clear();
 	m_completedRunResults = RunResults();
 	m_completedTimetableResults.clear();
+	m_pendingRunProvenance = RunProvenance();
+	m_completedRunProvenance = RunProvenance();
 	if (m_runResultsTable)
 		m_runResultsTable->setRowCount(0);
 	if (m_runResultsSummaryLabel)
@@ -15776,6 +15806,30 @@ bool MainWindow::showRunReview() {
 	return false;
 }
 
+RunProvenance MainWindow::captureRunProvenance() const {
+	RunProvenance provenance;
+	provenance.caseName = m_sceneModel.name;
+	provenance.sceneSchemaVersion = m_sceneModel.schemaVersion;
+	provenance.input = captureSavedInput(m_sceneDir.toStdString(),
+		m_sceneIsBundle ? "bundle" : "directory", m_sceneDirty);
+	provenance.appliedScenario = m_appliedScenarioId;
+	provenance.baseTimeSeconds = static_cast<double>(initial_variables.startingSimulationTime);
+	provenance.durationSeconds = initial_variables.times;
+	provenance.timestepSeconds = timestep;
+	provenance.bufferSeconds = bufferTime;
+	provenance.recoveryPercent = recoveryTimePercentage;
+	provenance.paxMode = initial_variables.PAX_GUI ? 1 : 0;
+	provenance.tsmMode = initial_variables.TSM;
+	provenance.routeChoiceMode = initial_variables.RChoice;
+	provenance.selectedOccurrences.reserve(static_cast<std::size_t>(std::max(0, numRegions)));
+	for (int index = 0; index < numRegions; ++index) {
+		const Train& train = regional_train[index];
+		provenance.selectedOccurrences.push_back({train.serviceId, train.serviceOccurrence,
+			train.operatingCode});
+	}
+	return provenance;
+}
+
 DelayRunSnapshot MainWindow::completedDelaySnapshot() const {
 	DelayRunSnapshot snapshot;
 	if (!m_resultsAvailable || m_completedRunResults.trains.empty())
@@ -15793,6 +15847,7 @@ DelayRunSnapshot MainWindow::completedDelaySnapshot() const {
 		snapshot.hasEntranceDelays = !scenario.entranceDelays.empty();
 		break;
 	}
+	snapshot.provenance = m_completedRunProvenance;
 	snapshot.run = m_completedRunResults;
 	snapshot.timetable = m_completedTimetableResults;
 	return snapshot;
@@ -15832,7 +15887,7 @@ void MainWindow::showDelayComparison() {
 	dialog.resize(1180, 520);
 	QVBoxLayout* layout = new QVBoxLayout(&dialog);
 	QLabel* context = new QLabel(QString("Baseline: %1 | Scenario: %2 | Total positive arrival delay: %3 s")
-		.arg(QString::fromStdString(m_delayBaseline->scenarioId), QString::fromStdString(scenario.scenarioId))
+		.arg(completedRunContext(m_delayBaseline->provenance), completedRunContext(scenario.provenance))
 		.arg(comparison.totalArrivalDelay.available ? QString::number(comparison.totalArrivalDelay.value, 'g', 12) : QStringLiteral("-")), &dialog);
 	context->setWordWrap(true);
 	layout->addWidget(context);
@@ -15871,8 +15926,15 @@ void MainWindow::showDelayComparison() {
 	QHBoxLayout* actions = new QHBoxLayout();
 	QPushButton* exportButton = new QPushButton("Export CSV...", &dialog);
 	exportButton->setObjectName("delayComparisonExportCsvButton");
-	connect(exportButton, &QPushButton::clicked, &dialog, [this, scenario, comparison]() {
-		saveCsvInteractive(this, "delay_comparison.csv", delayComparisonCsv(*m_delayBaseline, scenario, comparison));
+	const RunProvenance baselineProvenance = m_delayBaseline->provenance;
+	const RunProvenance scenarioProvenance = scenario.provenance;
+	connect(exportButton, &QPushButton::clicked, &dialog, [this, scenario, comparison,
+			baselineProvenance, scenarioProvenance]() {
+		saveCsvInteractive(this, "delay_comparison.csv", delayComparisonCsv(*m_delayBaseline, scenario, comparison),
+			[baselineProvenance, scenarioProvenance](const QString& path) {
+				return writeDelayProvenanceSidecar(path.toStdString(), "csv", baselineProvenance,
+					scenarioProvenance);
+			});
 	});
 	actions->addWidget(exportButton);
 	actions->addStretch();
@@ -15923,10 +15985,13 @@ void MainWindow::onSimulationFinished() {
 	if (m_resultsAvailable) {
 		const auto trains = runResultTrainPointers();
 		// Freeze result values before a subsequent run replaces the runtime trains.
+		m_completedRunProvenance = m_pendingRunProvenance;
 		m_completedRunResults = buildRunResults(trains, timestep);
 		m_completedTimetableResults = buildTimetableResults(trains);
 		refreshRunResults();
 	} else {
+		m_pendingRunProvenance = RunProvenance();
+		m_completedRunProvenance = RunProvenance();
 		if (m_runResultsTable)
 			m_runResultsTable->setRowCount(0);
 		if (m_runResultsSummaryLabel)
@@ -15938,6 +16003,7 @@ void MainWindow::onSimulationFinished() {
 			m_runResultsDock->hide();
 		}
 	}
+	m_pendingRunProvenance = RunProvenance();
 	refreshLoadedDataTree();
 
 	// verification hook: write every CSV export from the completed run, then exit
@@ -15945,8 +16011,14 @@ void MainWindow::onSimulationFinished() {
 		const QString dir = qEnvironmentVariable("QEGTRAIN_E2E_EXPORT_DIR");
 		const QStringList ids = allTrainIds();
 		// Skip an export with no rows, matching the interactive "nothing to export".
-		const auto dump = [&dir](const QString& file, const std::string& content) {
-			return content.empty() ? true : writeCsvFile(dir + "/" + file, content);
+		const auto dump = [&dir, this](const QString& file, const std::string& content) {
+			if (content.empty())
+				return true;
+			const QString path = dir + "/" + file;
+			if (writeCsvFileWithProvenance(path, content, m_completedRunProvenance))
+				return true;
+			std::fprintf(stderr, "E2E_PROVENANCE_EXPORT_WARNING: %s\n", path.toStdString().c_str());
+			return false;
 		};
 		bool ok = m_resultsAvailable;
 		if (ok) {
@@ -16131,6 +16203,7 @@ void MainWindow::runScene() {
 	refreshLoadedDataTree();
 	initial_variables.startingSimulationTime = baseTimeToSeconds(m_sceneModel.baseTime);
 	m_startOffsetSeconds = initial_variables.startingSimulationTime;
+	m_pendingRunProvenance = captureRunProvenance();
 
 	setupGUI();
 	fitView();
@@ -16825,7 +16898,11 @@ void MainWindow::setupRunResultsDock() {
 	exportCsvBtn->setObjectName("resultView_ExportCSV");
 	exportCsvBtn->setToolTip("Write travel time and energy per train to a CSV file");
 	connect(exportCsvBtn, &QPushButton::clicked, this, [this]() {
-		saveCsvInteractive(this, "run_summary.csv", buildRunSummaryCsv(m_completedRunResults));
+		const RunProvenance provenance = m_completedRunProvenance;
+		saveCsvInteractive(this, "run_summary.csv", buildRunSummaryCsv(m_completedRunResults),
+			[provenance](const QString& path) {
+				return writeRunProvenanceSidecar(path.toStdString(), "csv", provenance);
+			});
 	});
 	QPushButton* exportPngBtn = new QPushButton("Export PNG...", container);
 	exportPngBtn->setObjectName("resultView_ExportPNG");
@@ -16838,7 +16915,11 @@ void MainWindow::setupRunResultsDock() {
 			path += ".png";
 		if (!m_runResultsTable->grab().save(path, "PNG"))
 			QMessageBox::warning(this, "Export failed", QString("Could not write the image to:\n%1").arg(path));
-	});
+		else if (!writeRunProvenanceSidecar(path.toStdString(), "png", m_completedRunProvenance))
+			QMessageBox::warning(this, "Export warning",
+				QString("The image was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+					.arg(path));
+		});
 	QHBoxLayout* toolRow = new QHBoxLayout();
 	toolRow->addWidget(exportCsvBtn);
 	toolRow->addWidget(exportPngBtn);
@@ -16872,15 +16953,15 @@ void MainWindow::refreshRunResults() {
 			++destinationTerminationCount;
 	}
 	if (m_runResultsSummaryLabel) {
-		QString summary = QString("Case: %1 | Scenario: %2 | Occurrences: %3/%4 selected | Status: Completed | Direct incident evidence: %5 | Destination terminations: %6")
-			.arg(QString::fromStdString(m_sceneModel.name), scenarioContext())
+		QString summary = QString("Run: %1 | Occurrences: %2/%3 selected | Status: Completed | Direct incident evidence: %4 | Destination terminations: %5")
+			.arg(completedRunContext(m_completedRunProvenance))
 			.arg(m_lastRunSelectedOccurrences).arg(m_lastRunTotalOccurrences)
 			.arg(directEvidenceCount).arg(destinationTerminationCount);
 		if (m_delayBaseline)
-			summary += QString(" | Delay baseline: %1").arg(QString::fromStdString(m_delayBaseline->scenarioId));
+			summary += QString(" | Delay baseline: %1").arg(completedRunContext(m_delayBaseline->provenance));
 		m_runResultsSummaryLabel->setText(summary);
 	}
-	m_runResultsDock->setWindowTitle(QString("Run Results — %1").arg(scenarioContext()));
+	m_runResultsDock->setWindowTitle(QString("Run Results — %1").arg(completedRunContext(m_completedRunProvenance)));
 
 	const RunResults& results = m_completedRunResults;
 	const int totalColumns = 11;
@@ -18458,7 +18539,7 @@ void MainWindow::buildCorridorTrainPathDiagram(std::string corridor) {
 
 	QString title = "Train paths (time vs distance), corridor ";
 	title.append(QString::fromStdString(corridor));
-	title += QString(" [%1]").arg(scenarioContext());
+	title += QString(" [%1]").arg(completedRunContext(m_completedRunProvenance));
 	chart->setTitle(title);
 
 	for (int i = 0; i < numRegions; i++) {
@@ -18559,6 +18640,7 @@ void MainWindow::buildCorridorTrainPathDiagram(std::string corridor) {
 	DiagramWindow* win = new DiagramWindow(title, this);
 	win->setChart(chart);
 	win->setCsvProvider(snapshotCsv(&buildTrajectoryCsv), "train_path.csv");
+	attachRunProvenance(win, m_completedRunProvenance);
 	connect(win, &DiagramWindow::trainSelected, this, &MainWindow::focusTrainInScene);
 	win->setTimeAxisX(true, m_startOffsetSeconds);
 	win->setAttribute(Qt::WA_DeleteOnClose);
@@ -18682,7 +18764,7 @@ void MainWindow::buildPerTrainDiagram(int mode) {
 	}
 
 	const char* titles[] = {"Speed vs Distance", "Speed vs Time", "Time vs Distance", "Simulated Tractive Effort vs Distance"};
-	const QString title = QString("%1 [%2]").arg(titles[mode], scenarioContext());
+	const QString title = QString("%1 [%2]").arg(titles[mode], completedRunContext(m_completedRunProvenance));
 	QChart* chart = new QChart();
 	chart->setTitle(title);
 
@@ -18724,6 +18806,7 @@ void MainWindow::buildPerTrainDiagram(int mode) {
 	DiagramWindow* win = new DiagramWindow(title, this);
 	win->setChart(chart);
 	win->setCsvProvider(snapshotCsv(&buildTrajectoryCsv), "trajectory.csv");
+	attachRunProvenance(win, m_completedRunProvenance);
 	connect(win, &DiagramWindow::trainSelected, this, &MainWindow::focusTrainInScene);
 	win->setTimeAxisX(mode == 1 || mode == 2, m_startOffsetSeconds);
 	win->setAttribute(Qt::WA_DeleteOnClose);
@@ -18752,7 +18835,8 @@ void MainWindow::showTimetableTable() {
 
 	auto* window = new TimetableTableWindow(m_completedTimetableResults,
 									m_startOffsetSeconds, snapshotCsv(&buildTimetableCsv), this);
-	window->setWindowTitle(QString("Timetable: planned vs simulated [%1]").arg(scenarioContext()));
+	window->setRunProvenance(m_completedRunProvenance);
+	window->setWindowTitle(QString("Timetable: planned vs simulated [%1]").arg(completedRunContext(m_completedRunProvenance)));
 	window->setAttribute(Qt::WA_DeleteOnClose);
 	window->show();
 }
@@ -18764,7 +18848,7 @@ void MainWindow::showDelayDiagram() {
 	}
 
 	QChart* chart = new QChart();
-	const QString title = QString("Arrival delay along journey (minutes) [%1]").arg(scenarioContext());
+	const QString title = QString("Arrival delay along journey (minutes) [%1]").arg(completedRunContext(m_completedRunProvenance));
 	chart->setTitle(title);
 	const auto& rows = m_completedTimetableResults;
 
@@ -18797,6 +18881,7 @@ void MainWindow::showDelayDiagram() {
 	DiagramWindow* win = new DiagramWindow(title, this);
 	win->setChart(chart);
 	win->setCsvProvider(snapshotCsv(&buildTimetableCsv), "timetable.csv");
+	attachRunProvenance(win, m_completedRunProvenance);
 	connect(win, &DiagramWindow::trainSelected, this, &MainWindow::focusTrainInScene);
 	win->setTimeAxisX(false, m_startOffsetSeconds);
 	win->setAttribute(Qt::WA_DeleteOnClose);
@@ -18811,7 +18896,7 @@ void MainWindow::showTimetableGraph() {
 
 	QChart* chart = new QChart();
 	const QString title = QString("Train graph: planned vs simulated arrival/departure [%1]")
-		.arg(scenarioContext());
+		.arg(completedRunContext(m_completedRunProvenance));
 	chart->setTitle(title);
 	const auto rows = buildTimetableResults(runResultTrainPointers());
 
@@ -18879,6 +18964,7 @@ void MainWindow::showTimetableGraph() {
 	DiagramWindow* win = new DiagramWindow(title, this);
 	win->setChart(chart);
 	win->setCsvProvider(snapshotCsv(&buildTimetableCsv), "timetable.csv");
+	attachRunProvenance(win, m_completedRunProvenance);
 	connect(win, &DiagramWindow::trainSelected, this, &MainWindow::focusTrainInScene);
 	win->setTimeAxisX(true, m_startOffsetSeconds);
 	win->setAttribute(Qt::WA_DeleteOnClose);
@@ -18923,7 +19009,7 @@ void MainWindow::showBlockingTimeDiagram() {
 		.arg(routeScope,
 			QString::fromStdString(formatSimTime(static_cast<long long>(scope.startTime), m_startOffsetSeconds)),
 			QString::fromStdString(formatSimTime(static_cast<long long>(scope.endTime), m_startOffsetSeconds)),
-			scenarioContext());
+			completedRunContext(m_completedRunProvenance));
 	chart->setTitle(title);
 
 	addBlockingTimeSeries(chart, segments, false);
@@ -18982,6 +19068,7 @@ void MainWindow::showBlockingTimeDiagram() {
 			return buildBlockingTimeCsv(visibleTrainIds, segments, plannedReferences);
 		};
 	win->setCsvProvider(snapshotCsv(scopedCsv), "blocking_time.csv");
+	attachRunProvenance(win, m_completedRunProvenance);
 	connect(win, &DiagramWindow::trainSelected, this, &MainWindow::focusTrainInScene);
 	win->setTimeAxisX(true, m_startOffsetSeconds);
 	win->setAttribute(Qt::WA_DeleteOnClose);
@@ -19028,9 +19115,11 @@ void MainWindow::showCapacityAnalysis() {
 		return;
 	}
 
+	const RunProvenance provenance = m_completedRunProvenance;
 	QDialog* dialog = new QDialog(this);
 	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->setWindowTitle(QString("Capacity analysis | %1").arg(sectionLabel));
+	dialog->setWindowTitle(QString("Capacity analysis | %1 [%2]").arg(sectionLabel,
+		completedRunContext(provenance)));
 	dialog->setModal(false);
 	dialog->resize(1050, 650);
 	auto* layout = new QVBoxLayout(dialog);
@@ -19124,12 +19213,15 @@ void MainWindow::showCapacityAnalysis() {
 
 	auto* buttons = new QHBoxLayout();
 	QPushButton* exportButton = new QPushButton("Export capacity CSV...", dialog);
-	connect(exportButton, &QPushButton::clicked, dialog, [this, result, sectionLabel]() {
-		saveCsvInteractive(this, "capacity_analysis.csv", buildCapacityAnalysisCsv(result, sectionLabel));
+	connect(exportButton, &QPushButton::clicked, dialog, [this, result, sectionLabel, provenance]() {
+		saveCsvInteractive(this, "capacity_analysis.csv", buildCapacityAnalysisCsv(result, sectionLabel),
+			[provenance](const QString& path) {
+				return writeRunProvenanceSidecar(path.toStdString(), "csv", provenance);
+			});
 	});
 	QPushButton* diagramButton = new QPushButton("Open compressed blocking-time diagram", dialog);
-	connect(diagramButton, &QPushButton::clicked, dialog, [this, result, sectionLabel]() {
-		showCompressedBlockingTimeDiagram(result, sectionLabel);
+	connect(diagramButton, &QPushButton::clicked, dialog, [this, result, sectionLabel, provenance]() {
+		showCompressedBlockingTimeDiagram(result, sectionLabel, provenance);
 	});
 	QPushButton* closeButton = new QPushButton("Close", dialog);
 	connect(closeButton, &QPushButton::clicked, dialog, &QDialog::close);
@@ -19142,7 +19234,7 @@ void MainWindow::showCapacityAnalysis() {
 }
 
 void MainWindow::showCompressedBlockingTimeDiagram(const CapacityAnalysisResult& result,
-	const QString& sectionLabel) {
+	const QString& sectionLabel, RunProvenance provenance) {
 	const std::vector<BlockingTimeDiagramSegment> segments = buildBlockingTimeDiagramSegments(
 		result.compressedOccupations, result.trainIdentities);
 	if (segments.empty()) {
@@ -19150,9 +19242,9 @@ void MainWindow::showCompressedBlockingTimeDiagram(const CapacityAnalysisResult&
 		return;
 	}
 	QChart* chart = new QChart();
-	chart->setTitle(QString("Compressed blocking-time diagram | %1 | cycle %2 to %3")
+	chart->setTitle(QString("Compressed blocking-time diagram | %1 | cycle %2 to %3 [%4]")
 		.arg(sectionLabel, QString::fromStdString(result.firstIdentity),
-			QString::fromStdString(result.cycleEndIdentity)));
+			QString::fromStdString(result.cycleEndIdentity), completedRunContext(provenance)));
 	addBlockingTimeSeries(chart, segments, true);
 	auto addKey = [chart](const QString& name, const QColor& color) {
 		auto* series = new QLineSeries();
@@ -19174,8 +19266,9 @@ void MainWindow::showCompressedBlockingTimeDiagram(const CapacityAnalysisResult&
 	const std::function<std::string(const QStringList&)> csvProvider =
 		[segments](const QStringList& visibleTrainIds) {
 			return buildBlockingTimeCsv(visibleTrainIds, segments, {});
-		};
+	};
 	window->setCsvProvider(csvProvider, "capacity_compressed_blocking_time.csv");
+	attachRunProvenance(window, std::move(provenance));
 	connect(window, &DiagramWindow::trainSelected, this, &MainWindow::focusTrainInScene);
 	window->setTimeAxisX(true, m_startOffsetSeconds);
 	window->setAttribute(Qt::WA_DeleteOnClose);

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -15277,6 +15277,55 @@ void MainWindow::runCreatorAcceptanceE2E() {
 		QTimer::singleShot(0, this, [poll]() { (*poll)(); });
 	};
 	auto emitPath = [](const QString& value) { return QFileInfo(value).absoluteFilePath(); };
+	auto facet = [&](const char* name) {
+		const int index = m_infrastructureFacetCombo->findData(QString::fromLatin1(name));
+		if (index < 0)
+			return false;
+		m_infrastructureFacetCombo->setCurrentIndex(index);
+		process();
+		return m_infrastructureFacetCombo->currentData().toString() == QString::fromLatin1(name);
+	};
+	auto addRow = [&](const char* name) {
+		if (!facet(name) || !m_addInfrastructureButton->isEnabled())
+			return false;
+		m_addInfrastructureButton->click();
+		process();
+		return m_infrastructureTable->rowCount() > 0;
+	};
+	auto rowFor = [&](const QString& id) {
+		for (int row = 0; row < m_infrastructureTable->rowCount(); ++row)
+			if (m_infrastructureTable->item(row, 0)
+					&& m_infrastructureTable->item(row, 0)->text() == id)
+				return row;
+		return -1;
+	};
+	auto setCell = [&](const char* name, const QString& id, int column, const QString& value) {
+		if (!facet(name))
+			return false;
+		const int row = rowFor(id);
+		if (row < 0 || !m_infrastructureTable->item(row, column))
+			return false;
+		m_infrastructureTable->setCurrentCell(row, column);
+		m_infrastructureTable->item(row, column)->setText(value);
+		process();
+		return true;
+	};
+	auto setSection = [&](const char* name, int row, int column, const QString& prefix) {
+		if (!facet(name))
+			return QString();
+		auto* combo = qobject_cast<QComboBox*>(m_infrastructureTable->cellWidget(row, column));
+		if (!combo)
+			return QString();
+		for (int index = 0; index < combo->count(); ++index) {
+			if (combo->itemData(index).toString().isEmpty()
+					|| (!prefix.isEmpty() && !combo->itemText(index).startsWith(prefix)))
+				continue;
+			combo->setCurrentIndex(index);
+			process();
+			return combo->itemData(index).toString();
+		}
+		return QString();
+	};
 
 	if (m_creatorAcceptancePhase == 0) {
 		// The first observable operation in this mode is the public New action.
@@ -15308,57 +15357,6 @@ void MainWindow::runCreatorAcceptanceE2E() {
 		m_caseBufferSecondsEdit->setValue(30.0);
 		m_caseRecoveryPercentEdit->setValue(5.0);
 		process();
-
-		auto facet = [&](const char* name) {
-			const int index = m_infrastructureFacetCombo->findData(QString::fromLatin1(name));
-			if (index < 0)
-				return false;
-			m_infrastructureFacetCombo->setCurrentIndex(index);
-			process();
-			return m_infrastructureFacetCombo->currentData().toString() == QString::fromLatin1(name);
-		};
-		auto addRow = [&](const char* name) {
-			if (!facet(name) || !m_addInfrastructureButton->isEnabled())
-				return false;
-			m_addInfrastructureButton->click();
-			process();
-			return m_infrastructureTable->rowCount() > 0;
-		};
-		auto rowFor = [&](const QString& id) {
-			for (int row = 0; row < m_infrastructureTable->rowCount(); ++row)
-				if (m_infrastructureTable->item(row, 0)
-						&& m_infrastructureTable->item(row, 0)->text() == id)
-					return row;
-			return -1;
-		};
-		auto setCell = [&](const char* name, const QString& id, int column, const QString& value) {
-			if (!facet(name))
-				return false;
-			const int row = rowFor(id);
-			if (row < 0 || !m_infrastructureTable->item(row, column))
-				return false;
-			m_infrastructureTable->setCurrentCell(row, column);
-			m_infrastructureTable->item(row, column)->setText(value);
-			process();
-			return m_infrastructureTable->item(row, column)
-				&& m_infrastructureTable->item(row, column)->text() == value;
-		};
-		auto setSection = [&](const char* name, int row, int column, const QString& prefix) {
-			if (!facet(name))
-				return QString();
-			auto* combo = qobject_cast<QComboBox*>(m_infrastructureTable->cellWidget(row, column));
-			if (!combo)
-				return QString();
-			for (int index = 0; index < combo->count(); ++index) {
-				if (combo->itemData(index).toString().isEmpty()
-						|| (!prefix.isEmpty() && !combo->itemText(index).startsWith(prefix)))
-					continue;
-				combo->setCurrentIndex(index);
-				process();
-				return combo->itemData(index).toString();
-			}
-			return QString();
-		};
 
 		if (!addRow("tracks")) {
 			fail(QStringLiteral("track add 1 failed"));
@@ -15517,56 +15515,6 @@ void MainWindow::runCreatorAcceptanceE2E() {
 			fail(QStringLiteral("infrastructure controls disappeared before signalling authoring"));
 			return;
 		}
-		auto facet = [&](const char* name) {
-			const int index = m_infrastructureFacetCombo->findData(QString::fromLatin1(name));
-			if (index < 0)
-				return false;
-			m_infrastructureFacetCombo->setCurrentIndex(index);
-			process();
-			return true;
-		};
-		auto addRow = [&](const char* name) {
-			if (!facet(name) || !m_addInfrastructureButton->isEnabled())
-				return false;
-			m_addInfrastructureButton->click();
-			process();
-			return m_infrastructureTable->rowCount() > 0;
-		};
-		auto rowFor = [&](const QString& id) {
-			for (int row = 0; row < m_infrastructureTable->rowCount(); ++row)
-				if (m_infrastructureTable->item(row, 0)
-						&& m_infrastructureTable->item(row, 0)->text() == id)
-					return row;
-			return -1;
-		};
-		auto setCell = [&](const char* name, const QString& id, int column, const QString& value) {
-			if (!facet(name))
-				return false;
-			const int row = rowFor(id);
-			if (row < 0 || !m_infrastructureTable->item(row, column))
-				return false;
-			m_infrastructureTable->setCurrentCell(row, column);
-			m_infrastructureTable->item(row, column)->setText(value);
-			process();
-			return true;
-		};
-		auto setSection = [&](const char* name, int row, int column, const QString& prefix) {
-			if (!facet(name))
-				return QString();
-			auto* combo = qobject_cast<QComboBox*>(m_infrastructureTable->cellWidget(row, column));
-			if (!combo)
-				return QString();
-			for (int index = 0; index < combo->count(); ++index) {
-				if (combo->itemData(index).toString().isEmpty()
-						|| (!prefix.isEmpty() && !combo->itemText(index).startsWith(prefix)))
-					continue;
-				combo->setCurrentIndex(index);
-				process();
-				return combo->itemData(index).toString();
-			}
-			return QString();
-		};
-
 		if (!addRow("stations") || !setCell("stations", "station", 0, "creator-station-a")
 			|| !setCell("stations", "creator-station-a", 1, "Creator A")
 			|| !setCell("stations", "creator-station-a", 2, "true")
@@ -16474,10 +16422,6 @@ void MainWindow::runCreatorAcceptanceE2E() {
 					return button;
 			return nullptr;
 		};
-		auto readNonEmpty = [](const QString& file) {
-			QFile input(file);
-			return input.open(QIODevice::ReadOnly) && !input.readAll().isEmpty();
-		};
 
 		if (!m_creatorBaselineDiagram
 				|| !exportButton(m_creatorBaselineDiagram, QStringLiteral("Export CSV..."),
@@ -16619,34 +16563,6 @@ void MainWindow::runCreatorAcceptanceE2E() {
 			if (auto* dialog = qobject_cast<QDialog*>(widget))
 				if (dialog->windowTitle() == QStringLiteral("Incident delay comparison"))
 					dialog->close();
-		const std::array<const char*, 15> required = {
-				"baseline_time_distance.csv", "trajectory.csv", "trajectory.png",
-				"timetable.csv", "timetable.png", "blocking_time.csv", "blocking_time.png",
-				"run_summary.csv", "run_summary.png", "tractive_effort.csv", "tractive_effort.png",
-				"delay_comparison.csv", "capacity_analysis.csv", "capacity_compressed_blocking_time.csv",
-				"capacity_compressed_blocking_time.png"};
-		for (const char* file : required) {
-			const QString target = path(file);
-			if (!readNonEmpty(target)) {
-				fail(QStringLiteral("export is missing or empty: ") + target);
-				return;
-			}
-		}
-		const std::array<const char*, 15> requiredSidecars = {
-			"baseline_time_distance.csv.provenance.json", "trajectory.csv.provenance.json",
-			"trajectory.png.provenance.json", "timetable.csv.provenance.json",
-			"timetable.png.provenance.json", "blocking_time.csv.provenance.json",
-			"blocking_time.png.provenance.json", "run_summary.csv.provenance.json",
-			"run_summary.png.provenance.json", "delay_comparison.csv.provenance.json",
-			"tractive_effort.csv.provenance.json", "tractive_effort.png.provenance.json",
-			"capacity_analysis.csv.provenance.json",
-			"capacity_compressed_blocking_time.csv.provenance.json",
-			"capacity_compressed_blocking_time.png.provenance.json"};
-		for (const char* file : requiredSidecars)
-			if (!readNonEmpty(path(file))) {
-				fail(QStringLiteral("missing or empty provenance sidecar: ") + path(file));
-				return;
-			}
 		marker("E2E_CREATOR_EXPORTS_OK");
 		next();
 		return;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -1142,8 +1142,8 @@ void saveCsvInteractive(QWidget* parent, const QString& suggestedName, const std
 		QMessageBox::warning(parent, "Export failed",
 							 QString("Could not write the data to:\n%1").arg(path));
 	} else if (sidecarWriter && !sidecarWriter(path)) {
-		QMessageBox::warning(parent, "Export warning",
-							 QString("The CSV was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+		QMessageBox::warning(parent, "Export failed",
+							 QString("The CSV was removed because its provenance sidecar could not be written:\n%1.provenance.json")
 								.arg(path));
 	}
 }
@@ -3109,6 +3109,7 @@ void MainWindow::newScene() {
 	teardownGUI();
 	simulation.resetState();
 	m_sceneDir.clear();
+	m_savedSceneSha256.clear();
 	m_sceneModel = makeNewSceneModel();
 	++m_sceneRevision;
 	m_delayBaseline.reset();
@@ -3170,6 +3171,10 @@ void MainWindow::openSceneFolderDialog() {
 
 bool MainWindow::openSceneDirectory(const QString& dir) {
 	const QString scenePath = QFileInfo(dir).absoluteFilePath();
+	const bool sceneIsBundle = QFileInfo(scenePath).isFile();
+	const std::string savedSceneSha256 = sceneIsBundle
+		? hashSceneBundle(scenePath.toStdString())
+		: hashSceneDirectory(scenePath.toStdString());
 	const bool reloadingSameScene = m_sceneLoaded
 		&& QFileInfo(m_sceneDir).absoluteFilePath() == scenePath;
 	auto result = loadScenePath(scenePath.toStdString());
@@ -3194,7 +3199,8 @@ bool MainWindow::openSceneDirectory(const QString& dir) {
 	++m_sceneRevision;
 	m_delayBaseline.reset();
 	m_sceneLoaded = true;
-	m_sceneIsBundle = QFileInfo(scenePath).isFile();
+	m_sceneIsBundle = sceneIsBundle;
+	m_savedSceneSha256 = savedSceneSha256;
 	m_sceneDirty = false;
 	m_selectedScenarioId = m_sceneModel.defaultScenarioId;
 	if (m_selectedScenarioId.empty() && !m_sceneModel.scenarios.empty()) {
@@ -3508,6 +3514,9 @@ bool MainWindow::finishSceneSave(const SceneSaveResult& result) {
 	}
 
 	refreshSavedSceneMetadata(m_sceneModel);
+	m_savedSceneSha256 = m_sceneIsBundle
+		? hashSceneBundle(m_sceneDir.toStdString())
+		: hashSceneDirectory(m_sceneDir.toStdString());
 	m_sceneDirty = false;
 	m_modifiedScenarioIds.clear();
 	updateSceneWindowTitle();
@@ -17389,7 +17398,7 @@ RunProvenance MainWindow::captureRunProvenance() const {
 	provenance.caseName = m_sceneModel.name;
 	provenance.sceneSchemaVersion = m_sceneModel.schemaVersion;
 	provenance.input = captureSavedInput(m_sceneDir.toStdString(),
-		m_sceneIsBundle ? "bundle" : "directory", m_sceneDirty);
+		m_sceneIsBundle ? "bundle" : "directory", m_sceneDirty, m_savedSceneSha256);
 	provenance.appliedScenario = m_appliedScenarioId;
 	provenance.baseTimeSeconds = static_cast<double>(initial_variables.startingSimulationTime);
 	provenance.durationSeconds = initial_variables.times;
@@ -18494,8 +18503,8 @@ void MainWindow::setupRunResultsDock() {
 		if (!m_runResultsTable->grab().save(path, "PNG"))
 			QMessageBox::warning(this, "Export failed", QString("Could not write the image to:\n%1").arg(path));
 		else if (!writeRunProvenanceSidecar(path.toStdString(), "png", m_completedRunProvenance))
-			QMessageBox::warning(this, "Export warning",
-				QString("The image was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+			QMessageBox::warning(this, "Export failed",
+				QString("The image was removed because its provenance sidecar could not be written:\n%1.provenance.json")
 					.arg(path));
 		});
 	QHBoxLayout* toolRow = new QHBoxLayout();

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -24,6 +24,7 @@
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
 #include <QtCharts/QLegendMarker>
+#include <QBuffer>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -118,8 +119,8 @@ QString completedRunContext(const RunProvenance& provenance) {
 
 void attachRunProvenance(DiagramWindow* window, RunProvenance provenance) {
 	window->setProvenanceWriter([provenance = std::move(provenance)](
-			const QString& path, const char* kind) {
-		return writeRunProvenanceSidecar(path.toStdString(), kind, provenance);
+			const QString& path, const char* kind, const std::string& bytes) {
+		return writeRunArtifactWithProvenance(path.toStdString(), kind, bytes, provenance);
 	});
 }
 
@@ -1114,14 +1115,13 @@ bool writeCsvFile(const QString& path, const std::string& content) {
 
 bool writeCsvFileWithProvenance(const QString& path, const std::string& content,
 		const RunProvenance& provenance) {
-	return writeCsvFile(path, content)
-		&& writeRunProvenanceSidecar(path.toStdString(), "csv", provenance);
+	return writeRunArtifactWithProvenance(path.toStdString(), "csv", content, provenance);
 }
 
 // Prompt for a path and write CSV text atomically. A cancelled dialog or a write
 // failure never leaves a partial file behind.
 void saveCsvInteractive(QWidget* parent, const QString& suggestedName, const std::string& content,
-		const std::function<bool(const QString&)>& sidecarWriter = {}) {
+		const std::function<bool(const QString&, const std::string&)>& artifactWriter) {
 	if (content.empty()) {
 		QMessageBox::information(parent, "Nothing to export", "There is no data to export.");
 		return;
@@ -1131,20 +1131,9 @@ void saveCsvInteractive(QWidget* parent, const QString& suggestedName, const std
 		return;
 	if (QFileInfo(path).suffix().compare("csv", Qt::CaseInsensitive) != 0)
 		path += ".csv";
-	QSaveFile file(path);
-	if (!file.open(QIODevice::WriteOnly)) {
+	if (!artifactWriter(path, content)) {
 		QMessageBox::warning(parent, "Export failed",
-							 QString("Could not open the file for writing:\n%1").arg(path));
-		return;
-	}
-	const QByteArray bytes = QByteArray::fromStdString(content);
-	if (file.write(bytes) != bytes.size() || !file.commit()) {
-		QMessageBox::warning(parent, "Export failed",
-							 QString("Could not write the data to:\n%1").arg(path));
-	} else if (sidecarWriter && !sidecarWriter(path)) {
-		QMessageBox::warning(parent, "Export failed",
-							 QString("The CSV was removed because its provenance sidecar could not be written:\n%1.provenance.json")
-								.arg(path));
+			QString("Could not export the data and provenance to:\n%1").arg(path));
 	}
 }
 
@@ -3172,9 +3161,6 @@ void MainWindow::openSceneFolderDialog() {
 bool MainWindow::openSceneDirectory(const QString& dir) {
 	const QString scenePath = QFileInfo(dir).absoluteFilePath();
 	const bool sceneIsBundle = QFileInfo(scenePath).isFile();
-	const std::string savedSceneSha256 = sceneIsBundle
-		? hashSceneBundle(scenePath.toStdString())
-		: hashSceneDirectory(scenePath.toStdString());
 	const bool reloadingSameScene = m_sceneLoaded
 		&& QFileInfo(m_sceneDir).absoluteFilePath() == scenePath;
 	auto result = loadScenePath(scenePath.toStdString());
@@ -3200,7 +3186,7 @@ bool MainWindow::openSceneDirectory(const QString& dir) {
 	m_delayBaseline.reset();
 	m_sceneLoaded = true;
 	m_sceneIsBundle = sceneIsBundle;
-	m_savedSceneSha256 = savedSceneSha256;
+	m_savedSceneSha256 = hashSceneInputSnapshot(result.inputSnapshot);
 	m_sceneDirty = false;
 	m_selectedScenarioId = m_sceneModel.defaultScenarioId;
 	if (m_selectedScenarioId.empty() && !m_sceneModel.scenarios.empty()) {
@@ -3514,9 +3500,7 @@ bool MainWindow::finishSceneSave(const SceneSaveResult& result) {
 	}
 
 	refreshSavedSceneMetadata(m_sceneModel);
-	m_savedSceneSha256 = m_sceneIsBundle
-		? hashSceneBundle(m_sceneDir.toStdString())
-		: hashSceneDirectory(m_sceneDir.toStdString());
+	m_savedSceneSha256 = hashSceneInputSnapshot(result.inputSnapshot);
 	m_sceneDirty = false;
 	m_modifiedScenarioIds.clear();
 	updateSceneWindowTitle();
@@ -17518,9 +17502,9 @@ void MainWindow::showDelayComparison() {
 	connect(exportButton, &QPushButton::clicked, &dialog, [this, scenario, comparison,
 			baselineProvenance, scenarioProvenance]() {
 		saveCsvInteractive(this, "delay_comparison.csv", delayComparisonCsv(*m_delayBaseline, scenario, comparison),
-			[baselineProvenance, scenarioProvenance](const QString& path) {
-				return writeDelayProvenanceSidecar(path.toStdString(), "csv", baselineProvenance,
-					scenarioProvenance);
+			[baselineProvenance, scenarioProvenance](const QString& path, const std::string& bytes) {
+				return writeDelayArtifactWithProvenance(path.toStdString(), "csv", bytes,
+					baselineProvenance, scenarioProvenance);
 			});
 	});
 	actions->addWidget(exportButton);
@@ -18487,8 +18471,8 @@ void MainWindow::setupRunResultsDock() {
 	connect(exportCsvBtn, &QPushButton::clicked, this, [this]() {
 		const RunProvenance provenance = m_completedRunProvenance;
 		saveCsvInteractive(this, "run_summary.csv", buildRunSummaryCsv(m_completedRunResults),
-			[provenance](const QString& path) {
-				return writeRunProvenanceSidecar(path.toStdString(), "csv", provenance);
+			[provenance](const QString& path, const std::string& bytes) {
+				return writeRunArtifactWithProvenance(path.toStdString(), "csv", bytes, provenance);
 			});
 	});
 	QPushButton* exportPngBtn = new QPushButton("Export PNG...", container);
@@ -18500,12 +18484,16 @@ void MainWindow::setupRunResultsDock() {
 			return;
 		if (QFileInfo(path).suffix().compare("png", Qt::CaseInsensitive) != 0)
 			path += ".png";
-		if (!m_runResultsTable->grab().save(path, "PNG"))
+		QByteArray data;
+		QBuffer buffer(&data);
+		if (!buffer.open(QIODevice::WriteOnly) || !m_runResultsTable->grab().save(&buffer, "PNG")) {
 			QMessageBox::warning(this, "Export failed", QString("Could not write the image to:\n%1").arg(path));
-		else if (!writeRunProvenanceSidecar(path.toStdString(), "png", m_completedRunProvenance))
+			return;
+		}
+		const std::string bytes(data.constData(), static_cast<std::size_t>(data.size()));
+		if (!writeRunArtifactWithProvenance(path.toStdString(), "png", bytes, m_completedRunProvenance))
 			QMessageBox::warning(this, "Export failed",
-				QString("The image was removed because its provenance sidecar could not be written:\n%1.provenance.json")
-					.arg(path));
+				QString("Could not export the image and provenance to:\n%1").arg(path));
 		});
 	QHBoxLayout* toolRow = new QHBoxLayout();
 	toolRow->addWidget(exportCsvBtn);
@@ -20803,8 +20791,8 @@ void MainWindow::showCapacityAnalysis() {
 	QPushButton* exportButton = new QPushButton("Export capacity CSV...", dialog);
 	connect(exportButton, &QPushButton::clicked, dialog, [this, result, sectionLabel, provenance]() {
 		saveCsvInteractive(this, "capacity_analysis.csv", buildCapacityAnalysisCsv(result, sectionLabel),
-			[provenance](const QString& path) {
-				return writeRunProvenanceSidecar(path.toStdString(), "csv", provenance);
+			[provenance](const QString& path, const std::string& bytes) {
+				return writeRunArtifactWithProvenance(path.toStdString(), "csv", bytes, provenance);
 			});
 	});
 	QPushButton* diagramButton = new QPushButton("Open compressed blocking-time diagram", dialog);

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -59,6 +59,8 @@
 #include <cmath>
 #include <limits>
 #include <map>
+#include <functional>
+#include <memory>
 
 // utilization of GUI
 // bool GUI = true; // GUI used by default
@@ -1183,6 +1185,7 @@ bool e2eDialogsSuppressed() {
 		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_STATION_OVERLAYS")
 		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_SCENE_RUN")
 		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_EDITOR_SMOKE")
+		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_CREATOR_ACCEPTANCE")
 		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_TRACK_PREVIEW")
 		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_LEGACY_IMPORT")
 		|| qEnvironmentVariableIsSet("QEGTRAIN_E2E_EXPORT_DIR");
@@ -1542,13 +1545,19 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_newSceneAction->setObjectName("actionNewCaseStudy");
 	m_newSceneAction->setShortcut(QKeySequence::New);
 	QAction* openSceneAction = new QAction("Open Case Study...", this);
+	openSceneAction->setObjectName("actionOpenCaseStudyBundle");
 	openSceneAction->setShortcut(QKeySequence::Open);
 	QAction* openSceneFolderAction = new QAction("Open Scene Folder...", this);
+	openSceneFolderAction->setObjectName("actionOpenSceneFolder");
 	m_saveSceneAction = new QAction("Save Scene", this);
+	m_saveSceneAction->setObjectName("actionSaveScene");
 	m_saveSceneAction->setShortcut(QKeySequence::Save);
 	m_saveSceneAsAction = new QAction("Save Case Study As...", this);
+	m_saveSceneAsAction->setObjectName("actionSaveCaseStudyBundle");
 	m_saveSceneAsFolderAction = new QAction("Save Scene As Folder...", this);
+	m_saveSceneAsFolderAction->setObjectName("actionSaveSceneFolder");
 	m_runSceneAction = new QAction("Run Scene", this);
+	m_runSceneAction->setObjectName("actionRunScene");
 	m_recentScenesMenu = new QMenu("Recent Scenes", this);
 	connect(m_newSceneAction, &QAction::triggered, this, &MainWindow::newScene);
 	connect(openSceneAction, &QAction::triggered, this, &MainWindow::openSceneDialog);
@@ -11883,7 +11892,7 @@ void MainWindow::runEditorSmokeE2E() {
 				if (!dialog || !dialog->isVisible())
 					continue;
 				dialog->setTextValue(unitId);
-				dialog->accept();
+				QMetaObject::invokeMethod(dialog, "accept", Qt::DirectConnection);
 				break;
 			}
 		});
@@ -15113,6 +15122,1571 @@ void MainWindow::runLegacyImportE2E() {
 	QCoreApplication::exit(2);
 }
 
+void MainWindow::runCreatorAcceptanceE2E() {
+	if (m_creatorAcceptanceFinished)
+		return;
+
+	auto marker = [](const char* name) {
+		std::fprintf(stdout, "%s\n", name);
+		std::fflush(stdout);
+	};
+	auto fail = [this](const QString& message) {
+		if (m_creatorAcceptanceFinished)
+			return;
+		m_creatorAcceptanceFinished = true;
+		std::fprintf(stderr, "E2E_CREATOR_ACCEPTANCE_FAIL: %s\n", message.toStdString().c_str());
+		std::fflush(stderr);
+		QCoreApplication::exit(2);
+	};
+	auto next = [this]() {
+		++m_creatorAcceptancePhase;
+		QTimer::singleShot(75, this, &MainWindow::runCreatorAcceptanceE2E);
+	};
+	auto process = []() { QApplication::processEvents(); };
+	auto editLine = [process](QLineEdit* edit, const QString& value) {
+		if (!edit)
+			return false;
+		edit->setFocus(Qt::OtherFocusReason);
+		edit->setText(value);
+		QMetaObject::invokeMethod(edit, "editingFinished", Qt::DirectConnection);
+		edit->clearFocus();
+		process();
+		return edit->text() == value;
+	};
+	auto choose = [process](QComboBox* combo, const QString& value) {
+		if (!combo)
+			return false;
+		int index = combo->findData(value);
+		if (index < 0)
+			index = combo->findText(value);
+		if (index < 0)
+			return false;
+		combo->setCurrentIndex(index);
+		process();
+		return combo->currentIndex() == index;
+	};
+	auto acceptFileDialog = [this, fail](const QString& path, bool directory) {
+		auto poll = std::make_shared<std::function<void()>>();
+		auto attempts = std::make_shared<int>(0);
+		auto seen = std::make_shared<bool>(false);
+		*poll = [this, path, directory, poll, attempts, seen, fail]() {
+			if (++*attempts > 200) {
+				fail(QStringLiteral("file dialog did not appear for ") + path);
+				return;
+			}
+			QFileDialog* fileDialog = nullptr;
+			for (QWidget* widget : QApplication::topLevelWidgets()) {
+				auto* dialog = qobject_cast<QFileDialog*>(widget);
+				if (!dialog || !dialog->isVisible())
+					continue;
+				fileDialog = dialog;
+				break;
+			}
+			if (!fileDialog) {
+				if (*seen)
+					return;
+				QTimer::singleShot(25, this, [poll]() { (*poll)(); });
+				return;
+			}
+			*seen = true;
+			if (directory) {
+				fileDialog->setDirectory(path);
+				static_cast<QDialog*>(fileDialog)->done(QDialog::Accepted);
+			} else {
+				const QFileInfo target(path);
+				fileDialog->setDirectory(target.absolutePath());
+				fileDialog->selectFile(target.fileName());
+				if (QLineEdit* fileName = fileDialog->findChild<QLineEdit*>(QStringLiteral("fileNameEdit")))
+					fileName->setText(target.fileName());
+				QMetaObject::invokeMethod(fileDialog, "accept", Qt::DirectConnection);
+			}
+			QTimer::singleShot(25, this, [poll]() { (*poll)(); });
+		};
+		QTimer::singleShot(0, this, [poll]() { (*poll)(); });
+	};
+	auto acceptInputDialog = [this, fail](const QString& value) {
+		auto poll = std::make_shared<std::function<void()>>();
+		auto attempts = std::make_shared<int>(0);
+		*poll = [this, value, poll, attempts, fail]() {
+			if (++*attempts > 200) {
+				fail(QStringLiteral("input dialog did not appear"));
+				return;
+			}
+			for (QWidget* widget : QApplication::topLevelWidgets()) {
+				auto* dialog = qobject_cast<QInputDialog*>(widget);
+				if (!dialog || !dialog->isVisible())
+					continue;
+				dialog->setTextValue(value);
+				dialog->accept();
+				return;
+			}
+			QTimer::singleShot(25, this, [poll]() { (*poll)(); });
+		};
+		QTimer::singleShot(0, this, [poll]() { (*poll)(); });
+	};
+	auto acceptMessageBox = [this, fail](QMessageBox::StandardButton desired = QMessageBox::Ok) {
+		auto poll = std::make_shared<std::function<void()>>();
+		auto attempts = std::make_shared<int>(0);
+		*poll = [this, desired, poll, attempts, fail]() {
+			if (++*attempts > 200) {
+				fail(QStringLiteral("message box did not appear"));
+				return;
+			}
+			for (QWidget* widget : QApplication::topLevelWidgets()) {
+				auto* dialog = qobject_cast<QMessageBox*>(widget);
+				if (!dialog || !dialog->isVisible())
+					continue;
+				if (QAbstractButton* button = dialog->button(desired))
+					button->click();
+				else
+					dialog->accept();
+				return;
+			}
+			QTimer::singleShot(25, this, [poll]() { (*poll)(); });
+		};
+		QTimer::singleShot(0, this, [poll]() { (*poll)(); });
+	};
+	auto acceptCapacityScope = [this, fail]() {
+		auto poll = std::make_shared<std::function<void()>>();
+		auto attempts = std::make_shared<int>(0);
+		*poll = [this, poll, attempts, fail]() {
+			if (++*attempts > 200) {
+				fail(QStringLiteral("capacity scope dialog did not appear"));
+				return;
+			}
+			for (QWidget* widget : QApplication::topLevelWidgets()) {
+				if (auto* message = qobject_cast<QMessageBox*>(widget); message && message->isVisible()) {
+					const QString detail = message->text();
+					message->accept();
+					fail(QStringLiteral("capacity analysis rejected the creator run: ") + detail);
+					return;
+				}
+				auto* dialog = qobject_cast<QDialog*>(widget);
+				if (!dialog || !dialog->isVisible() || !dialog->isModal()
+						|| dialog->windowTitle() != QStringLiteral("Capacity analysis"))
+					continue;
+				QComboBox* cycleEnd = nullptr;
+				for (QComboBox* combo : dialog->findChildren<QComboBox*>())
+					if (combo->count() >= 3
+							&& combo->itemText(0).startsWith(QStringLiteral("Select the first train")))
+						cycleEnd = combo;
+				QDialogButtonBox* buttons = dialog->findChild<QDialogButtonBox*>();
+				if (!cycleEnd || !buttons || !buttons->button(QDialogButtonBox::Ok)) {
+					fail(QStringLiteral("capacity scope controls are incomplete"));
+					return;
+				}
+				cycleEnd->setCurrentIndex(2);
+				buttons->button(QDialogButtonBox::Ok)->click();
+				return;
+			}
+			QTimer::singleShot(25, this, [poll]() { (*poll)(); });
+		};
+		QTimer::singleShot(0, this, [poll]() { (*poll)(); });
+	};
+	auto emitPath = [](const QString& value) { return QFileInfo(value).absoluteFilePath(); };
+
+	if (m_creatorAcceptancePhase == 0) {
+		// The first observable operation in this mode is the public New action.
+		if (!m_newSceneAction) {
+			fail(QStringLiteral("actionNewCaseStudy is unavailable"));
+			return;
+		}
+		m_newSceneAction->trigger();
+		marker("E2E_CREATOR_NEW_CASE_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 1) {
+		if (!m_sceneLoaded || !m_infrastructureFacetCombo || !m_infrastructureTable
+				|| !m_addInfrastructureButton || !m_caseSettingsDock) {
+			fail(QStringLiteral("blank case or creator controls did not load"));
+			return;
+		}
+		m_caseSettingsDock->show();
+		m_caseSettingsDock->raise();
+		if (!editLine(m_caseNameEdit, QStringLiteral("creator_acceptance_case"))
+			|| !editLine(m_caseDescriptionEdit, QStringLiteral("synthetic creator acceptance"))
+			|| !editLine(m_caseBaseTimeEdit, QStringLiteral("09:15:30"))) {
+			fail(QStringLiteral("case metadata editing did not commit"));
+			return;
+		}
+		m_caseDurationSecondsEdit->setValue(900.0);
+		m_caseBufferSecondsEdit->setValue(30.0);
+		m_caseRecoveryPercentEdit->setValue(5.0);
+		process();
+
+		auto facet = [&](const char* name) {
+			const int index = m_infrastructureFacetCombo->findData(QString::fromLatin1(name));
+			if (index < 0)
+				return false;
+			m_infrastructureFacetCombo->setCurrentIndex(index);
+			process();
+			return m_infrastructureFacetCombo->currentData().toString() == QString::fromLatin1(name);
+		};
+		auto addRow = [&](const char* name) {
+			if (!facet(name) || !m_addInfrastructureButton->isEnabled())
+				return false;
+			m_addInfrastructureButton->click();
+			process();
+			return m_infrastructureTable->rowCount() > 0;
+		};
+		auto rowFor = [&](const QString& id) {
+			for (int row = 0; row < m_infrastructureTable->rowCount(); ++row)
+				if (m_infrastructureTable->item(row, 0)
+						&& m_infrastructureTable->item(row, 0)->text() == id)
+					return row;
+			return -1;
+		};
+		auto setCell = [&](const char* name, const QString& id, int column, const QString& value) {
+			if (!facet(name))
+				return false;
+			const int row = rowFor(id);
+			if (row < 0 || !m_infrastructureTable->item(row, column))
+				return false;
+			m_infrastructureTable->setCurrentCell(row, column);
+			m_infrastructureTable->item(row, column)->setText(value);
+			process();
+			return m_infrastructureTable->item(row, column)
+				&& m_infrastructureTable->item(row, column)->text() == value;
+		};
+		auto setSection = [&](const char* name, int row, int column, const QString& prefix) {
+			if (!facet(name))
+				return QString();
+			auto* combo = qobject_cast<QComboBox*>(m_infrastructureTable->cellWidget(row, column));
+			if (!combo)
+				return QString();
+			for (int index = 0; index < combo->count(); ++index) {
+				if (combo->itemData(index).toString().isEmpty()
+						|| (!prefix.isEmpty() && !combo->itemText(index).startsWith(prefix)))
+					continue;
+				combo->setCurrentIndex(index);
+				process();
+				return combo->itemData(index).toString();
+			}
+			return QString();
+		};
+
+		if (!addRow("tracks")) {
+			fail(QStringLiteral("track add 1 failed"));
+			return;
+		}
+		if (!facet("tracks") || m_infrastructureTable->rowCount() < 1
+				|| !m_infrastructureTable->item(0, 0)) {
+			fail(QStringLiteral("track row 1 unavailable"));
+			return;
+		}
+		m_infrastructureTable->item(0, 0)->setText("creator-main");
+		process();
+		if (m_infrastructureTable->item(0, 0)->text() != "creator-main") {
+			fail(QStringLiteral("track rename 1 failed"));
+			return;
+		}
+		if (!addRow("tracks")) {
+			fail(QStringLiteral("track add 2 failed"));
+			return;
+		}
+		if (!facet("tracks") || m_infrastructureTable->rowCount() < 2
+				|| !m_infrastructureTable->item(1, 0)) {
+			fail(QStringLiteral("track row 2 unavailable"));
+			return;
+		}
+		m_infrastructureTable->item(1, 0)->setText("creator-yard");
+		process();
+		if (m_infrastructureTable->item(1, 0)->text() != "creator-yard") {
+			fail(QStringLiteral("track rename 2 failed"));
+			return;
+		}
+		const std::array<QString, 6> nodeIds = {QStringLiteral("creator-main-node-0"), QStringLiteral("creator-main-node-1"), QStringLiteral("creator-main-node-2"), QStringLiteral("creator-yard-node-0"), QStringLiteral("creator-yard-node-1"), QStringLiteral("creator-yard-node-2")};
+		const std::array<double, 6> nodeX = {0.0, 1.0, 2.0, 0.0, 1.5, 2.0};
+		const std::array<double, 6> nodeY = {0.0, 0.25, 0.0, 1.0, 1.0, 1.0};
+		for (int row = 0; row < 6; ++row) {
+			if (!addRow("nodes")) {
+				fail(QStringLiteral("node row add failed"));
+				return;
+			}
+			const int createdRow = m_infrastructureTable->rowCount() - 1;
+			const QString generated = m_infrastructureTable->item(createdRow, 0)
+				? m_infrastructureTable->item(createdRow, 0)->text() : QString();
+			const QString track = row < 3 ? QStringLiteral("creator-main") : QStringLiteral("creator-yard");
+			if (!setCell("nodes", generated, 0, nodeIds[static_cast<std::size_t>(row)])
+				|| !setCell("nodes", nodeIds[static_cast<std::size_t>(row)], 1, track)
+				|| !setCell("nodes", nodeIds[static_cast<std::size_t>(row)], 2, QString::number(nodeX[static_cast<std::size_t>(row)]))
+				|| !setCell("nodes", nodeIds[static_cast<std::size_t>(row)], 3, QString::number(nodeY[static_cast<std::size_t>(row)]))) {
+				fail(QStringLiteral("node geometry editing failed"));
+				return;
+			}
+		}
+		const std::array<QString, 4> arcIds = {QStringLiteral("creator-main-arc-0"), QStringLiteral("creator-main-arc-1"), QStringLiteral("creator-yard-arc-0"), QStringLiteral("creator-yard-arc-1")};
+		for (int row = 0; row < 4; ++row) {
+			if (!addRow("arcs")) {
+				fail(QStringLiteral("arc row add failed"));
+				return;
+			}
+			const int createdRow = m_infrastructureTable->rowCount() - 1;
+			const QString generated = m_infrastructureTable->item(createdRow, 0)
+				? m_infrastructureTable->item(createdRow, 0)->text() : QString();
+			const QString track = row < 2 ? QStringLiteral("creator-main") : QStringLiteral("creator-yard");
+			const int nodeOffset = row < 2 ? 0 : 3;
+			const int localRow = row % 2;
+			const QString from = nodeIds[static_cast<std::size_t>(nodeOffset + localRow)];
+			const QString to = nodeIds[static_cast<std::size_t>(nodeOffset + localRow + 1)];
+			QString arcFailure;
+			if (!setCell("arcs", generated, 0, arcIds[static_cast<std::size_t>(row)]))
+				arcFailure = QStringLiteral("id");
+			else if (!setCell("arcs", arcIds[static_cast<std::size_t>(row)], 1, track))
+				arcFailure = QStringLiteral("track");
+			else if (!setCell("arcs", arcIds[static_cast<std::size_t>(row)], 2, from))
+				arcFailure = QStringLiteral("from");
+			else if (!setCell("arcs", arcIds[static_cast<std::size_t>(row)], 3, to))
+				arcFailure = QStringLiteral("to");
+			else if (!setCell("arcs", arcIds[static_cast<std::size_t>(row)], 4, row == 1 ? QStringLiteral("1250.5") : QStringLiteral("0")))
+				arcFailure = QStringLiteral("curvature");
+			else if (!setCell("arcs", arcIds[static_cast<std::size_t>(row)], 5, row == 0 ? QStringLiteral("-0.001953125") : (row == 1 ? QStringLiteral("0.00390625") : QStringLiteral("0.0009765625"))))
+				arcFailure = QStringLiteral("gradient");
+			else if (!setCell("arcs", arcIds[static_cast<std::size_t>(row)], 6, row < 2 ? QStringLiteral("22.5") : QStringLiteral("18")))
+				arcFailure = QStringLiteral("speed");
+			if (!arcFailure.isEmpty()) {
+				fail(QStringLiteral("arc geometry editing failed (%1 row %2)").arg(arcFailure).arg(row));
+				return;
+			}
+		}
+		if (!facet("blocks")) {
+			fail(QStringLiteral("block facet unavailable"));
+			return;
+		}
+		for (const QString& track : {QStringLiteral("creator-main"), QStringLiteral("creator-yard")}) {
+			const int filterIndex = m_blockTrackFilterCombo->findData(track);
+			if (filterIndex < 0) {
+				fail(QStringLiteral("block track selector unavailable"));
+				return;
+			}
+			m_blockTrackFilterCombo->setCurrentIndex(filterIndex);
+			process();
+			for (int count = 0; count < 2; ++count) {
+				m_addInfrastructureButton->click();
+				process();
+			}
+			if (m_infrastructureTable->rowCount() != 2) {
+				fail(QStringLiteral("base block rows did not add"));
+				return;
+			}
+			const QString firstGenerated = m_infrastructureTable->item(0, 0)
+				? m_infrastructureTable->item(0, 0)->text() : QString();
+			const QString secondGenerated = m_infrastructureTable->item(1, 0)
+				? m_infrastructureTable->item(1, 0)->text() : QString();
+			const bool yard = track == QStringLiteral("creator-yard");
+			QString blockFailure;
+			if (!setCell("blocks", firstGenerated, 0, track + QStringLiteral("-block-0")))
+				blockFailure = QStringLiteral("first id");
+			else if (!setCell("blocks", secondGenerated, 0, track + QStringLiteral("-block-2")))
+				blockFailure = QStringLiteral("second id");
+			else if (!setCell("blocks", track + QStringLiteral("-block-0"), 2,
+					yard ? QStringLiteral("0.5") : QStringLiteral("0.75")))
+				blockFailure = QStringLiteral("first length");
+			else if (!setCell("blocks", track + QStringLiteral("-block-2"), 2,
+					yard ? QStringLiteral("0.25") : QStringLiteral("0.75")))
+				blockFailure = QStringLiteral("second length");
+			if (!blockFailure.isEmpty()) {
+				fail(QStringLiteral("base block fields did not commit (%1, %2)")
+					.arg(track, blockFailure));
+				return;
+			}
+			m_infrastructureTable->setCurrentCell(1, 0);
+			m_insertBlockButton->click();
+			process();
+			if (m_infrastructureTable->rowCount() != 3) {
+				fail(QStringLiteral("block insert did not create the third visible block"));
+				return;
+			}
+			const QString insertedGenerated = m_infrastructureTable->item(1, 0)
+				? m_infrastructureTable->item(1, 0)->text() : QString();
+			if (!setCell("blocks", insertedGenerated, 0, track + QStringLiteral("-block-1"))
+				|| !setCell("blocks", track + QStringLiteral("-block-1"), 2,
+					yard ? QStringLiteral("1.25") : QStringLiteral("0.5"))) {
+				fail(QStringLiteral("inserted block fields did not commit"));
+				return;
+			}
+			m_infrastructureTable->setCurrentCell(1, 0);
+			m_moveBlockDownButton->click();
+			process();
+			m_moveBlockUpButton->click();
+			process();
+		}
+		marker("E2E_CREATOR_INFRASTRUCTURE_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 2) {
+		if (!m_sceneLoaded || !m_infrastructureFacetCombo || !m_infrastructureTable
+				|| !m_addInfrastructureButton || !m_deleteInfrastructureButton) {
+			fail(QStringLiteral("infrastructure controls disappeared before signalling authoring"));
+			return;
+		}
+		auto facet = [&](const char* name) {
+			const int index = m_infrastructureFacetCombo->findData(QString::fromLatin1(name));
+			if (index < 0)
+				return false;
+			m_infrastructureFacetCombo->setCurrentIndex(index);
+			process();
+			return true;
+		};
+		auto addRow = [&](const char* name) {
+			if (!facet(name) || !m_addInfrastructureButton->isEnabled())
+				return false;
+			m_addInfrastructureButton->click();
+			process();
+			return m_infrastructureTable->rowCount() > 0;
+		};
+		auto rowFor = [&](const QString& id) {
+			for (int row = 0; row < m_infrastructureTable->rowCount(); ++row)
+				if (m_infrastructureTable->item(row, 0)
+						&& m_infrastructureTable->item(row, 0)->text() == id)
+					return row;
+			return -1;
+		};
+		auto setCell = [&](const char* name, const QString& id, int column, const QString& value) {
+			if (!facet(name))
+				return false;
+			const int row = rowFor(id);
+			if (row < 0 || !m_infrastructureTable->item(row, column))
+				return false;
+			m_infrastructureTable->setCurrentCell(row, column);
+			m_infrastructureTable->item(row, column)->setText(value);
+			process();
+			return true;
+		};
+		auto setSection = [&](const char* name, int row, int column, const QString& prefix) {
+			if (!facet(name))
+				return QString();
+			auto* combo = qobject_cast<QComboBox*>(m_infrastructureTable->cellWidget(row, column));
+			if (!combo)
+				return QString();
+			for (int index = 0; index < combo->count(); ++index) {
+				if (combo->itemData(index).toString().isEmpty()
+						|| (!prefix.isEmpty() && !combo->itemText(index).startsWith(prefix)))
+					continue;
+				combo->setCurrentIndex(index);
+				process();
+				return combo->itemData(index).toString();
+			}
+			return QString();
+		};
+
+		if (!addRow("stations") || !setCell("stations", "station", 0, "creator-station-a")
+			|| !setCell("stations", "creator-station-a", 1, "Creator A")
+			|| !setCell("stations", "creator-station-a", 2, "true")
+			|| !setCell("stations", "creator-station-a", 3, "1.0")
+			|| !addRow("stations") || !setCell("stations", "station", 0, "creator-station-b")
+			|| !setCell("stations", "creator-station-b", 1, "Creator B")
+			|| !setCell("stations", "creator-station-b", 2, "true")
+			|| !setCell("stations", "creator-station-b", 3, "1.5")) {
+			fail(QStringLiteral("station geometry authoring failed"));
+			return;
+		}
+		if (!addRow("platforms") || !addRow("platforms")
+				|| m_infrastructureTable->rowCount() != 2) {
+			fail(QStringLiteral("platform rows did not add"));
+			return;
+		}
+		auto setPlatformCell = [&](int row, int column, const QString& value) {
+			if (!facet("platforms") || row < 0 || row >= m_infrastructureTable->rowCount()
+					|| !m_infrastructureTable->item(row, column))
+				return false;
+			m_infrastructureTable->setCurrentCell(row, column);
+			m_infrastructureTable->item(row, column)->setText(value);
+			process();
+			return true;
+		};
+		if (!setPlatformCell(0, 0, "creator-station-a")
+				|| !setPlatformCell(0, 1, "creator-platform-a")
+				|| !setPlatformCell(0, 2, "creator-main-node-1")
+				|| !setPlatformCell(1, 0, "creator-station-b")
+				|| !setPlatformCell(1, 1, "creator-platform-b")
+				|| !setPlatformCell(1, 2, "creator-yard-node-1")) {
+			fail(QStringLiteral("platform station/node references did not commit"));
+			return;
+		}
+		if (!facet("platforms")) {
+			fail(QStringLiteral("platform facet unavailable for geometry"));
+			return;
+		}
+		for (int row = 0; row < m_infrastructureTable->rowCount(); ++row) {
+			if (auto* length = qobject_cast<QDoubleSpinBox*>(m_infrastructureTable->cellWidget(row, 3)))
+				length->setValue(123.75);
+			if (auto* width = qobject_cast<QDoubleSpinBox*>(m_infrastructureTable->cellWidget(row, 4)))
+				width->setValue(4.25);
+			process();
+		}
+		if (!addRow("connections")
+				|| !setCell("connections", "connection", 0, "creator-switch")
+				|| !setCell("connections", "creator-switch", 1, "creator-main-node-1")
+				|| !setCell("connections", "creator-switch", 2, "creator-yard-node-1")
+				|| !setCell("connections", "creator-switch", 3, "true")
+				|| !setCell("connections", "creator-switch", 4, "9.25")) {
+			fail(QStringLiteral("connection authoring failed"));
+			return;
+		}
+		if (!addRow("signals") || !setCell("signals", "signal", 0, "creator-signal")) {
+			fail(QStringLiteral("signal row did not add"));
+			return;
+		}
+		const QString mainSection = setSection("signals", 0, 1,
+			QStringLiteral("base block creator-main-block-0 /"));
+		if (mainSection.isEmpty()) {
+			fail(QStringLiteral("signal protected-section selector lacked the authored block"));
+			return;
+		}
+		if (!addRow("signalling_areas")
+				|| !setCell("signalling_areas", "signalling-area", 0, "creator-signalling-area")
+				|| !setCell("signalling_areas", "creator-signalling-area", 1, "0")
+				|| !setCell("signalling_areas", "creator-signalling-area", 2, "2")
+				|| !setCell("signalling_areas", "creator-signalling-area", 3, "0")) {
+			fail(QStringLiteral("signalling area authoring failed"));
+			return;
+		}
+		if (!addRow("routes")
+				|| !setCell("routes", "route", 0, "creator-route")
+				|| !setCell("routes", "creator-route", 2, "true")
+				|| !setCell("routes", "creator-route", 3, "creator-corridor")
+				|| !setCell("routes", "creator-route", 4, "false")) {
+			fail(QStringLiteral("route metadata authoring failed"));
+			return;
+		}
+		if (!facet("routes") || !m_routeSectionCatalogCombo || !m_addRouteSectionButton
+				|| !m_routeSectionListWidget) {
+			fail(QStringLiteral("route section controls unavailable"));
+			return;
+		}
+		const std::array<QString, 3> routePrefixes = {
+			QStringLiteral("base block creator-main-block-0 /"),
+			QStringLiteral("connection creator-switch /"),
+			QStringLiteral("base block creator-yard-block-2 /")};
+		for (const QString& prefix : routePrefixes) {
+			QString raw;
+			for (int index = 0; index < m_routeSectionCatalogCombo->count(); ++index) {
+				if (m_routeSectionCatalogCombo->itemText(index).startsWith(prefix)) {
+					m_routeSectionCatalogCombo->setCurrentIndex(index);
+					raw = m_routeSectionCatalogCombo->itemData(index).toString();
+					break;
+				}
+			}
+			if (raw.isEmpty()) {
+				fail(QStringLiteral("route catalog lacked creator-facing section: ") + prefix);
+				return;
+			}
+			m_addRouteSectionButton->click();
+			process();
+		}
+		if (m_routeSectionListWidget->count() != 3) {
+			fail(QStringLiteral("route section order was not authored"));
+			return;
+		}
+		if (!addRow("block_dependencies")) {
+			fail(QStringLiteral("dependency row did not add"));
+			return;
+		}
+		if (setSection("block_dependencies", 0, 0,
+				QStringLiteral("base block creator-main-block-0 /")).isEmpty()
+			|| setSection("block_dependencies", 0, 1,
+				QStringLiteral("base block creator-yard-block-2 /")).isEmpty()) {
+			fail(QStringLiteral("dependency typed selectors lacked safe sections"));
+			return;
+		}
+		if (!addRow("single_track_restrictions")) {
+			fail(QStringLiteral("restriction row did not add"));
+			return;
+		}
+		const std::array<QString, 4> restrictionPrefixes = {
+			QStringLiteral("base block creator-main-block-0 /"),
+			QStringLiteral("base block creator-yard-block-2 /"),
+			QStringLiteral("connection creator-switch /"),
+			QStringLiteral("base block creator-yard-block-2 /")};
+		for (int column = 0; column < 4; ++column)
+			if (setSection("single_track_restrictions", 0, column,
+					restrictionPrefixes[static_cast<std::size_t>(column)]).isEmpty()) {
+				fail(QStringLiteral("restriction typed selector lacked a safe section"));
+				return;
+			}
+		if (!addRow("station_boundaries")
+				|| setSection("station_boundaries", 0, 0,
+					QStringLiteral("base block creator-main-block-0 /")).isEmpty()
+				|| setSection("station_boundaries", 0, 1,
+					QStringLiteral("base block creator-yard-block-2 /")).isEmpty()) {
+			fail(QStringLiteral("station boundary typed selectors lacked safe sections"));
+			return;
+		}
+		const QString renamedBlock = QStringLiteral("creator-main-block-renamed");
+		if (!facet("blocks")) {
+			fail(QStringLiteral("block facet unavailable for reference rename"));
+			return;
+		}
+		const int mainTrackIndex = m_blockTrackFilterCombo->findData("creator-main");
+		if (mainTrackIndex < 0) {
+			fail(QStringLiteral("main block filter disappeared"));
+			return;
+		}
+		m_blockTrackFilterCombo->setCurrentIndex(mainTrackIndex);
+		process();
+		const int mainBlockRow = rowFor(QStringLiteral("creator-main-block-0"));
+		if (mainBlockRow < 0 || !m_infrastructureTable->item(mainBlockRow, 0)) {
+			fail(QStringLiteral("referenced block row was not visible"));
+			return;
+		}
+		m_infrastructureTable->item(mainBlockRow, 0)->setText(renamedBlock);
+		process();
+		bool referenceStillValid = false;
+		if (m_sceneModel.routes.size() == 1 && m_sceneModel.routes.front().blocks.size() == 3
+				&& m_sceneModel.blockDependencies.size() == 1
+				&& m_sceneModel.singleTrackRestrictions.size() == 1
+				&& m_sceneModel.stationBoundaries.size() == 1
+					&& !sceneSignals(m_sceneModel).empty()) {
+			const auto mentions = [&renamedBlock](const std::string& value) {
+				return value.find(renamedBlock.toStdString()) != std::string::npos;
+			};
+			const auto& route = m_sceneModel.routes.front();
+			const auto& dependency = m_sceneModel.blockDependencies.front();
+			const auto& restriction = m_sceneModel.singleTrackRestrictions.front();
+			const auto& boundary = m_sceneModel.stationBoundaries.front();
+			referenceStillValid = mentions(route.blocks.front()) && mentions(dependency.block)
+				&& mentions(restriction.startBlock) && mentions(boundary.entranceBlock)
+				&& mentions(sceneSignals(m_sceneModel).front().protectedSection);
+		}
+		if (!referenceStillValid) {
+			fail(QStringLiteral("public block rename did not retain all references"));
+			return;
+		}
+		const std::size_t blockCount = m_sceneModel.blocks.size();
+		const int renamedRow = rowFor(renamedBlock);
+		if (renamedRow < 0) {
+			fail(QStringLiteral("renamed block could not be selected for delete check"));
+			return;
+		}
+		m_infrastructureTable->setCurrentCell(renamedRow, 0);
+		m_deleteInfrastructureButton->click();
+		process();
+		if (m_sceneModel.blocks.size() != blockCount) {
+			fail(QStringLiteral("referenced delete changed canonical data"));
+			return;
+		}
+		marker("E2E_CREATOR_STATIONS_SIGNALLING_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 3) {
+		if (!m_sceneLoaded || !m_trainUnitDock || !m_trainUnitListWidget
+				|| !m_addTrainUnitButton || !m_trainUnitIdEdit || !m_compositionDock
+				|| !m_addCompositionButton || !m_addUnitButton || !m_addTrainUnitTractionButton) {
+			fail(QStringLiteral("rolling-stock creator controls are unavailable"));
+			return;
+		}
+		m_trainUnitDock->show();
+		m_trainUnitDock->raise();
+		auto setUnit = [&](int row, const QString& id, double seed) {
+			m_trainUnitListWidget->setCurrentRow(row);
+			process();
+			if (!editLine(m_trainUnitIdEdit, id))
+				return false;
+			const std::array<double, 9> values = {90000.0 + seed, 22000.0 + seed,
+				2.0, 30.0, 0.8, 9.0, 0.002, 0.4, 80.0};
+			for (std::size_t index = 0; index < values.size(); ++index) {
+				if (!m_trainUnitPhysicalEdits[index])
+					return false;
+				m_trainUnitPhysicalEdits[index]->setValue(values[index]);
+			}
+			if (!editLine(m_trainUnitSourceDataEdit, QStringLiteral("creator-parameters.csv"))
+				|| !editLine(m_trainUnitSourceTractionEdit, QStringLiteral("creator-traction.csv")))
+				return false;
+			m_addTrainUnitTractionButton->click();
+			process();
+			if (!m_trainUnitTractionTable || m_trainUnitTractionTable->rowCount() < 1)
+				return false;
+			const std::array<double, 5> traction = {0.0, 30.0, 220000.0, -3500.0, 0.0};
+			for (int column = 0; column < 5; ++column)
+				if (auto* edit = qobject_cast<QDoubleSpinBox*>(m_trainUnitTractionTable->cellWidget(0, column)))
+					edit->setValue(traction[static_cast<std::size_t>(column)]);
+				else
+					return false;
+			process();
+			return true;
+		};
+		m_addTrainUnitButton->click();
+		process();
+		if (m_trainUnitListWidget->count() != 1 || !setUnit(0, QStringLiteral("creator-unit-a"), 0.0)) {
+			fail(QStringLiteral("first train unit did not author through controls"));
+			return;
+		}
+		m_addTrainUnitButton->click();
+		process();
+		if (m_trainUnitListWidget->count() != 2 || !setUnit(1, QStringLiteral("creator-unit-b"), 5000.0)) {
+			fail(QStringLiteral("second train unit did not author through controls"));
+			return;
+		}
+		m_compositionDock->show();
+		m_compositionDock->raise();
+		m_addCompositionButton->click();
+		process();
+		if (m_compositionListWidget->count() != 1
+				|| !editLine(m_compositionIdEdit, QStringLiteral("creator-composition"))) {
+			fail(QStringLiteral("composition row did not author through controls"));
+			return;
+		}
+		acceptInputDialog(QStringLiteral("creator-unit-a"));
+		m_addUnitButton->click();
+		process();
+		acceptInputDialog(QStringLiteral("creator-unit-b"));
+		m_addUnitButton->click();
+		process();
+		if (m_compositionUnitsListWidget->count() != 2
+				|| m_sceneModel.compositions.empty()
+				|| m_sceneModel.compositions.front().units.size() != 2
+				|| m_sceneModel.compositions.front().units.front() != "creator-unit-a"
+				|| m_sceneModel.compositions.front().units.back() != "creator-unit-b") {
+			fail(QStringLiteral("composition membership did not retain both units in order"));
+			return;
+		}
+		marker("E2E_CREATOR_ROLLING_STOCK_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 4) {
+		if (!m_sceneLoaded || !m_serviceDock || !m_serviceListWidget || !m_addServiceButton
+				|| !m_serviceIdEdit || !m_serviceOperatingCodeEdit || !m_serviceCompositionCombo
+				|| !m_serviceRouteCombo || !m_addStopButton || !m_stopListWidget
+				|| !m_stopStationCombo || !m_stopPlatformCombo) {
+			fail(QStringLiteral("service creator controls are unavailable"));
+			return;
+		}
+		m_serviceDock->show();
+		m_serviceDock->raise();
+		m_addServiceButton->click();
+		process();
+		if (m_serviceListWidget->count() != 1
+				|| !editLine(m_serviceIdEdit, QStringLiteral("creator-service"))
+				|| !editLine(m_serviceOperatingCodeEdit, QStringLiteral("1701"))
+				|| !choose(m_serviceCompositionCombo, QStringLiteral("creator-composition"))
+				|| !choose(m_serviceRouteCombo, QStringLiteral("creator-route"))) {
+			fail(QStringLiteral("service identity or typed references did not commit"));
+			return;
+		}
+		m_serviceThroughCheck->setChecked(false);
+		m_serviceHasEntryTimeCheck->setChecked(true);
+		if (!editLine(m_serviceEntryTimeSecondsEdit, QStringLiteral("60"))) {
+			fail(QStringLiteral("service entry time did not commit"));
+			return;
+		}
+		m_serviceHasRepeatCheck->setChecked(true);
+		if (!editLine(m_serviceHeadwaySecondsEdit, QStringLiteral("300"))) {
+			fail(QStringLiteral("service headway did not commit"));
+			return;
+		}
+		m_serviceHasRepeatCountCheck->setChecked(true);
+		if (!editLine(m_serviceRepeatCountEdit, QStringLiteral("3"))) {
+			fail(QStringLiteral("service repeat count did not commit"));
+			return;
+		}
+		m_servicePerformancePercentEdit->setValue(92.0);
+		m_serviceHasMaximumSpeedCheck->setChecked(true);
+		m_serviceMaximumSpeedKmhEdit->setValue(100.0);
+		m_serviceHasOperatingCodeStepCheck->setChecked(true);
+		if (!editLine(m_serviceOperatingCodeStepEdit, QStringLiteral("1"))) {
+			fail(QStringLiteral("service operating-code increment did not commit"));
+			return;
+		}
+		const auto configureStop = [&](const QString& station, const QString& platform,
+				double arrival, double departure, double dwell) {
+			if (!choose(m_stopStationCombo, station) || !choose(m_stopPlatformCombo, platform))
+				return false;
+			m_stopHasArrivalCheck->setChecked(true);
+			m_stopHasDepartureCheck->setChecked(true);
+			if (!editLine(m_stopArrivalSecondsEdit, QString::number(arrival))
+					|| !editLine(m_stopDepartureSecondsEdit, QString::number(departure))
+					|| !editLine(m_stopDwellSecondsEdit, QString::number(dwell)))
+				return false;
+			QMetaObject::invokeMethod(m_stopArrivalSecondsEdit, "editingFinished", Qt::DirectConnection);
+			QMetaObject::invokeMethod(m_stopDepartureSecondsEdit, "editingFinished", Qt::DirectConnection);
+			QMetaObject::invokeMethod(m_stopDwellSecondsEdit, "editingFinished", Qt::DirectConnection);
+			process();
+			return true;
+		};
+		m_addStopButton->click();
+		process();
+		if (!configureStop(QStringLiteral("creator-station-a"), QStringLiteral("creator-platform-a"),
+				180.0, 240.0, 60.0)) {
+			fail(QStringLiteral("first service stop did not commit station/platform timetable"));
+			return;
+		}
+		m_addStopButton->click();
+		process();
+		if (!configureStop(QStringLiteral("creator-station-b"), QStringLiteral("creator-platform-b"),
+				480.0, 540.0, 60.0)) {
+			fail(QStringLiteral("second service stop did not commit station/platform timetable"));
+			return;
+		}
+		if (m_sceneModel.services.empty() || m_sceneModel.services.front().stops.size() != 2
+				|| !m_sceneModel.services.front().hasRepeat
+				|| !m_sceneModel.services.front().hasRepeatCount
+				|| m_sceneModel.services.front().repeatCount != 3
+				|| m_sceneModel.services.front().headwaySeconds != 300.0
+				|| m_sceneModel.services.front().stops.front().stationId != "creator-station-a"
+				|| m_sceneModel.services.front().stops.back().stationId != "creator-station-b"
+				|| !m_sceneModel.services.front().stops.front().hasPlannedArrival
+				|| !m_sceneModel.services.front().stops.front().hasPlannedDeparture
+				|| m_sceneModel.services.front().stops.front().plannedArrivalSeconds != 180.0
+				|| m_sceneModel.services.front().stops.front().plannedDepartureSeconds != 240.0
+				|| m_sceneModel.services.front().stops.front().dwellSeconds != 60.0
+				|| m_sceneModel.services.front().stops.back().plannedArrivalSeconds != 480.0
+				|| m_sceneModel.services.front().stops.back().plannedDepartureSeconds != 540.0
+				|| m_sceneModel.services.front().stops.back().dwellSeconds != 60.0) {
+			const SceneService* service = m_sceneModel.services.empty()
+				? nullptr : &m_sceneModel.services.front();
+			fail(QStringLiteral("service repeat or ordered stop values were not retained: stops=%1 repeat=%2 count-flag=%3 count=%4 headway=%5 first=%6 last=%7 arrival=%8 departure=%9 dwell=%10")
+				.arg(service ? static_cast<int>(service->stops.size()) : -1)
+				.arg(service && service->hasRepeat)
+				.arg(service && service->hasRepeatCount)
+				.arg(service ? service->repeatCount : -1)
+				.arg(service ? service->headwaySeconds : -1.0)
+				.arg(service && !service->stops.empty() ? QString::fromStdString(service->stops.front().stationId) : QStringLiteral("-"))
+				.arg(service && !service->stops.empty() ? QString::fromStdString(service->stops.back().stationId) : QStringLiteral("-"))
+				.arg(service && !service->stops.empty() && service->stops.front().hasPlannedArrival)
+				.arg(service && !service->stops.empty() && service->stops.front().hasPlannedDeparture)
+				.arg(service && !service->stops.empty() ? service->stops.front().dwellSeconds : -1.0));
+			return;
+		}
+		if (m_serviceOccurrenceTable->rowCount() != 3 || hasErrors(m_sceneDiagnostics)) {
+			QString detail;
+			for (const SceneDiagnostic& diagnostic : m_sceneDiagnostics)
+				if (diagnostic.severity == SceneSeverity::Error) {
+					detail = QString::fromStdString(toDisplayText(diagnostic));
+					break;
+				}
+			fail(QStringLiteral("service occurrence preview or validation is not runnable: rows=%1 %2")
+				.arg(m_serviceOccurrenceTable->rowCount()).arg(detail));
+			return;
+		}
+		marker("E2E_CREATOR_SERVICE_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 5) {
+		if (!m_sceneLoaded || !m_incidentDock || !m_scenarioListWidget
+				|| !m_blankScenarioButton || !m_addIncidentButton || !m_addEntranceDelayButton
+				|| !m_incidentHasReducedSpeedCheck || !m_incidentReducedSpeedKmhEdit) {
+			fail(QStringLiteral("scenario creator controls are unavailable"));
+			return;
+		}
+		m_incidentDock->show();
+		m_incidentDock->raise();
+		m_blankScenarioButton->click();
+		process();
+		if (!editLine(m_scenarioIdEdit, QStringLiteral("incident"))
+				|| !editLine(m_scenarioNameEdit, QStringLiteral("Incident scenario"))
+				|| !editLine(m_scenarioDescriptionEdit, QStringLiteral("signal and breakdown evidence"))) {
+			fail(QStringLiteral("incident scenario metadata did not commit"));
+			return;
+		}
+		m_addIncidentButton->click();
+		process();
+		if (!editLine(m_incidentIdEdit, QStringLiteral("creator-signal-failure"))
+				|| !choose(m_incidentTargetCombo, QStringLiteral("creator-signal"))
+				|| !editLine(m_incidentStartSecondsEdit, QStringLiteral("350"))
+				|| !editLine(m_incidentEndSecondsEdit, QStringLiteral("500"))) {
+			fail(QStringLiteral("signal failure incident did not bind through controls"));
+			return;
+		}
+		m_addIncidentButton->click();
+		process();
+		m_incidentTypeCombo->setCurrentText(QStringLiteral("train_breakdown"));
+		process();
+		if (!editLine(m_incidentIdEdit, QStringLiteral("creator-breakdown"))
+				|| !choose(m_incidentTargetCombo, QStringLiteral("creator-service"))
+				|| !editLine(m_incidentStartSecondsEdit, QStringLiteral("60"))
+				|| !editLine(m_incidentEndSecondsEdit, QStringLiteral("100"))) {
+			fail(QStringLiteral("breakdown incident target or finite interval did not commit"));
+			return;
+		}
+		m_incidentHasOccurrenceCheck->setChecked(true);
+		if (!editLine(m_incidentOccurrenceEdit, QStringLiteral("1"))) {
+			fail(QStringLiteral("breakdown occurrence did not commit"));
+			return;
+		}
+		m_incidentHasReducedSpeedCheck->setChecked(true);
+		m_incidentReducedSpeedKmhEdit->setValue(10.0);
+		QMetaObject::invokeMethod(m_incidentReducedSpeedKmhEdit, "editingFinished", Qt::DirectConnection);
+		process();
+		m_blankScenarioButton->click();
+		process();
+		if (!editLine(m_scenarioIdEdit, QStringLiteral("entrance"))
+				|| !editLine(m_scenarioNameEdit, QStringLiteral("Entrance delay"))
+				|| !editLine(m_scenarioDescriptionEdit, QStringLiteral("positive entrance delay at station A"))) {
+			fail(QStringLiteral("entrance scenario metadata did not commit"));
+			return;
+		}
+		m_addEntranceDelayButton->click();
+		process();
+		if (!choose(m_entranceDelayServiceCombo, QStringLiteral("creator-service"))) {
+			fail(QStringLiteral("entrance delay service selector lacked authored service"));
+			return;
+		}
+		m_entranceDelayOccurrenceEdit->setValue(2);
+		QMetaObject::invokeMethod(m_entranceDelayOccurrenceEdit, "editingFinished", Qt::DirectConnection);
+		process();
+		if (!choose(m_entranceDelayStationCombo, QStringLiteral("creator-station-a"))) {
+			fail(QStringLiteral("entrance delay station selector lacked station A"));
+			return;
+		}
+		m_entranceDelaySecondsEdit->setValue(90.0);
+		QMetaObject::invokeMethod(m_entranceDelaySecondsEdit, "editingFinished", Qt::DirectConnection);
+		process();
+		if (m_sceneModel.scenarios.size() != 3
+				|| m_sceneModel.scenarios[1].incidents.size() != 2
+				|| m_sceneModel.scenarios[2].entranceDelays.size() != 1
+				|| m_sceneModel.scenarios[2].entranceDelays.front().occurrence != 2
+				|| m_sceneModel.scenarios[2].entranceDelays.front().delaySeconds <= 0.0
+				|| hasErrors(m_sceneDiagnostics)) {
+			QString detail;
+			for (const SceneDiagnostic& diagnostic : m_sceneDiagnostics)
+				if (diagnostic.severity == SceneSeverity::Error) {
+					detail = QString::fromStdString(toDisplayText(diagnostic));
+					break;
+				}
+			fail(QStringLiteral("scenario library or validation did not retain all three scenarios: scenarios=%1 incident-count=%2 delay-count=%3 occurrence=%4 seconds=%5 %6")
+				.arg(static_cast<int>(m_sceneModel.scenarios.size()))
+				.arg(m_sceneModel.scenarios.size() > 1 ? static_cast<int>(m_sceneModel.scenarios[1].incidents.size()) : -1)
+				.arg(m_sceneModel.scenarios.size() > 2 ? static_cast<int>(m_sceneModel.scenarios[2].entranceDelays.size()) : -1)
+				.arg(m_sceneModel.scenarios.size() > 2 && !m_sceneModel.scenarios[2].entranceDelays.empty() ? m_sceneModel.scenarios[2].entranceDelays.front().occurrence : -1)
+				.arg(m_sceneModel.scenarios.size() > 2 && !m_sceneModel.scenarios[2].entranceDelays.empty() ? m_sceneModel.scenarios[2].entranceDelays.front().delaySeconds : -1.0)
+				.arg(detail));
+			return;
+		}
+		marker("E2E_CREATOR_SCENARIOS_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 6) {
+		if (!m_sceneLoaded || !m_passengerDock || !m_passengerListWidget
+				|| !m_addPassengerButton || !m_addPassengerJourneyButton
+				|| !m_addPassengerLegButton || !m_passengerTabs) {
+			fail(QStringLiteral("passenger creator controls are unavailable"));
+			return;
+		}
+		m_passengerDock->show();
+		m_passengerDock->raise();
+		m_addPassengerButton->click();
+		process();
+		if (m_passengerListWidget->count() != 1
+				|| !editLine(m_passengerIdEdit, QStringLiteral("creator-passenger"))) {
+			fail(QStringLiteral("passenger ID did not commit"));
+			return;
+		}
+		m_addPassengerJourneyButton->click();
+		process();
+		if (!editLine(m_passengerJourneyIdEdit, QStringLiteral("creator-journey"))
+				|| !editLine(m_passengerJourneyActivityEdit, QStringLiteral("creator commute"))
+				|| !choose(m_passengerJourneyOriginCombo, QStringLiteral("creator-station-a"))
+				|| !choose(m_passengerJourneyDestinationCombo, QStringLiteral("creator-station-b"))) {
+			fail(QStringLiteral("journey station or metadata controls did not commit"));
+			return;
+		}
+		const std::array<double, 4> windows = {120.0, 420.0, 300.0, 720.0};
+		for (std::size_t index = 0; index < windows.size(); ++index)
+			m_passengerJourneyWindowEdits[index]->setValue(windows[index]);
+		process();
+		m_passengerTabs->setCurrentIndex(1);
+		m_addPassengerLegButton->click();
+		process();
+		if (!editLine(m_passengerLegIdEdit, QStringLiteral("creator-leg"))
+				|| !choose(m_passengerLegOriginCombo, QStringLiteral("creator-station-a"))
+				|| !choose(m_passengerLegDestinationCombo, QStringLiteral("creator-station-b"))
+				|| !choose(m_passengerLegServiceCombo, QStringLiteral("creator-service"))) {
+			fail(QStringLiteral("passenger leg public CRUD did not commit references"));
+			return;
+		}
+		m_passengerLegOccurrenceEdit->setFocus(Qt::OtherFocusReason);
+		m_passengerLegOccurrenceEdit->setValue(1);
+		m_passengerLegOccurrenceEdit->clearFocus();
+		process();
+		if (m_sceneModel.passengers.size() != 1
+				|| m_sceneModel.passengers.front().journeys.size() != 1
+				|| m_sceneModel.passengers.front().journeys.front().legs.size() != 1
+				|| m_sceneModel.passengers.front().journeys.front().legs.front().occurrence != 1
+				|| hasErrors(m_sceneDiagnostics)) {
+			fail(QStringLiteral("passenger journey/leg or validation did not retain authored values"));
+			return;
+		}
+		marker("E2E_CREATOR_PASSENGER_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 7) {
+		const QString folder = emitPath(qEnvironmentVariable("QEGTRAIN_E2E_CREATOR_FOLDER"));
+		if (!m_sceneLoaded || folder.isEmpty() || !m_saveSceneAsFolderAction
+				|| !m_newSceneAction || !m_trainUnitListWidget) {
+			fail(QStringLiteral("folder persistence controls or target are unavailable"));
+			return;
+		}
+		activateWindow();
+		m_trainUnitDock->show();
+		m_trainUnitDock->raise();
+		process();
+		m_trainUnitListWidget->setCurrentRow(0);
+		process();
+		QLineEdit* pendingMass = m_trainUnitPhysicalEdits[0]
+			? m_trainUnitPhysicalEdits[0]->findChild<QLineEdit*>() : nullptr;
+		if (!pendingMass) {
+			fail(QStringLiteral("focused train-unit mass editor is unavailable"));
+			return;
+		}
+		pendingMass->setFocus(Qt::OtherFocusReason);
+		pendingMass->setText(QStringLiteral("91000"));
+		process();
+		if (!pendingMass->hasFocus()) {
+			fail(QStringLiteral("focused train-unit mass editor did not retain focus before Save As"));
+			return;
+		}
+		acceptFileDialog(folder, true);
+		m_saveSceneAsFolderAction->trigger();
+		process();
+		if (QFileInfo(m_sceneDir).absoluteFilePath() != folder || m_sceneIsBundle
+				|| m_sceneDirty || !QFileInfo(QDir(folder).filePath("scene.json")).exists()) {
+			fail(QStringLiteral("public Save Scene As Folder did not persist the focused physical value"));
+			return;
+		}
+		m_newSceneAction->trigger();
+		process();
+		QAction* openFolder = findChild<QAction*>("actionOpenSceneFolder");
+		if (!openFolder) {
+			fail(QStringLiteral("public Open Scene Folder action is unavailable"));
+			return;
+		}
+		acceptFileDialog(folder, true);
+		acceptMessageBox(QMessageBox::Discard);
+		openFolder->trigger();
+		process();
+		if (QFileInfo(m_sceneDir).absoluteFilePath() != folder || m_sceneIsBundle
+				|| m_sceneModel.name != "creator_acceptance_case"
+				|| m_sceneModel.tracks.size() != 2 || m_sceneModel.nodes.size() != 6
+				|| m_sceneModel.arcs.size() != 4 || m_sceneModel.blocks.size() != 6
+				|| m_sceneModel.connections.size() != 1 || m_sceneModel.stations.size() != 2
+				|| m_sceneModel.trainUnits.size() != 2 || m_sceneModel.compositions.size() != 1
+				|| m_sceneModel.services.size() != 1 || m_sceneModel.scenarios.size() != 3
+				|| m_sceneModel.passengers.size() != 1
+				|| m_sceneModel.trainUnits.front().physical.mass_of_traction_unit_kg != 91000.0
+				|| m_sceneModel.passengers.front().id != "creator-passenger"
+				|| m_sceneModel.passengers.front().journeys.size() != 1
+				|| m_sceneModel.passengers.front().journeys.front().id != "creator-journey"
+				|| hasErrors(m_sceneDiagnostics)) {
+			fail(QStringLiteral("folder reopen did not retain complete creator rows"));
+			return;
+		}
+		marker("E2E_CREATOR_FOLDER_ROUNDTRIP_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 8) {
+		const QString bundle = emitPath(qEnvironmentVariable("QEGTRAIN_E2E_CREATOR_BUNDLE"));
+		if (!m_sceneLoaded || bundle.isEmpty() || !m_saveSceneAsAction || !m_newSceneAction) {
+			fail(QStringLiteral("bundle persistence controls or target are unavailable"));
+			return;
+		}
+		acceptFileDialog(bundle, false);
+		m_saveSceneAsAction->trigger();
+		process();
+		if (QFileInfo(m_sceneDir).absoluteFilePath() != bundle || !m_sceneIsBundle
+				|| m_sceneDirty || !QFileInfo(bundle).exists()) {
+			fail(QStringLiteral("public Save Case Study As bundle did not complete"));
+			return;
+		}
+		m_newSceneAction->trigger();
+		process();
+		QAction* openBundle = findChild<QAction*>("actionOpenCaseStudyBundle");
+		if (!openBundle) {
+			fail(QStringLiteral("public Open Case Study bundle action is unavailable"));
+			return;
+		}
+		acceptFileDialog(bundle, false);
+		acceptMessageBox(QMessageBox::Discard);
+		openBundle->trigger();
+		process();
+		if (QFileInfo(m_sceneDir).absoluteFilePath() != bundle || !m_sceneIsBundle
+				|| m_sceneModel.name != "creator_acceptance_case"
+				|| m_sceneModel.blocks.size() != 6 || m_sceneModel.trainUnits.size() != 2
+				|| m_sceneModel.compositions.size() != 1 || m_sceneModel.services.size() != 1
+				|| m_sceneModel.scenarios.size() != 3 || m_sceneModel.passengers.size() != 1
+				|| m_sceneModel.services.front().repeatCount != 3
+				|| m_sceneModel.services.front().stops.size() != 2 || hasErrors(m_sceneDiagnostics)) {
+			fail(QStringLiteral("bundle reopen did not retain complete creator IDs and values: path=%1 bundle=%2 name=%3 blocks=%4 units=%5 compositions=%6 services=%7 scenarios=%8 passengers=%9 repeat=%10 stops=%11 errors=%12")
+				.arg(m_sceneDir).arg(m_sceneIsBundle).arg(QString::fromStdString(m_sceneModel.name))
+				.arg(static_cast<int>(m_sceneModel.blocks.size()))
+				.arg(static_cast<int>(m_sceneModel.trainUnits.size()))
+				.arg(static_cast<int>(m_sceneModel.compositions.size()))
+				.arg(static_cast<int>(m_sceneModel.services.size()))
+				.arg(static_cast<int>(m_sceneModel.scenarios.size()))
+				.arg(static_cast<int>(m_sceneModel.passengers.size()))
+				.arg(m_sceneModel.services.empty() ? -1 : m_sceneModel.services.front().repeatCount)
+				.arg(m_sceneModel.services.empty() ? -1 : static_cast<int>(m_sceneModel.services.front().stops.size()))
+				.arg(hasErrors(m_sceneDiagnostics)));
+			return;
+		}
+		if (!m_loadedDataDock || !m_loadedDataTree) {
+			fail(QStringLiteral("Loaded Data review is unavailable after bundle reopen"));
+			return;
+		}
+		if (!m_loadedDataDock->isVisible())
+			m_loadedDataDock->toggleViewAction()->trigger();
+		m_loadedDataDock->raise();
+		process();
+		QTreeWidgetItem* caseRoot = m_loadedDataTree->topLevelItemCount() > 0
+			? m_loadedDataTree->topLevelItem(0) : nullptr;
+		bool loadedDataOk = caseRoot && caseRoot->text(0) == "Case Study"
+			&& QFileInfo(caseRoot->text(1)).absoluteFilePath() == bundle;
+		for (const QString& label : {QStringLiteral("Infrastructure"), QStringLiteral("Scenarios"),
+				QStringLiteral("Passengers"), QStringLiteral("Canonical schema version"),
+				QStringLiteral("Bundle format version")}) {
+			const QList<QTreeWidgetItem*> rows = m_loadedDataTree->findItems(
+				label, Qt::MatchExactly | Qt::MatchRecursive, 0);
+			loadedDataOk = loadedDataOk && !rows.isEmpty()
+				&& rows.front()->text(3) != "Invalid" && rows.front()->text(3) != "Failed";
+		}
+		if (!m_loadedDataDock->isVisible() || !loadedDataOk) {
+			fail(QStringLiteral("Loaded Data did not expose the reopened bundle inputs"));
+			return;
+		}
+		marker("E2E_CREATOR_BUNDLE_ROUNDTRIP_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 9) {
+		if (!m_sceneLoaded || !m_runSceneAction || !m_serviceOccurrenceTable
+				|| !m_scenarioListWidget || !m_setDelayBaselineButton) {
+			fail(QStringLiteral("run and occurrence controls are unavailable"));
+			return;
+		}
+		int baselineRow = -1;
+		for (int row = 0; row < m_sceneModel.scenarios.size(); ++row)
+			if (m_sceneModel.scenarios[static_cast<std::size_t>(row)].id == "baseline")
+				baselineRow = row;
+		if (baselineRow < 0) {
+			fail(QStringLiteral("baseline scenario was not retained after bundle reopen"));
+			return;
+		}
+		m_scenarioListWidget->setCurrentRow(baselineRow);
+		process();
+		if (m_serviceOccurrenceTable->rowCount() != 3) {
+			fail(QStringLiteral("three service occurrences were not exposed after reopen"));
+			return;
+		}
+		for (int row = 0; row < m_serviceOccurrenceTable->rowCount(); ++row) {
+			if (auto* item = m_serviceOccurrenceTable->item(row, 0))
+				item->setCheckState(row == 2 ? Qt::Unchecked : Qt::Checked);
+		}
+		process();
+		m_creatorAcceptancePolls = 0;
+		m_runSceneAction->trigger();
+		marker("E2E_CREATOR_BASELINE_RUN_STARTED");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 10) {
+		if (m_worker || !m_resultsAvailable) {
+			if (++m_creatorAcceptancePolls > 600) {
+				fail(QStringLiteral("baseline simulation did not complete"));
+				return;
+			}
+			QTimer::singleShot(100, this, &MainWindow::runCreatorAcceptanceE2E);
+			return;
+		}
+		m_creatorAcceptancePolls = 0;
+		if (m_completedRunProvenance.appliedScenario != "baseline"
+				|| m_completedRunProvenance.selectedOccurrences.size() != 2) {
+			fail(QStringLiteral("baseline provenance did not retain scenario and selected occurrences 1+2"));
+			return;
+		}
+		QPushButton* timeDistance = nullptr;
+		for (QPushButton* button : findChildren<QPushButton*>())
+			if (button->text() == QStringLiteral("Time / distance"))
+				timeDistance = button;
+		if (!timeDistance) {
+			fail(QStringLiteral("public Time / distance result control is unavailable"));
+			return;
+		}
+		timeDistance->click();
+		process();
+		for (QWidget* widget : QApplication::topLevelWidgets()) {
+			if (auto* diagram = qobject_cast<DiagramWindow*>(widget))
+				if (diagram->windowTitle().contains(QStringLiteral("Time vs Distance")))
+					m_creatorBaselineDiagram = diagram;
+		}
+		if (!m_creatorBaselineDiagram) {
+			fail(QStringLiteral("baseline result diagram did not open"));
+			return;
+		}
+		m_setDelayBaselineButton->click();
+		if (!m_delayBaseline) {
+			fail(QStringLiteral("public delay baseline control did not freeze baseline"));
+			return;
+		}
+		marker("E2E_CREATOR_BASELINE_RUN_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 11) {
+		int entranceRow = -1;
+		for (int row = 0; row < m_sceneModel.scenarios.size(); ++row)
+			if (m_sceneModel.scenarios[static_cast<std::size_t>(row)].id == "entrance")
+				entranceRow = row;
+		if (entranceRow < 0 || !m_scenarioListWidget || !m_runSceneAction) {
+			fail(QStringLiteral("entrance scenario was not available for public run"));
+			return;
+		}
+		m_scenarioListWidget->setCurrentRow(entranceRow);
+		process();
+		m_creatorAcceptancePolls = 0;
+		m_runSceneAction->trigger();
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 12) {
+		if (m_worker || !m_resultsAvailable) {
+			if (++m_creatorAcceptancePolls > 600) {
+				fail(QStringLiteral("entrance-delay simulation did not complete"));
+				return;
+			}
+			QTimer::singleShot(100, this, &MainWindow::runCreatorAcceptanceE2E);
+			return;
+		}
+		m_creatorAcceptancePolls = 0;
+		if (m_completedRunProvenance.appliedScenario != "entrance") {
+			fail(QStringLiteral("entrance run did not stage the entrance scenario"));
+			return;
+		}
+		const auto stationADeparture = [](const std::vector<TimetableResultRow>& rows)
+				-> const TimetableResultRow* {
+			for (const TimetableResultRow& row : rows)
+				if (row.serviceId == "creator-service" && row.occurrence == 2
+						&& row.stationId == "Creator A")
+					return &row;
+			return nullptr;
+		};
+		const TimetableResultRow* baselineDeparture = m_delayBaseline
+			? stationADeparture(m_delayBaseline->timetable) : nullptr;
+		const TimetableResultRow* delayedDeparture = stationADeparture(m_completedTimetableResults);
+		if (!baselineDeparture || !delayedDeparture
+				|| !baselineDeparture->plannedDepartureSeconds.available
+				|| !delayedDeparture->plannedDepartureSeconds.available
+				|| !baselineDeparture->departureDelaySeconds.available
+				|| !delayedDeparture->departureDelaySeconds.available
+				|| delayedDeparture->plannedDepartureSeconds.value
+					- baselineDeparture->plannedDepartureSeconds.value < 89.0
+				|| std::abs(delayedDeparture->departureDelaySeconds.value
+					- baselineDeparture->departureDelaySeconds.value) < 1.0) {
+			fail(QStringLiteral("entrance delay did not shift occurrence 2 station-A plan by 90 seconds and change its reported delay: baseline=%1/%2 delayed=%3/%4 rows=%5/%6")
+				.arg(baselineDeparture && baselineDeparture->plannedDepartureSeconds.available
+					? baselineDeparture->plannedDepartureSeconds.value : -1.0)
+				.arg(baselineDeparture && baselineDeparture->departureDelaySeconds.available
+					? baselineDeparture->departureDelaySeconds.value : -1.0)
+				.arg(delayedDeparture && delayedDeparture->plannedDepartureSeconds.available
+					? delayedDeparture->plannedDepartureSeconds.value : -1.0)
+				.arg(delayedDeparture && delayedDeparture->departureDelaySeconds.available
+					? delayedDeparture->departureDelaySeconds.value : -1.0)
+				.arg(m_delayBaseline ? static_cast<int>(m_delayBaseline->timetable.size()) : -1)
+				.arg(static_cast<int>(m_completedTimetableResults.size())));
+			return;
+		}
+		marker("E2E_CREATOR_ENTRANCE_RUN_OK");
+		int incidentRow = -1;
+		for (int row = 0; row < m_sceneModel.scenarios.size(); ++row)
+			if (m_sceneModel.scenarios[static_cast<std::size_t>(row)].id == "incident")
+				incidentRow = row;
+		if (incidentRow < 0 || !m_scenarioListWidget || !m_runSceneAction) {
+			fail(QStringLiteral("incident scenario was not available for final public run"));
+			return;
+		}
+		m_scenarioListWidget->setCurrentRow(incidentRow);
+		process();
+		m_creatorAcceptancePolls = 0;
+		m_runSceneAction->trigger();
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 13) {
+		if (m_worker || !m_resultsAvailable) {
+			if (++m_creatorAcceptancePolls > 600) {
+				fail(QStringLiteral("incident simulation did not complete"));
+				return;
+			}
+			QTimer::singleShot(100, this, &MainWindow::runCreatorAcceptanceE2E);
+			return;
+		}
+		m_creatorAcceptancePolls = 0;
+		bool directEvidence = false;
+		for (const auto& train : m_completedRunResults.trains)
+			if (!train.directIncidentIds.empty())
+				directEvidence = true;
+		if (m_completedRunProvenance.appliedScenario != "incident" || !directEvidence) {
+			fail(QStringLiteral("final incident run lacked direct incident evidence"));
+			return;
+		}
+		marker("E2E_CREATOR_INCIDENT_RUN_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 14) {
+		const QString exportDir = emitPath(qEnvironmentVariable("QEGTRAIN_E2E_CREATOR_EXPORT_DIR"));
+		if (!m_resultsAvailable || exportDir.isEmpty() || !m_runResultsDock) {
+			fail(QStringLiteral("public result controls or export target are unavailable"));
+			return;
+		}
+		QDir().mkpath(exportDir);
+		auto path = [&](const char* name) { return QDir(exportDir).filePath(QString::fromLatin1(name)); };
+		auto exportButton = [&](QWidget* window, const QString& text, const QString& target) {
+			if (!window)
+				return false;
+			QPushButton* button = nullptr;
+			for (QPushButton* candidate : window->findChildren<QPushButton*>())
+				if (candidate->text() == text) {
+					button = candidate;
+					break;
+				}
+			if (!button)
+				return false;
+			acceptFileDialog(target, false);
+			button->click();
+			process();
+			return true;
+		};
+		auto findDiagram = [&](const QString& titlePart) -> DiagramWindow* {
+			for (QWidget* widget : QApplication::topLevelWidgets())
+				if (auto* diagram = qobject_cast<DiagramWindow*>(widget))
+					if (diagram->windowTitle().contains(titlePart))
+						return diagram;
+			return nullptr;
+		};
+		auto findResultButton = [&](const QString& text) -> QPushButton* {
+			for (QPushButton* button : findChildren<QPushButton*>())
+				if (button->text() == text)
+					return button;
+			return nullptr;
+		};
+		auto readNonEmpty = [](const QString& file) {
+			QFile input(file);
+			return input.open(QIODevice::ReadOnly) && !input.readAll().isEmpty();
+		};
+
+		if (!m_creatorBaselineDiagram
+				|| !exportButton(m_creatorBaselineDiagram, QStringLiteral("Export CSV..."),
+					path("baseline_time_distance.csv"))) {
+			fail(QStringLiteral("baseline diagram CSV export was not driven through its public button"));
+			return;
+		}
+		QPushButton* speedButton = findResultButton(QStringLiteral("Speed / distance"));
+		if (!speedButton) {
+			fail(QStringLiteral("speed/distance result control is unavailable"));
+			return;
+		}
+		speedButton->click();
+		process();
+		DiagramWindow* speedDiagram = findDiagram(QStringLiteral("Speed vs Distance"));
+		if (!speedDiagram
+				|| !exportButton(speedDiagram, QStringLiteral("Export CSV..."), path("trajectory.csv"))
+				|| !exportButton(speedDiagram, QStringLiteral("Export PNG..."), path("trajectory.png"))) {
+			fail(QStringLiteral("current trajectory/speed exports were not driven through the diagram"));
+			return;
+		}
+		QPushButton* tractiveButton = findResultButton(QStringLiteral("Tractive effort / distance"));
+		if (!tractiveButton) {
+			fail(QStringLiteral("tractive-effort result control is unavailable"));
+			return;
+		}
+		tractiveButton->click();
+		process();
+		DiagramWindow* tractiveDiagram = findDiagram(QStringLiteral("Simulated Tractive Effort vs Distance"));
+		if (!tractiveDiagram
+				|| !exportButton(tractiveDiagram, QStringLiteral("Export CSV..."), path("tractive_effort.csv"))
+				|| !exportButton(tractiveDiagram, QStringLiteral("Export PNG..."), path("tractive_effort.png"))) {
+			fail(QStringLiteral("simulated tractive-effort exports were not driven through the diagram"));
+			return;
+		}
+		QPushButton* timetableButton = findResultButton(QStringLiteral("Timetable"));
+		if (!timetableButton) {
+			fail(QStringLiteral("timetable result control is unavailable"));
+			return;
+		}
+		timetableButton->click();
+		process();
+		TimetableTableWindow* timetable = nullptr;
+		for (QWidget* widget : QApplication::topLevelWidgets())
+			if (auto* candidate = qobject_cast<TimetableTableWindow*>(widget))
+				timetable = candidate;
+		if (!timetable
+				|| !exportButton(timetable, QStringLiteral("Export CSV..."), path("timetable.csv"))
+				|| !exportButton(timetable, QStringLiteral("Export PNG..."), path("timetable.png"))) {
+			fail(QStringLiteral("timetable exports were not driven through the public table"));
+			return;
+		}
+		QPushButton* blockingButton = findResultButton(QStringLiteral("Blocking time"));
+		if (!blockingButton) {
+			fail(QStringLiteral("blocking-time result control is unavailable"));
+			return;
+		}
+		acceptMessageBox();
+		blockingButton->click();
+		process();
+		DiagramWindow* blocking = findDiagram(QStringLiteral("Blocking time:"));
+		if (!blocking
+				|| !exportButton(blocking, QStringLiteral("Export CSV..."), path("blocking_time.csv"))
+				|| !exportButton(blocking, QStringLiteral("Export PNG..."), path("blocking_time.png"))) {
+			fail(QStringLiteral("blocking-time exports were not driven through the public diagram"));
+			return;
+		}
+		QPushButton* summaryCsv = findChild<QPushButton*>("resultView_ExportCSV");
+		QPushButton* summaryPng = findChild<QPushButton*>("resultView_ExportPNG");
+		if (!summaryCsv || !summaryPng) {
+			fail(QStringLiteral("run-summary result controls are unavailable"));
+			return;
+		}
+		acceptFileDialog(path("run_summary.csv"), false);
+		summaryCsv->click();
+		process();
+		acceptFileDialog(path("run_summary.png"), false);
+		summaryPng->click();
+		process();
+
+		QPushButton* capacityButton = findResultButton(QStringLiteral("Capacity"));
+		if (!capacityButton) {
+			fail(QStringLiteral("capacity result control is unavailable"));
+			return;
+		}
+		acceptCapacityScope();
+		capacityButton->click();
+		process();
+		QDialog* capacity = nullptr;
+		for (QWidget* widget : QApplication::topLevelWidgets())
+			if (auto* dialog = qobject_cast<QDialog*>(widget))
+				if (!dialog->isModal() && dialog->windowTitle().contains(QStringLiteral("Capacity analysis")))
+					capacity = dialog;
+		if (!capacity
+				|| !exportButton(capacity, QStringLiteral("Export capacity CSV..."), path("capacity_analysis.csv"))) {
+			fail(QStringLiteral("capacity analysis did not open and export through public controls"));
+			return;
+		}
+		QPushButton* compressedButton = nullptr;
+		for (QPushButton* candidate : capacity->findChildren<QPushButton*>())
+			if (candidate->text().contains(QStringLiteral("compressed blocking-time")))
+				compressedButton = candidate;
+		if (!compressedButton) {
+			fail(QStringLiteral("compressed blocking-time control is unavailable"));
+			return;
+		}
+		compressedButton->click();
+		process();
+		DiagramWindow* compressed = findDiagram(QStringLiteral("Compressed blocking-time diagram"));
+		if (!compressed
+				|| !exportButton(compressed, QStringLiteral("Export CSV..."), path("capacity_compressed_blocking_time.csv"))
+				|| !exportButton(compressed, QStringLiteral("Export PNG..."), path("capacity_compressed_blocking_time.png"))) {
+			fail(QStringLiteral("compressed capacity diagram did not export"));
+			return;
+		}
+		capacity->close();
+		QPushButton* compareButton = findChild<QPushButton*>("compareDelayButton");
+		if (!compareButton) {
+			fail(QStringLiteral("delay comparison result control is unavailable"));
+			return;
+		}
+		acceptFileDialog(path("delay_comparison.csv"), false);
+		QTimer::singleShot(75, this, [this]() {
+			for (QWidget* widget : QApplication::topLevelWidgets()) {
+				auto* dialog = qobject_cast<QDialog*>(widget);
+				if (!dialog || dialog->windowTitle() != QStringLiteral("Incident delay comparison"))
+					continue;
+				for (QPushButton* button : dialog->findChildren<QPushButton*>())
+					if (button->text() == QStringLiteral("Export CSV...")) {
+						button->click();
+						dialog->accept();
+						return;
+					}
+			}
+		});
+		compareButton->click();
+		process();
+		for (QWidget* widget : QApplication::topLevelWidgets())
+			if (auto* dialog = qobject_cast<QDialog*>(widget))
+				if (dialog->windowTitle() == QStringLiteral("Incident delay comparison"))
+					dialog->close();
+		const std::array<const char*, 15> required = {
+				"baseline_time_distance.csv", "trajectory.csv", "trajectory.png",
+				"timetable.csv", "timetable.png", "blocking_time.csv", "blocking_time.png",
+				"run_summary.csv", "run_summary.png", "tractive_effort.csv", "tractive_effort.png",
+				"delay_comparison.csv", "capacity_analysis.csv", "capacity_compressed_blocking_time.csv",
+				"capacity_compressed_blocking_time.png"};
+		for (const char* file : required) {
+			const QString target = path(file);
+			if (!readNonEmpty(target)) {
+				fail(QStringLiteral("export is missing or empty: ") + target);
+				return;
+			}
+		}
+		const std::array<const char*, 15> requiredSidecars = {
+			"baseline_time_distance.csv.provenance.json", "trajectory.csv.provenance.json",
+			"trajectory.png.provenance.json", "timetable.csv.provenance.json",
+			"timetable.png.provenance.json", "blocking_time.csv.provenance.json",
+			"blocking_time.png.provenance.json", "run_summary.csv.provenance.json",
+			"run_summary.png.provenance.json", "delay_comparison.csv.provenance.json",
+			"tractive_effort.csv.provenance.json", "tractive_effort.png.provenance.json",
+			"capacity_analysis.csv.provenance.json",
+			"capacity_compressed_blocking_time.csv.provenance.json",
+			"capacity_compressed_blocking_time.png.provenance.json"};
+		for (const char* file : requiredSidecars)
+			if (!readNonEmpty(path(file))) {
+				fail(QStringLiteral("missing or empty provenance sidecar: ") + path(file));
+				return;
+			}
+		marker("E2E_CREATOR_EXPORTS_OK");
+		next();
+		return;
+	}
+
+	if (m_creatorAcceptancePhase == 15) {
+		if (!m_caseSettingsDock || !m_caseDescriptionEdit || !m_runResultsDock) {
+			fail(QStringLiteral("stale-result invalidation controls are unavailable"));
+			return;
+		}
+		m_caseSettingsDock->show();
+		m_caseSettingsDock->raise();
+		if (!editLine(m_caseDescriptionEdit,
+				QStringLiteral("creator acceptance edited after incident exports"))) {
+			fail(QStringLiteral("description editing did not commit through editingFinished"));
+			return;
+		}
+		process();
+		bool resultButtonsDisabled = true;
+		for (QPushButton* button : findChildren<QPushButton*>())
+			if (button->objectName().startsWith(QStringLiteral("resultView_")))
+				resultButtonsDisabled = resultButtonsDisabled && !button->isEnabled();
+		if (m_resultsAvailable || m_runResultsDock->isVisible() || !resultButtonsDisabled) {
+			fail(QStringLiteral("editing case description did not invalidate stale result views"));
+			return;
+		}
+		m_creatorAcceptanceFinished = true;
+		marker("E2E_CREATOR_ACCEPTANCE_OK");
+		QCoreApplication::exit(0);
+		return;
+	}
+}
+
 void MainWindow::clearSimulationWorker(bool requestStop) {
 	if (m_worker && requestStop)
 		m_worker->requestStop();
@@ -15526,6 +17100,10 @@ void MainWindow::showEvent(QShowEvent* e) {
 		return;
 	m_promptedLoad = true;
 	extern InitialParameters initial_variables;
+	if (qEnvironmentVariableIsSet("QEGTRAIN_E2E_CREATOR_ACCEPTANCE")) {
+		QTimer::singleShot(0, this, &MainWindow::runCreatorAcceptanceE2E);
+		return;
+	}
 	// skip the chooser when -n was given so scripted runs load directly
 	if (!initial_variables.nArgProvided)
 		QTimer::singleShot(0, this, &MainWindow::showStartupChooser);
@@ -19088,7 +20666,8 @@ void MainWindow::showCapacityAnalysis() {
 			"Run a scene with explicit signalling data; EGTRAIN does not infer a signalling system or blocking-time parameters.");
 		return;
 	}
-	if (!e2eDialogsSuppressed() && !chooseCapacityAnalysisScope(this, scope))
+	if ((!e2eDialogsSuppressed() || qEnvironmentVariableIsSet("QEGTRAIN_E2E_CREATOR_ACCEPTANCE"))
+			&& !chooseCapacityAnalysisScope(this, scope))
 		return;
 	if (scope.routeIndex < 0 || scope.blockIds.empty()) {
 		QMessageBox::information(this, "Capacity analysis",

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -432,6 +432,8 @@ private:
 	std::set<std::string> m_modifiedScenarioIds;
 	RunResults m_completedRunResults;
 	std::vector<TimetableResultRow> m_completedTimetableResults;
+	RunProvenance m_pendingRunProvenance;
+	RunProvenance m_completedRunProvenance;
 	std::optional<DelayRunSnapshot> m_delayBaseline;
 	quint64 m_sceneRevision = 0;
 	QLabel* m_runResultsSummaryLabel = nullptr;
@@ -822,6 +824,7 @@ private:
 	void setDelayBaseline();
 	void showDelayComparison();
 	DelayRunSnapshot completedDelaySnapshot() const;
+	RunProvenance captureRunProvenance() const;
 
 	void runVisualPolishE2E();
 	void runStationOverlayE2E();
@@ -888,7 +891,8 @@ private slots:
 	void showDelayDiagram();
 	void showBlockingTimeDiagram();
 	void showCapacityAnalysis();
-	void showCompressedBlockingTimeDiagram(const CapacityAnalysisResult& result, const QString& sectionLabel);
+	void showCompressedBlockingTimeDiagram(const CapacityAnalysisResult& result, const QString& sectionLabel,
+		RunProvenance provenance);
 	void focusTrainInScene(const QString& trainId); // centre the network view on a diagram selection
 
 };

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -96,6 +96,7 @@
 QT_CHARTS_USE_NAMESPACE
 
 class ConsoleWidget; // forward declaration for m_logPane
+class DiagramWindow;
 
 // custom GUI files
 #include "graphics/NetworkView.h"
@@ -361,6 +362,10 @@ private:
 	int m_e2eAttempts = 0;
 	bool m_e2eFinished = false;
 	bool m_editorE2eFinished = false;
+	bool m_creatorAcceptanceFinished = false;
+	int m_creatorAcceptancePhase = 0;
+	int m_creatorAcceptancePolls = 0;
+	QPointer<DiagramWindow> m_creatorBaselineDiagram;
 	QMap<int, QPointF> m_prevTrainPositions;
 	QMap<int, QGraphicsSimpleTextItem*> m_trainSpeedLabels; // per-train speed overlay
 	QMap<int, TrainBadgeItem*> m_trainBadges;
@@ -829,6 +834,7 @@ private:
 	void runVisualPolishE2E();
 	void runStationOverlayE2E();
 	void runEditorSmokeE2E();
+	void runCreatorAcceptanceE2E();
 	void runSceneRenderE2E();
 	void runTrackPreviewE2E();
 	void runLegacyImportE2E();

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -387,6 +387,7 @@ private:
 	QMenu* m_diagramsMenu = nullptr;	// Diagrams top-level menu
 	QMenu* m_editorsMenu = nullptr;		// Editors top-level menu (dock toggles)
 	QString m_sceneDir;
+	std::string m_savedSceneSha256;
 	SceneModel m_sceneModel;
 	bool m_sceneLoaded = false;
 	bool m_sceneIsBundle = false;

--- a/EGTRAIN/QEGTRAIN/app/main.cpp
+++ b/EGTRAIN/QEGTRAIN/app/main.cpp
@@ -40,6 +40,7 @@ bool interactivePromptModeEnabled(int argc, char* argv[]) {
 void parseCmdOptions(int argc, char* argv[]) {
 	// Keep the legacy questionnaire opt-in so normal launches open the GUI.
 	const bool promptForMissingOptions = interactivePromptModeEnabled(argc, argv);
+	const bool creatorAcceptance = qEnvironmentVariableIsSet("QEGTRAIN_E2E_CREATOR_ACCEPTANCE");
 
 	// no options entered
 	if (argc < 2) {
@@ -47,7 +48,9 @@ void parseCmdOptions(int argc, char* argv[]) {
 	}
 
 	// select case study
-	if (cmdOptionEntered(argv, argv + argc, "-n")) {
+	if (creatorAcceptance) {
+		initial_variables.name.clear();
+	} else if (cmdOptionEntered(argv, argv + argc, "-n")) {
 		char* argument = getCmdOption(argv, argv + argc, "-n");
 		if (argument) {
 			initial_variables.set_case(std::atoi(argument));
@@ -191,7 +194,8 @@ int main(int argc, char* argv[]) {
 		return 1;
 	}
 	const std::string defaultName = initial_variables.name;
-	if (defaultName.empty()) {
+	const bool creatorAcceptance = qEnvironmentVariableIsSet("QEGTRAIN_E2E_CREATOR_ACCEPTANCE");
+	if (!creatorAcceptance && defaultName.empty()) {
 		std::cerr << "ERROR: Unknown case study id. Valid ids: 1 Netherlands, 2 Paimpol, 3 Copenhagen, 4 Milano_Brescia, 5 Assignment_Gvc_Gdg_Ut, 6 Lebanon.\n";
 		return 1;
 	}
@@ -206,6 +210,23 @@ int main(int argc, char* argv[]) {
 
 	if (gui) {
 		QApplication application(argc, argv);
+		if (creatorAcceptance) {
+			const QString output = QFileInfo(qEnvironmentVariable("QEGTRAIN_E2E_OUT")).absoluteFilePath();
+			if (output.isEmpty() || output == QFileInfo(QString()).absoluteFilePath()) {
+				std::cerr << "ERROR: QEGTRAIN_E2E_OUT is required for creator acceptance.\n";
+				return 1;
+			}
+			if (!QDir().mkpath(output)) {
+				std::cerr << "ERROR: Could not create QEGTRAIN_E2E_OUT.\n";
+				return 1;
+			}
+			initial_variables.OutputMainFolder = output.toStdString();
+			InputMainFolder.clear();
+			initial_variables.InputMainFolder.clear();
+			MainWindow window;
+			window.openGUI();
+			return application.exec();
+		}
 		const QString scenePath = resolveScenePath(
 			sceneOption ? QString::fromLocal8Bit(sceneArgument) : QString(), defaultName);
 		SceneLoadResult loaded = loadScenePath(scenePath.toStdString());

--- a/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
@@ -2,6 +2,7 @@
 #include "diagrams/TrainFilterButton.h"
 #include "util/TimeFormat.h"
 
+#include <QBuffer>
 #include <QColor>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -31,6 +32,14 @@ QPen mutedPen(const QPen& base) {
 	color.setAlpha(60);
 	pen.setColor(color);
 	return pen;
+}
+
+bool writeArtifact(const QString& path, const std::string& bytes) {
+	QSaveFile file(path);
+	if (!file.open(QIODevice::WriteOnly))
+		return false;
+	const QByteArray data = QByteArray::fromStdString(bytes);
+	return file.write(data) == data.size() && file.commit();
 }
 
 // Emphasised pen for the pinned train.
@@ -128,7 +137,7 @@ void DiagramWindow::setCsvProvider(std::function<std::string(const QStringList&)
 }
 
 void DiagramWindow::setProvenanceWriter(
-		std::function<bool(const QString&, const char*)> writer) {
+		std::function<bool(const QString&, const char*, const std::string&)> writer) {
 	m_provenanceWriter = std::move(writer);
 }
 
@@ -367,14 +376,20 @@ void DiagramWindow::exportPng() {
 	if (QFileInfo(path).suffix().compare("png", Qt::CaseInsensitive) != 0)
 		path += ".png";
 	QPixmap pix = m_view->grab();
-	if (!pix.save(path, "PNG")) {
+	QByteArray data;
+	QBuffer buffer(&data);
+	if (!buffer.open(QIODevice::WriteOnly) || !pix.save(&buffer, "PNG")) {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the image to:\n%1").arg(path));
-	} else if (m_provenanceWriter && !m_provenanceWriter(path, "png")) {
-		QMessageBox::warning(this, "Export failed",
-							 QString("The image was removed because its provenance sidecar could not be written:\n%1.provenance.json")
-								.arg(path));
+		return;
 	}
+	const std::string bytes(data.constData(), static_cast<std::size_t>(data.size()));
+	const bool written = m_provenanceWriter
+		? m_provenanceWriter(path, "png", bytes)
+		: writeArtifact(path, bytes);
+	if (!written)
+		QMessageBox::warning(this, "Export failed",
+			QString("Could not export the image and provenance to:\n%1").arg(path));
 }
 
 void DiagramWindow::exportCsv() {
@@ -392,23 +407,12 @@ void DiagramWindow::exportCsv() {
 		return;  // cancelled: no file is written
 	if (QFileInfo(path).suffix().compare("csv", Qt::CaseInsensitive) != 0)
 		path += ".csv";
-	// QSaveFile writes to a temporary file and renames on commit, so a failure or
-	// cancellation never leaves a partial file in place.
-	QSaveFile file(path);
-	if (!file.open(QIODevice::WriteOnly)) {
+	const bool written = m_provenanceWriter
+		? m_provenanceWriter(path, "csv", content)
+		: writeArtifact(path, content);
+	if (!written)
 		QMessageBox::warning(this, "Export failed",
-							 QString("Could not open the file for writing:\n%1").arg(path));
-		return;
-	}
-	const QByteArray bytes = QByteArray::fromStdString(content);
-	if (file.write(bytes) != bytes.size() || !file.commit()) {
-		QMessageBox::warning(this, "Export failed",
-							 QString("Could not write the data to:\n%1").arg(path));
-	} else if (m_provenanceWriter && !m_provenanceWriter(path, "csv")) {
-		QMessageBox::warning(this, "Export failed",
-							 QString("The CSV was removed because its provenance sidecar could not be written:\n%1.provenance.json")
-								.arg(path));
-	}
+			QString("Could not export the data and provenance to:\n%1").arg(path));
 }
 
 bool DiagramWindow::eventFilter(QObject* obj, QEvent* ev) {

--- a/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
@@ -371,8 +371,8 @@ void DiagramWindow::exportPng() {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the image to:\n%1").arg(path));
 	} else if (m_provenanceWriter && !m_provenanceWriter(path, "png")) {
-		QMessageBox::warning(this, "Export warning",
-							 QString("The image was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+		QMessageBox::warning(this, "Export failed",
+							 QString("The image was removed because its provenance sidecar could not be written:\n%1.provenance.json")
 								.arg(path));
 	}
 }
@@ -405,8 +405,8 @@ void DiagramWindow::exportCsv() {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the data to:\n%1").arg(path));
 	} else if (m_provenanceWriter && !m_provenanceWriter(path, "csv")) {
-		QMessageBox::warning(this, "Export warning",
-							 QString("The CSV was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+		QMessageBox::warning(this, "Export failed",
+							 QString("The CSV was removed because its provenance sidecar could not be written:\n%1.provenance.json")
 								.arg(path));
 	}
 }

--- a/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.cpp
@@ -22,7 +22,6 @@
 #include <QtCharts/QXYSeries>
 
 #include <cmath>
-
 namespace {
 
 // Reduced-opacity pen for lines that are not the pinned train.
@@ -126,6 +125,11 @@ void DiagramWindow::setCsvProvider(std::function<std::string(const QStringList&)
 	m_csvSuggestedName = suggestedFileName;
 	if (m_csvButton)
 		m_csvButton->setEnabled(static_cast<bool>(m_csvProvider));
+}
+
+void DiagramWindow::setProvenanceWriter(
+		std::function<bool(const QString&, const char*)> writer) {
+	m_provenanceWriter = std::move(writer);
 }
 
 // Shared look for every diagram: quiet grid, readable title, line weight that
@@ -366,6 +370,10 @@ void DiagramWindow::exportPng() {
 	if (!pix.save(path, "PNG")) {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the image to:\n%1").arg(path));
+	} else if (m_provenanceWriter && !m_provenanceWriter(path, "png")) {
+		QMessageBox::warning(this, "Export warning",
+							 QString("The image was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+								.arg(path));
 	}
 }
 
@@ -396,6 +404,10 @@ void DiagramWindow::exportCsv() {
 	if (file.write(bytes) != bytes.size() || !file.commit()) {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the data to:\n%1").arg(path));
+	} else if (m_provenanceWriter && !m_provenanceWriter(path, "csv")) {
+		QMessageBox::warning(this, "Export warning",
+							 QString("The CSV was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+								.arg(path));
 	}
 }
 

--- a/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.h
@@ -41,7 +41,7 @@ public:
 	void setCsvProvider(std::function<std::string(const QStringList& visibleTrainIds)> provider,
 						const QString& suggestedFileName);
 	void setProvenanceWriter(std::function<bool(const QString& artifactPath,
-		const char* artifactKind)> writer);
+		const char* artifactKind, const std::string& artifactBytes)> writer);
 
 signals:
 	void trainSelected(const QString& trainId);  // scene linkage on click
@@ -85,7 +85,7 @@ private:
 	QString m_pinnedTrainId;
 	std::function<std::string(const QStringList&)> m_csvProvider;
 	QString m_csvSuggestedName;
-	std::function<bool(const QString&, const char*)> m_provenanceWriter;
+	std::function<bool(const QString&, const char*, const std::string&)> m_provenanceWriter;
 };
 
 #endif // DIAGRAMWINDOW_H

--- a/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/DiagramWindow.h
@@ -40,6 +40,8 @@ public:
 	// An empty return means there is nothing to export. Enables the CSV button.
 	void setCsvProvider(std::function<std::string(const QStringList& visibleTrainIds)> provider,
 						const QString& suggestedFileName);
+	void setProvenanceWriter(std::function<bool(const QString& artifactPath,
+		const char* artifactKind)> writer);
 
 signals:
 	void trainSelected(const QString& trainId);  // scene linkage on click
@@ -83,6 +85,7 @@ private:
 	QString m_pinnedTrainId;
 	std::function<std::string(const QStringList&)> m_csvProvider;
 	QString m_csvSuggestedName;
+	std::function<bool(const QString&, const char*)> m_provenanceWriter;
 };
 
 #endif // DIAGRAMWINDOW_H

--- a/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
@@ -256,7 +256,7 @@ std::string hashSceneDirectory(const std::string& sceneDirectory) {
 }
 
 RunInputProvenance captureSavedInput(const std::string& savedPath, const std::string& inputKind,
-		bool dirty) {
+		bool dirty, const std::string& savedSha256) {
 	RunInputProvenance result;
 	result.kind = savedPath.empty() ? "unsaved" : inputKind;
 	result.path = savedPath.empty() ? std::string() : absolutePath(savedPath).toStdString();
@@ -270,17 +270,32 @@ RunInputProvenance captureSavedInput(const std::string& savedPath, const std::st
 	const SceneHashResult hash = inputKind == "bundle"
 		? hashBundle(QString::fromStdString(result.path))
 		: hashDirectory(QString::fromStdString(result.path));
-	result.sha256 = hash.hash;
+	const bool changedOnDisk = !savedSha256.empty() && hash.hash != savedSha256;
+	result.sha256 = changedOnDisk ? savedSha256 : hash.hash;
 	if (dirty) {
 		result.status = "non-reproducible";
-		result.reason = hash.reason.empty()
-			? "input is dirty"
-			: "input is dirty; " + hash.reason;
+		result.reason = "input is dirty";
+		if (changedOnDisk)
+			result.reason += "; saved input changed since it was loaded or saved";
+		else if (!hash.reason.empty())
+			result.reason += "; " + hash.reason;
+		return result;
+	}
+	if (changedOnDisk) {
+		result.status = "non-reproducible";
+		result.reason = hash.hash.empty()
+			? hash.reason
+			: "saved input changed since it was loaded or saved";
 		return result;
 	}
 	if (hash.hash.empty()) {
 		result.status = "non-reproducible";
 		result.reason = hash.reason.empty() ? "saved input is missing or unreadable" : hash.reason;
+		return result;
+	}
+	if (savedSha256.empty()) {
+		result.status = "non-reproducible";
+		result.reason = "loaded input snapshot could not be verified";
 		return result;
 	}
 	result.reproducible = true;
@@ -290,14 +305,20 @@ RunInputProvenance captureSavedInput(const std::string& savedPath, const std::st
 
 bool writeRunProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
 		const RunProvenance& run) {
-	return writeSidecar(artifactPath, artifactKind, runJson(run));
+	if (writeSidecar(artifactPath, artifactKind, runJson(run)))
+		return true;
+	QFile::remove(QString::fromStdString(artifactPath));
+	return false;
 }
 
 bool writeDelayProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
 		const RunProvenance& baselineRun, const RunProvenance& scenarioRun) {
 	const QJsonObject baseline = runJson(baselineRun);
 	const QJsonObject scenario = runJson(scenarioRun);
-	return writeSidecar(artifactPath, artifactKind, {}, &baseline, &scenario);
+	if (writeSidecar(artifactPath, artifactKind, {}, &baseline, &scenario))
+		return true;
+	QFile::remove(QString::fromStdString(artifactPath));
+	return false;
 }
 
 std::vector<TimetableResultRow> buildTimetableResults(const std::vector<const Train*>& trains) {

--- a/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
@@ -1,8 +1,19 @@
 #include "diagrams/RunResults.h"
 
+#include "simulation/RollingStock.h"
 #include "util/TrajectoryUtil.h"
 
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
+
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -11,6 +22,146 @@
 #include <utility>
 
 namespace {
+
+struct SceneHashResult {
+	std::string hash;
+	std::string reason;
+};
+
+constexpr std::array<const char*, 6> kRequiredSceneFiles = {
+	"scene.json", "infrastructure.json", "stations.json", "signalling.json",
+	"rolling_stock.json", "services.json"};
+
+QString absolutePath(const std::string& path) {
+	return QFileInfo(QString::fromStdString(path)).absoluteFilePath();
+}
+
+bool readFile(const QString& path, QByteArray& bytes) {
+	QFile file(path);
+	if (!file.open(QIODevice::ReadOnly))
+		return false;
+	bytes = file.readAll();
+	return file.error() == QFile::NoError;
+}
+
+std::string hexDigest(const QByteArray& bytes) {
+	return QCryptographicHash::hash(bytes, QCryptographicHash::Sha256).toHex().toStdString();
+}
+
+SceneHashResult hashBundle(const QString& path) {
+	QByteArray bytes;
+	if (!readFile(path, bytes))
+		return {{}, "saved bundle is missing or unreadable"};
+	return {hexDigest(bytes), {}};
+}
+
+SceneHashResult hashDirectory(const QString& path) {
+	const QDir directory(path);
+	if (!directory.exists())
+		return {{}, "saved scene directory is missing or unreadable"};
+
+	QStringList files;
+	for (const char* required : kRequiredSceneFiles) {
+		const QString file = QString::fromUtf8(required);
+		const QFileInfo info(directory.filePath(file));
+		if (!info.isFile())
+			return {{}, "required scene input is missing or unreadable: " + file.toStdString()};
+		files.append(file);
+	}
+	const QString scenarios = QStringLiteral("scenarios.json");
+	const QString incidents = QStringLiteral("incidents.json");
+	if (QFileInfo(directory.filePath(scenarios)).isFile())
+		files.append(scenarios);
+	if (QFileInfo(directory.filePath(incidents)).isFile())
+		files.append(incidents);
+	if (!files.contains(scenarios) && !files.contains(incidents))
+		return {{}, "required scene input is missing or unreadable: scenarios.json or incidents.json"};
+	const QString passengers = QStringLiteral("passengers.json");
+	if (QFileInfo(directory.filePath(passengers)).isFile())
+		files.append(passengers);
+	files.sort(Qt::CaseSensitive);
+
+	QCryptographicHash hash(QCryptographicHash::Sha256);
+	for (const QString& fileName : files) {
+		QByteArray bytes;
+		if (!readFile(directory.filePath(fileName), bytes))
+			return {{}, "scene input is missing or unreadable: " + fileName.toStdString()};
+		const QByteArray name = fileName.toUtf8();
+		hash.addData(QByteArray::number(name.size()));
+		hash.addData(":");
+		hash.addData(name);
+		hash.addData(":");
+		hash.addData(QByteArray::number(bytes.size()));
+		hash.addData(":");
+		hash.addData(bytes);
+	}
+	return {hash.result().toHex().toStdString(), {}};
+}
+
+QJsonValue finiteJsonNumber(double value) {
+	return std::isfinite(value) ? QJsonValue(value) : QJsonValue();
+}
+
+QJsonObject runJson(const RunProvenance& run) {
+	QJsonObject input;
+	input.insert(QStringLiteral("kind"), QString::fromStdString(run.input.kind));
+	input.insert(QStringLiteral("path"), QString::fromStdString(run.input.path));
+	input.insert(QStringLiteral("sha256"), QString::fromStdString(run.input.sha256));
+	input.insert(QStringLiteral("dirty"), run.input.dirty);
+	input.insert(QStringLiteral("reproducible"), run.input.reproducible);
+	input.insert(QStringLiteral("status"), QString::fromStdString(run.input.status));
+	input.insert(QStringLiteral("reason"), QString::fromStdString(run.input.reason));
+
+	QJsonArray selected;
+	for (const RunOccurrenceProvenance& occurrence : run.selectedOccurrences) {
+		QJsonObject item;
+		item.insert(QStringLiteral("service_id"), QString::fromStdString(occurrence.serviceId));
+		item.insert(QStringLiteral("occurrence"), occurrence.occurrence);
+		item.insert(QStringLiteral("operating_code"), QString::fromStdString(occurrence.operatingCode));
+		selected.append(item);
+	}
+
+	QJsonObject result;
+	result.insert(QStringLiteral("case_name"), QString::fromStdString(run.caseName));
+	result.insert(QStringLiteral("scene_schema_version"), run.sceneSchemaVersion);
+	result.insert(QStringLiteral("input"), input);
+	result.insert(QStringLiteral("applied_scenario"), QString::fromStdString(run.appliedScenario));
+	result.insert(QStringLiteral("base_time_seconds"), finiteJsonNumber(run.baseTimeSeconds));
+	result.insert(QStringLiteral("duration_seconds"), finiteJsonNumber(run.durationSeconds));
+	result.insert(QStringLiteral("timestep_seconds"), finiteJsonNumber(run.timestepSeconds));
+	result.insert(QStringLiteral("buffer_seconds"), finiteJsonNumber(run.bufferSeconds));
+	result.insert(QStringLiteral("recovery_percent"), finiteJsonNumber(run.recoveryPercent));
+	result.insert(QStringLiteral("pax_mode"), run.paxMode);
+	result.insert(QStringLiteral("tsm_mode"), run.tsmMode);
+	result.insert(QStringLiteral("route_choice_mode"), run.routeChoiceMode);
+	result.insert(QStringLiteral("selected_occurrences"), selected);
+	return result;
+}
+
+bool writeSidecar(const std::string& artifactPath, const std::string& artifactKind,
+		const QJsonObject& runObject, const QJsonObject* baselineObject = nullptr,
+		const QJsonObject* scenarioObject = nullptr) {
+	const QString path = QString::fromStdString(artifactPath);
+	QFileInfo artifactInfo(path);
+	QJsonObject artifact;
+	artifact.insert(QStringLiteral("kind"), QString::fromStdString(artifactKind));
+	artifact.insert(QStringLiteral("file_name"), artifactInfo.fileName());
+	QJsonObject root;
+	root.insert(QStringLiteral("schema_version"), 1);
+	root.insert(QStringLiteral("artifact"), artifact);
+	if (baselineObject && scenarioObject) {
+		root.insert(QStringLiteral("baseline_run"), *baselineObject);
+		root.insert(QStringLiteral("scenario_run"), *scenarioObject);
+	} else {
+		root.insert(QStringLiteral("run"), runObject);
+	}
+
+	const QByteArray bytes = QJsonDocument(root).toJson(QJsonDocument::Indented);
+	QSaveFile file(path + QStringLiteral(".provenance.json"));
+	if (!file.open(QIODevice::WriteOnly))
+		return false;
+	return file.write(bytes) == bytes.size() && file.commit();
+}
 
 RunResultValue availableValue(double value) {
 	return std::isfinite(value) ? RunResultValue{true, value} : RunResultValue{};
@@ -95,6 +246,59 @@ void addTotal(const RunResultValue& value, double& sum, bool& complete) {
 }
 
 } // namespace
+
+std::string hashSceneBundle(const std::string& bundlePath) {
+	return hashBundle(absolutePath(bundlePath)).hash;
+}
+
+std::string hashSceneDirectory(const std::string& sceneDirectory) {
+	return hashDirectory(absolutePath(sceneDirectory)).hash;
+}
+
+RunInputProvenance captureSavedInput(const std::string& savedPath, const std::string& inputKind,
+		bool dirty) {
+	RunInputProvenance result;
+	result.kind = savedPath.empty() ? "unsaved" : inputKind;
+	result.path = savedPath.empty() ? std::string() : absolutePath(savedPath).toStdString();
+	result.dirty = dirty;
+	if (savedPath.empty()) {
+		result.status = "non-reproducible";
+		result.reason = "input is unsaved";
+		return result;
+	}
+
+	const SceneHashResult hash = inputKind == "bundle"
+		? hashBundle(QString::fromStdString(result.path))
+		: hashDirectory(QString::fromStdString(result.path));
+	result.sha256 = hash.hash;
+	if (dirty) {
+		result.status = "non-reproducible";
+		result.reason = hash.reason.empty()
+			? "input is dirty"
+			: "input is dirty; " + hash.reason;
+		return result;
+	}
+	if (hash.hash.empty()) {
+		result.status = "non-reproducible";
+		result.reason = hash.reason.empty() ? "saved input is missing or unreadable" : hash.reason;
+		return result;
+	}
+	result.reproducible = true;
+	result.status = "reproducible";
+	return result;
+}
+
+bool writeRunProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
+		const RunProvenance& run) {
+	return writeSidecar(artifactPath, artifactKind, runJson(run));
+}
+
+bool writeDelayProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
+		const RunProvenance& baselineRun, const RunProvenance& scenarioRun) {
+	const QJsonObject baseline = runJson(baselineRun);
+	const QJsonObject scenario = runJson(scenarioRun);
+	return writeSidecar(artifactPath, artifactKind, {}, &baseline, &scenario);
+}
 
 std::vector<TimetableResultRow> buildTimetableResults(const std::vector<const Train*>& trains) {
 	std::vector<TimetableResultRow> results;

--- a/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/RunResults.cpp
@@ -1,10 +1,10 @@
 #include "diagrams/RunResults.h"
 
+#include "scene/SceneModel.h"
 #include "simulation/RollingStock.h"
 #include "util/TrajectoryUtil.h"
 
 #include <QCryptographicHash>
-#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonArray>
@@ -13,7 +13,6 @@
 #include <QSaveFile>
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -27,10 +26,6 @@ struct SceneHashResult {
 	std::string hash;
 	std::string reason;
 };
-
-constexpr std::array<const char*, 6> kRequiredSceneFiles = {
-	"scene.json", "infrastructure.json", "stations.json", "signalling.json",
-	"rolling_stock.json", "services.json"};
 
 QString absolutePath(const std::string& path) {
 	return QFileInfo(QString::fromStdString(path)).absoluteFilePath();
@@ -56,46 +51,10 @@ SceneHashResult hashBundle(const QString& path) {
 }
 
 SceneHashResult hashDirectory(const QString& path) {
-	const QDir directory(path);
-	if (!directory.exists())
-		return {{}, "saved scene directory is missing or unreadable"};
-
-	QStringList files;
-	for (const char* required : kRequiredSceneFiles) {
-		const QString file = QString::fromUtf8(required);
-		const QFileInfo info(directory.filePath(file));
-		if (!info.isFile())
-			return {{}, "required scene input is missing or unreadable: " + file.toStdString()};
-		files.append(file);
-	}
-	const QString scenarios = QStringLiteral("scenarios.json");
-	const QString incidents = QStringLiteral("incidents.json");
-	if (QFileInfo(directory.filePath(scenarios)).isFile())
-		files.append(scenarios);
-	if (QFileInfo(directory.filePath(incidents)).isFile())
-		files.append(incidents);
-	if (!files.contains(scenarios) && !files.contains(incidents))
-		return {{}, "required scene input is missing or unreadable: scenarios.json or incidents.json"};
-	const QString passengers = QStringLiteral("passengers.json");
-	if (QFileInfo(directory.filePath(passengers)).isFile())
-		files.append(passengers);
-	files.sort(Qt::CaseSensitive);
-
-	QCryptographicHash hash(QCryptographicHash::Sha256);
-	for (const QString& fileName : files) {
-		QByteArray bytes;
-		if (!readFile(directory.filePath(fileName), bytes))
-			return {{}, "scene input is missing or unreadable: " + fileName.toStdString()};
-		const QByteArray name = fileName.toUtf8();
-		hash.addData(QByteArray::number(name.size()));
-		hash.addData(":");
-		hash.addData(name);
-		hash.addData(":");
-		hash.addData(QByteArray::number(bytes.size()));
-		hash.addData(":");
-		hash.addData(bytes);
-	}
-	return {hash.result().toHex().toStdString(), {}};
+	const SceneInputSnapshot snapshot = readSceneDirectorySnapshot(path.toStdString());
+	return snapshot.bytes.empty()
+		? SceneHashResult{{}, snapshot.reason}
+		: SceneHashResult{hexDigest(QByteArray::fromStdString(snapshot.bytes)), {}};
 }
 
 QJsonValue finiteJsonNumber(double value) {
@@ -161,6 +120,22 @@ bool writeSidecar(const std::string& artifactPath, const std::string& artifactKi
 	if (!file.open(QIODevice::WriteOnly))
 		return false;
 	return file.write(bytes) == bytes.size() && file.commit();
+}
+
+template <typename SidecarWriter>
+bool writeArtifactWithSidecar(const std::string& artifactPath,
+		const std::string& artifactBytes, SidecarWriter writeProvenance) {
+	const QString path = QString::fromStdString(artifactPath);
+	QSaveFile artifact(path);
+	if (!artifact.open(QIODevice::WriteOnly))
+		return false;
+	const QByteArray bytes = QByteArray::fromStdString(artifactBytes);
+	if (artifact.write(bytes) != bytes.size() || !writeProvenance())
+		return false;
+	if (artifact.commit())
+		return true;
+	QFile::remove(path + QStringLiteral(".provenance.json"));
+	return false;
 }
 
 RunResultValue availableValue(double value) {
@@ -255,6 +230,10 @@ std::string hashSceneDirectory(const std::string& sceneDirectory) {
 	return hashDirectory(absolutePath(sceneDirectory)).hash;
 }
 
+std::string hashSceneInputSnapshot(const std::string& snapshot) {
+	return snapshot.empty() ? std::string() : hexDigest(QByteArray::fromStdString(snapshot));
+}
+
 RunInputProvenance captureSavedInput(const std::string& savedPath, const std::string& inputKind,
 		bool dirty, const std::string& savedSha256) {
 	RunInputProvenance result;
@@ -303,22 +282,22 @@ RunInputProvenance captureSavedInput(const std::string& savedPath, const std::st
 	return result;
 }
 
-bool writeRunProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
+bool writeRunArtifactWithProvenance(const std::string& artifactPath,
+		const std::string& artifactKind, const std::string& artifactBytes,
 		const RunProvenance& run) {
-	if (writeSidecar(artifactPath, artifactKind, runJson(run)))
-		return true;
-	QFile::remove(QString::fromStdString(artifactPath));
-	return false;
+	return writeArtifactWithSidecar(artifactPath, artifactBytes, [&]() {
+		return writeSidecar(artifactPath, artifactKind, runJson(run));
+	});
 }
 
-bool writeDelayProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
+bool writeDelayArtifactWithProvenance(const std::string& artifactPath,
+		const std::string& artifactKind, const std::string& artifactBytes,
 		const RunProvenance& baselineRun, const RunProvenance& scenarioRun) {
 	const QJsonObject baseline = runJson(baselineRun);
 	const QJsonObject scenario = runJson(scenarioRun);
-	if (writeSidecar(artifactPath, artifactKind, {}, &baseline, &scenario))
-		return true;
-	QFile::remove(QString::fromStdString(artifactPath));
-	return false;
+	return writeArtifactWithSidecar(artifactPath, artifactBytes, [&]() {
+		return writeSidecar(artifactPath, artifactKind, {}, &baseline, &scenario);
+	});
 }
 
 std::vector<TimetableResultRow> buildTimetableResults(const std::vector<const Train*>& trains) {

--- a/EGTRAIN/QEGTRAIN/diagrams/RunResults.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/RunResults.h
@@ -40,11 +40,14 @@ struct RunProvenance {
 
 std::string hashSceneBundle(const std::string& bundlePath);
 std::string hashSceneDirectory(const std::string& sceneDirectory);
+std::string hashSceneInputSnapshot(const std::string& snapshot);
 RunInputProvenance captureSavedInput(const std::string& savedPath, const std::string& inputKind,
 		bool dirty, const std::string& savedSha256);
-bool writeRunProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
+bool writeRunArtifactWithProvenance(const std::string& artifactPath,
+		const std::string& artifactKind, const std::string& artifactBytes,
 		const RunProvenance& run);
-bool writeDelayProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
+bool writeDelayArtifactWithProvenance(const std::string& artifactPath,
+		const std::string& artifactKind, const std::string& artifactBytes,
 		const RunProvenance& baselineRun, const RunProvenance& scenarioRun);
 
 struct RunResultValue {

--- a/EGTRAIN/QEGTRAIN/diagrams/RunResults.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/RunResults.h
@@ -1,10 +1,51 @@
 #ifndef RUNRESULTS_H
 #define RUNRESULTS_H
 
-#include "simulation/RollingStock.h"
-
 #include <string>
 #include <vector>
+
+class Train;
+
+struct RunOccurrenceProvenance {
+	std::string serviceId;
+	int occurrence = 1;
+	std::string operatingCode;
+};
+
+struct RunInputProvenance {
+	std::string kind;
+	std::string path;
+	std::string sha256;
+	bool dirty = false;
+	bool reproducible = false;
+	std::string status;
+	std::string reason;
+};
+
+struct RunProvenance {
+	std::string caseName;
+	int sceneSchemaVersion = 0;
+	RunInputProvenance input;
+	std::string appliedScenario;
+	double baseTimeSeconds = 0.0;
+	double durationSeconds = 0.0;
+	double timestepSeconds = 0.0;
+	double bufferSeconds = 0.0;
+	double recoveryPercent = 0.0;
+	int paxMode = 0;
+	int tsmMode = 0;
+	int routeChoiceMode = 0;
+	std::vector<RunOccurrenceProvenance> selectedOccurrences;
+};
+
+std::string hashSceneBundle(const std::string& bundlePath);
+std::string hashSceneDirectory(const std::string& sceneDirectory);
+RunInputProvenance captureSavedInput(const std::string& savedPath, const std::string& inputKind,
+		bool dirty);
+bool writeRunProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
+		const RunProvenance& run);
+bool writeDelayProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
+		const RunProvenance& baselineRun, const RunProvenance& scenarioRun);
 
 struct RunResultValue {
 	bool available = false;
@@ -73,6 +114,7 @@ struct DelayRunSnapshot {
 	double timestep = 0.0;
 	bool hasIncidents = false;
 	bool hasEntranceDelays = false;
+	RunProvenance provenance;
 	RunResults run;
 	std::vector<TimetableResultRow> timetable;
 };

--- a/EGTRAIN/QEGTRAIN/diagrams/RunResults.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/RunResults.h
@@ -41,7 +41,7 @@ struct RunProvenance {
 std::string hashSceneBundle(const std::string& bundlePath);
 std::string hashSceneDirectory(const std::string& sceneDirectory);
 RunInputProvenance captureSavedInput(const std::string& savedPath, const std::string& inputKind,
-		bool dirty);
+		bool dirty, const std::string& savedSha256);
 bool writeRunProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,
 		const RunProvenance& run);
 bool writeDelayProvenanceSidecar(const std::string& artifactPath, const std::string& artifactKind,

--- a/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp
@@ -2,6 +2,7 @@
 #include "diagrams/TrainFilterButton.h"
 #include "util/TimeFormat.h"
 
+#include <QBuffer>
 #include <QBrush>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -22,6 +23,14 @@
 namespace {
 
 constexpr int kSortRole = Qt::UserRole + 1;
+
+bool writeArtifact(const QString& path, const std::string& bytes) {
+	QSaveFile file(path);
+	if (!file.open(QIODevice::WriteOnly))
+		return false;
+	const QByteArray data = QByteArray::fromStdString(bytes);
+	return file.write(data) == data.size() && file.commit();
+}
 
 // Table item that sorts by a numeric key instead of its display text, so time
 // and delay columns order correctly.
@@ -200,21 +209,12 @@ void TimetableTableWindow::exportCsv() {
 		return;
 	if (QFileInfo(path).suffix().compare("csv", Qt::CaseInsensitive) != 0)
 		path += ".csv";
-	QSaveFile file(path);
-	if (!file.open(QIODevice::WriteOnly)) {
+	const bool written = m_hasRunProvenance
+		? writeRunArtifactWithProvenance(path.toStdString(), "csv", content, m_runProvenance)
+		: writeArtifact(path, content);
+	if (!written)
 		QMessageBox::warning(this, "Export failed",
-							 QString("Could not open the file for writing:\n%1").arg(path));
-		return;
-	}
-	const QByteArray bytes = QByteArray::fromStdString(content);
-	if (file.write(bytes) != bytes.size() || !file.commit()) {
-		QMessageBox::warning(this, "Export failed",
-							 QString("Could not write the data to:\n%1").arg(path));
-	} else if (m_hasRunProvenance && !writeRunProvenanceSidecar(path.toStdString(), "csv", m_runProvenance)) {
-		QMessageBox::warning(this, "Export failed",
-							 QString("The CSV was removed because its provenance sidecar could not be written:\n%1.provenance.json")
-								.arg(path));
-	}
+			QString("Could not export the data and provenance to:\n%1").arg(path));
 }
 
 void TimetableTableWindow::exportPng() {
@@ -224,12 +224,18 @@ void TimetableTableWindow::exportPng() {
 	if (QFileInfo(path).suffix().compare("png", Qt::CaseInsensitive) != 0)
 		path += ".png";
 	QPixmap pix = m_table->grab();
-	if (!pix.save(path, "PNG")) {
+	QByteArray data;
+	QBuffer buffer(&data);
+	if (!buffer.open(QIODevice::WriteOnly) || !pix.save(&buffer, "PNG")) {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the image to:\n%1").arg(path));
-	} else if (m_hasRunProvenance && !writeRunProvenanceSidecar(path.toStdString(), "png", m_runProvenance)) {
-		QMessageBox::warning(this, "Export failed",
-							 QString("The image was removed because its provenance sidecar could not be written:\n%1.provenance.json")
-								.arg(path));
+		return;
 	}
+	const std::string bytes(data.constData(), static_cast<std::size_t>(data.size()));
+	const bool written = m_hasRunProvenance
+		? writeRunArtifactWithProvenance(path.toStdString(), "png", bytes, m_runProvenance)
+		: writeArtifact(path, bytes);
+	if (!written)
+		QMessageBox::warning(this, "Export failed",
+			QString("Could not export the image and provenance to:\n%1").arg(path));
 }

--- a/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp
@@ -17,6 +17,7 @@
 #include <QVBoxLayout>
 
 #include <limits>
+#include <utility>
 
 namespace {
 
@@ -101,6 +102,11 @@ TimetableTableWindow::TimetableTableWindow(std::vector<TimetableResultRow> rows,
 	m_trainsButton->setTrains(trains);
 
 	fillTable();
+}
+
+void TimetableTableWindow::setRunProvenance(RunProvenance provenance) {
+	m_runProvenance = std::move(provenance);
+	m_hasRunProvenance = true;
 }
 
 void TimetableTableWindow::fillTable() {
@@ -204,6 +210,10 @@ void TimetableTableWindow::exportCsv() {
 	if (file.write(bytes) != bytes.size() || !file.commit()) {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the data to:\n%1").arg(path));
+	} else if (m_hasRunProvenance && !writeRunProvenanceSidecar(path.toStdString(), "csv", m_runProvenance)) {
+		QMessageBox::warning(this, "Export warning",
+							 QString("The CSV was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+								.arg(path));
 	}
 }
 
@@ -217,5 +227,9 @@ void TimetableTableWindow::exportPng() {
 	if (!pix.save(path, "PNG")) {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the image to:\n%1").arg(path));
+	} else if (m_hasRunProvenance && !writeRunProvenanceSidecar(path.toStdString(), "png", m_runProvenance)) {
+		QMessageBox::warning(this, "Export warning",
+							 QString("The image was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+								.arg(path));
 	}
 }

--- a/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.cpp
@@ -211,8 +211,8 @@ void TimetableTableWindow::exportCsv() {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the data to:\n%1").arg(path));
 	} else if (m_hasRunProvenance && !writeRunProvenanceSidecar(path.toStdString(), "csv", m_runProvenance)) {
-		QMessageBox::warning(this, "Export warning",
-							 QString("The CSV was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+		QMessageBox::warning(this, "Export failed",
+							 QString("The CSV was removed because its provenance sidecar could not be written:\n%1.provenance.json")
 								.arg(path));
 	}
 }
@@ -228,8 +228,8 @@ void TimetableTableWindow::exportPng() {
 		QMessageBox::warning(this, "Export failed",
 							 QString("Could not write the image to:\n%1").arg(path));
 	} else if (m_hasRunProvenance && !writeRunProvenanceSidecar(path.toStdString(), "png", m_runProvenance)) {
-		QMessageBox::warning(this, "Export warning",
-							 QString("The image was written, but its provenance sidecar could not be written:\n%1.provenance.json")
+		QMessageBox::warning(this, "Export failed",
+							 QString("The image was removed because its provenance sidecar could not be written:\n%1.provenance.json")
 								.arg(path));
 	}
 }

--- a/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.h
+++ b/EGTRAIN/QEGTRAIN/diagrams/TimetableTableWindow.h
@@ -22,6 +22,7 @@ public:
 						 long long startOffsetSeconds,
 						 std::function<std::string(const QStringList&)> csvProvider,
 						 QWidget* parent = nullptr);
+	void setRunProvenance(RunProvenance provenance);
 
 private slots:
 	void applyTrainVisibility();
@@ -36,6 +37,8 @@ private:
 	std::function<std::string(const QStringList&)> m_csvProvider;
 	QPointer<QTableWidget> m_table;
 	QPointer<TrainFilterButton> m_trainsButton;
+	RunProvenance m_runProvenance;
+	bool m_hasRunProvenance = false;
 };
 
 #endif // TIMETABLETABLEWINDOW_H

--- a/EGTRAIN/QEGTRAIN/scene/SceneBundle.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneBundle.cpp
@@ -200,7 +200,7 @@ static bool readBoundedFile(const fs::path& path, std::string& contents,
 	return true;
 }
 
-static bool inspectBundle(const fs::path& path, ZipReader& reader, std::vector<ArchiveEntry>& entries,
+static bool readArchiveFile(const fs::path& path, std::string& contents,
 		std::vector<SceneDiagnostic>& diagnostics) {
 	std::error_code ec;
 	const auto status = fs::symlink_status(path, ec);
@@ -209,18 +209,37 @@ static bool inspectBundle(const fs::path& path, ZipReader& reader, std::vector<A
 				path.string());
 		return false;
 	}
-	const std::uintmax_t archiveSize = fs::file_size(path, ec);
+	const std::uintmax_t size = fs::file_size(path, ec);
 	if (ec) {
 		addDiagnostic(diagnostics, "scene.bundle.file.read", "Cannot determine bundle size", path.string());
 		return false;
 	}
-	if (archiveSize > kMaxBundleFileSize) {
+	if (size > kMaxBundleFileSize) {
 		addDiagnostic(diagnostics, "scene.bundle.size", "Bundle file exceeds the 32 MiB compressed limit",
 				path.string());
 		return false;
 	}
+	std::ifstream input(path, std::ios::binary);
+	if (!input) {
+		addDiagnostic(diagnostics, "scene.bundle.file.read", "Cannot open bundle file", path.string());
+		return false;
+	}
+	contents.resize(static_cast<std::size_t>(size));
+	if (size != 0) {
+		input.read(contents.data(), static_cast<std::streamsize>(size));
+		if (!input || static_cast<std::uintmax_t>(input.gcount()) != size) {
+			addDiagnostic(diagnostics, "scene.bundle.file.read", "Cannot read bundle file", path.string());
+			return false;
+		}
+	}
+	return true;
+}
 
-	if (!mz_zip_reader_init_file(&reader.zip, path.string().c_str(), 0)) {
+static bool inspectBundle(const fs::path& path, const std::string& archiveBytes, ZipReader& reader,
+		std::vector<ArchiveEntry>& entries,
+		std::vector<SceneDiagnostic>& diagnostics) {
+	const mz_uint64 archiveSize = archiveBytes.size();
+	if (!mz_zip_reader_init_mem(&reader.zip, archiveBytes.data(), archiveBytes.size(), 0)) {
 		addDiagnostic(diagnostics, "scene.bundle.archive", "Cannot open ZIP bundle: " + zipError(reader.zip),
 				path.string());
 		return false;
@@ -417,9 +436,12 @@ static bool publishPath(const fs::path& staging, const fs::path& target,
 
 SceneLoadResult loadSceneBundle(const std::string& bundlePath) {
 	SceneLoadResult result;
+	std::string archiveBytes;
+	if (!readArchiveFile(fs::path(bundlePath), archiveBytes, result.diagnostics))
+		return result;
 	ZipReader reader;
 	std::vector<ArchiveEntry> entries;
-	if (!inspectBundle(fs::path(bundlePath), reader, entries, result.diagnostics))
+	if (!inspectBundle(fs::path(bundlePath), archiveBytes, reader, entries, result.diagnostics))
 		return result;
 
 	TempDirectory temp;
@@ -427,7 +449,9 @@ SceneLoadResult loadSceneBundle(const std::string& bundlePath) {
 		return result;
 	if (!extractEntries(reader, entries, temp.path, result.diagnostics))
 		return result;
-	return loadScene(temp.path.string());
+	SceneLoadResult loaded = loadScene(temp.path.string());
+	loaded.inputSnapshot = std::move(archiveBytes);
+	return loaded;
 }
 
 SceneLoadResult loadScenePath(const std::string& path) {
@@ -563,15 +587,20 @@ SceneSaveResult saveSceneBundle(const SceneModel& scene, const std::string& bund
 		return result;
 	}
 
+	std::string archiveBytes;
+	if (!readArchiveFile(staging, archiveBytes, result.diagnostics))
+		return result;
 	{
 		ZipReader checkReader;
 		std::vector<ArchiveEntry> checkEntries;
-		if (!inspectBundle(staging, checkReader, checkEntries, result.diagnostics))
+		if (!inspectBundle(staging, archiveBytes, checkReader, checkEntries, result.diagnostics))
 			return result;
 	}
 	if (!publishPath(staging, target, result.diagnostics, "bundle", true))
 		return result;
 	result.wroteAll = !hasErrors(result.diagnostics);
+	if (result.wroteAll)
+		result.inputSnapshot = std::move(archiveBytes);
 	return result;
 }
 
@@ -593,8 +622,11 @@ SceneSaveResult unpackSceneBundle(const std::string& bundlePath, const std::stri
 	}
 
 	ZipReader reader;
+	std::string archiveBytes;
+	if (!readArchiveFile(fs::path(bundlePath), archiveBytes, result.diagnostics))
+		return result;
 	std::vector<ArchiveEntry> entries;
-	if (!inspectBundle(fs::path(bundlePath), reader, entries, result.diagnostics))
+	if (!inspectBundle(fs::path(bundlePath), archiveBytes, reader, entries, result.diagnostics))
 		return result;
 	const fs::path parent = destination.parent_path().empty() ? fs::path(".") : destination.parent_path();
 	std::error_code ec;

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
@@ -17,11 +17,17 @@ namespace fs = std::filesystem;
 namespace {
 
 bool readFile(const fs::path& path, std::string& content) {
-	std::ifstream input(path);
+	std::ifstream input(path, std::ios::binary);
 	if (!input)
 		return false;
 	content.assign(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
 	return true;
+}
+
+bool canonicalSnapshotFile(const std::string& file) {
+	return file == "scene.json" || file == "infrastructure.json" || file == "stations.json"
+			|| file == "signalling.json" || file == "rolling_stock.json" || file == "services.json"
+			|| file == "scenarios.json" || file == "incidents.json" || file == "passengers.json";
 }
 
 std::string joinPath(const std::string& parent, const std::string& key) {
@@ -61,6 +67,86 @@ std::size_t loadedDataIndexForDiagnostic(const SceneModel& scene, const SceneDia
 }
 
 } // namespace
+
+std::string buildSceneDirectorySnapshot(
+		const std::vector<std::pair<std::string, std::string>>& files) {
+	std::vector<std::pair<std::string, std::string>> sorted = files;
+	std::sort(sorted.begin(), sorted.end(), [](const auto& first, const auto& second) {
+		return first.first < second.first;
+	});
+
+	std::string snapshot;
+	for (const auto& file : sorted) {
+		snapshot += std::to_string(file.first.size());
+		snapshot += ':';
+		snapshot += file.first;
+		snapshot += ':';
+		snapshot += std::to_string(file.second.size());
+		snapshot += ':';
+		snapshot += file.second;
+	}
+	return snapshot;
+}
+
+SceneInputSnapshot readSceneDirectorySnapshot(const std::string& sceneDir) {
+	SceneInputSnapshot result;
+	std::error_code ec;
+	if (!fs::is_directory(sceneDir, ec) || ec) {
+		result.reason = "scene directory is missing or unreadable";
+		return result;
+	}
+
+	std::vector<std::pair<std::string, std::string>> files;
+	const auto read = [&](const char* name, bool required) {
+		const fs::path path = fs::path(sceneDir) / name;
+		ec.clear();
+		if (!fs::is_regular_file(path, ec) || ec) {
+			if (required)
+				result.reason = std::string("required scene input is missing or unreadable: ") + name;
+			return !required;
+		}
+		std::string content;
+		if (!readFile(path, content)) {
+			result.reason = std::string("scene input is missing or unreadable: ") + name;
+			return false;
+		}
+		files.emplace_back(name, std::move(content));
+		return true;
+	};
+	const auto exists = [&](const char* name, bool& present) {
+		ec.clear();
+		present = fs::exists(fs::path(sceneDir) / name, ec);
+		if (!ec)
+			return true;
+		result.reason = std::string("scene input is missing or unreadable: ") + name;
+		return false;
+	};
+
+	for (const char* name : {"scene.json", "infrastructure.json", "stations.json", "signalling.json",
+			"rolling_stock.json", "services.json"}) {
+		if (!read(name, true))
+			return result;
+	}
+	bool scenariosPresent = false;
+	bool incidentsPresent = false;
+	if (!exists("scenarios.json", scenariosPresent) || !exists("incidents.json", incidentsPresent))
+		return result;
+	if (!scenariosPresent && !incidentsPresent) {
+		result.reason = "required scene input is missing or unreadable: scenarios.json or incidents.json";
+		return result;
+	}
+	if (scenariosPresent && !read("scenarios.json", true))
+		return result;
+	if (incidentsPresent && !read("incidents.json", true))
+		return result;
+	bool passengersPresent = false;
+	if (!exists("passengers.json", passengersPresent)
+			|| (passengersPresent && !read("passengers.json", true)))
+		return result;
+
+	result.bytes = buildSceneDirectorySnapshot(files);
+	return result;
+}
 
 int sceneServiceOccurrenceCount(const SceneService& service, double durationSeconds) {
 	if (!service.hasRepeat)
@@ -553,13 +639,18 @@ SceneLoadResult loadScene(const std::string& sceneDir) {
 		return result;
 	}
 
-	auto parseObject = [&](const std::string& file, json& value, bool required) {
+	std::vector<std::pair<std::string, std::string>> inputFiles;
+	auto parseObject = [&](const std::string& file, json& value, bool required, bool parseValue = true) {
 		std::string content;
 		if (!readFile(fs::path(sceneDir) / file, content)) {
 			if (required)
 				addError("scene.file.missing", file, "Required file is missing");
 			return false;
 		}
+		if (canonicalSnapshotFile(file))
+			inputFiles.emplace_back(file, content);
+		if (!parseValue)
+			return true;
 		try {
 			value = json::parse(content);
 		} catch (const json::parse_error& error) {
@@ -685,8 +776,7 @@ SceneLoadResult loadScene(const std::string& sceneDir) {
 	const bool scenariosPresent = fs::exists(fs::path(sceneDir) / "scenarios.json");
 	const bool incidentsPresent = fs::exists(fs::path(sceneDir) / "incidents.json");
 	const bool scenariosOk = parseObject("scenarios.json", scenariosJson, scenariosPresent);
-	const bool incidentsOk = !scenariosPresent
-			&& parseObject("incidents.json", incidentsJson, incidentsPresent);
+	const bool incidentsOk = parseObject("incidents.json", incidentsJson, incidentsPresent, !scenariosPresent);
 	const bool passengersOk = parseObject("passengers.json", passengersJson,
 			fs::exists(fs::path(sceneDir) / "passengers.json"));
 	parseObject("views.json", viewsJson, false);
@@ -1308,5 +1398,6 @@ SceneLoadResult loadScene(const std::string& sceneDir) {
 	}
 
 	refreshLoadedDataSummary(result.scene);
+	result.inputSnapshot = buildSceneDirectorySnapshot(inputFiles);
 	return result;
 }

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
@@ -131,10 +131,6 @@ SceneInputSnapshot readSceneDirectorySnapshot(const std::string& sceneDir) {
 	bool incidentsPresent = false;
 	if (!exists("scenarios.json", scenariosPresent) || !exists("incidents.json", incidentsPresent))
 		return result;
-	if (!scenariosPresent && !incidentsPresent) {
-		result.reason = "required scene input is missing or unreadable: scenarios.json or incidents.json";
-		return result;
-	}
 	if (scenariosPresent && !read("scenarios.json", true))
 		return result;
 	if (incidentsPresent && !read("incidents.json", true))

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 struct SceneSimulationSettings {
@@ -321,7 +322,17 @@ const std::vector<SceneIncident>& defaultScenarioIncidents(const SceneModel& sce
 struct SceneLoadResult {
 	SceneModel scene; // partial on structural failure
 	std::vector<SceneDiagnostic> diagnostics;
+	std::string inputSnapshot;
 };
+
+struct SceneInputSnapshot {
+	std::string bytes;
+	std::string reason;
+};
+
+std::string buildSceneDirectorySnapshot(
+		const std::vector<std::pair<std::string, std::string>>& files);
+SceneInputSnapshot readSceneDirectorySnapshot(const std::string& sceneDir);
 
 SceneLoadResult loadScene(const std::string& sceneDir);
 void refreshLoadedDataSummary(SceneModel& scene);

--- a/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
@@ -28,17 +28,20 @@ static void addWriteError(SceneSaveResult& result, const std::string& file,
 }
 
 static bool writeJsonFile(SceneSaveResult& result, const fs::path& scenePath,
-		const std::string& filename, const json& value) {
-	std::ofstream output(scenePath / filename);
+		const std::string& filename, const json& value, std::string* writtenBytes = nullptr) {
+	const std::string bytes = value.dump(4) + "\n";
+	std::ofstream output(scenePath / filename, std::ios::binary);
 	if (!output) {
 		addWriteError(result, filename, "Cannot open " + filename + " for writing");
 		return false;
 	}
-	output << value.dump(4) << "\n";
+	output.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
 	if (!output) {
 		addWriteError(result, filename, "Cannot write " + filename);
 		return false;
 	}
+	if (writtenBytes)
+		*writtenBytes = bytes;
 	return true;
 }
 
@@ -570,17 +573,25 @@ SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) 
 		signalling["station_boundaries"].push_back(value);
 	}
 
+	std::vector<std::pair<std::string, std::string>> inputFiles;
+	const auto writeCanonical = [&](const std::string& filename, const json& value) {
+		std::string bytes;
+		const bool written = writeJsonFile(result, scenePath, filename, value, &bytes);
+		if (written)
+			inputFiles.emplace_back(filename, std::move(bytes));
+		return written;
+	};
 	bool wroteAll = true;
-	wroteAll = writeJsonFile(result, scenePath, "scene.json", sceneJson) && wroteAll;
-	wroteAll = writeJsonFile(result, scenePath, "infrastructure.json", infrastructure) && wroteAll;
-	wroteAll = writeJsonFile(result, scenePath, "stations.json", {{"stations", stations}}) && wroteAll;
-	wroteAll = writeJsonFile(result, scenePath, "signalling.json", signalling) && wroteAll;
-	wroteAll = writeJsonFile(result, scenePath, "rolling_stock.json",
+	wroteAll = writeCanonical("scene.json", sceneJson) && wroteAll;
+	wroteAll = writeCanonical("infrastructure.json", infrastructure) && wroteAll;
+	wroteAll = writeCanonical("stations.json", {{"stations", stations}}) && wroteAll;
+	wroteAll = writeCanonical("signalling.json", signalling) && wroteAll;
+	wroteAll = writeCanonical("rolling_stock.json",
 			{{"train_units", writeTrainUnits(scene)}, {"compositions", writeCompositions(scene)}}) && wroteAll;
-	wroteAll = writeJsonFile(result, scenePath, "services.json", {{"services", writeServices(scene)}}) && wroteAll;
-	wroteAll = writeJsonFile(result, scenePath, "scenarios.json", writeScenarios(scene)) && wroteAll;
+	wroteAll = writeCanonical("services.json", {{"services", writeServices(scene)}}) && wroteAll;
+	wroteAll = writeCanonical("scenarios.json", writeScenarios(scene)) && wroteAll;
 	if (!scene.passengers.empty()) {
-		wroteAll = writeJsonFile(result, scenePath, "passengers.json", writePassengers(scene)) && wroteAll;
+		wroteAll = writeCanonical("passengers.json", writePassengers(scene)) && wroteAll;
 	}
 
 	// Keep the old flat file until every new canonical file was persisted.
@@ -603,5 +614,7 @@ SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) 
 	}
 
 	result.wroteAll = wroteAll && !hasErrors(result.diagnostics);
+	if (result.wroteAll)
+		result.inputSnapshot = buildSceneDirectorySnapshot(inputFiles);
 	return result;
 }

--- a/EGTRAIN/QEGTRAIN/scene/SceneWriter.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneWriter.h
@@ -10,6 +10,7 @@
 struct SceneSaveResult {
 	bool wroteAll = false;
 	std::vector<SceneDiagnostic> diagnostics;
+	std::string inputSnapshot;
 	bool success() const;
 };
 

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -3,10 +3,47 @@
 #include "scene/SectionInventory.h"
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 extern Logger owl;
+
+namespace {
+
+struct ConnectedSectionIdentity {
+	std::string firstBlockId;
+	std::string secondBlockId;
+	double firstCoordinate = 0.0;
+	double secondCoordinate = 0.0;
+};
+
+bool parseConnectedSectionPart(const std::string& part, std::string& blockId, double& coordinate) {
+	if (part.empty() || part.front() != '@')
+		return false;
+	const std::size_t blockEnd = part.find('@', 1);
+	if (blockEnd == std::string::npos || blockEnd + 2 > part.size() || part[blockEnd + 1] != '-')
+		return false;
+	const std::string coordinateText = part.substr(blockEnd + 2);
+	char* end = nullptr;
+	coordinate = std::strtod(coordinateText.c_str(), &end);
+	if (end == coordinateText.c_str() || *end != '\0' || !std::isfinite(coordinate))
+		return false;
+	blockId = part.substr(0, blockEnd + 1);
+	return true;
+}
+
+bool parseConnectedSectionIdentity(const std::string& id, ConnectedSectionIdentity& result) {
+	const std::size_t separator = id.find('/');
+	return separator != std::string::npos
+			&& id.find('/', separator + 1) == std::string::npos
+			&& parseConnectedSectionPart(id.substr(0, separator), result.firstBlockId,
+				result.firstCoordinate)
+			&& parseConnectedSectionPart(id.substr(separator + 1), result.secondBlockId,
+				result.secondCoordinate);
+}
+
+} // namespace
 
 
 TrainEvent::TrainEvent() {
@@ -3343,12 +3380,6 @@ void occupyBlockAndConnected(const Section& BLS, const Section& BLSPrev, double 
 					BlocksConnected.push_back(IDToFree[i]);
 			}
 		}
-		// only for the Copenhagen case where double switches are used for the rail crossings X
-
-		if (BLS.ID == "@5-B6@")
-			; // BlocksOccupied.push_back("@1-B30@-4.592000/@5-B7@-4.620000");
-			  // if (BLS.ID == "@1-B30@-4.592000/@5-B7@-4.620000")
-		//	BlocksOccupied.push_back("@5-B6@");
 	}
 	// fill only with previous signalling_block_sections
 	/*else {
@@ -3406,31 +3437,11 @@ void occupyDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
 
 		{
 			// occupy connected single signalling_block_sections
-
-			// Defining the token of this connected Block the first token is the ID of the first block section, the second token is instead the ID of the second block section
-			string tok1[10];
-			int N_tok1 = 0;
-			string BlockID1, BlockID2;
-			char* p = strtok((char*)BLS.ID.c_str(), "/-");
-			while (p != NULL) {
-				tok1[N_tok1] = p;
-				p = strtok(NULL, "/-");
-				N_tok1++;
-			}
-			BlockID1 = tok1[0] + "-" + tok1[1];
-			BlockID2 = tok1[3] + "-" + tok1[4];
-			// Identify the TrackLine ID of BlockID1 and BlockID2;
-			int TrackLineIDBlock1 = -1, TrackLineIDBlock2 = -1;
-			TrackLineIDBlock1 = atoi(strtok((char*)tok1[1].c_str(), "B@"));
-			TrackLineIDBlock2 = atoi(strtok((char*)tok1[4].c_str(), "B@"));
-
-			/*//if TrackLineIDPrevBS is -1 or is equal to the trackLineId of the previous block section leave everything as it is otherwise
-			if (TrackLineIDBlock2 == TrackLineIDPrevBS) {//if the trackLineId of the second block section is equal to the one of the previous block section then invert BlockID1 and BlockID2
-				string TEMPBlockID;
-				TEMPBlockID = BlockID2;
-				BlockID2 = BlockID1;
-				BlockID1 = TEMPBlockID;
-			}*/
+			ConnectedSectionIdentity identity;
+			if (!parseConnectedSectionIdentity(BLS.ID, identity))
+				continue;
+			const string& BlockID1 = identity.firstBlockId;
+			const string& BlockID2 = identity.secondBlockId;
 
 			// Adding ID of Connected Block Sections to the lists BlocksOccupied and BlocksConnected
 			string IDToAdd[2];
@@ -3553,22 +3564,15 @@ void releaseDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
 			bool IsInBlocksConnected[40]; // These contain the ID of Block Sections, the test to see if that ID is present in the BlocksConnected
 			IDToAdd[0] = BLS.ID;
 			IsInBlocksConnected[0] = false; // The first element of the array is the ID of BLS
-											// Defining the token of this connected Block the first token is the ID of the first block section, the second token is instead the ID of the second block section
-			string tok1[10];
-			int N_tok1 = 0;
-			string BlockID1, BlockID2;
-			char* p = strtok((char*)BLS.ID.c_str(), "/-");
-			while (p != NULL) {
-				tok1[N_tok1] = p;
-				p = strtok(NULL, "/-");
-				N_tok1++;
+			ConnectedSectionIdentity identity;
+			if (!parseConnectedSectionIdentity(BLS.ID, identity)) {
+				delete[] IDToAdd;
+				continue;
 			}
-			BlockID1 = tok1[0] + "-" + tok1[1];
-			BlockID2 = tok1[3] + "-" + tok1[4];
 			// Adding ID of Connected Block Sections to the lists BlocksOccupied and BlocksConnected
-			IDToAdd[1] = BlockID1;
+			IDToAdd[1] = identity.firstBlockId;
 			IsInBlocksConnected[1] = false;
-			IDToAdd[2] = BlockID2;
+			IDToAdd[2] = identity.secondBlockId;
 			IsInBlocksConnected[2] = false;
 			for (int i = 0; i < BLS.N_ConnectedBS; i++) {
 				IDToAdd[i + 3] = BLS.IDConnectedBS[i];
@@ -3588,10 +3592,10 @@ void releaseDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
 			Section branchBS1, branchBS2;
 			bool branch1 = false, branch2 = false;
 			for (int b = 0; b < Blocks; b++) {
-				if (::signalling_block_sections[b].ID == BlockID1) {
+				if (::signalling_block_sections[b].ID == identity.firstBlockId) {
 					branchBS1 = ::signalling_block_sections[b];
 					branch1 = true;
-				} else if (::signalling_block_sections[b].ID == BlockID2) {
+				} else if (::signalling_block_sections[b].ID == identity.secondBlockId) {
 					branchBS2 = ::signalling_block_sections[b];
 					branch2 = true;
 				}
@@ -3642,31 +3646,14 @@ void unlockDoubleSwitches() {
 
 // Function to Activate blocks connected with block sections having switches in diverging position
 void activateBlocksWithSwitchesDiv(const Section& BS, int TrackLineIDPrevBS, double S) {
-	// Defining the token of this connected Block the first token is the ID of the first block section, the second token is instead the ID of the second block section
-	string tok1[10];
-	int N_tok1 = 0;
-	string BlockID1, BlockID2;
-	char* p = strtok((char*)BS.ID.c_str(), "/-");
-	while (p != NULL) {
-		tok1[N_tok1] = p;
-		p = strtok(NULL, "/-");
-		N_tok1++;
-	}
-	BlockID1 = tok1[0] + "-" + tok1[1];
-	BlockID2 = tok1[3] + "-" + tok1[4];
-	// Identify the TrackLine ID of BlockID1 and BlockID2;
-	int TrackLineIDBlock1 = -1, TrackLineIDBlock2 = -1;
-	// A simple (non switch-transition) block ID has only two tokens, so tok1[4]
-	// is empty and strtok returns NULL; guard against atoi(NULL) dereferencing.
-	{
-		char* trackTok1 = strtok((char*)tok1[1].c_str(), "B@");
-		char* trackTok2 = strtok((char*)tok1[4].c_str(), "B@");
-		TrackLineIDBlock1 = trackTok1 ? atoi(trackTok1) : -1;
-		TrackLineIDBlock2 = trackTok2 ? atoi(trackTok2) : -1;
-	}
+	ConnectedSectionIdentity identity;
+	if (!parseConnectedSectionIdentity(BS.ID, identity))
+		return;
+	string BlockID1 = identity.firstBlockId;
+	string BlockID2 = identity.secondBlockId;
 
 	// if TrackLineIDPrevBS is -1 or is equal to the trackLineId of the previous block section leave everything as it is otherwise
-	if (TrackLineIDBlock2 == TrackLineIDPrevBS) { // if the trackLineId of the second block section is equal to the one of the previous block section then invert BlockID1 and BlockID2
+	if (BS.SecondConnectedTrackLineID == TrackLineIDPrevBS) { // if the trackLineId of the second block section is equal to the one of the previous block section then invert BlockID1 and BlockID2
 		string TEMPBlockID;
 		TEMPBlockID = BlockID2;
 		BlockID2 = BlockID1;
@@ -3725,31 +3712,14 @@ void activateBlocksWithSwitchesDiv(const Section& BS, int TrackLineIDPrevBS, dou
 
 // Function to Activate blocks connected with block sections having switches in diverging position
 void activateBlocksWithSwitchesDivFixedBlock(const Section& BS, int TrackLineIDPrevBS, double S) {
-	// Defining the token of this connected Block the first token is the ID of the first block section, the second token is instead the ID of the second block section
-	string tok1[10];
-	int N_tok1 = 0;
-	string BlockID1, BlockID2;
-	char* p = strtok((char*)BS.ID.c_str(), "/-");
-	while (p != NULL) {
-		tok1[N_tok1] = p;
-		p = strtok(NULL, "/-");
-		N_tok1++;
-	}
-	BlockID1 = tok1[0] + "-" + tok1[1];
-	BlockID2 = tok1[3] + "-" + tok1[4];
-	// Identify the TrackLine ID of BlockID1 and BlockID2;
-	int TrackLineIDBlock1 = -1, TrackLineIDBlock2 = -1;
-	// A simple (non switch-transition) block ID has only two tokens, so tok1[4]
-	// is empty and strtok returns NULL; guard against atoi(NULL) dereferencing.
-	{
-		char* trackTok1 = strtok((char*)tok1[1].c_str(), "B@");
-		char* trackTok2 = strtok((char*)tok1[4].c_str(), "B@");
-		TrackLineIDBlock1 = trackTok1 ? atoi(trackTok1) : -1;
-		TrackLineIDBlock2 = trackTok2 ? atoi(trackTok2) : -1;
-	}
+	ConnectedSectionIdentity identity;
+	if (!parseConnectedSectionIdentity(BS.ID, identity))
+		return;
+	string BlockID1 = identity.firstBlockId;
+	string BlockID2 = identity.secondBlockId;
 
 	// if TrackLineIDPrevBS is -1 or is equal to the trackLineId of the previous block section leave everything as it is otherwise
-	if (TrackLineIDBlock2 == TrackLineIDPrevBS) { // if the trackLineId of the second block section is equal to the one of the previous block section then invert BlockID1 and BlockID2
+	if (BS.SecondConnectedTrackLineID == TrackLineIDPrevBS) { // if the trackLineId of the second block section is equal to the one of the previous block section then invert BlockID1 and BlockID2
 		string TEMPBlockID;
 		TEMPBlockID = BlockID2;
 		BlockID2 = BlockID1;
@@ -3818,22 +3788,15 @@ void releaseLastBlockAndConnected(const Section& BLS) {
 		bool IsInBlocksConnected[40]; // These contain the ID of Block Sections, the test to see if that ID is present in the BlocksConnected
 		IDToAdd[0] = BLS.ID;
 		IsInBlocksConnected[0] = false; // The first element of the array is the ID of BLS
-										// Defining the token of this connected Block the first token is the ID of the first block section, the second token is instead the ID of the second block section
-		string tok1[10];
-		int N_tok1 = 0;
-		string BlockID1, BlockID2;
-		char* p = strtok((char*)BLS.ID.c_str(), "/-");
-		while (p != NULL) {
-			tok1[N_tok1] = p;
-			p = strtok(NULL, "/-");
-			N_tok1++;
+		ConnectedSectionIdentity identity;
+		if (!parseConnectedSectionIdentity(BLS.ID, identity)) {
+			delete[] IDToAdd;
+			return;
 		}
-		BlockID1 = tok1[0] + "-" + tok1[1];
-		BlockID2 = tok1[3] + "-" + tok1[4];
 		// Adding ID of Connected Block Sections to the lists BlocksOccupied and BlocksConnected
-		IDToAdd[1] = BlockID1;
+		IDToAdd[1] = identity.firstBlockId;
 		IsInBlocksConnected[1] = false;
-		IDToAdd[2] = BlockID2;
+		IDToAdd[2] = identity.secondBlockId;
 		IsInBlocksConnected[2] = false;
 		for (int i = 0; i < BLS.N_ConnectedBS; i++) {
 			IDToAdd[i + 3] = BLS.IDConnectedBS[i];
@@ -3893,21 +3856,14 @@ void lockSwitchesOnAllConnectedSections(double FrontEndPos, double BackEndPos, d
 		if (ListBlocksConnected.size() > 0) {
 			for (list<string>::iterator h = ListBlocksConnected.begin(); h != ListBlocksConnected.end(); h++) {
 				MovementAuthority MA1, MA2, MA3;
-				string tok1[10];
-				int N_tok1 = 0;
-				string BlockID1, BlockID2; // The ID of the first and the second blocks connected by the switch
-				double SwitchStartPos, SwitchEndPos;
 				string ConnectedBlockName = *h;
-				char* p = strtok((char*)ConnectedBlockName.c_str(), "/-");
-				while (p != NULL) {
-					tok1[N_tok1] = p;
-					p = strtok(NULL, "/-");
-					N_tok1++;
-				}
-				BlockID1 = tok1[0] + "-" + tok1[1];
-				BlockID2 = tok1[3] + "-" + tok1[4];
-				SwitchStartPos = atof((char*)tok1[2].c_str());
-				SwitchEndPos = atof((char*)tok1[5].c_str());
+				ConnectedSectionIdentity identity;
+				if (!parseConnectedSectionIdentity(ConnectedBlockName, identity))
+					continue;
+				const string& BlockID1 = identity.firstBlockId;
+				const string& BlockID2 = identity.secondBlockId;
+				const double SwitchStartPos = identity.firstCoordinate;
+				const double SwitchEndPos = identity.secondCoordinate;
 				// We do not need to block the switch edge connected to a non-diverging block connected with Block signalling_block_sections, but just the switch edge on Block signalling_block_sections and the switch edges on the connected Blocks with Switch Div=true. In this way we allow trains on non-diverging block connected with signalling_block_sections to go ahead flawlessly
 				string RightSectionToConsider;
 				double RightSwitchEdgeToConsider = 0.0;
@@ -4049,29 +4005,11 @@ void elaborateRbcMas(double S_i, double V_i, double Acc_i, const Section& BLS, c
 void elaborateMaOnBlockSectionsWithSwitchDiv(double S_i, double V_i, double Acc_i, const Section& BS, const string& trainDescription, const Route& TrainRoute, const string& typePart) {
 	// the string of the next block section ID
 	string NextSectionID;
-	// Defining the token of this connected Block the first token is the ID of the first block section, the second token is instead the ID of the second block section
-	string tok1[10];
-	int N_tok1 = 0;
-	string BlockID1, BlockID2; // The ID of the first and the second blocks connected by the switch
-	string BSID = BS.ID;
-	char* p = strtok((char*)BSID.c_str(), "/-");
-	while (p != NULL) {
-		tok1[N_tok1] = p;
-		p = strtok(NULL, "/-");
-		N_tok1++;
-	}
-	BlockID1 = tok1[0] + "-" + tok1[1];
-	BlockID2 = tok1[3] + "-" + tok1[4];
-	// Identify the TrackLine ID of BlockID1 and BlockID2;
-	int TrackLineIDBlock1 = -1, TrackLineIDBlock2 = -1;
-	// A simple (non switch-transition) block ID has only two tokens, so tok1[4]
-	// is empty and strtok returns NULL; guard against atoi(NULL) dereferencing.
-	{
-		char* trackTok1 = strtok((char*)tok1[1].c_str(), "B@");
-		char* trackTok2 = strtok((char*)tok1[4].c_str(), "B@");
-		TrackLineIDBlock1 = trackTok1 ? atoi(trackTok1) : -1;
-		TrackLineIDBlock2 = trackTok2 ? atoi(trackTok2) : -1;
-	}
+	ConnectedSectionIdentity identity;
+	if (!parseConnectedSectionIdentity(BS.ID, identity))
+		return;
+	string BlockID1 = identity.firstBlockId;
+	string BlockID2 = identity.secondBlockId;
 
 	// Identifying the next section ID
 	for (int b = 0; b < TrainRoute.N_Block_Sections; b++) {
@@ -4131,29 +4069,11 @@ void elaborateMaOnBlockSectionsWithSwitchDiv(double S_i, double V_i, double Acc_
 void lockSwitchesWhileTrainTraverses(double FrontEndPos, double BackEndPos, double V_i, double Acc_i, const Section& BLS, const string& trainDescription, const Route& TrainRoute, const string& typePart) {
 	// Defining the next block section ID on the route of the train after BLS
 	string NextSectionID;
-
-	string tok1[10];
-	int N_tok1 = 0;
-	string BlockID1, BlockID2; // The ID of the first and the second blocks connected by the switch
-	string BSID = BLS.ID;
-	char* p = strtok((char*)BSID.c_str(), "/-");
-	while (p != NULL) {
-		tok1[N_tok1] = p;
-		p = strtok(NULL, "/-");
-		N_tok1++;
-	}
-	BlockID1 = tok1[0] + "-" + tok1[1];
-	BlockID2 = tok1[3] + "-" + tok1[4];
-	// Identify the TrackLine ID of BlockID1 and BlockID2;
-	int TrackLineIDBlock1 = -1, TrackLineIDBlock2 = -1;
-	// A simple (non switch-transition) block ID has only two tokens, so tok1[4]
-	// is empty and strtok returns NULL; guard against atoi(NULL) dereferencing.
-	{
-		char* trackTok1 = strtok((char*)tok1[1].c_str(), "B@");
-		char* trackTok2 = strtok((char*)tok1[4].c_str(), "B@");
-		TrackLineIDBlock1 = trackTok1 ? atoi(trackTok1) : -1;
-		TrackLineIDBlock2 = trackTok2 ? atoi(trackTok2) : -1;
-	}
+	ConnectedSectionIdentity identity;
+	if (!parseConnectedSectionIdentity(BLS.ID, identity))
+		return;
+	string BlockID1 = identity.firstBlockId;
+	string BlockID2 = identity.secondBlockId;
 
 	// Identifying the next section ID
 	for (int b = 0; b < TrainRoute.N_Block_Sections; b++) {

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -21,7 +21,7 @@ struct ConnectedSectionIdentity {
 bool parseConnectedSectionPart(const std::string& part, std::string& blockId, double& coordinate) {
 	if (part.empty() || part.front() != '@')
 		return false;
-	const std::size_t blockEnd = part.find('@', 1);
+	const std::size_t blockEnd = part.rfind('@');
 	if (blockEnd == std::string::npos || blockEnd + 2 > part.size() || part[blockEnd + 1] != '-')
 		return false;
 	const std::string coordinateText = part.substr(blockEnd + 2);

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -3404,9 +3404,24 @@ void occupyDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
 		return;
 	}
 
-	std::list<const Section*> doubleSwitchBS = {&BLS, &BLSPrev};
-	for (auto itBS = doubleSwitchBS.begin(); itBS != doubleSwitchBS.end(); ++itBS) {
-		const auto& BLS = **itBS;
+	const Section* doubleSwitchBS[2] = {&BLS, &BLSPrev};
+	ConnectedSectionIdentity identities[2];
+	Section* branchSections[2][2] = {};
+	for (int switchIndex = 0; switchIndex < 2; ++switchIndex) {
+		if (!parseConnectedSectionIdentity(doubleSwitchBS[switchIndex]->ID, identities[switchIndex]))
+			return;
+		for (int blockIndex = 0; blockIndex < Blocks; ++blockIndex) {
+			if (::signalling_block_sections[blockIndex].ID == identities[switchIndex].firstBlockId)
+				branchSections[switchIndex][0] = &::signalling_block_sections[blockIndex];
+			else if (::signalling_block_sections[blockIndex].ID == identities[switchIndex].secondBlockId)
+				branchSections[switchIndex][1] = &::signalling_block_sections[blockIndex];
+		}
+		if (!branchSections[switchIndex][0] || !branchSections[switchIndex][1])
+			return;
+	}
+
+	for (int switchIndex = 0; switchIndex < 2; ++switchIndex) {
+		const auto& BLS = *doubleSwitchBS[switchIndex];
 
 		// occupy compound signalling_block_sections
 		{
@@ -3437,9 +3452,7 @@ void occupyDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
 
 		{
 			// occupy connected single signalling_block_sections
-			ConnectedSectionIdentity identity;
-			if (!parseConnectedSectionIdentity(BLS.ID, identity))
-				continue;
+			const ConnectedSectionIdentity& identity = identities[switchIndex];
 			const string& BlockID1 = identity.firstBlockId;
 			const string& BlockID2 = identity.secondBlockId;
 
@@ -3472,25 +3485,9 @@ void occupyDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
 					BlocksConnected.push_back(IDToAdd[h]);
 			}
 
-			// find signalling_block_sections from other branches
-			Section *branchBS1 = nullptr, *branchBS2 = nullptr;
-			bool branch1 = false, branch2 = false;
-			for (int b = 0; b < Blocks; b++) {
-				if (::signalling_block_sections[b].ID == BlockID1) {
-					branchBS1 = &::signalling_block_sections[b];
-					branch1 = true;
-				} else if (::signalling_block_sections[b].ID == BlockID2) {
-					branchBS2 = &::signalling_block_sections[b];
-					branch2 = true;
-				}
-				// found both signalling_block_sections
-				if (branch1 && branch2) {
-					break;
-				}
-			}
-
 			// occupy compound signalling_block_sections connected to single signalling_block_sections (other branches of double switch)
-			std::list<Section*> branchBS = {branchBS1, branchBS2};
+			std::list<Section*> branchBS = {
+				branchSections[switchIndex][0], branchSections[switchIndex][1]};
 			for (auto itb = branchBS.begin(); itb != branchBS.end(); ++itb) {
 				const auto& BLS = **itb;
 

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -43,6 +43,26 @@ bool parseConnectedSectionIdentity(const std::string& id, ConnectedSectionIdenti
 				result.secondCoordinate);
 }
 
+bool resolveDoubleSwitchSections(const Section& current, const Section& previous,
+		const Section* sections[2], ConnectedSectionIdentity identities[2],
+		Section* branches[2][2]) {
+	sections[0] = &current;
+	sections[1] = &previous;
+	for (int switchIndex = 0; switchIndex < 2; ++switchIndex) {
+		if (!parseConnectedSectionIdentity(sections[switchIndex]->ID, identities[switchIndex]))
+			return false;
+		for (int blockIndex = 0; blockIndex < Blocks; ++blockIndex) {
+			if (::signalling_block_sections[blockIndex].ID == identities[switchIndex].firstBlockId)
+				branches[switchIndex][0] = &::signalling_block_sections[blockIndex];
+			else if (::signalling_block_sections[blockIndex].ID == identities[switchIndex].secondBlockId)
+				branches[switchIndex][1] = &::signalling_block_sections[blockIndex];
+		}
+		if (!branches[switchIndex][0] || !branches[switchIndex][1])
+			return false;
+	}
+	return true;
+}
+
 } // namespace
 
 
@@ -3399,26 +3419,11 @@ void occupyBlockAndConnected(const Section& BLS, const Section& BLSPrev, double 
 
 // Function to occupy a double switch
 void occupyDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
-	// prevent cases not crossing the full double switch (e.g. region jumps)
-	if (BLS.ID.find('/') == std::string::npos || BLSPrev.ID.find('/') == std::string::npos) {
-		return;
-	}
-
-	const Section* doubleSwitchBS[2] = {&BLS, &BLSPrev};
+	const Section* doubleSwitchBS[2] = {};
 	ConnectedSectionIdentity identities[2];
 	Section* branchSections[2][2] = {};
-	for (int switchIndex = 0; switchIndex < 2; ++switchIndex) {
-		if (!parseConnectedSectionIdentity(doubleSwitchBS[switchIndex]->ID, identities[switchIndex]))
-			return;
-		for (int blockIndex = 0; blockIndex < Blocks; ++blockIndex) {
-			if (::signalling_block_sections[blockIndex].ID == identities[switchIndex].firstBlockId)
-				branchSections[switchIndex][0] = &::signalling_block_sections[blockIndex];
-			else if (::signalling_block_sections[blockIndex].ID == identities[switchIndex].secondBlockId)
-				branchSections[switchIndex][1] = &::signalling_block_sections[blockIndex];
-		}
-		if (!branchSections[switchIndex][0] || !branchSections[switchIndex][1])
-			return;
-	}
+	if (!resolveDoubleSwitchSections(BLS, BLSPrev, doubleSwitchBS, identities, branchSections))
+		return;
 
 	for (int switchIndex = 0; switchIndex < 2; ++switchIndex) {
 		const auto& BLS = *doubleSwitchBS[switchIndex];
@@ -3522,14 +3527,14 @@ void occupyDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
 
 // Function to release a double switch
 void releaseDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
-	// prevent cases not crossing the full double switch (e.g. region jumps)
-	if (BLS.ID.find('/') == std::string::npos || BLSPrev.ID.find('/') == std::string::npos) {
+	const Section* doubleSwitchBS[2] = {};
+	ConnectedSectionIdentity identities[2];
+	Section* branchSections[2][2] = {};
+	if (!resolveDoubleSwitchSections(BLS, BLSPrev, doubleSwitchBS, identities, branchSections))
 		return;
-	}
 
-	std::list<const Section*> doubleSwitchBS = {&BLS, &BLSPrev};
-	for (auto it = doubleSwitchBS.begin(); it != doubleSwitchBS.end(); ++it) {
-		const auto& BLS = **it;
+	for (int switchIndex = 0; switchIndex < 2; ++switchIndex) {
+		const auto& BLS = *doubleSwitchBS[switchIndex];
 
 		string* IDToAdd;
 		// Load the BLS ID and the ones of the connected Blocks in the BlocksConnected list when the former has not a diverging switch
@@ -3561,11 +3566,7 @@ void releaseDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
 			bool IsInBlocksConnected[40]; // These contain the ID of Block Sections, the test to see if that ID is present in the BlocksConnected
 			IDToAdd[0] = BLS.ID;
 			IsInBlocksConnected[0] = false; // The first element of the array is the ID of BLS
-			ConnectedSectionIdentity identity;
-			if (!parseConnectedSectionIdentity(BLS.ID, identity)) {
-				delete[] IDToAdd;
-				continue;
-			}
+			const ConnectedSectionIdentity& identity = identities[switchIndex];
 			// Adding ID of Connected Block Sections to the lists BlocksOccupied and BlocksConnected
 			IDToAdd[1] = identity.firstBlockId;
 			IsInBlocksConnected[1] = false;
@@ -3585,26 +3586,9 @@ void releaseDoubleSwitch(const Section& BLS, const Section& BLSPrev) {
 					BlocksConnected.push_back(IDToAdd[i]);
 			}
 
-			// find signalling_block_sections from other branches
-			Section branchBS1, branchBS2;
-			bool branch1 = false, branch2 = false;
-			for (int b = 0; b < Blocks; b++) {
-				if (::signalling_block_sections[b].ID == identity.firstBlockId) {
-					branchBS1 = ::signalling_block_sections[b];
-					branch1 = true;
-				} else if (::signalling_block_sections[b].ID == identity.secondBlockId) {
-					branchBS2 = ::signalling_block_sections[b];
-					branch2 = true;
-				}
-				// found both signalling_block_sections
-				if (branch1 && branch2) {
-					break;
-				}
-			}
-
 			// release compound signalling_block_sections connected to single signalling_block_sections (other branches of double switch)
-			releaseLastBlockAndConnected(branchBS1);
-			releaseLastBlockAndConnected(branchBS2);
+			releaseLastBlockAndConnected(*branchSections[switchIndex][0]);
+			releaseLastBlockAndConnected(*branchSections[switchIndex][1]);
 		}
 		delete[] IDToAdd;
 	}

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -1,5 +1,6 @@
 #include "diagrams/RunResults.h"
 
+#include "scene/SceneModel.h"
 #include "simulation/RollingStock.h"
 #include "simulation/Simulation.h"
 #include "util/Logger.hpp"
@@ -34,6 +35,14 @@ static bool closeTo(double actual, double expected) {
 static bool writeBytes(const QString& path, const QByteArray& bytes) {
 	QFile file(path);
 	return file.open(QIODevice::WriteOnly) && file.write(bytes) == bytes.size();
+}
+
+static bool readBytes(const QString& path, QByteArray& bytes) {
+	QFile file(path);
+	if (!file.open(QIODevice::ReadOnly))
+		return false;
+	bytes = file.readAll();
+	return file.error() == QFile::NoError;
 }
 
 static QJsonObject readJsonObject(const QString& path) {
@@ -631,6 +640,17 @@ int main() {
 		const std::string directoryHash = hashSceneDirectory(sceneDir.toStdString());
 		ok &= expect(!directoryHash.empty() && directoryHash == hashSceneDirectory(sceneDir.toStdString()),
 				"directory hash is deterministic");
+		const SceneInputSnapshot directorySnapshot = readSceneDirectorySnapshot(sceneDir.toStdString());
+		ok &= expect(directorySnapshot.reason.empty()
+				&& hashSceneInputSnapshot(directorySnapshot.bytes) == directoryHash,
+				"directory snapshot hash uses the shared exact-byte framing");
+		const QString passengerPath = QDir(sceneDir).filePath("passengers.json");
+		ok &= expect(QFile::remove(passengerPath) && QDir().mkpath(passengerPath)
+				&& hashSceneDirectory(sceneDir.toStdString()).empty(),
+				"an unreadable optional canonical input cannot be ignored");
+		ok &= expect(QDir(passengerPath).removeRecursively()
+				&& writeBytes(passengerPath, "{passengers.json}"),
+				"optional-input failure fixture is restored");
 		ok &= expect(writeBytes(QDir(sceneDir).filePath("services.json"), "{services changed}"),
 				"directory input can be changed");
 		ok &= expect(directoryHash != hashSceneDirectory(sceneDir.toStdString()),
@@ -647,6 +667,10 @@ int main() {
 		const std::string bundleHash = hashSceneBundle(bundlePath.toStdString());
 		ok &= expect(!bundleHash.empty() && bundleHash == hashSceneBundle(bundlePath.toStdString()),
 				"bundle hash is deterministic");
+		QFile bundleFile(bundlePath);
+		ok &= expect(bundleFile.open(QIODevice::ReadOnly)
+				&& hashSceneInputSnapshot(bundleFile.readAll().toStdString()) == bundleHash,
+				"bundle snapshot hash uses the exact archive bytes");
 		ok &= expect(writeBytes(bundlePath, "bundle bytes changed\n"), "bundle input can be changed");
 		ok &= expect(bundleHash != hashSceneBundle(bundlePath.toStdString()),
 				"bundle hash changes when exact bytes change");
@@ -698,9 +722,12 @@ int main() {
 		provenance.routeChoiceMode = 3;
 		provenance.selectedOccurrences = {{"service-A", 2, "A\\\"2"}, {"service-B", 1, "B1"}};
 		const QString artifactPath = temp.filePath("result.csv");
-		ok &= expect(writeBytes(artifactPath, "header\nrow\n"), "normal artifact is written");
-		ok &= expect(writeRunProvenanceSidecar(artifactPath.toStdString(), "csv", provenance),
-				"normal provenance sidecar is written atomically");
+		ok &= expect(writeRunArtifactWithProvenance(
+				artifactPath.toStdString(), "csv", "header\nrow\n", provenance),
+				"normal artifact and provenance sidecar are written together");
+		QByteArray artifactBytes;
+		ok &= expect(readBytes(artifactPath, artifactBytes) && artifactBytes == "header\nrow\n",
+				"paired export preserves exact artifact bytes");
 		const QJsonObject sidecar = readJsonObject(artifactPath + ".provenance.json");
 		const QJsonObject run = sidecar.value("run").toObject();
 		const QJsonObject input = run.value("input").toObject();
@@ -720,32 +747,30 @@ int main() {
 				&& occurrences.at(0).toObject().value("operating_code").toString() == "A\\\"2",
 				"sidecar preserves exact selected occurrence identities");
 		const QString failedArtifact = temp.filePath("failed.csv");
-		ok &= expect(writeBytes(failedArtifact, "header\n"), "failed-sidecar artifact is written");
 		ok &= expect(QDir().mkpath(failedArtifact + ".provenance.json"),
 				"sidecar failure path is occupied by a directory");
-		ok &= expect(!writeRunProvenanceSidecar(failedArtifact.toStdString(), "csv", provenance)
+		ok &= expect(!writeRunArtifactWithProvenance(
+				failedArtifact.toStdString(), "csv", "header\n", provenance)
 				&& !QFileInfo::exists(failedArtifact),
-				"a result artifact is removed when its required provenance sidecar fails");
+				"sidecar failure does not publish the artifact");
 
 		RunProvenance scenario = provenance;
 		scenario.appliedScenario = "incident";
 		const QString delayArtifact = temp.filePath("delay.csv");
-		ok &= expect(writeBytes(delayArtifact, "header\n"), "delay artifact is written");
-		ok &= expect(writeDelayProvenanceSidecar(delayArtifact.toStdString(), "csv", provenance, scenario),
-				"delay sidecar is written with two runs");
+		ok &= expect(writeDelayArtifactWithProvenance(
+				delayArtifact.toStdString(), "csv", "header\n", provenance, scenario),
+				"delay artifact and sidecar are written with two runs");
 		const QJsonObject delaySidecar = readJsonObject(delayArtifact + ".provenance.json");
 		ok &= expect(delaySidecar.value("baseline_run").toObject().value("applied_scenario").toString() == "scenario/\\quoted"
 				&& delaySidecar.value("scenario_run").toObject().value("applied_scenario").toString() == "incident",
 				"delay sidecar keeps baseline and scenario provenance distinct");
 		const QString failedDelayArtifact = temp.filePath("failed-delay.csv");
-		ok &= expect(writeBytes(failedDelayArtifact, "header\n"),
-				"failed delay-sidecar artifact is written");
 		ok &= expect(QDir().mkpath(failedDelayArtifact + ".provenance.json"),
 				"delay sidecar failure path is occupied by a directory");
-		ok &= expect(!writeDelayProvenanceSidecar(
-				failedDelayArtifact.toStdString(), "csv", provenance, scenario)
+		ok &= expect(!writeDelayArtifactWithProvenance(
+				failedDelayArtifact.toStdString(), "csv", "header\n", provenance, scenario)
 				&& !QFileInfo::exists(failedDelayArtifact),
-				"a delay artifact is removed when its required provenance sidecar fails");
+				"delay sidecar failure does not publish the artifact");
 	}
 
 	if (!ok)

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -4,6 +4,14 @@
 #include "simulation/Simulation.h"
 #include "util/Logger.hpp"
 
+#include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTemporaryDir>
+
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -21,6 +29,18 @@ static bool expect(bool condition, const char* message) {
 
 static bool closeTo(double actual, double expected) {
 	return std::fabs(actual - expected) < 1e-9;
+}
+
+static bool writeBytes(const QString& path, const QByteArray& bytes) {
+	QFile file(path);
+	return file.open(QIODevice::WriteOnly) && file.write(bytes) == bytes.size();
+}
+
+static QJsonObject readJsonObject(const QString& path) {
+	QFile file(path);
+	if (!file.open(QIODevice::ReadOnly))
+		return {};
+	return QJsonDocument::fromJson(file.readAll()).object();
 }
 
 static std::unique_ptr<Train> makeTimetableTrain(const std::string& id,
@@ -595,6 +615,101 @@ int main() {
 		const DelayComparisonResult incompleteResult = compareDelayRuns(incompleteBaseline, incompleteScenario);
 		ok &= expect(!incompleteResult.valid,
 				"delay comparison rejects an unavailable final destination arrival");
+	}
+
+	{
+		QTemporaryDir temp;
+		ok &= expect(temp.isValid(), "temporary directory for provenance tests is available");
+		const QString sceneDir = temp.filePath("scene");
+		QDir().mkpath(sceneDir);
+		const std::vector<QString> sceneFiles = {
+			"scene.json", "infrastructure.json", "stations.json", "signalling.json",
+			"rolling_stock.json", "services.json", "scenarios.json", "incidents.json", "passengers.json"};
+		for (const QString& file : sceneFiles)
+			ok &= expect(writeBytes(QDir(sceneDir).filePath(file), ("{" + file + "}").toUtf8()),
+				"accepted scene input is written");
+		const std::string directoryHash = hashSceneDirectory(sceneDir.toStdString());
+		ok &= expect(!directoryHash.empty() && directoryHash == hashSceneDirectory(sceneDir.toStdString()),
+				"directory hash is deterministic");
+		ok &= expect(writeBytes(QDir(sceneDir).filePath("services.json"), "{services changed}"),
+				"directory input can be changed");
+		ok &= expect(directoryHash != hashSceneDirectory(sceneDir.toStdString()),
+				"directory hash changes when an accepted file changes");
+
+		const QString bundlePath = temp.filePath("case.egscene");
+		ok &= expect(writeBytes(bundlePath, "bundle bytes\n"), "bundle input is written");
+		const std::string bundleHash = hashSceneBundle(bundlePath.toStdString());
+		ok &= expect(!bundleHash.empty() && bundleHash == hashSceneBundle(bundlePath.toStdString()),
+				"bundle hash is deterministic");
+		ok &= expect(writeBytes(bundlePath, "bundle bytes changed\n"), "bundle input can be changed");
+		ok &= expect(bundleHash != hashSceneBundle(bundlePath.toStdString()),
+				"bundle hash changes when exact bytes change");
+
+		const RunInputProvenance clean = captureSavedInput(sceneDir.toStdString(), "directory", false);
+		ok &= expect(clean.reproducible && clean.status == "reproducible"
+				&& clean.path == QFileInfo(sceneDir).absoluteFilePath().toStdString()
+				&& !clean.sha256.empty(), "clean saved directory is reproducible with an absolute path");
+		const RunInputProvenance dirty = captureSavedInput(sceneDir.toStdString(), "directory", true);
+		ok &= expect(!dirty.reproducible && dirty.dirty && dirty.status == "non-reproducible"
+				&& dirty.reason.find("dirty") != std::string::npos,
+				"dirty saved input is marked non-reproducible with a reason");
+		const RunInputProvenance unsaved = captureSavedInput({}, "directory", false);
+		ok &= expect(unsaved.kind == "unsaved" && !unsaved.reproducible
+				&& unsaved.reason.find("unsaved") != std::string::npos,
+				"unsaved input is marked non-reproducible with a reason");
+		const RunInputProvenance unreadable = captureSavedInput(temp.filePath("missing").toStdString(),
+			"directory", false);
+		ok &= expect(!unreadable.reproducible
+				&& unreadable.reason.find("missing or unreadable") != std::string::npos,
+				"unreadable saved input is marked non-reproducible with a reason");
+
+		RunProvenance provenance;
+		provenance.caseName = "Case \"quoted\" \\ path";
+		provenance.sceneSchemaVersion = 1;
+		provenance.input = clean;
+		provenance.appliedScenario = "scenario/\\quoted";
+		provenance.baseTimeSeconds = 3600.0;
+		provenance.durationSeconds = 7200.0;
+		provenance.timestepSeconds = 0.5;
+		provenance.bufferSeconds = 7.0;
+		provenance.recoveryPercent = 12.5;
+		provenance.paxMode = 1;
+		provenance.tsmMode = 2;
+		provenance.routeChoiceMode = 3;
+		provenance.selectedOccurrences = {{"service-A", 2, "A\\\"2"}, {"service-B", 1, "B1"}};
+		const QString artifactPath = temp.filePath("result.csv");
+		ok &= expect(writeBytes(artifactPath, "header\nrow\n"), "normal artifact is written");
+		ok &= expect(writeRunProvenanceSidecar(artifactPath.toStdString(), "csv", provenance),
+				"normal provenance sidecar is written atomically");
+		const QJsonObject sidecar = readJsonObject(artifactPath + ".provenance.json");
+		const QJsonObject run = sidecar.value("run").toObject();
+		const QJsonObject input = run.value("input").toObject();
+		const QJsonArray occurrences = run.value("selected_occurrences").toArray();
+		ok &= expect(sidecar.value("schema_version").toInt() == 1
+				&& sidecar.value("artifact").toObject().value("kind").toString() == "csv"
+				&& sidecar.value("artifact").toObject().value("file_name").toString() == "result.csv",
+				"normal sidecar has schema and artifact fields");
+		ok &= expect(run.value("case_name").toString() == QString::fromStdString(provenance.caseName)
+				&& run.value("applied_scenario").toString() == QString::fromStdString(provenance.appliedScenario)
+				&& input.value("path").toString() == QString::fromStdString(clean.path)
+				&& input.value("sha256").toString() == QString::fromStdString(clean.sha256),
+				"sidecar preserves escaped JSON fields and saved-input fields");
+		ok &= expect(occurrences.size() == 2
+				&& occurrences.at(0).toObject().value("service_id").toString() == "service-A"
+				&& occurrences.at(0).toObject().value("occurrence").toInt() == 2
+				&& occurrences.at(0).toObject().value("operating_code").toString() == "A\\\"2",
+				"sidecar preserves exact selected occurrence identities");
+
+		RunProvenance scenario = provenance;
+		scenario.appliedScenario = "incident";
+		const QString delayArtifact = temp.filePath("delay.csv");
+		ok &= expect(writeBytes(delayArtifact, "header\n"), "delay artifact is written");
+		ok &= expect(writeDelayProvenanceSidecar(delayArtifact.toStdString(), "csv", provenance, scenario),
+				"delay sidecar is written with two runs");
+		const QJsonObject delaySidecar = readJsonObject(delayArtifact + ".provenance.json");
+		ok &= expect(delaySidecar.value("baseline_run").toObject().value("applied_scenario").toString() == "scenario/\\quoted"
+				&& delaySidecar.value("scenario_run").toObject().value("applied_scenario").toString() == "incident",
+				"delay sidecar keeps baseline and scenario provenance distinct");
 	}
 
 	if (!ok)

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -635,6 +635,12 @@ int main() {
 				"directory input can be changed");
 		ok &= expect(directoryHash != hashSceneDirectory(sceneDir.toStdString()),
 				"directory hash changes when an accepted file changes");
+		const RunInputProvenance changedDirectory = captureSavedInput(
+			sceneDir.toStdString(), "directory", false, directoryHash);
+		ok &= expect(!changedDirectory.reproducible
+				&& changedDirectory.sha256 == directoryHash
+				&& changedDirectory.reason.find("changed since") != std::string::npos,
+				"externally changed directory is tied to the loaded hash and marked non-reproducible");
 
 		const QString bundlePath = temp.filePath("case.egscene");
 		ok &= expect(writeBytes(bundlePath, "bundle bytes\n"), "bundle input is written");
@@ -644,21 +650,35 @@ int main() {
 		ok &= expect(writeBytes(bundlePath, "bundle bytes changed\n"), "bundle input can be changed");
 		ok &= expect(bundleHash != hashSceneBundle(bundlePath.toStdString()),
 				"bundle hash changes when exact bytes change");
+		const RunInputProvenance changedBundle = captureSavedInput(
+			bundlePath.toStdString(), "bundle", false, bundleHash);
+		ok &= expect(!changedBundle.reproducible
+				&& changedBundle.sha256 == bundleHash
+				&& changedBundle.reason.find("changed since") != std::string::npos,
+				"externally changed bundle is tied to the loaded hash and marked non-reproducible");
 
-		const RunInputProvenance clean = captureSavedInput(sceneDir.toStdString(), "directory", false);
+		const std::string currentDirectoryHash = hashSceneDirectory(sceneDir.toStdString());
+		const RunInputProvenance clean = captureSavedInput(
+			sceneDir.toStdString(), "directory", false, currentDirectoryHash);
 		ok &= expect(clean.reproducible && clean.status == "reproducible"
 				&& clean.path == QFileInfo(sceneDir).absoluteFilePath().toStdString()
 				&& !clean.sha256.empty(), "clean saved directory is reproducible with an absolute path");
-		const RunInputProvenance dirty = captureSavedInput(sceneDir.toStdString(), "directory", true);
+		const RunInputProvenance unverified = captureSavedInput(
+			sceneDir.toStdString(), "directory", false, {});
+		ok &= expect(!unverified.reproducible
+				&& unverified.reason.find("could not be verified") != std::string::npos,
+				"saved input without a load/save hash is not labeled reproducible");
+		const RunInputProvenance dirty = captureSavedInput(
+			sceneDir.toStdString(), "directory", true, currentDirectoryHash);
 		ok &= expect(!dirty.reproducible && dirty.dirty && dirty.status == "non-reproducible"
 				&& dirty.reason.find("dirty") != std::string::npos,
 				"dirty saved input is marked non-reproducible with a reason");
-		const RunInputProvenance unsaved = captureSavedInput({}, "directory", false);
+		const RunInputProvenance unsaved = captureSavedInput({}, "directory", false, {});
 		ok &= expect(unsaved.kind == "unsaved" && !unsaved.reproducible
 				&& unsaved.reason.find("unsaved") != std::string::npos,
 				"unsaved input is marked non-reproducible with a reason");
 		const RunInputProvenance unreadable = captureSavedInput(temp.filePath("missing").toStdString(),
-			"directory", false);
+			"directory", false, {});
 		ok &= expect(!unreadable.reproducible
 				&& unreadable.reason.find("missing or unreadable") != std::string::npos,
 				"unreadable saved input is marked non-reproducible with a reason");
@@ -699,6 +719,13 @@ int main() {
 				&& occurrences.at(0).toObject().value("occurrence").toInt() == 2
 				&& occurrences.at(0).toObject().value("operating_code").toString() == "A\\\"2",
 				"sidecar preserves exact selected occurrence identities");
+		const QString failedArtifact = temp.filePath("failed.csv");
+		ok &= expect(writeBytes(failedArtifact, "header\n"), "failed-sidecar artifact is written");
+		ok &= expect(QDir().mkpath(failedArtifact + ".provenance.json"),
+				"sidecar failure path is occupied by a directory");
+		ok &= expect(!writeRunProvenanceSidecar(failedArtifact.toStdString(), "csv", provenance)
+				&& !QFileInfo::exists(failedArtifact),
+				"a result artifact is removed when its required provenance sidecar fails");
 
 		RunProvenance scenario = provenance;
 		scenario.appliedScenario = "incident";
@@ -710,6 +737,15 @@ int main() {
 		ok &= expect(delaySidecar.value("baseline_run").toObject().value("applied_scenario").toString() == "scenario/\\quoted"
 				&& delaySidecar.value("scenario_run").toObject().value("applied_scenario").toString() == "incident",
 				"delay sidecar keeps baseline and scenario provenance distinct");
+		const QString failedDelayArtifact = temp.filePath("failed-delay.csv");
+		ok &= expect(writeBytes(failedDelayArtifact, "header\n"),
+				"failed delay-sidecar artifact is written");
+		ok &= expect(QDir().mkpath(failedDelayArtifact + ".provenance.json"),
+				"delay sidecar failure path is occupied by a directory");
+		ok &= expect(!writeDelayProvenanceSidecar(
+				failedDelayArtifact.toStdString(), "csv", provenance, scenario)
+				&& !QFileInfo::exists(failedDelayArtifact),
+				"a delay artifact is removed when its required provenance sidecar fails");
 	}
 
 	if (!ok)

--- a/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_runresults.cpp
@@ -644,6 +644,14 @@ int main() {
 		ok &= expect(directorySnapshot.reason.empty()
 				&& hashSceneInputSnapshot(directorySnapshot.bytes) == directoryHash,
 				"directory snapshot hash uses the shared exact-byte framing");
+		const QString scenariosPath = QDir(sceneDir).filePath("scenarios.json");
+		const QString incidentsPath = QDir(sceneDir).filePath("incidents.json");
+		ok &= expect(QFile::remove(scenariosPath) && QFile::remove(incidentsPath)
+				&& !hashSceneDirectory(sceneDir.toStdString()).empty(),
+				"a compatible scene without scenario files remains reproducible");
+		ok &= expect(writeBytes(scenariosPath, "{scenarios.json}")
+				&& writeBytes(incidentsPath, "{incidents.json}"),
+				"scenario compatibility fixture is restored");
 		const QString passengerPath = QDir(sceneDir).filePath("passengers.json");
 		ok &= expect(QFile::remove(passengerPath) && QDir().mkpath(passengerPath)
 				&& hashSceneDirectory(sceneDir.toStdString()).empty(),

--- a/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
@@ -209,19 +209,19 @@ static bool runTinyBuilderChecks() {
 					|| signalling_block_sections[2].arcs_in_signalling_block_section[index].speedLimit == 7.5;
 		ok &= expect(hasCanonicalSwitchSpeed, "connection speed is retained independently of endpoint order");
 		Section creatorNamedSwitch = signalling_block_sections[2];
-		creatorNamedSwitch.ID = "@creator-main-block@-1.000000/@creator-yard-block@-2.000000";
+		creatorNamedSwitch.ID = "@creator@main-block@-1.000000/@creator-yard@block@-2.000000";
 		creatorNamedSwitch.FirstConnectedTrackLineID = 0;
 		creatorNamedSwitch.SecondConnectedTrackLineID = 1;
 		BlocksOccupied.clear();
 		BlocksConnected.clear();
 		activateBlocksWithSwitchesDivFixedBlock(creatorNamedSwitch, 0, -1.0);
 		ok &= expect(creatorNamedSwitch.ID
-				== "@creator-main-block@-1.000000/@creator-yard-block@-2.000000"
-				&& std::find(BlocksOccupied.begin(), BlocksOccupied.end(), "@creator-main-block@")
+				== "@creator@main-block@-1.000000/@creator-yard@block@-2.000000"
+				&& std::find(BlocksOccupied.begin(), BlocksOccupied.end(), "@creator@main-block@")
 						!= BlocksOccupied.end()
-				&& std::find(BlocksOccupied.begin(), BlocksOccupied.end(), "@creator-yard-block@")
+				&& std::find(BlocksOccupied.begin(), BlocksOccupied.end(), "@creator-yard@block@")
 						!= BlocksOccupied.end(),
-			"switch occupation preserves and resolves hyphenated creator section IDs");
+			"switch occupation preserves creator section IDs containing hyphens and wrapper characters");
 		BlocksOccupied.clear();
 		BlocksConnected.clear();
 	}

--- a/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
@@ -2,6 +2,7 @@
 #include "scene/SectionInventory.h"
 #include "simulation/Signalling.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <string>
@@ -207,6 +208,22 @@ static bool runTinyBuilderChecks() {
 			hasCanonicalSwitchSpeed = hasCanonicalSwitchSpeed
 					|| signalling_block_sections[2].arcs_in_signalling_block_section[index].speedLimit == 7.5;
 		ok &= expect(hasCanonicalSwitchSpeed, "connection speed is retained independently of endpoint order");
+		Section creatorNamedSwitch = signalling_block_sections[2];
+		creatorNamedSwitch.ID = "@creator-main-block@-1.000000/@creator-yard-block@-2.000000";
+		creatorNamedSwitch.FirstConnectedTrackLineID = 0;
+		creatorNamedSwitch.SecondConnectedTrackLineID = 1;
+		BlocksOccupied.clear();
+		BlocksConnected.clear();
+		activateBlocksWithSwitchesDivFixedBlock(creatorNamedSwitch, 0, -1.0);
+		ok &= expect(creatorNamedSwitch.ID
+				== "@creator-main-block@-1.000000/@creator-yard-block@-2.000000"
+				&& std::find(BlocksOccupied.begin(), BlocksOccupied.end(), "@creator-main-block@")
+						!= BlocksOccupied.end()
+				&& std::find(BlocksOccupied.begin(), BlocksOccupied.end(), "@creator-yard-block@")
+						!= BlocksOccupied.end(),
+			"switch occupation preserves and resolves hyphenated creator section IDs");
+		BlocksOccupied.clear();
+		BlocksConnected.clear();
 	}
 	const int blocksBeforeDisconnectedRoute = Blocks;
 	const std::string firstSectionBeforeDisconnectedRoute = signalling_block_sections[0].ID;

--- a/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
@@ -233,13 +233,25 @@ static bool runTinyBuilderChecks() {
 		occupyDoubleSwitch(malformedSwitch, malformedPrevious);
 		ok &= expect(BlocksOccupied == occupiedBefore && BlocksConnected == connectedBefore,
 			"malformed double-switch identities are rejected before occupancy mutation");
+		releaseDoubleSwitch(malformedSwitch, malformedPrevious);
+		ok &= expect(BlocksOccupied == occupiedBefore && BlocksConnected == connectedBefore,
+			"malformed double-switch identities are rejected before release mutation");
+		occupyDoubleSwitch(signalling_block_sections[2], malformedPrevious);
+		releaseDoubleSwitch(signalling_block_sections[2], malformedPrevious);
+		ok &= expect(BlocksOccupied == occupiedBefore && BlocksConnected == connectedBefore,
+			"a valid first switch half cannot mutate before a malformed second half is rejected");
 		Section unresolvedSwitch;
 		unresolvedSwitch.ID = "@missing.a@-1.000000/@missing.b@-2.000000";
+		unresolvedSwitch.withSwitchDiv = true;
 		Section unresolvedPrevious;
 		unresolvedPrevious.ID = "@missing.c@-3.000000/@missing.d@-4.000000";
+		unresolvedPrevious.withSwitchDiv = true;
 		occupyDoubleSwitch(unresolvedSwitch, unresolvedPrevious);
 		ok &= expect(BlocksOccupied == occupiedBefore && BlocksConnected == connectedBefore,
 			"unresolved double-switch branches are rejected before occupancy mutation");
+		releaseDoubleSwitch(unresolvedSwitch, unresolvedPrevious);
+		ok &= expect(BlocksOccupied == occupiedBefore && BlocksConnected == connectedBefore,
+			"unresolved double-switch branches are rejected before release mutation");
 		BlocksOccupied.clear();
 		BlocksConnected.clear();
 	}

--- a/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenebuilder.cpp
@@ -222,6 +222,24 @@ static bool runTinyBuilderChecks() {
 				&& std::find(BlocksOccupied.begin(), BlocksOccupied.end(), "@creator-yard@block@")
 						!= BlocksOccupied.end(),
 			"switch occupation preserves creator section IDs containing hyphens and wrapper characters");
+		BlocksOccupied = {"occupied.before"};
+		BlocksConnected = {"connected.before"};
+		const auto occupiedBefore = BlocksOccupied;
+		const auto connectedBefore = BlocksConnected;
+		Section malformedSwitch;
+		malformedSwitch.ID = "malformed/switch";
+		Section malformedPrevious;
+		malformedPrevious.ID = "also-malformed/switch";
+		occupyDoubleSwitch(malformedSwitch, malformedPrevious);
+		ok &= expect(BlocksOccupied == occupiedBefore && BlocksConnected == connectedBefore,
+			"malformed double-switch identities are rejected before occupancy mutation");
+		Section unresolvedSwitch;
+		unresolvedSwitch.ID = "@missing.a@-1.000000/@missing.b@-2.000000";
+		Section unresolvedPrevious;
+		unresolvedPrevious.ID = "@missing.c@-3.000000/@missing.d@-4.000000";
+		occupyDoubleSwitch(unresolvedSwitch, unresolvedPrevious);
+		ok &= expect(BlocksOccupied == occupiedBefore && BlocksConnected == connectedBefore,
+			"unresolved double-switch branches are rejected before occupancy mutation");
 		BlocksOccupied.clear();
 		BlocksConnected.clear();
 	}

--- a/EGTRAIN/QEGTRAIN/tests/test_scenebundle.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenebundle.cpp
@@ -213,6 +213,20 @@ int main(int argc, char** argv) {
 	const fs::path secondBundle = temp.path / "second.egscene";
 	const SceneSaveResult firstSave = saveSceneBundle(source.scene, firstBundle.string());
 	ok &= expect(firstSave.success(), "canonical directory packs");
+	const std::string firstBundleBytes = readBytes(firstBundle);
+	ok &= expect(!firstSave.inputSnapshot.empty() && firstSave.inputSnapshot == firstBundleBytes,
+			"successful bundle save retains the exact staged archive bytes");
+	const SceneLoadResult firstLoad = loadScenePath(firstBundle.string());
+	ok &= expect(!hasErrors(firstLoad.diagnostics) && firstLoad.inputSnapshot == firstBundleBytes,
+			"bundle load retains the exact archive bytes it parsed");
+	ok &= expect(writeBytes(firstBundle, "external replacement"),
+			"external bundle replacement writes");
+	ok &= expect(firstSave.inputSnapshot == firstBundleBytes
+			&& firstLoad.inputSnapshot == firstBundleBytes
+			&& readBytes(firstBundle) != firstBundleBytes,
+			"external bundle replacement does not mutate retained snapshots");
+	ok &= expect(saveSceneBundle(source.scene, firstBundle.string()).success(),
+			"bundle replacement restores the external test fixture");
 	const SceneSaveResult secondSave = saveSceneBundle(source.scene, secondBundle.string());
 	ok &= expect(secondSave.success(), "canonical directory packs twice");
 	ok &= expect(readBytes(firstBundle) == readBytes(secondBundle), "bundle bytes are deterministic");

--- a/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
@@ -16,6 +16,11 @@ static bool expect(bool condition, const char* message) {
 	return condition;
 }
 
+static std::string readBytes(const fs::path& path) {
+	std::ifstream input(path, std::ios::binary);
+	return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
 static void printErrors(const std::vector<SceneDiagnostic>& diagnostics, const char* label) {
 	for (const auto& diagnostic : diagnostics) {
 		if (diagnostic.severity == SceneSeverity::Error)
@@ -186,6 +191,11 @@ int main() {
 	for (const char* file : {"scene.json", "infrastructure.json", "stations.json", "signalling.json",
 			"rolling_stock.json", "services.json", "scenarios.json", "passengers.json"})
 		ok &= expect(fs::exists(temp.path / file), "all canonical files are written");
+	const std::string savedSnapshot = saved.inputSnapshot;
+	const SceneInputSnapshot onDiskSnapshot = readSceneDirectorySnapshot(temp.path.string());
+	ok &= expect(!savedSnapshot.empty() && onDiskSnapshot.reason.empty()
+			&& savedSnapshot == onDiskSnapshot.bytes,
+			"successful save retains the exact framed canonical input snapshot");
 	ok &= expect(!fs::exists(temp.path / "incidents.json"), "writer does not emit flat incidents.json");
 	json stations;
 	{
@@ -327,6 +337,19 @@ int main() {
 
 	SceneModel reloaded;
 	ok &= expect(loadHasNoErrors(temp.path, reloaded), "canonical scene reloads without structural errors");
+	const SceneLoadResult loadedSnapshot = loadScene(temp.path.string());
+	ok &= expect(!loadedSnapshot.inputSnapshot.empty()
+			&& loadedSnapshot.inputSnapshot == savedSnapshot,
+			"load retains the exact framed snapshot emitted by save");
+	{
+		std::ofstream output(temp.path / "services.json", std::ios::binary | std::ios::app);
+		output << ' ';
+	}
+	const SceneInputSnapshot changedOnDisk = readSceneDirectorySnapshot(temp.path.string());
+	ok &= expect(changedOnDisk.reason.empty() && changedOnDisk.bytes != savedSnapshot
+			&& saved.inputSnapshot == savedSnapshot
+			&& loadedSnapshot.inputSnapshot == savedSnapshot,
+			"external canonical-file changes do not mutate retained snapshots");
 	ok &= expect(reloaded.tracks.size() == 1 && reloaded.nodes.size() == 2 && reloaded.blocks.size() == 2,
 			"topology round-trips");
 	ok &= expect(reloaded.routes[0].corridor == "corridor-1" && reloaded.routes[0].reversed,

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -7,11 +7,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 ## Current state
 
 - Planning baseline: `59128cea7a50b2fbc83e147f2e6d9dd6f451c2cf`
-- Current `origin/main`: `10f15b5ba6f52715adcc390519204de4169ba77c`
-- Current milestone: PR 5, passenger authoring and explicit platform geometry
-- Current worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/passenger-authoring`
-- Current branch: `feature/passenger-authoring`
-- Current PR: #294, `Add passenger and platform authoring` (draft)
+- Current `origin/main`: `1f095b2bfe7c95bc6b68940349a9357c43c49468`
+- Current milestone: PR 6, reproducible exports and UI-only seventh-case proof
+- Current worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/creator-acceptance`
+- Current branch: `feature/result-provenance-creator-acceptance`
+- Current PR: none yet
 - Completed milestones and PRs:
   - PR #290, `Bind signals to canonical track sections`, merged as
     `d90eb24de0f6f72e33b5206d1ffecec7ab64f7a2`;
@@ -20,8 +20,10 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   - PR #292, `Make editor mutations reference-safe`, merged as
     `3a3ec8d5eb1ff0c21ba4d2aa31235e058f5fe128`;
   - PR #293, `Add entrance delay scenario authoring`, merged as
-    `10f15b5ba6f52715adcc390519204de4169ba77c`.
-- Open milestone dependencies: PR 5 depends on merged PR #293. Issues #85 and #86 remain parity gates.
+    `10f15b5ba6f52715adcc390519204de4169ba77c`;
+  - PR #294, `Add passenger and platform authoring`, merged as
+    `1f095b2bfe7c95bc6b68940349a9357c43c49468`.
+- Open milestone dependencies: PR 6 depends on merged PRs #290 through #294. Issues #85 and #86 remain parity gates.
 
 ## Planning-baseline creator gaps
 
@@ -114,6 +116,17 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   the exact resolved stop indices rather than independent first-name matches.
 - A selected-occurrence run stages a passenger journey only when every leg is selected and resolvable. It omits
   the whole journey instead of constructing a disconnected partial journey from the original endpoints.
+- PR 6 will capture one immutable run-provenance value after successful native preparation and preserve it by
+  value with completed results and already-open result windows. It records the case, schema version, saved input,
+  SHA-256 snapshot, dirty/reproducible status, applied scenario, effective runtime settings, passenger/TSM/route-
+  choice modes, and expanded selected service occurrences.
+- PR 6 will use additive `*.provenance.json` sidecars for current CSV and PNG artifacts. Directory snapshots hash
+  the sorted canonical scene files; `.egscene` snapshots hash the bundle bytes. Dirty, unsaved, missing, or
+  unreadable inputs remain runnable but are marked non-reproducible. Delay comparison records both runs.
+- PR 6 will add one adjacent public-widget creator smoke, not a second automation framework. Its startup path
+  begins without loading a bundled default, triggers New Case, and authors through existing actions and widgets.
+  Private model reads may support assertions; private model writes, direct writers, runtime tokens, Cumpari input,
+  hidden case data, and magic case names are prohibited.
 
 ## Compatibility decisions
 
@@ -132,6 +145,8 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - New canonical scenes reject a passenger leg whose destination does not follow its origin. A scene carrying
   `legacy_root` provenance retains such historical data with an actionable warning, and native staging omits the
   affected journey instead of stranding the passenger. No committed case data is changed or guessed.
+- PR 6 changes neither scene schema version nor existing CSV columns. Provenance sidecars are additive and use
+  Qt's existing JSON, atomic-file, and SHA-256 support. No results-project format or new dependency is introduced.
 
 ## GitHub issue state
 
@@ -139,7 +154,8 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - Closed by PR #291: #57 and #286.
 - Closed by PR #292: #287.
 - Closed by PR #293: #126.
-- Current milestone: #164 and #288.
+- Closed by PR #294: #164 and #288.
+- Current milestone: #129 and #289.
 - Reused: #85, #86, #129, #164.
 - Created during planning: #286, #287, #288, #289.
 - Authoritative-data dependencies only: #181, #182, #228.
@@ -499,6 +515,10 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - The PR 5 untouched-default correction graph update completed with 5034 nodes, 11497 edges, and 235 communities.
 - The final PR 5 geometry correction graph update completed with 5034 nodes, 11496 edges, and 242 communities.
 - The PR 5 post-Ponytail graph update completed with 5034 nodes, 11496 edges, and 243 communities.
+- The final PR 5 build passed. CTest passed 43 of 43 in 129.54 seconds; editor smoke, six-case headless,
+  six-case round-trip (`ROUNDTRIP PASS`), Assignment, and DPR 1/DPR 2 visual-polish smokes passed. All six
+  committed scenes validated with exit 0. GitHub build and sanitizer jobs passed at the exact final head.
+- PR #294 merged as `1f095b2bfe7c95bc6b68940349a9357c43c49468`; issues #164 and #288 closed with the merge.
 
 ## Review record
 
@@ -786,10 +806,10 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 
 ### Unresolved application blockers
 
-- PRs 1 through 4 are complete. PRs 5 and 6 remain open.
+- PRs 1 through 5 are complete. PR 6 remains open: immutable export provenance and the public UI-only
+  seventh-case acceptance proof.
 
 ## Next action
 
-Commit and push this final PR 5 ledger update, wait for GitHub build and sanitizer checks on that exact head,
-mark PR #294 ready, and merge when clean. Then record the merge in the PR 6 worktree and begin provenance work
-from the new `origin/main`.
+Configure and build the clean PR 6 worktree at `1f095b2`, run the focused results/export baseline, then implement
+immutable run provenance and additive CSV/PNG sidecars before adding the public seventh-case creator smoke.

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -574,6 +574,8 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   passed 7 of 7 in 12.40 seconds. Its direct `test_runresults` regression passed 1 of 1 in 0.52 seconds.
 - The complete PR 6 configure and build passed, and CTest passed 44 of 44 in 145.38 seconds at `3baa718` before
   the subsequent scenario-less compatibility correction.
+- After the PR 6 Ponytail reductions, the affected target built and the public creator smoke passed in 5.20
+  seconds. The full seven-test focused gate then passed 7 of 7 in 11.24 seconds, and `git diff --check` passed.
 
 ## Review record
 
@@ -603,6 +605,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   found one P2 compatibility regression: `readSceneDirectorySnapshot` required a scenario file even though
   `loadScene` accepts neither file and synthesizes the baseline scenario. The reviewer reproduced a clean
   Paimpol-derived directory being labeled non-reproducible after removing only `scenarios.json`.
+- The final fresh correctness review found no P0, P1, or P2 issue at `08c9830`. It independently passed the four
+  snapshot/writer/bundle/builder tests and both public CSV/creator smokes, accepted a direct six-file
+  scenario-less directory, rejected a present directory-valued passenger input, and approved the diff.
 
 - The fresh post-Ponytail correctness review found no P0, P1, or P2 issue at `538ac72`. It traced native
   passenger preflight and no-mutation behavior, importer station resolution, occurrence filtering, passenger
@@ -877,6 +882,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   predicate, remove the duplicate occurrence `editingFinished` connection, and remove repeated passenger refreshes.
   The refresh suggestion was rejected because pending Save suppresses nested validation, making those explicit
   refreshes the only UI update for ID and related focused commits.
+- The PR 6 Ponytail review identified four possible reductions: share duplicate infrastructure-driving helpers,
+  keep only the final sequential acceptance marker in the shell gate, let the shell wrapper be the sole export
+  artifact verifier, and replace DiagramWindow's injected paired writer with stored provenance.
 
 ### Simplifications made
 
@@ -893,6 +901,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - PR 5 removes post-preflight station/window checks from native passenger publication, uses `knownStation` for
   importer resolution, and relies on `valueChanged` plus the pending Save flush for passenger occurrence edits.
   These reductions remove 25 net lines without changing diagnostics or public behavior.
+- PR 6 now shares one infrastructure editor helper set across its adjacent creator phases, checks one final marker
+  after the sequential state machine, and verifies artifacts and sidecars once in the wrapper that also parses
+  their contents. This removes 109 net lines while retaining public control driving and exact serialized/output
+  assertions. DiagramWindow keeps its injected paired writer because storing provenance directly would pull
+  `RunResults.cpp` and its simulation dependencies into the lightweight diagram unit target.
 
 ## Blockers
 
@@ -902,12 +915,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 
 ### Unresolved application blockers
 
-- PRs 1 through 5 are complete. PR 6 provenance and the public UI-only seventh-case implementation pass their
-  focused gates. The scenario-less compatibility finding is corrected and passes focused regressions. One fresh
-  review of the exact corrected commit, Ponytail review, the final local regression gate, CI, and the merged-main
+- PRs 1 through 5 are complete. PR 6 correctness and Ponytail gates are clean, and the simplified creator path
+  passes the focused regressions. The final complete local regression gate, CI, merge, and merged-main
   completeness review remain before the verdict can change.
 
 ## Next action
 
-Commit and push the scenario-less provenance correction, run a fresh independent review of the exact corrected
-diff, fix every confirmed finding, then run the Ponytail review and complete regression gate before merge.
+Commit and push the PR 6 Ponytail reductions, run a fresh correctness check of the simplified diff, then complete
+the final regression, CI, merge, and merged-main completeness gates.

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -11,7 +11,7 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - Current milestone: PR 6, reproducible exports and UI-only seventh-case proof
 - Current worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/creator-acceptance`
 - Current branch: `feature/result-provenance-creator-acceptance`
-- Current PR: none yet
+- Current PR: draft PR #295, `Add reproducible creator acceptance`
 - Completed milestones and PRs:
   - PR #290, `Bind signals to canonical track sections`, merged as
     `d90eb24de0f6f72e33b5206d1ffecec7ab64f7a2`;
@@ -123,6 +123,12 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - PR 6 will use additive `*.provenance.json` sidecars for current CSV and PNG artifacts. Directory snapshots hash
   the sorted canonical scene files; `.egscene` snapshots hash the bundle bytes. Dirty, unsaved, missing, or
   unreadable inputs remain runnable but are marked non-reproducible. Delay comparison records both runs.
+- The application retains the exact saved-input hash captured before load or after successful Save. Run compares the
+  current disk bytes with that value, so external source replacement cannot be mislabeled as the input used by
+  the in-memory simulation. A mismatch remains runnable but is explicitly non-reproducible and retains the
+  loaded/saved hash.
+- A result artifact and its provenance sidecar form one usable export. If the atomic sidecar write fails, the
+  just-written artifact is removed rather than leaving a result that cannot identify its run input.
 - PR 6 will add one adjacent public-widget creator smoke, not a second automation framework. Its startup path
   begins without loading a bundled default, triggers New Case, and authors through existing actions and widgets.
   Private model reads may support assertions; private model writes, direct writers, runtime tokens, Cumpari input,
@@ -554,10 +560,25 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   2 of 2 in 4.43 seconds.
 - After the lead's parser-boundary trace, the affected build passed and the scene-builder plus creator-acceptance
   gate passed 2 of 2 in 6.00 seconds.
+- After the first PR 6 correctness corrections, `test_runresults`, `test_scenebuilder`, and
+  `test_creator_acceptance_smoke` passed 3 of 3 in 5.22 seconds on the final correction. The regressions cover directory and bundle drift,
+  artifact cleanup after normal and delay sidecar failure, malformed and unresolved double-switch preflight,
+  and an exact match between exported provenance and the saved bundle bytes.
 
 ## Review record
 
 ### Independent correctness findings
+
+- The first fresh PR 6 review found one P1 and two P2 merge blockers:
+  1. Run hashed the current path after native staging instead of retaining the exact bytes loaded into the
+     in-memory model, so external directory or bundle replacement could be labeled reproducible for the wrong
+     input;
+  2. `occupyDoubleSwitch` published compound occupancy before parsing identities and could dereference missing
+     branch sections on a direct malformed call;
+  3. interactive export committed the primary CSV or PNG before its sidecar, leaving a provenance-free artifact
+     when the sidecar failed.
+  The reviewer independently passed the focused provenance and scene-builder tests, the seventh-case creator
+  smoke, and the CSV export smoke before reproducing each boundary defect.
 
 - The fresh post-Ponytail correctness review found no P0, P1, or P2 issue at `538ac72`. It traced native
   passenger preflight and no-mutation behavior, importer station resolution, occurrence filtering, passenger
@@ -696,6 +717,14 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   the reduced refresh scope and public spin-box signal path.
 
 ### Corrections made
+
+- Captured the exact directory or bundle hash on load and successful Save, compared it with the current disk
+  snapshot at Run, and marked drift non-reproducible while retaining the hash of the loaded/saved input.
+- Preflighted both double-switch identities and all four base branches before mutating the global occupied or
+  connected lists. Malformed and unresolved direct calls now return without mutation or dereference.
+- Removed a just-written result when its required normal or delay provenance sidecar cannot be committed, and
+  changed the interactive failure messages to describe that behavior.
+- Strengthened the seventh-case wrapper to compare every run sidecar hash with the exact `.egscene` bytes.
 
 - Corrected connection-derived adjacency to use actual section boundaries instead of internal switch endpoints.
 - Kept switch-chain pairs direction-neutral so legacy double-switch routes do not conflict with route direction.
@@ -845,10 +874,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 ### Unresolved application blockers
 
 - PRs 1 through 5 are complete. PR 6 provenance and the public UI-only seventh-case implementation pass their
-  focused gates. Independent correctness review, Ponytail review, the full local regression gate, CI, and the
-  final merged-main completeness review remain before the verdict can change.
+  focused gates. The first correctness review's three findings are corrected and pass focused regressions. A
+  fresh corrected-diff review, Ponytail review, the full local regression gate, CI, and the final merged-main
+  completeness review remain before the verdict can change.
 
 ## Next action
 
-Commit the verified seventh-case implementation, run a fresh independent correctness review of the actual diff,
-fix every confirmed finding, then run the fresh Ponytail review and complete regression gate before publishing.
+Commit and push the first PR 6 correctness corrections, run a fresh independent review of the exact corrected
+diff, fix every confirmed finding, then run the Ponytail review and complete regression gate before merge.

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -552,6 +552,8 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   instead of assuming the runtime occurrence-ID format. It also checks exact authored curvature, gradient, and
   speed-limit values after both persistence forms. The direct smoke passed, and the focused two-test gate passed
   2 of 2 in 4.43 seconds.
+- After the lead's parser-boundary trace, the affected build passed and the scene-builder plus creator-acceptance
+  gate passed 2 of 2 in 6.00 seconds.
 
 ## Review record
 
@@ -791,6 +793,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   is consumed on focus loss or pending Save. Merely focusing a displayed compatibility default leaves the optional
   field absent, while same-valued, changed, and spin-button edits become explicit through existing commit paths.
   The public editor smoke covers untouched focus, same-value focus loss, and a changed still-focused Save.
+- The connected-section parser now finds the final `@` wrapper marker. Canonical block IDs containing `@` remain
+  resolvable while hyphens and signed coordinates retain their exact meaning; the focused native regression covers
+  both legal block-ID characters without mutating the compound section identity.
 
 ### Ponytail findings
 

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -127,6 +127,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   begins without loading a bundled default, triggers New Case, and authors through existing actions and widgets.
   Private model reads may support assertions; private model writes, direct writers, runtime tokens, Cumpari input,
   hidden case data, and magic case names are prohibited.
+- The seventh-case run exposed undefined legacy switch parsing that called `strtok` on live
+  `std::string::c_str()` storage. Hyphens and the compound separator were replaced with NUL bytes in runtime
+  section IDs and result CSVs. PR 6 replaces every such parser in signalling with one non-mutating parser for
+  the established `@block@-coordinate/@block@-coordinate` grammar and uses existing connected-track metadata
+  for direction. It does not add a new identity or sanitize exports.
 
 ## Compatibility decisions
 
@@ -206,6 +211,12 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - PR 6 captures immutable case, schema, saved-input hash/status, scenario, effective settings, modes, and exact
   staged service occurrences after native preparation. Existing CSV schemas remain unchanged; CSV and PNG
   exports receive atomic `.provenance.json` sidecars, and delay comparison sidecars retain both runs.
+- PR 6 adds one CTest-registered `creator_acceptance_smoke.sh` around an in-application public-widget workflow.
+  It starts with New Case, authors and corrects an independent switched case, saves and reopens both persistence
+  forms, runs baseline/entrance-delay/incident scenarios, selects individual occurrences, opens and exports
+  trajectory, timetable, blocking-time, capacity, and compressed results, verifies provenance, and proves a
+  later visible edit invalidates prior results. The wrapper validates both saved forms and parses the resulting
+  canonical data and exports, including complete block occupations for both selected occurrences.
 
 ## Verification record
 
@@ -530,6 +541,17 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   The strengthened CSV smoke then passed alone in 6.40 seconds and verified Paimpol's exact case/schema,
   directory snapshot path and SHA-256, clean reproducible status, baseline scenario, effective run settings,
   modes, and selected occurrence records for every emitted artifact.
+- The first complete seventh-case run passed every in-application marker and all folder, bundle, native-run,
+  result, capacity, and stale-result assertions. Its strict wrapper then exposed embedded NUL bytes in exported
+  connection-derived section IDs instead of accepting or stripping them.
+- After the shared signalling parser correction, `test_scenebuilder` and
+  `test_creator_acceptance_smoke` passed 2 of 2 in 5.99 seconds. A direct rerun of
+  `tools/e2e/creator_acceptance_smoke.sh` also passed. The wrapper's standard CSV parser now reads blocking and
+  capacity exports without NUL handling and proves complete actual occupations for occurrences 1 and 2.
+- The final pre-review acceptance wrapper derives selected train IDs from trajectory service/occurrence columns
+  instead of assuming the runtime occurrence-ID format. It also checks exact authored curvature, gradient, and
+  speed-limit values after both persistence forms. The direct smoke passed, and the focused two-test gate passed
+  2 of 2 in 4.43 seconds.
 
 ## Review record
 
@@ -817,10 +839,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 
 ### Unresolved application blockers
 
-- PRs 1 through 5 are complete. PR 6 export provenance is implemented and focused tests pass. The remaining
-  blocker is the public UI-only seventh-case acceptance proof and its complete regression gate.
+- PRs 1 through 5 are complete. PR 6 provenance and the public UI-only seventh-case implementation pass their
+  focused gates. Independent correctness review, Ponytail review, the full local regression gate, CI, and the
+  final merged-main completeness review remain before the verdict can change.
 
 ## Next action
 
-Commit the verified provenance checkpoint, then add the public seventh-case creator smoke from a blank process
-through New Case, public folder/bundle persistence, native runs, result exports, and stale-result invalidation.
+Commit the verified seventh-case implementation, run a fresh independent correctness review of the actual diff,
+fix every confirmed finding, then run the fresh Ponytail review and complete regression gate before publishing.

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -123,12 +123,13 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - PR 6 will use additive `*.provenance.json` sidecars for current CSV and PNG artifacts. Directory snapshots hash
   the sorted canonical scene files; `.egscene` snapshots hash the bundle bytes. Dirty, unsaved, missing, or
   unreadable inputs remain runnable but are marked non-reproducible. Delay comparison records both runs.
-- The application retains the exact saved-input hash captured before load or after successful Save. Run compares the
-  current disk bytes with that value, so external source replacement cannot be mislabeled as the input used by
-  the in-memory simulation. A mismatch remains runnable but is explicitly non-reproducible and retains the
-  loaded/saved hash.
-- A result artifact and its provenance sidecar form one usable export. If the atomic sidecar write fails, the
-  just-written artifact is removed rather than leaving a result that cannot identify its run input.
+- Scene load retains the exact directory-file buffers or bundle bytes it parsed. Save retains the exact serialized
+  directory buffers or archive bytes it published. Run compares the current path with that retained hash, so an
+  external replacement cannot be mislabeled as the input used by the in-memory simulation. A mismatch remains
+  runnable but is explicitly non-reproducible and retains the loaded/saved hash.
+- A result artifact and its provenance sidecar form one usable export. The artifact remains in `QSaveFile` staging
+  until the atomic sidecar commit succeeds, then the artifact is published. A sidecar failure cannot leave a new
+  provenance-free result, and an artifact publish failure removes the staged sidecar.
 - PR 6 will add one adjacent public-widget creator smoke, not a second automation framework. Its startup path
   begins without loading a bundled default, triggers New Case, and authors through existing actions and widgets.
   Private model reads may support assertions; private model writes, direct writers, runtime tokens, Cumpari input,
@@ -564,6 +565,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   `test_creator_acceptance_smoke` passed 3 of 3 in 5.22 seconds on the final correction. The regressions cover directory and bundle drift,
   artifact cleanup after normal and delay sidecar failure, malformed and unresolved double-switch preflight,
   and an exact match between exported provenance and the saved bundle bytes.
+- After the second correctness corrections, the affected targets built and `test_runresults`,
+  `test_diagramwindow`, `test_scenewriter`, `test_scenebundle`, `test_scenebuilder`,
+  `test_csv_export_smoke`, and `test_creator_acceptance_smoke` passed 7 of 7 in 12.45 seconds.
+  A follow-up `test_runresults` rebuild and run passed 1 of 1 in 0.51 seconds after covering a non-file optional
+  canonical input. `git diff --check` passed.
 
 ## Review record
 
@@ -579,6 +585,15 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
      when the sidecar failed.
   The reviewer independently passed the focused provenance and scene-builder tests, the seventh-case creator
   smoke, and the CSV export smoke before reproducing each boundary defect.
+- The fresh review of the first correction found two remaining P1 defects and one P2 defect:
+  1. hashing a scene path separately before load or after Save retained a different snapshot if the path was
+     replaced between the I/O operation and the hash;
+  2. `releaseDoubleSwitch` could mutate `BlocksConnected` for the first valid half before rejecting a malformed
+     second half, and could default-construct missing branches;
+  3. deleting an already-published artifact after sidecar failure was best effort, so a deletion failure could
+     leave a provenance-free result.
+  The reviewer independently passed the five-test provenance, diagram, scene-builder, CSV, and creator gate
+  before reproducing the boundaries.
 
 - The fresh post-Ponytail correctness review found no P0, P1, or P2 issue at `538ac72`. It traced native
   passenger preflight and no-mutation behavior, importer station resolution, occurrence filtering, passenger
@@ -718,12 +733,14 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 
 ### Corrections made
 
-- Captured the exact directory or bundle hash on load and successful Save, compared it with the current disk
-  snapshot at Run, and marked drift non-reproducible while retaining the hash of the loaded/saved input.
-- Preflighted both double-switch identities and all four base branches before mutating the global occupied or
-  connected lists. Malformed and unresolved direct calls now return without mutation or dereference.
-- Removed a just-written result when its required normal or delay provenance sidecar cannot be committed, and
-  changed the interactive failure messages to describe that behavior.
+- Returned the exact directory buffers or archive bytes from scene load and Save, hashed those retained bytes,
+  and reused the same directory framing for later drift checks. There is no second path read between parsing or
+  publishing and retaining the input identity. Optional canonical inputs that exist but are not readable files
+  also make the current snapshot unverifiable.
+- Reused one all-or-nothing resolver in both double-switch occupation and release. Both compound identities and
+  all four base branches resolve before either function mutates the global occupied or connected lists.
+- Replaced standalone sidecar writes with one paired artifact writer. Every result CSV and PNG remains staged
+  until its normal or delay provenance sidecar commits; failure leaves no newly published artifact.
 - Strengthened the seventh-case wrapper to compare every run sidecar hash with the exact `.egscene` bytes.
 
 - Corrected connection-derived adjacency to use actual section boundaries instead of internal switch endpoints.
@@ -874,11 +891,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 ### Unresolved application blockers
 
 - PRs 1 through 5 are complete. PR 6 provenance and the public UI-only seventh-case implementation pass their
-  focused gates. The first correctness review's three findings are corrected and pass focused regressions. A
-  fresh corrected-diff review, Ponytail review, the full local regression gate, CI, and the final merged-main
+  focused gates. Both correctness-review rounds are corrected and pass focused regressions. A fresh review of
+  the exact corrected commit, Ponytail review, the full local regression gate, CI, and the final merged-main
   completeness review remain before the verdict can change.
 
 ## Next action
 
-Commit and push the first PR 6 correctness corrections, run a fresh independent review of the exact corrected
+Commit and push the second PR 6 correctness corrections, run a fresh independent review of the exact corrected
 diff, fix every confirmed finding, then run the Ponytail review and complete regression gate before merge.

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -11,6 +11,7 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - Current milestone: PR 6, reproducible exports and UI-only seventh-case proof
 - Current worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/creator-acceptance`
 - Current branch: `feature/result-provenance-creator-acceptance`
+- Current branch head: `095bfa554d43576d1eea52d5cc4d5d1f7c6e86ba`
 - Current PR: draft PR #295, `Add reproducible creator acceptance`
 - Completed milestones and PRs:
   - PR #290, `Bind signals to canonical track sections`, merged as
@@ -576,6 +577,23 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   the subsequent scenario-less compatibility correction.
 - After the PR 6 Ponytail reductions, the affected target built and the public creator smoke passed in 5.20
   seconds. The full seven-test focused gate then passed 7 of 7 in 11.24 seconds, and `git diff --check` passed.
+- The final PR 6 gate at `095bfa554d43576d1eea52d5cc4d5d1f7c6e86ba` passed:
+  - configure and full build;
+  - CTest 44 of 44 in 141.13 seconds, including CSV provenance and the creator acceptance smoke;
+  - editor smoke after all seven scene tests;
+  - six-case native headless smoke with every movement, non-sentinel, and served-station assertion;
+  - six-case validate, export, reimport, and count parity with `ROUNDTRIP PASS`;
+  - Assignment canonical timetable smoke;
+  - breakdown and protected-signal incident hold/release smoke;
+  - DPR 1 and DPR 2 visual-polish, station-overlay, scene-render, and legacy-import smoke;
+  - packing and validation of all six `.egscene` bundles plus a native headless Assignment bundle run;
+  - `git diff --check` from merged PR 5 main to the exact PR 6 head.
+- The final graph update scanned the PR 6 worktree and wrote only to the canonical maintained graph. It rebuilt
+  6,298 nodes, 10,749 edges, and 1,619 communities.
+- The current native structural, movement, station-service, round-trip, and bundle checks required as the live
+  portions of #85 and #86 passed. Those two issues remain open because their separate historical acceptance also
+  asks for retained pre-cutover artifact comparisons and explicit expanded-train baselines; this execution does
+  not invent or silently claim that missing historical evidence.
 
 ## Review record
 
@@ -608,6 +626,10 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - The final fresh correctness review found no P0, P1, or P2 issue at `08c9830`. It independently passed the four
   snapshot/writer/bundle/builder tests and both public CSV/creator smokes, accepted a direct six-file
   scenario-less directory, rejected a present directory-valued passenger input, and approved the diff.
+- The fresh post-Ponytail correctness review found no P0, P1, or P2 issue at `095bfa5`. It verified that the
+  simplified state machine cannot emit its final marker early, that the wrapper still parses all 15 result
+  artifacts and sidecars, and that no provenance or double-switch production path was weakened. Its seven-test
+  focused gate, direct creator smoke, and both diff checks passed.
 
 - The fresh post-Ponytail correctness review found no P0, P1, or P2 issue at `538ac72`. It traced native
   passenger preflight and no-mutation behavior, importer station resolution, occurrence filtering, passenger
@@ -915,11 +937,10 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 
 ### Unresolved application blockers
 
-- PRs 1 through 5 are complete. PR 6 correctness and Ponytail gates are clean, and the simplified creator path
-  passes the focused regressions. The final complete local regression gate, CI, merge, and merged-main
-  completeness review remain before the verdict can change.
+- PRs 1 through 5 are complete. PR 6 implementation, local regression, correctness, and Ponytail gates are clean.
+  Current-head CI, merge, and the independent merged-main completeness review remain before the verdict can change.
 
 ## Next action
 
-Commit and push the PR 6 Ponytail reductions, run a fresh correctness check of the simplified diff, then complete
-the final regression, CI, merge, and merged-main completeness gates.
+Commit and push this final verification record, wait for exact-head CI, merge PR #295, then run the independent
+creator-completeness review against merged `origin/main` and finalize the ledger.

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -203,6 +203,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 - Station and service rename/delete integrity now includes passenger journey and leg references. The public
   smoke covers passenger/journey/leg add, edit, move, delete, import, focused Save, folder/bundle reopen, and
   native passenger/platform staging without private model mutation for the claimed authoring operations.
+- PR 6 captures immutable case, schema, saved-input hash/status, scenario, effective settings, modes, and exact
+  staged service occurrences after native preparation. Existing CSV schemas remain unchanged; CSV and PNG
+  exports receive atomic `.provenance.json` sidecars, and delay comparison sidecars retain both runs.
 
 ## Verification record
 
@@ -519,6 +522,14 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   six-case round-trip (`ROUNDTRIP PASS`), Assignment, and DPR 1/DPR 2 visual-polish smokes passed. All six
   committed scenes validated with exit 0. GitHub build and sanitizer jobs passed at the exact final head.
 - PR #294 merged as `1f095b2bfe7c95bc6b68940349a9357c43c49468`; issues #164 and #288 closed with the merge.
+- PR 6 baseline configured and built successfully from merged main `1f095b2`. `test_runresults` and
+  `test_csv_export_smoke` passed 2 of 2 in 7.27 seconds. The baseline editor smoke passed after all 7
+  scene tests passed.
+- After the provenance implementation and removal of a test-only DiagramWindow compile branch, the focused
+  `test_runresults`, `test_diagramwindow`, and `test_csv_export_smoke` gate passed 3 of 3 in 7.18 seconds.
+  The strengthened CSV smoke then passed alone in 6.40 seconds and verified Paimpol's exact case/schema,
+  directory snapshot path and SHA-256, clean reproducible status, baseline scenario, effective run settings,
+  modes, and selected occurrence records for every emitted artifact.
 
 ## Review record
 
@@ -806,10 +817,10 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 
 ### Unresolved application blockers
 
-- PRs 1 through 5 are complete. PR 6 remains open: immutable export provenance and the public UI-only
-  seventh-case acceptance proof.
+- PRs 1 through 5 are complete. PR 6 export provenance is implemented and focused tests pass. The remaining
+  blocker is the public UI-only seventh-case acceptance proof and its complete regression gate.
 
 ## Next action
 
-Configure and build the clean PR 6 worktree at `1f095b2`, run the focused results/export baseline, then implement
-immutable run provenance and additive CSV/PNG sidecars before adding the public seventh-case creator smoke.
+Commit the verified provenance checkpoint, then add the public seventh-case creator smoke from a blank process
+through New Case, public folder/bundle persistence, native runs, result exports, and stale-result invalidation.

--- a/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
+++ b/docs/planning/CREATOR_IMPLEMENTATION_LEDGER.md
@@ -570,6 +570,10 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   `test_csv_export_smoke`, and `test_creator_acceptance_smoke` passed 7 of 7 in 12.45 seconds.
   A follow-up `test_runresults` rebuild and run passed 1 of 1 in 0.51 seconds after covering a non-file optional
   canonical input. `git diff --check` passed.
+- After the scenario-less compatibility correction, the same affected targets built and the seven-test gate
+  passed 7 of 7 in 12.40 seconds. Its direct `test_runresults` regression passed 1 of 1 in 0.52 seconds.
+- The complete PR 6 configure and build passed, and CTest passed 44 of 44 in 145.38 seconds at `3baa718` before
+  the subsequent scenario-less compatibility correction.
 
 ## Review record
 
@@ -594,6 +598,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
      leave a provenance-free result.
   The reviewer independently passed the five-test provenance, diagram, scene-builder, CSV, and creator gate
   before reproducing the boundaries.
+- The repository-configured adversarial review found no P0, P1, or P2 issue at `3baa718` after tracing the exact
+  snapshot, bundle, paired-export, double-switch, and public creator paths. The requested second fresh review
+  found one P2 compatibility regression: `readSceneDirectorySnapshot` required a scenario file even though
+  `loadScene` accepts neither file and synthesizes the baseline scenario. The reviewer reproduced a clean
+  Paimpol-derived directory being labeled non-reproducible after removing only `scenarios.json`.
 
 - The fresh post-Ponytail correctness review found no P0, P1, or P2 issue at `538ac72`. It traced native
   passenger preflight and no-mutation behavior, importer station resolution, occurrence filtering, passenger
@@ -741,6 +750,9 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
   all four base branches resolve before either function mutates the global occupied or connected lists.
 - Replaced standalone sidecar writes with one paired artifact writer. Every result CSV and PNG remains staged
   until its normal or delay provenance sidecar commits; failure leaves no newly published artifact.
+- Matched current-snapshot reconstruction to loader compatibility: `scenarios.json` and legacy `incidents.json`
+  are hashed when present, but neither is required. A scenario-less saved directory can retain reproducible
+  provenance, while an existing unreadable optional file still fails closed.
 - Strengthened the seventh-case wrapper to compare every run sidecar hash with the exact `.egscene` bytes.
 
 - Corrected connection-derived adjacency to use actual section boundaries instead of internal switch endpoints.
@@ -891,11 +903,11 @@ Make EGTRAIN creator-complete for an independent seventh network. A user with au
 ### Unresolved application blockers
 
 - PRs 1 through 5 are complete. PR 6 provenance and the public UI-only seventh-case implementation pass their
-  focused gates. Both correctness-review rounds are corrected and pass focused regressions. A fresh review of
-  the exact corrected commit, Ponytail review, the full local regression gate, CI, and the final merged-main
+  focused gates. The scenario-less compatibility finding is corrected and passes focused regressions. One fresh
+  review of the exact corrected commit, Ponytail review, the final local regression gate, CI, and the merged-main
   completeness review remain before the verdict can change.
 
 ## Next action
 
-Commit and push the second PR 6 correctness corrections, run a fresh independent review of the exact corrected
+Commit and push the scenario-less provenance correction, run a fresh independent review of the exact corrected
 diff, fix every confirmed finding, then run the Ponytail review and complete regression gate before merge.

--- a/tools/e2e/creator_acceptance_smoke.sh
+++ b/tools/e2e/creator_acceptance_smoke.sh
@@ -128,6 +128,7 @@ fi
 
 python3 - "$FOLDER" "$UNPACKED" "$BUNDLE" "$EXPORTS" <<'PY'
 import csv
+import hashlib
 import json
 import math
 import re
@@ -421,6 +422,8 @@ def check_input(run, scenario, bundle_path):
            "provenance input is not reproducible")
     expect(re.fullmatch(r"[0-9a-f]{64}", input_data["sha256"] or "") is not None,
            "provenance input hash is not a 64-character lowercase SHA-256")
+    expect(input_data["sha256"] == hashlib.sha256(bundle_path.read_bytes()).hexdigest(),
+           "provenance input hash does not match the exact saved bundle bytes")
     occurrences = {(item["service_id"], item["occurrence"])
                    for item in run["selected_occurrences"]}
     expect(occurrences == EXPECTED_OCCURRENCES,

--- a/tools/e2e/creator_acceptance_smoke.sh
+++ b/tools/e2e/creator_acceptance_smoke.sh
@@ -1,0 +1,513 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+APP="$ROOT/build/QEGTRAIN.app/Contents/MacOS/QEGTRAIN"
+SCENE_TOOL="$ROOT/build/scene_tool"
+
+if [[ ! -x "$APP" ]]; then
+	echo "QEGTRAIN app not found or not executable: $APP" >&2
+	exit 1
+fi
+if [[ ! -x "$SCENE_TOOL" ]]; then
+	echo "scene_tool not found or not executable: $SCENE_TOOL" >&2
+	exit 1
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/qegtrain-creator-acceptance.XXXXXX")"
+cleanup() {
+	local exit_code=$?
+	trap - EXIT
+	rm -rf "$TMP_ROOT"
+	exit "$exit_code"
+}
+trap cleanup EXIT
+
+FOLDER="$TMP_ROOT/creator-folder"
+BUNDLE="$TMP_ROOT/creator.egscene"
+UNPACKED="$TMP_ROOT/unpacked-bundle"
+OUTPUT="$TMP_ROOT/output"
+EXPORTS="$TMP_ROOT/exports"
+LOG="$TMP_ROOT/creator-acceptance.log"
+mkdir -p "$FOLDER" "$OUTPUT" "$EXPORTS"
+
+set +e
+python3 - "$ROOT" "$APP" "$LOG" "$OUTPUT" "$FOLDER" "$BUNDLE" "$EXPORTS" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+root, app, log, output, folder, bundle, exports = map(Path, sys.argv[1:])
+environment = os.environ.copy()
+environment.update({
+    "QEGTRAIN_E2E_CREATOR_ACCEPTANCE": "1",
+    "QEGTRAIN_E2E_OUT": str(output),
+    "QEGTRAIN_E2E_CREATOR_FOLDER": str(folder),
+    "QEGTRAIN_E2E_CREATOR_BUNDLE": str(bundle),
+    "QEGTRAIN_E2E_CREATOR_EXPORT_DIR": str(exports),
+    "QT_QPA_PLATFORM": "offscreen",
+})
+command = [str(app), "-g", "1", "-pax", "1", "-TSM", "0", "-RC", "0"]
+
+
+def stop_group(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=5)
+
+
+with log.open("wb") as stream:
+    process = subprocess.Popen(
+        command,
+        cwd=root / "EGTRAIN" / "QEGTRAIN",
+        env=environment,
+        stdout=stream,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        exit_code = process.wait(timeout=180)
+    except subprocess.TimeoutExpired:
+        stop_group(process)
+        print("creator acceptance app timed out after 180 seconds", file=sys.stderr)
+        sys.exit(124)
+
+if exit_code:
+    print(f"creator acceptance app exited with {exit_code}", file=sys.stderr)
+sys.exit(exit_code)
+PY
+APP_EXIT=$?
+set -e
+
+required_markers=(
+	E2E_CREATOR_NEW_CASE_OK
+	E2E_CREATOR_INFRASTRUCTURE_OK
+	E2E_CREATOR_STATIONS_SIGNALLING_OK
+	E2E_CREATOR_ROLLING_STOCK_OK
+	E2E_CREATOR_SERVICE_OK
+	E2E_CREATOR_SCENARIOS_OK
+	E2E_CREATOR_PASSENGER_OK
+	E2E_CREATOR_FOLDER_ROUNDTRIP_OK
+	E2E_CREATOR_BUNDLE_ROUNDTRIP_OK
+	E2E_CREATOR_BASELINE_RUN_OK
+	E2E_CREATOR_ENTRANCE_RUN_OK
+	E2E_CREATOR_INCIDENT_RUN_OK
+	E2E_CREATOR_EXPORTS_OK
+	E2E_CREATOR_ACCEPTANCE_OK
+)
+missing_markers=()
+for marker in "${required_markers[@]}"; do
+	if ! grep -Fqx "$marker" "$LOG"; then
+		missing_markers+=("$marker")
+	fi
+done
+if [[ "$APP_EXIT" -ne 0 || "${#missing_markers[@]}" -ne 0 ]]; then
+	echo "creator acceptance smoke failed (app exit $APP_EXIT)" >&2
+	if [[ "${#missing_markers[@]}" -gt 0 ]]; then
+		echo "missing markers: ${missing_markers[*]}" >&2
+	fi
+	echo "--- log tail ---" >&2
+	tail -40 "$LOG" >&2 || true
+	exit 1
+fi
+
+"$SCENE_TOOL" validate "$FOLDER"
+"$SCENE_TOOL" validate "$BUNDLE"
+"$SCENE_TOOL" unpack "$BUNDLE" "$UNPACKED"
+"$SCENE_TOOL" validate "$UNPACKED"
+
+python3 - "$FOLDER" "$UNPACKED" "$BUNDLE" "$EXPORTS" <<'PY'
+import csv
+import json
+import math
+import re
+import sys
+from pathlib import Path
+
+folder, unpacked, bundle, exports = map(Path, sys.argv[1:])
+EXPECTED_FILES = (
+    "scene.json",
+    "infrastructure.json",
+    "stations.json",
+    "signalling.json",
+    "rolling_stock.json",
+    "services.json",
+    "scenarios.json",
+    "passengers.json",
+)
+LEGACY_CASE_NAMES = (
+    "netherlands",
+    "paimpol",
+    "copenhagen",
+    "milano_brescia",
+    "assignment_gvc_gdg_ut",
+    "lebanon",
+)
+LEGACY_PATH_PARTS = (
+    "legacy/",
+    "tracklines/",
+    "timetable/",
+    "traindata/",
+    "trains/",
+    "routestowrite/",
+    "routes/",
+    "gui/",
+    "passengers/",
+)
+EXPECTED_OCCURRENCES = {
+    ("creator-service", 1),
+    ("creator-service", 2),
+}
+
+
+def expect(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def number(value, label):
+    value = float(value)
+    expect(math.isfinite(value), f"{label} is not finite")
+    return value
+
+
+def close(value, expected, label):
+    expect(math.isclose(number(value, label), expected, rel_tol=0, abs_tol=1e-9),
+           f"{label} expected {expected}, got {value}")
+
+
+def load_scene(root):
+    documents = {}
+    for name in EXPECTED_FILES:
+        path = root / name
+        expect(path.is_file(), f"missing canonical file: {path}")
+        try:
+            documents[name] = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise AssertionError(f"cannot parse {path}: {error}") from error
+    return documents
+
+
+def reject_legacy_values(value, location="root"):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            key_text = str(key).lower()
+            expect(key_text not in {"legacy_root", "import_report"},
+                   f"legacy provenance key in canonical data: {location}.{key}")
+            reject_legacy_values(child, f"{location}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_legacy_values(child, f"{location}[{index}]")
+    elif isinstance(value, str):
+        lowered = value.lower()
+        expect("legacy_root" not in lowered,
+               f"legacy_root in canonical value at {location}")
+        expect(not any(name in lowered for name in LEGACY_CASE_NAMES),
+               f"legacy case name in canonical value at {location}: {value}")
+        expect(not any(part in lowered for part in LEGACY_PATH_PARTS),
+               f"legacy path in canonical value at {location}: {value}")
+        expect(not re.search(r"(?:^|[/\\])(?:users|private|var|tmp|home)/", lowered),
+               f"absolute legacy path in canonical value at {location}: {value}")
+
+
+def check_scene(documents, label):
+    for name, document in documents.items():
+        reject_legacy_values(document, f"{label}/{name}")
+
+    scene = documents["scene.json"]
+    expect(scene["schema_version"] == 1, f"{label}: scene schema is not v1")
+    expect(scene["name"] == "creator_acceptance_case", f"{label}: wrong case name")
+    settings = scene["simulation_settings"]
+    close(settings["duration_seconds"], 900, f"{label}: duration")
+
+    infrastructure = documents["infrastructure.json"]
+    tracks = infrastructure["tracks"]
+    expect([track["id"] for track in tracks] == ["creator-main", "creator-yard"],
+           f"{label}: tracks are not the authored pair")
+    nodes = infrastructure["nodes"]
+    expect(len(nodes) == 6, f"{label}: expected 6 nodes")
+    expected_nodes = {
+        "creator-main-node-0": ("creator-main", 0.0, 0.0),
+        "creator-main-node-1": ("creator-main", 1.0, 0.25),
+        "creator-main-node-2": ("creator-main", 2.0, 0.0),
+        "creator-yard-node-0": ("creator-yard", 0.0, 1.0),
+        "creator-yard-node-1": ("creator-yard", 1.5, 1.0),
+        "creator-yard-node-2": ("creator-yard", 2.0, 1.0),
+    }
+    expect({node["id"] for node in nodes} == set(expected_nodes),
+           f"{label}: node IDs do not match authored topology")
+    for node in nodes:
+        track, x, y = expected_nodes[node["id"]]
+        expect(node["track"] == track, f"{label}: node track mismatch: {node['id']}")
+        close(node["x_km"], x, f"{label}: node x {node['id']}")
+        close(node["y_km"], y, f"{label}: node y {node['id']}")
+
+    arcs = infrastructure["arcs"]
+    expect(len(arcs) == 4, f"{label}: expected 4 arcs")
+    expected_arcs = {
+        "creator-main-arc-0": ("creator-main-node-0", "creator-main-node-1", 0, -0.001953125, 22.5),
+        "creator-main-arc-1": ("creator-main-node-1", "creator-main-node-2", 1250.5, 0.00390625, 22.5),
+        "creator-yard-arc-0": ("creator-yard-node-0", "creator-yard-node-1", 0, 0.0009765625, 18),
+        "creator-yard-arc-1": ("creator-yard-node-1", "creator-yard-node-2", 0, 0.0009765625, 18),
+    }
+    for arc in arcs:
+        source, target, curvature, gradient, speed = expected_arcs[arc["id"]]
+        expect((arc["from"], arc["to"]) == (source, target),
+               f"{label}: arc endpoints mismatch: {arc['id']}")
+        close(arc["curvature_radius_m"], curvature, f"{label}: arc curvature {arc['id']}")
+        close(arc["gradient_percent"], gradient, f"{label}: arc gradient {arc['id']}")
+        close(arc["speed_limit_ms"], speed, f"{label}: arc speed {arc['id']}")
+
+    blocks = infrastructure["blocks"]
+    expected_blocks = [
+        "creator-main-block-renamed",
+        "creator-main-block-1",
+        "creator-main-block-2",
+        "creator-yard-block-0",
+        "creator-yard-block-1",
+        "creator-yard-block-2",
+    ]
+    expect([block["id"] for block in blocks] == expected_blocks,
+           f"{label}: blocks are not in authored order")
+    expect(all(number(block["length_km"], f"{label}: block length") > 0 for block in blocks),
+           f"{label}: block lengths are not positive")
+
+    connections = infrastructure["connections"]
+    expect(len(connections) == 1, f"{label}: expected one connection")
+    expect(connections[0]["id"] == "creator-switch"
+           and connections[0]["from"] == "creator-main-node-1"
+           and connections[0]["to"] == "creator-yard-node-1",
+           f"{label}: authored switch connection missing")
+
+    stations = documents["stations.json"]["stations"]
+    expect(len(stations) == 2, f"{label}: expected two stations")
+    expect([station["id"] for station in stations]
+           == ["creator-station-a", "creator-station-b"],
+           f"{label}: station order mismatch")
+    for station in stations:
+        expect(len(station["platforms"]) == 1,
+               f"{label}: station lacks its authored platform: {station['id']}")
+        platform = station["platforms"][0]
+        expect(number(platform["length_m"], f"{label}: platform length") > 0
+               and number(platform["width_m"], f"{label}: platform width") > 0
+               and platform["nodes"],
+               f"{label}: platform geometry is not explicit and positive")
+
+    signalling = documents["signalling.json"]
+    signals = [signal for signal in signalling["signals"]
+               if signal["id"] == "creator-signal"]
+    expect(len(signals) == 1 and signals[0]["protected_section"],
+           f"{label}: signal lacks an explicit protected section")
+    areas = signalling["signalling_areas"]
+    expect(len(areas) == 1 and areas[0]["id"] == "creator-signalling-area"
+           and areas[0]["level"] == 0 and "track" not in areas[0],
+           f"{label}: global conventional signalling area missing")
+    close(areas[0]["start_km"], 0, f"{label}: signalling area start")
+    close(areas[0]["end_km"], 2, f"{label}: signalling area end")
+    routes = [route for route in signalling["routes"] if route["id"] == "creator-route"]
+    expect(len(routes) == 1 and len(routes[0]["blocks"]) == 3,
+           f"{label}: switched route does not have three sections")
+    route_blocks = routes[0]["blocks"]
+    expect(route_blocks[0].startswith("@creator-main-block-renamed@")
+           and "/" in route_blocks[1]
+           and route_blocks[2].startswith("@creator-yard-block-2@"),
+           f"{label}: switched route section order is wrong")
+
+    rolling_stock = documents["rolling_stock.json"]
+    units = rolling_stock["train_units"]
+    expect(len(units) == 2, f"{label}: expected two train units")
+    expect([unit["id"] for unit in units] == ["creator-unit-a", "creator-unit-b"],
+           f"{label}: train-unit order mismatch")
+    physical_fields = (
+        "mass_of_traction_unit_kg",
+        "mass_of_a_wagon_kg",
+        "number_of_wagons",
+        "max_deceleration_ms2",
+        "max_speed_ms",
+        "frontal_area_m2",
+        "jerk_ms3",
+        "resistance_coefficient",
+        "length_m",
+    )
+    for unit in units:
+        physical = unit["physical"]
+        expect(all(field in physical for field in physical_fields),
+               f"{label}: incomplete physical train-unit data")
+        expect(unit["traction_curve"] and all(len(row) >= 5 for row in unit["traction_curve"]),
+               f"{label}: missing train-unit traction data")
+    close(units[0]["physical"]["mass_of_traction_unit_kg"], 91000,
+          f"{label}: focused-save traction-unit mass")
+    compositions = rolling_stock["compositions"]
+    expect(len(compositions) == 1
+           and compositions[0]["units"] == ["creator-unit-a", "creator-unit-b"],
+           f"{label}: two-unit composition was not retained in order")
+
+    services = documents["services.json"]["services"]
+    expect(len(services) == 1, f"{label}: expected one service")
+    service = services[0]
+    expect(service["id"] == "creator-service", f"{label}: service ID mismatch")
+    expect(service["composition"] == "creator-composition"
+           and service["route"] == "creator-route", f"{label}: service references mismatch")
+    close(service["performance_percent"], 92, f"{label}: service performance")
+    close(service["maximum_speed_kmh"], 100, f"{label}: service maximum speed")
+    repeat = service["repeat"]
+    expect(repeat["count"] == 3 and repeat["headway_seconds"] == 300
+           and repeat["operating_code_step"] == 1,
+           f"{label}: repeat/headway/code-step values mismatch")
+    stops = service["stops"]
+    expect(len(stops) == 2, f"{label}: expected two ordered service stops")
+    expect(stops[0]["station"] == "creator-station-a"
+           and stops[1]["station"] == "creator-station-b",
+           f"{label}: service stop order mismatch")
+    close(stops[0]["planned_arrival_seconds"], 180, f"{label}: first arrival")
+    close(stops[0]["planned_departure_seconds"], 240, f"{label}: first departure")
+    close(stops[1]["planned_arrival_seconds"], 480, f"{label}: second arrival")
+    close(stops[1]["planned_departure_seconds"], 540, f"{label}: second departure")
+    expect(stops[0]["planned_arrival_seconds"] != stops[0]["planned_departure_seconds"],
+           f"{label}: arrival and departure were collapsed")
+
+    scenarios = documents["scenarios.json"]["scenarios"]
+    expect([scenario["id"] for scenario in scenarios] == ["baseline", "incident", "entrance"],
+           f"{label}: expected baseline, incident, and entrance scenarios")
+    incident = scenarios[1]
+    expect(any(item["type"] == "signal_failure" and item["target"] == "creator-signal"
+               for item in incident["incidents"]), f"{label}: signal failure missing")
+    expect(any(item["type"] == "train_breakdown" and item.get("occurrence") == 1
+               and item.get("reduced_speed_kmh") == 10
+               for item in incident["incidents"]), f"{label}: occurrence-1 reduced-speed breakdown missing")
+    entrance_delays = scenarios[2]["entrance_delays"]
+    expect(len(entrance_delays) == 1 and entrance_delays[0]["occurrence"] == 2
+           and entrance_delays[0]["service"] == "creator-service"
+           and entrance_delays[0]["station"] == "creator-station-a",
+           f"{label}: occurrence-2 entrance delay binding missing")
+    close(entrance_delays[0]["delay_seconds"], 90, f"{label}: entrance delay")
+
+    passengers = documents["passengers.json"]["passengers"]
+    expect(len(passengers) == 1, f"{label}: expected one passenger")
+    journey = passengers[0]["journeys"][0]
+    expect(journey["id"] == "creator-journey" and journey["legs"],
+           f"{label}: passenger journey/leg missing")
+    leg = journey["legs"][0]
+    expect(leg["id"] == "creator-leg" and leg["service"] == "creator-service"
+           and leg["occurrence"] == 1 and leg["origin"] == "creator-station-a"
+           and leg["destination"] == "creator-station-b",
+           f"{label}: passenger leg semantics mismatch")
+
+
+def check_input(run, scenario, bundle_path):
+    expect(run["applied_scenario"] == scenario,
+           f"provenance scenario mismatch: expected {scenario}")
+    expect(run["case_name"] == "creator_acceptance_case", "provenance case name mismatch")
+    expect(run["scene_schema_version"] == 1, "provenance scene schema mismatch")
+    expect(run["duration_seconds"] == 900 and run["pax_mode"] == 1
+           and run["tsm_mode"] == 0 and run["route_choice_mode"] == 0,
+           "provenance run settings mismatch")
+    input_data = run["input"]
+    expect(input_data["kind"] == "bundle", "provenance input is not the saved bundle")
+    expect(Path(input_data["path"]).resolve() == bundle_path.resolve(),
+           "provenance input path does not identify the saved bundle")
+    expect(input_data["reproducible"] is True and input_data["dirty"] is False
+           and input_data["status"] == "reproducible" and input_data["reason"] == "",
+           "provenance input is not reproducible")
+    expect(re.fullmatch(r"[0-9a-f]{64}", input_data["sha256"] or "") is not None,
+           "provenance input hash is not a 64-character lowercase SHA-256")
+    occurrences = {(item["service_id"], item["occurrence"])
+                   for item in run["selected_occurrences"]}
+    expect(occurrences == EXPECTED_OCCURRENCES,
+           "provenance does not retain selected occurrences 1 and 2")
+
+
+def check_sidecar(path, expected_scenario, bundle_path):
+    sidecar = Path(str(path) + ".provenance.json")
+    expect(sidecar.is_file() and sidecar.stat().st_size > 0,
+           f"missing or empty provenance sidecar: {sidecar.name}")
+    document = json.loads(sidecar.read_text(encoding="utf-8"))
+    expect(document["schema_version"] == 1, f"{sidecar.name}: schema mismatch")
+    expect(document["artifact"]["file_name"] == path.name,
+           f"{sidecar.name}: artifact filename mismatch")
+    expected_kind = "png" if path.suffix.lower() == ".png" else "csv"
+    expect(document["artifact"]["kind"] == expected_kind,
+           f"{sidecar.name}: artifact kind mismatch")
+    check_input(document["run"], expected_scenario, bundle_path)
+
+
+def check_exports(bundle_path):
+    expected = {
+        "baseline_time_distance.csv": "baseline",
+        "trajectory.csv": "incident",
+        "trajectory.png": "incident",
+        "timetable.csv": "incident",
+        "timetable.png": "incident",
+        "blocking_time.csv": "incident",
+        "blocking_time.png": "incident",
+        "tractive_effort.csv": "incident",
+        "tractive_effort.png": "incident",
+        "run_summary.csv": "incident",
+        "run_summary.png": "incident",
+        "capacity_analysis.csv": "incident",
+        "capacity_compressed_blocking_time.csv": "incident",
+        "capacity_compressed_blocking_time.png": "incident",
+        "delay_comparison.csv": "delay",
+    }
+    for name, scenario in expected.items():
+        path = exports / name
+        expect(path.is_file() and path.stat().st_size > 0,
+               f"missing or empty principal export: {name}")
+        if path.suffix.lower() == ".png":
+            expect(path.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n", f"invalid PNG export: {name}")
+        if scenario == "delay":
+            sidecar = Path(str(path) + ".provenance.json")
+            expect(sidecar.is_file() and sidecar.stat().st_size > 0,
+                   f"missing or empty provenance sidecar: {sidecar.name}")
+            document = json.loads(sidecar.read_text(encoding="utf-8"))
+            expect(document["schema_version"] == 1
+                   and document["artifact"] == {"kind": "csv", "file_name": name},
+                   f"{name}: delay provenance envelope mismatch")
+            check_input(document["baseline_run"], "baseline", bundle_path)
+            check_input(document["scenario_run"], "incident", bundle_path)
+        else:
+            check_sidecar(path, scenario, bundle_path)
+
+    with (exports / "blocking_time.csv").open(newline="", encoding="utf-8") as stream:
+        blocking_rows = list(csv.DictReader(stream))
+    with (exports / "trajectory.csv").open(newline="", encoding="utf-8") as stream:
+        trajectory_rows = list(csv.DictReader(stream))
+    selected_train_ids = {
+        row["Train"] for row in trajectory_rows
+        if row["Service ID"] == "creator-service" and int(row["Occurrence"]) in (1, 2)
+    }
+    expect(len(selected_train_ids) == 2,
+           "trajectory export does not identify both selected service occurrences")
+    actual = [row for row in blocking_rows if row["Segment type"] != "planned reference"]
+    expect({row["Train"] for row in actual} == selected_train_ids,
+           "blocking-time export lacks actual occupations for both selected occurrences")
+    expect(all(row["Block"] and row["Occupation start[s]"] and row["Occupation end[s]"]
+               for row in actual), "blocking-time actual occupation is incomplete")
+
+    with (exports / "capacity_analysis.csv").open(newline="", encoding="utf-8") as stream:
+        capacity_rows = list(csv.DictReader(stream))
+    record_types = {row["Record type"] for row in capacity_rows}
+    expect({"summary", "pair", "compression"}.issubset(record_types),
+           "capacity export lacks summary, pair, or compression evidence")
+    summary = next(row for row in capacity_rows if row["Record type"] == "summary")
+    expect(number(summary["Cycle time[s]"], "capacity cycle") > 0,
+           "capacity cycle is not positive")
+
+
+for label, root in (("saved folder", folder), ("unpacked bundle", unpacked)):
+    check_scene(load_scene(root), label)
+check_exports(bundle)
+print("creator acceptance canonical semantics and exports passed")
+PY
+
+echo "creator acceptance smoke passed"

--- a/tools/e2e/creator_acceptance_smoke.sh
+++ b/tools/e2e/creator_acceptance_smoke.sh
@@ -89,33 +89,8 @@ PY
 APP_EXIT=$?
 set -e
 
-required_markers=(
-	E2E_CREATOR_NEW_CASE_OK
-	E2E_CREATOR_INFRASTRUCTURE_OK
-	E2E_CREATOR_STATIONS_SIGNALLING_OK
-	E2E_CREATOR_ROLLING_STOCK_OK
-	E2E_CREATOR_SERVICE_OK
-	E2E_CREATOR_SCENARIOS_OK
-	E2E_CREATOR_PASSENGER_OK
-	E2E_CREATOR_FOLDER_ROUNDTRIP_OK
-	E2E_CREATOR_BUNDLE_ROUNDTRIP_OK
-	E2E_CREATOR_BASELINE_RUN_OK
-	E2E_CREATOR_ENTRANCE_RUN_OK
-	E2E_CREATOR_INCIDENT_RUN_OK
-	E2E_CREATOR_EXPORTS_OK
-	E2E_CREATOR_ACCEPTANCE_OK
-)
-missing_markers=()
-for marker in "${required_markers[@]}"; do
-	if ! grep -Fqx "$marker" "$LOG"; then
-		missing_markers+=("$marker")
-	fi
-done
-if [[ "$APP_EXIT" -ne 0 || "${#missing_markers[@]}" -ne 0 ]]; then
+if [[ "$APP_EXIT" -ne 0 ]] || ! grep -Fqx E2E_CREATOR_ACCEPTANCE_OK "$LOG"; then
 	echo "creator acceptance smoke failed (app exit $APP_EXIT)" >&2
-	if [[ "${#missing_markers[@]}" -gt 0 ]]; then
-		echo "missing markers: ${missing_markers[*]}" >&2
-	fi
 	echo "--- log tail ---" >&2
 	tail -40 "$LOG" >&2 || true
 	exit 1

--- a/tools/e2e/csv_export_smoke.sh
+++ b/tools/e2e/csv_export_smoke.sh
@@ -31,10 +31,16 @@ for name in trajectory timetable run_summary; do
 		echo "missing or empty export: $OUTDIR/$name.csv" >&2
 		exit 1
 	fi
+	if [[ ! -s "$OUTDIR/$name.csv.provenance.json" ]]; then
+		echo "missing or empty provenance sidecar: $OUTDIR/$name.csv.provenance.json" >&2
+		exit 1
+	fi
 done
 
 # The blocking-time export also carries the visible planned reference layer.
 if [[ -s "$OUTDIR/blocking_time.csv" ]]; then
+	[[ -s "$OUTDIR/blocking_time.csv.provenance.json" ]] \
+		|| { echo "missing blocking_time.csv provenance sidecar" >&2; exit 1; }
 	head -n1 "$OUTDIR/blocking_time.csv" | grep -q "^Train,Block,Occupation start\[s\]" \
 		|| { echo "blocking_time.csv header mismatch" >&2; exit 1; }
 	grep -q ",planned reference," "$OUTDIR/blocking_time.csv" \
@@ -49,6 +55,8 @@ head -n1 "$OUTDIR/timetable.csv" | grep -q "^Train,Station,Journey order,Operati
 head -n1 "$OUTDIR/run_summary.csv" | grep -q "^Train,Operating code,Performance \[%\],Applied maximum speed \[km/h\],Start\[s\],End\[s\],Travel time\[s\]" \
 	|| { echo "run_summary.csv header mismatch" >&2; exit 1; }
 if [[ -s "$OUTDIR/capacity_analysis.csv" ]]; then
+	[[ -s "$OUTDIR/capacity_analysis.csv.provenance.json" ]] \
+		|| { echo "missing capacity_analysis.csv provenance sidecar" >&2; exit 1; }
 	head -n1 "$OUTDIR/capacity_analysis.csv" | grep -q "^Record type,Leader,Follower,Identity,Operating code,Original reference\[s\].*Cycle time\[s\],Period\[s\],Cycle / period \[%\],Section,Reference label,Reference source" \
 		|| { echo "capacity_analysis.csv header mismatch" >&2; exit 1; }
 	for record in summary pair compression critical; do
@@ -71,6 +79,44 @@ else
 	grep -q "E2E_CAPACITY_EXPORT_UNAVAILABLE" "$LOG" \
 		|| { echo "capacity export was skipped without an explicit unavailable marker" >&2; exit 1; }
 fi
+
+python3 - "$SCENE" "$OUTDIR" <<'PY'
+import json
+import os
+import re
+import sys
+
+scene, output = map(os.path.abspath, sys.argv[1:])
+artifacts = ["trajectory.csv", "timetable.csv", "run_summary.csv"]
+artifacts += [name for name in ("blocking_time.csv", "capacity_analysis.csv")
+              if os.path.exists(os.path.join(output, name))]
+for name in artifacts:
+    with open(os.path.join(output, name + ".provenance.json"), encoding="utf-8") as stream:
+        document = json.load(stream)
+    assert document["schema_version"] == 1
+    assert document["artifact"] == {"kind": "csv", "file_name": name}
+    run = document["run"]
+    assert run["case_name"] == "Paimpol"
+    assert run["scene_schema_version"] == 1
+    assert run["applied_scenario"] == "baseline"
+    assert run["base_time_seconds"] == 7 * 3600 + 10 * 60 + 40
+    assert run["duration_seconds"] == 8000
+    assert run["timestep_seconds"] == 1
+    assert run["buffer_seconds"] == 0
+    assert run["recovery_percent"] == 0
+    assert run["pax_mode"] == run["tsm_mode"] == run["route_choice_mode"] == 0
+    snapshot = run["input"]
+    assert snapshot["kind"] == "directory"
+    assert snapshot["path"] == scene
+    assert snapshot["dirty"] is False
+    assert snapshot["reproducible"] is True
+    assert snapshot["status"] == "reproducible"
+    assert snapshot["reason"] == ""
+    assert re.fullmatch(r"[0-9a-f]{64}", snapshot["sha256"])
+    occurrences = run["selected_occurrences"]
+    assert occurrences
+    assert all(item["service_id"] and item["occurrence"] >= 1 for item in occurrences)
+PY
 
 # Trajectory and timetable must carry data rows, not just a header.
 traj_rows=$(($(wc -l < "$OUTDIR/trajectory.csv") - 1))


### PR DESCRIPTION
## Problem

Result exports did not identify the saved canonical input or run settings that produced them. The creator smoke also bypassed public authoring paths, so it could not prove a new switched case from New Case through export.

## Changes

- Capture the exact saved scene or bundle bytes, SHA-256, case and schema identity, selected scenario, effective settings, modes, and selected service occurrences for each completed run.
- Write paired provenance JSON sidecars for current CSV and PNG exports without changing existing CSV columns.
- Add one CTest smoke that authors an independent switched case through public widgets, saves and reopens both persistence forms, runs scenarios, exports the principal analyses, and checks reference safety and stale-result invalidation.
- Replace destructive switch-section parsing exposed by the synthetic case with one non-mutating parser for the existing section grammar.

## Compatibility

Existing scene directories, `.egscene` bundles, and CSV columns remain compatible. Scenario files remain optional. Dirty, unsaved, missing, changed, or unreadable inputs still run but are marked non-reproducible. A failed sidecar write does not publish a provenance-free artifact.

## Checks

- focused result, scene, CSV, and creator gate: 7 of 7 passed
- CTest: 44 of 44 passed in 141.13 seconds
- editor, six-case headless, six-case round-trip, Assignment, incident, visual, and bundle smokes passed

Closes #129
Closes #289
