### PR TITLE
Verify native runtime parity for original cases

### DIFF
--- a/docs/guides/original-case-runtime-parity.md
+++ b/docs/guides/original-case-runtime-parity.md
@@ -1,0 +1,84 @@
+# Original-case native runtime parity
+
+This report closes the historical evidence gap for the Netherlands, Paimpol,
+Copenhagen, and Milano-Brescia native loaders. It compares generated output,
+not merely legacy conversion output.
+
+## Baseline and method
+
+The trusted pre-cutover baseline is
+`d3f5c7005c7030ba3745c8a41b0572e61974bd15` (PR #262). It is the direct parent
+of the native runtime cutover in PR #263. At that commit canonical scenes were
+already present, but normal GUI and CLI runs still built the simulation from
+the committed `Input/` trees. This makes it the last revision where the old
+and new representations coexist without making the native loader the normal
+runtime path.
+
+Both that revision and the current native revision were built with tests
+enabled and run headlessly for cases 1–4 with `-g 0 -TSM 0 -RC 0`. The retained
+observables are the canonical structure, `EnergyConsumptionPerTrain.txt`,
+`TrainServicePathDiagram.txt`, `TimetablePoints.txt`, and
+`Stats_Stations.txt`. PR #302 separately established conversion parity; its
+counts support the structure comparison below but are not used as a substitute
+for the runtime output comparison.
+
+## Infrastructure and signalling
+
+Counts are baseline / native:
+
+| Case | Blocks | Connections | Stations / platforms | Routes | Stable identifiers |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Netherlands | 1,984 / 1,984 | 708 / 708 | (41 / 156) / (41 / 156) | 74 / 74 | station `Ut`…`virtualDvdLink`; route `route0`…`route73` |
+| Paimpol | 140 / 140 | 8 / 8 | (10 / 15) / (10 / 15) | 15 / 15 | station `Guingamp`…`Paimpol`; route `route0`…`route14` |
+| Copenhagen | 1,513 / 1,513 | 328 / 328 | (94 / 203) / (94 / 203) | 24 / 24 | station `Frederikssund`…`Hillerod`; route `route0`…`route23` |
+| Milano-Brescia | 312 / 312 | 109 / 109 | (29 / 92) / (29 / 92) | 48 / 48 | station `Segrate`…`BivioRoncadelle`; route `route0`…`route47` |
+
+The complete station-ID and route-ID sets at the baseline and native revisions
+are identical. The focused smoke stores SHA-256 digests of those sets. Legacy
+runtime block and connection identifiers used a different derived syntax, so
+their identities cannot be compared honestly one-for-one; their counts match,
+and PR #302 verifies that importing each retained legacy source produces the
+same canonical block and connection data as the committed scene.
+
+## Trains, trajectories, and arrivals
+
+Each representative has the same trajectory origin and the same ordered stop
+set at both revisions. `End` is `(time seconds, position metres)` and `arrivals`
+is the first/last simulated station arrival. The tolerances are explicit in the
+focused smoke.
+
+| Case | Runtime trains baseline / native | Representative | End baseline → native | Arrivals baseline → native | Allowed end tolerance |
+| --- | ---: | --- | --- | --- | --- |
+| Netherlands | 40 / 40 | `SPR_2-1` | `(7999, 1252.38)` → `(7999, 1335.0)` | `(132, 847)` → `(135, 1190)` | 0 s, 100 m |
+| Paimpol | 2 / 2 | `Guin-Paim-EXPRESS-1-1` | `(2571, 37081.3)` → `(2789, 37076.9)` | `(43, 2558)` → `(36, 2705)` | 250 s, 10 m |
+| Copenhagen | 196 / 196 | `F-Hellerup-NyEllebjerg-2-1` | `(934, 37943.0)` → `(1877, 37951.9)` | `(367, 927)` → `(364, 1819)` | 950 s, 10 m |
+| Milano-Brescia | 65 / 65 | `201-1` | `(3673, 78768.2)` → `(3673, 78768.2)` | `(1855, 3666)` → `(1855, 3666)` | 0 s, 0.1 m |
+
+The longer Paimpol and Copenhagen times are not tuned values. Their retained
+legacy output recorded arrival and departure at the same instant through
+intermediate stops. The native path honors the canonical planned times and
+dwell values, so it reaches the same ordered stations and route endpoint later.
+The tolerances cover the observed scheduling correction while keeping the
+path endpoint tight. Netherlands remains active at the 8,000-second horizon;
+its final position and five-stop sequence are compared instead of inventing a
+completion time.
+
+The expanded train total is identical in all four cases. Milano's legacy
+output used `9707-1` and `9709-1` twice. The native output retains 65 trains but
+uses the distinct canonical service IDs `9707_2-1` and `9709_2-1` for the
+second pair.
+
+## Aggregate served-station output
+
+| Case | Served rows baseline / native | Comparison |
+| --- | ---: | --- |
+| Netherlands | 10 / 10 | same station set; some occurrence totals are lower after planned waits are honored |
+| Paimpol | 9 / 9 | same station set |
+| Copenhagen | 93 / 92 | native run has no served `BuddingeReverse` row within the horizon; the station, platform, and service stop remain canonical |
+| Milano-Brescia | 13 / 13 | sets differ: legacy output includes `MelzoScalo3-5`, while native output includes `MorengoBariano`; the representative 17-stop sequence is identical |
+
+These differences are recorded rather than converted into fabricated equality.
+The focused regression asserts exact network counts, stable station/route ID
+sets, expanded train counts, representative path endpoints, ordered stops, and
+arrival tolerances. The existing smoke additionally requires real movement and
+served arrivals for all four original cases, without legacy runtime staging.

--- a/tools/e2e/headless_smoke.py
+++ b/tools/e2e/headless_smoke.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import hashlib
 import json
 import math
 import os
@@ -20,8 +21,46 @@ SCENES = {
     6: "Lebanon",
 }
 
-ASSERT_MOVEMENT = {2, 3, 4, 5}
-ASSERT_STATION_ARRIVALS = {2, 3, 4, 5}
+ASSERT_MOVEMENT = {1, 2, 3, 4, 5}
+ASSERT_STATION_ARRIVALS = {1, 2, 3, 4, 5}
+
+# d3f5c7005c7030ba3745c8a41b0572e61974bd15 is the last pre-cutover
+# runtime baseline. These checks keep one representative observable per
+# original case instead of retaining large generated output trees.
+ORIGINAL_CASE_PARITY = {
+    1: {
+        "structure": (1984, 708, 41, 156, 74),
+        "station_ids": "7eb1725701ff3d105f0ff84ba9ac23cd27fe5642f462947d9fa7bf28492305ff",
+        "route_ids": "dea4515fec5d4b1cf241b7276b38dce3d283474635db5b379d6582e21f10e3c9",
+        "trains": 40,
+        "representative": ("SPR_2-1", 100, 18940.6, 7999, 1252.38, 0, 100),
+        "stops": ("425d9c987fddb82cf8812520e9094efd165533d5265aa4dd59367fb9ea146f28", 132, 847, 10, 350),
+    },
+    2: {
+        "structure": (140, 8, 10, 15, 15),
+        "station_ids": "76ee593e12c0ed1fc4ead4d497d16dc3f658e8a13e4fd60d233f2d8b4d7c05b5",
+        "route_ids": "b05b7d25ec4a281c582032a3b86c6cfef9c4cdd344be4da1340856531086b7ca",
+        "trains": 2,
+        "representative": ("Guin-Paim-EXPRESS-1-1", 10, 0.595063, 2571, 37081.3, 250, 10),
+        "stops": ("9d358eb8bb2575c8111f98791e0f1bca7b84381fafba1197173f684e7a998331", 43, 2558, 10, 150),
+    },
+    3: {
+        "structure": (1513, 328, 94, 203, 24),
+        "station_ids": "4d0343d22fd0d42f1ca19d406fc379a19589d5945cad35d9b7a76fdd7b927f78",
+        "route_ids": "39b7ca1c397a4830fe27ab3fe14366ba0b842b857ed3a4c819e24bc2c68565a7",
+        "trains": 196,
+        "representative": ("F-Hellerup-NyEllebjerg-2-1", 340, 50037.4, 934, 37943.0, 950, 10),
+        "stops": ("b11fe2560aa043b373523dcab19b1bf291f6a2a4c95f877141a26fb073c6fd34", 367, 927, 10, 900),
+    },
+    4: {
+        "structure": (312, 109, 29, 92, 48),
+        "station_ids": "091b2621fa7695b9fb368e13caa966d0da1864048cbae9fa91ea37f6aff973ca",
+        "route_ids": "73c9e9fd30a7f2c82ad5f7fe202083c6c3aa87c0a36215ace7d5a393da189494",
+        "trains": 65,
+        "representative": ("201-1", 1738, 9636.22, 3673, 78768.2, 0, 0.1),
+        "stops": ("b76878b055e51183a425ccdfe008049e66b8980fcc23f62d46636a0a53cd8981", 1855, 3666, 1, 1),
+    },
+}
 
 
 def run_command(args, cwd=None, input=None, timeout=None, env=None):
@@ -54,6 +93,33 @@ def case_command(case_id: int) -> list[str]:
 def scene_output_dir(case_id: int, out_base: Path = RUN_DIR) -> Path:
     scene = json.loads((SCENE_DIR / SCENES[case_id] / "scene.json").read_text(encoding="utf-8"))
     return out_base / "Output" / scene["name"]
+
+
+def _digest(ids: list[str]) -> str:
+    return hashlib.sha256("\n".join(ids).encode("utf-8")).hexdigest()
+
+
+def check_scene_structure(case_id: int) -> None:
+    expected = ORIGINAL_CASE_PARITY[case_id]
+    scene_dir = SCENE_DIR / SCENES[case_id]
+    infrastructure = json.loads((scene_dir / "infrastructure.json").read_text(encoding="utf-8"))
+    stations = json.loads((scene_dir / "stations.json").read_text(encoding="utf-8"))
+    signalling = json.loads((scene_dir / "signalling.json").read_text(encoding="utf-8"))
+    station_rows = stations["stations"]
+    actual = (
+        len(infrastructure["blocks"]),
+        len(infrastructure["connections"]),
+        len(station_rows),
+        sum(len(station["platforms"]) for station in station_rows),
+        len(signalling["routes"]),
+    )
+    if actual != expected["structure"]:
+        raise SystemExit(f"case {case_id} structure changed: expected {expected['structure']}, got {actual}")
+    if _digest(sorted(station["id"] for station in station_rows)) != expected["station_ids"]:
+        raise SystemExit(f"case {case_id} station identifiers changed")
+    if _digest(sorted(route["id"] for route in signalling["routes"])) != expected["route_ids"]:
+        raise SystemExit(f"case {case_id} route identifiers changed")
+    print(f"PASS case {case_id} matches the original-case structure baseline")
 
 
 def route_errors(output: str) -> list[str]:
@@ -187,12 +253,70 @@ def check_station_arrivals(case_id: int = 3, out_base: Path = RUN_DIR) -> None:
     print(f"PASS case {case_id} has {rows} served station rows")
 
 
+def check_original_case_runtime(case_id: int, out_base: Path = RUN_DIR) -> None:
+    expected = ORIGINAL_CASE_PARITY[case_id]
+    output_dir = scene_output_dir(case_id, out_base)
+
+    energy_rows = (output_dir / "EnergyConsumptionPerTrain.txt").read_text(
+        encoding="utf-8", errors="replace"
+    ).splitlines()[1:]
+    train_count = sum(bool(row.strip()) for row in energy_rows)
+    if train_count != expected["trains"]:
+        raise SystemExit(f"case {case_id} expanded {train_count} trains; expected {expected['trains']}")
+
+    train, start_time, start_position, end_time, end_position, time_tolerance, position_tolerance = expected[
+        "representative"
+    ]
+    trajectory = output_dir / "TrainTrajectories/TrainServicePathDiagram.txt"
+    samples = []
+    for line in trajectory.read_text(encoding="utf-8", errors="replace").splitlines():
+        cells = line.split("\t")
+        if cells[0] != train:
+            continue
+        for time_seconds, cell in enumerate(cells[4:]):
+            if cell:
+                samples.append((time_seconds, float(cell)))
+        break
+    if not samples:
+        raise SystemExit(f"case {case_id} has no trajectory for baseline train {train}")
+    if samples[0][0] != start_time or abs(samples[0][1] - start_position) > 0.1:
+        raise SystemExit(f"case {case_id} baseline train {train} changed its trajectory origin")
+    if abs(samples[-1][0] - end_time) > time_tolerance or abs(samples[-1][1] - end_position) > position_tolerance:
+        raise SystemExit(
+            f"case {case_id} baseline train {train} ended at {samples[-1]}; "
+            f"expected ({end_time}, {end_position}) within ({time_tolerance}s, {position_tolerance}m)"
+        )
+
+    stop_digest, first_arrival, last_arrival, first_tolerance, last_tolerance = expected["stops"]
+    timetable = output_dir / "TrainTrajectories/TimetablePoints.txt"
+    lines = timetable.read_text(encoding="utf-8", errors="replace").splitlines()
+    for index, line in enumerate(lines):
+        if line.split()[:1] == [train]:
+            station_names = lines[index + 1].split()
+            arrivals = [float(value) for value in lines[index + 4].split()]
+            break
+    else:
+        raise SystemExit(f"case {case_id} has no timetable for baseline train {train}")
+    if _digest(station_names) != stop_digest:
+        raise SystemExit(f"case {case_id} baseline train {train} changed its served-station sequence")
+    if abs(arrivals[0] - first_arrival) > first_tolerance or abs(arrivals[-1] - last_arrival) > last_tolerance:
+        raise SystemExit(
+            f"case {case_id} baseline train {train} arrivals changed: "
+            f"expected first/last {first_arrival}/{last_arrival}, got {arrivals[0]}/{arrivals[-1]}"
+        )
+    print(f"PASS case {case_id} matches the pre-cutover runtime observables ({train_count} trains)")
+
+
 def main() -> None:
     selected = [int(arg) for arg in sys.argv[1:]] or [1, 2, 3, 4, 5, 6]
     for case_id in selected:
+        if case_id in ORIGINAL_CASE_PARITY:
+            check_scene_structure(case_id)
         run_case(case_id)
         if case_id in ASSERT_MOVEMENT:
             check_movement(case_id)
+        if case_id in ORIGINAL_CASE_PARITY:
+            check_original_case_runtime(case_id)
     for case_id in selected:
         if case_id in ASSERT_STATION_ARRIVALS:
             check_station_arrivals(case_id)

--- a/tools/e2e/test_headless_smoke_decode.py
+++ b/tools/e2e/test_headless_smoke_decode.py
@@ -4,10 +4,13 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from headless_smoke import case_command, route_errors, run_command, scene_output_dir
+from headless_smoke import check_scene_structure, case_command, route_errors, run_command, scene_output_dir
 
 
 def main() -> None:
+    for case_id in range(1, 5):
+        check_scene_structure(case_id)
+
     command = case_command(3)
     expected = ["--scene", str(Path(__file__).resolve().parents[2] / "EGTRAIN/QEGTRAIN/Scenes/Copenhagen"),
                 "-g", "0", "-TSM", "0", "-RC", "0"]


### PR DESCRIPTION
## Summary

- names `d3f5c7005c7030ba3745c8a41b0572e61974bd15` as the last pre-cutover runtime baseline
- records four-case structure, stable identifiers, expanded train counts, trajectories, station arrivals, and served-station output
- extends the existing headless smoke with focused historical assertions for the Netherlands, Paimpol, Copenhagen, and Milano-Brescia
- documents retained timing and aggregate-output differences without treating conversion parity as runtime parity

## Verification

- `ctest --test-dir build --output-on-failure` (45/45)
- `python3 tools/e2e/headless_smoke.py 1 2 3 4`
- `python3 tools/e2e/roundtrip_smoke.py`
- detached baseline build and `python3 tools/e2e/headless_smoke.py 1 2 3 4` at `d3f5c70`

Closes #85
Closes #86