### PR TITLE
Align map key track states with network rendering

### DIFF
--- a/EGTRAIN/QEGTRAIN/tests/test_networklegend.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_networklegend.cpp
@@ -1,6 +1,7 @@
 #include "widgets/NetworkLegendWidget.h"
 
 #include <QApplication>
+#include <QImage>
 #include <QLabel>
 #include <QRegularExpression>
 #include <QToolButton>
@@ -12,6 +13,14 @@ static bool expect(bool condition, const char* message) {
 	if (!condition)
 		std::cerr << "failed: " << message << "\n";
 	return condition;
+}
+
+static bool containsColor(const QImage& image, const QColor& color) {
+	for (int y = 0; y < image.height(); ++y)
+		for (int x = 0; x < image.width(); ++x)
+			if (image.pixelColor(x, y).rgb() == color.rgb())
+				return true;
+	return false;
 }
 
 int main(int argc, char* argv[]) {
@@ -62,6 +71,12 @@ int main(int argc, char* argv[]) {
 	ok &= expect(entries.at(3).label == "Blocked section"
 		&& entries.at(3).penStyle == classifyTrackState(TrackOperationalState::Blocked).style,
 		"blocked track entry keeps its non-color cue");
+	auto* preparedSwatch = legend.findChild<QWidget*>("mapKeySwatch1");
+	const QImage preparedImage = preparedSwatch ? preparedSwatch->grab().toImage() : QImage();
+	ok &= expect(preparedSwatch && preparedSwatch->width() == 46
+		&& containsColor(preparedImage, classifyTrackState(TrackOperationalState::Prepared).color)
+		&& containsColor(preparedImage, freeTrackVisual().color),
+		"prepared track swatch mirrors the renderer state underlay and base rail");
 
 	int intercityCount = 0;
 	int interchangeCount = 0;

--- a/EGTRAIN/QEGTRAIN/widgets/NetworkLegendWidget.cpp
+++ b/EGTRAIN/QEGTRAIN/widgets/NetworkLegendWidget.cpp
@@ -14,7 +14,7 @@ class LegendSwatch : public QWidget {
 public:
 	explicit LegendSwatch(const NetworkLegendEntry& entry, QWidget* parent = nullptr)
 		: QWidget(parent), m_entry(entry) {
-		setFixedSize(30, 18);
+		setFixedSize(46, 18);
 		setAttribute(Qt::WA_TransparentForMouseEvents);
 	}
 
@@ -22,12 +22,18 @@ protected:
 	void paintEvent(QPaintEvent*) override {
 		QPainter painter(this);
 		painter.setRenderHint(QPainter::Antialiasing);
-		const QRectF cueRect(3.0, 3.0, 24.0, 12.0);
+		const QRectF cueRect(11.0, 3.0, 24.0, 12.0);
 		if (m_entry.kind == NetworkLegendEntryKind::Track) {
 			QPen pen(m_entry.color, qMax(2, m_entry.lineWidth));
 			pen.setStyle(m_entry.penStyle);
 			painter.setPen(pen);
-			painter.drawLine(QLineF(3.0, 9.0, 27.0, 9.0));
+			const QLineF line(3.0, 9.0, 43.0, 9.0);
+			painter.drawLine(line);
+			if (m_entry.trackState != TrackOperationalState::Free) {
+				const TrackVisual base = freeTrackVisual();
+				painter.setPen(QPen(base.color, base.width));
+				painter.drawLine(line);
+			}
 			return;
 		}
 
@@ -237,7 +243,9 @@ void NetworkLegendWidget::rebuildRows() {
 		auto* rowLayout = new QHBoxLayout(row);
 		rowLayout->setContentsMargins(2, 1, 2, 1);
 		rowLayout->setSpacing(5);
-		rowLayout->addWidget(new LegendSwatch(entry, row));
+		auto* swatch = new LegendSwatch(entry, row);
+		swatch->setObjectName(QString("mapKeySwatch%1").arg(i));
+		rowLayout->addWidget(swatch);
 		auto* label = new QLabel(entry.label, row);
 		label->setObjectName(QString("mapKeyEntry%1").arg(i));
 		label->setMaximumWidth(121);


### PR DESCRIPTION
## Summary

- Render operational-track swatches with the colored state underlay and neutral base rail used in the network view.
- Lengthen track cues so dash and dash-dot patterns remain recognizable without relying on color.
- Add a pixel-level regression check for the layered prepared-route cue.

## UX review

The case-specific content, labels, ordering, palette, and collapse behavior were already sound. This keeps them unchanged while making the track cues accurately match the network and improving non-color differentiation.

## Visual before and after

### Before

![Map key before the update](https://raw.githubusercontent.com/Ancientkingg/EGTRAIN/002c613d248bb561f4693e456fde56e75e280e1a/docs/images/map-key-before.png)

### After

![Map key after the update](https://raw.githubusercontent.com/Ancientkingg/EGTRAIN/002c613d248bb561f4693e456fde56e75e280e1a/docs/images/map-key-after.png)

## Verification

- `cmake --build build`
- `ctest --test-dir build --output-on-failure` — 44/44 passed
- `tools/e2e/visual_polish_smoke.sh` — passed at 1× and 2× DPR, including station overlays, scene rendering, and legacy import