### PR TITLE
Use active scene data for route-choice sharing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,6 +666,12 @@ if(EGTRAIN_BUILD_TESTS)
 	target_include_directories(test_railmlparser PRIVATE ${SRC_DIR})
 	target_link_libraries(test_railmlparser PRIVATE cppzmq nlohmann_json::nlohmann_json)
 	add_test(NAME test_railmlparser COMMAND test_railmlparser)
+	add_test(NAME test_route_choice_missing_data
+		COMMAND $<TARGET_FILE:QEGTRAIN> --scene ${SRC_DIR}/Scenes/Assignment_Gvc_Gdg_Ut
+			-g 0 -h 1 -TSM 0 -RC 1)
+	set_tests_properties(test_route_choice_missing_data PROPERTIES
+		PASS_REGULAR_EXPRESSION "scene.route_choice.passengers.none"
+		TIMEOUT 30)
 
 	add_test(NAME test_headless_smoke_decode
 		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/test_headless_smoke_decode.py)

--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -184,6 +184,21 @@ std::vector<SceneDiagnostic> DispatchController::prepareScene(const SceneModel& 
 		resetState();
 		return diagnostics;
 	}
+	if (initial_variables.RChoice) {
+		const bool hasUsablePassengerJourney = std::any_of(AllDailyPassengers.begin(), AllDailyPassengers.end(),
+			[](const Passenger& passenger) {
+				return std::any_of(passenger.Journeys.begin(), passenger.Journeys.end(),
+					[](const Journey& journey) { return journey.N_Trips > 0; });
+			});
+		if (!hasUsablePassengerJourney) {
+			diagnostics.push_back({SceneSeverity::Error, "scene.route_choice.passengers.none",
+				"Route choice requires at least one usable passenger journey in the prepared run",
+				"passengers.json", "passenger", {}, "passengers", {},
+				"Add a passenger journey with at least one selected route leg"});
+			resetState();
+			return diagnostics;
+		}
+	}
 
 	if (initial_variables.OutputMainFolder.empty())
 		initial_variables.OutputMainFolder = "Output";
@@ -368,7 +383,7 @@ void DispatchController::runSimulation() {
 }
 
 void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(double v1, double v2, double v3) {
-	nlohmann::json jsmsg, route_choice_json;
+	nlohmann::json jsmsg;
 
 	for (int t = 0; t < initial_variables.times; t++) {
 		// pause/stop/speed from GUI
@@ -516,18 +531,6 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 
 		jsmsg["time"] = t;
 
-		// Here we prepare the Route choice data
-		for (int n = 0; n < 100; n++) { // for all ACTIVE passengers
-			std::string station_names[10] = {"Guingamp", "Gourland", "Tregonnau_Squiffiec", "Brelidy_Plouec",
-											 "Pontrieux_halte", "Pontrieux", "Frynaudour", "Traou_Nez", "Lancerf", "Paimpol"};
-			int random_station = rand() % 10;
-			int random_passenger = rand() % 1000;
-
-			route_choice_json["passengers"][std::to_string(random_passenger) + "--1.0"]["origin"] = station_names[random_station];
-			route_choice_json["passengers"][std::to_string(random_passenger) + "--1.0"]["destination"] = station_names[rand() % 10];
-			route_choice_json["passengers"][std::to_string(random_passenger) + "--1.0"]["departure_time"] = t + random_passenger;
-		}
-		route_choice_json["time"] = t;
 		// for the ZeroMQbroker
 		if (initial_variables.TSM) {
 			std::cout << "\n\n Sending the following Traffic State XML file" << std::endl
@@ -536,6 +539,7 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 		}
 
 		if (initial_variables.RChoice) {
+			const nlohmann::json route_choice_json = routeChoicePayload(AllDailyPassengers, t);
 			std::cout << "\n\n Sending the following Route Choice XML file" << std::endl;
 			std::cout << routeChoice_xml(route_choice_json) << std::flush;
 			std::thread(send_traffic_state5556, route_choice_json, routeChoice_xml(route_choice_json)).detach();

--- a/EGTRAIN/QEGTRAIN/simulation/Passengers.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Passengers.cpp
@@ -1,7 +1,25 @@
 #include "simulation/Passengers.h"
+#include <algorithm>
 
 list<Passenger> AllDailyPassengers; // This list ocntains all the passengers which appear in the network throughout the whole day
 int numAllDailyPassengers = 0;		// This the overall number of passengers who will use the rail service across the whole day ( size of list AllDailyPassengers)
+
+nlohmann::json routeChoicePayload(const list<Passenger>& passengers, int timestep) {
+	nlohmann::json payload = {{"passengers", nlohmann::json::object()}, {"time", timestep}};
+	for (const Passenger& passenger : passengers) {
+		if (!passenger.IsIntheNetwork)
+			continue;
+		const auto journey = std::find_if(passenger.Journeys.begin(), passenger.Journeys.end(),
+				[&passenger](const Journey& value) { return value.ID == passenger.current_JourneyID; });
+		if (journey == passenger.Journeys.end() || journey->N_Trips <= 0)
+			continue;
+		payload["passengers"][passenger.ID + "--1.0"] = {
+			{"origin", journey->Dep_Station_ID},
+			{"destination", journey->Arr_Station_ID},
+			{"departure_time", static_cast<int>(journey->Actual_Planned_Departure_Time)}};
+	}
+	return payload;
+}
 
 void printCurrentPassengerStatus(int t, int StartSimulationTime, list<Passenger> ALLPAX, string MainFolder) {
 	string FileName;

--- a/EGTRAIN/QEGTRAIN/simulation/Passengers.h
+++ b/EGTRAIN/QEGTRAIN/simulation/Passengers.h
@@ -3,6 +3,7 @@
 
 #include "simulation/Infrastructure.h"
 #include "simulation/RollingStock.h"
+#include <nlohmann/json.hpp>
 
 using namespace std;
 
@@ -90,5 +91,7 @@ extern int numAllDailyPassengers;		   // This the overall number of passengers w
 void printCurrentPassengerStatus(int t, int StartSimulationTime, list<Passenger> ALLPAX, string MainFolder);
 
 void printPassengerTotalJourneyDelay(list<Passenger> ALLPAX, string MainFolder);
+
+nlohmann::json routeChoicePayload(const list<Passenger>& passengers, int timestep);
 
 #endif

--- a/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
@@ -338,6 +338,21 @@ int main() {
 		ok &= expect(unrouted != AllDailyPassengers.front().Journeys.end() && unrouted->N_Trips == 0,
 				"legless canonical journeys remain present");
 	}
+	auto routeChoicePassengers = AllDailyPassengers;
+	Passenger& active = routeChoicePassengers.front();
+	active.IsIntheNetwork = true;
+	active.current_JourneyID = active.Journeys.front().ID;
+	Passenger inactive = active;
+	inactive.ID = "inactive.passenger";
+	inactive.IsIntheNetwork = false;
+	routeChoicePassengers.push_back(inactive);
+	const nlohmann::json routeChoice = routeChoicePayload(routeChoicePassengers, 17);
+	ok &= expect(routeChoice == routeChoicePayload(routeChoicePassengers, 17)
+			&& routeChoice["time"] == 17 && routeChoice["passengers"].size() == 1
+			&& routeChoice["passengers"]["passenger.1--1.0"]["origin"] == "Zero"
+			&& routeChoice["passengers"]["passenger.1--1.0"]["destination"] == "Two"
+			&& routeChoicePayload({}, 17)["passengers"].empty(),
+			"route-choice sharing is deterministic and uses only active canonical passenger state");
 	ok &= expect(initial_variables.name == "native-operations-fixture"
 			&& initial_variables.startingSimulationTime == 23400
 			&& initial_variables.times == 90.0


### PR DESCRIPTION
## Summary

- build route-choice payloads from active passengers and their current canonical journeys
- remove the Paimpol-specific station list and random passenger generation from generic runtime code
- reject `-RC 1` scene preparation when the run has no usable passenger journey
- preserve the existing `-RC 0` path

## Verification

- focused route-choice and operations-builder tests
- CTest: 45/45 passed
- headless smoke: all six committed scenes passed
- roundtrip smoke: all six committed scenes validated and reimported
- independent correctness review: no findings
- simplicity review: no findings

Closes #296