### PR TITLE
Fix runtime memory safety edge cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,6 +685,11 @@ if(EGTRAIN_BUILD_TESTS)
 	set_tests_properties(test_native_startup_without_legacy PROPERTIES
 		ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 		TIMEOUT 120)
+	add_test(NAME test_runtime_memory_safety
+		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/runtime_memory_safety_smoke.py $<TARGET_FILE:QEGTRAIN>)
+	set_tests_properties(test_runtime_memory_safety PROPERTIES
+		ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+		TIMEOUT 240)
 	add_test(NAME test_gui_autostart_smoke
 		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/gui_autostart_smoke.py $<TARGET_FILE:QEGTRAIN>)
 	# Release completes in seconds; the ceiling exists for the instrumented

--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -339,7 +339,11 @@ void DispatchController::runSimulation() {
 	printPassengerTotalJourneyDelay(AllDailyPassengers, initial_variables.OutputMainFolder + "/PassengerStatus");
 
 	for (int j = 0; j < numRegions; j++) {
-		eglogger << "Station delay: " << std::to_string(regional_train[j].StationDelay[regional_train[j].numStations - 1]) << std::endl;
+		eglogger << "Station delay: "
+				 << (regional_train[j].numStations > 0
+						 ? std::to_string(regional_train[j].StationDelay[regional_train[j].numStations - 1])
+						 : "unavailable (no stops)")
+				 << std::endl;
 	}
 
 	// Calculating positive and negative Train Delays to debug the program
@@ -503,7 +507,7 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 
 			int Previous_Block_Index = 0;
 			Section SBs;
-			if (t >= regional_train[n].departure_time) {
+			if (t > 0 && t >= regional_train[n].departure_time) {
 				for (int h = 0; h < train_route[regional_train[n].indexOfRoute].N_Block_Sections; h++) {
 					if ((regional_train[n].instant_spatial_position[t - 1] < train_route[regional_train[n].indexOfRoute].sequence_of_block_sections[h].end_node.X * 1000) &&
 						(regional_train[n].instant_spatial_position[t - 1] >= train_route[regional_train[n].indexOfRoute].sequence_of_block_sections[h].start_node.X * 1000)) {

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp
@@ -2195,6 +2195,9 @@ void Set_RespectOrder_And_Index_OrderList_Upgraded_Improved_With_JunctionType() 
 
 // check train arrival/departure at/from destination/origin
 void Train::checkTrainArrDep(int trainIdx, int t) {
+	if (numStations <= 0 || Stations == nullptr)
+		return;
+
 	// add X to last station if needed (initialized as 0 in the beginning)
 	if (Stations[numStations - 1].X == 0) {
 		// find station position
@@ -2538,99 +2541,93 @@ void protectStationAreas(int i) {
 		// cout << ">>>>>>>>>" << regional_train[k].trainDescription << "is OutOfSimulation" << regional_train[k].OutOfSimulation << endl;
 		if (!regional_train[k].OutOfSimulation) {
 			if ((i >= regional_train[k].departure_time) && regional_train[k].CanEnter) {
+				if (timestep <= 0 || i < 0 || i >= static_cast<int>(regional_train[k].instant_spatial_position.size()) ||
+					regional_train[k].indexOfRoute < 0 || regional_train[k].indexOfRoute >= static_cast<int>(train_route.size()))
+					continue;
+				const int delayedIndex = i - static_cast<int>(S_delay / timestep);
+				if (delayedIndex < 0 || delayedIndex >= static_cast<int>(regional_train[k].instant_spatial_position.size()))
+					continue;
+				const Route& route = train_route[regional_train[k].indexOfRoute];
+				if (route.N_Block_Sections <= 0)
+					continue;
+
 				// find signalling_block_sections occupied by head of train
-				int hHead = 0; // hTail = 0;
-				for (int h = 0; h < train_route[regional_train[k].indexOfRoute].N_Block_Sections; h++) {
-					if ((regional_train[k].instant_spatial_position[i - (int)(S_delay / timestep)] < train_route[regional_train[k].indexOfRoute].sequence_of_block_sections[h].end_node.X * 1000) && (regional_train[k].instant_spatial_position[i - (int)(S_delay / timestep)] >= train_route[regional_train[k].indexOfRoute].sequence_of_block_sections[h].start_node.X * 1000)) {
+				int hHead = -1;
+				for (int h = 0; h < route.N_Block_Sections; h++) {
+					if ((regional_train[k].instant_spatial_position[delayedIndex] < route.sequence_of_block_sections[h].end_node.X * 1000) &&
+						(regional_train[k].instant_spatial_position[delayedIndex] >= route.sequence_of_block_sections[h].start_node.X * 1000)) {
 						hHead = h;
 						break;
 					}
 				}
+				if (hHead < 0)
+					continue;
+
+				const std::string stationName = regional_train[k].numStations > 0 && regional_train[k].Stations != nullptr
+					? regional_train[k].Stations[regional_train[k].numStations - 1].stationName
+					: std::string();
+				auto platformBookedFor = [&](const StationBoundarySection& boundary) {
+					if (stationName != "Alm" && stationName != "Asd" && stationName != "Asdz")
+						return false;
+					if (boundary.exit)
+						return false;
+					for (int tr = 0; tr < numRegions; tr++) {
+						if (regional_train[tr].ID == regional_train[k].ID && regional_train[tr].type == regional_train[k].type)
+							continue;
+						if (regional_train[tr].numStations <= 0 || regional_train[tr].Stations == nullptr)
+							continue;
+						if (regional_train[tr].Stations[regional_train[tr].numStations - 1].stationName == stationName &&
+							regional_train[tr].reservedPlatform == regional_train[k].arrivalPlatform)
+							return true;
+
+						// wait for trains leaving the station to prevent deadlocks
+						if (regional_train[tr].Stations[0].stationName != stationName ||
+							regional_train[tr].indexOfRoute < 0 ||
+							regional_train[tr].indexOfRoute >= static_cast<int>(train_route.size()) ||
+							i >= static_cast<int>(regional_train[tr].instant_spatial_position.size()))
+							continue;
+						if (train_route[regional_train[tr].indexOfRoute].reversed_direction != route.reversed_direction) {
+							// if the other train is not booking a platform, it is not at the platform - enough to check position
+							if (!route.reversed_direction && regional_train[tr].numStations > 1 &&
+								regional_train[tr].trainXPosition(i) > regional_train[k].trainXPosition(i))
+								return true;
+							if (route.reversed_direction && regional_train[tr].numStations > 1 &&
+								regional_train[tr].trainXPosition(i) < regional_train[k].trainXPosition(i))
+								return true;
+						}
+					}
+					return false;
+				};
 
 				// occupy station interlocking area
 				for (int s = 0; s < stationBoundarySections.size(); s++) {
-					// check if section ahead of train is entrance of station
-					if (stationBoundarySections[s].entrance->ID == train_route[regional_train[k].indexOfRoute].sequence_of_block_sections[hHead + 1].ID) {
-						// check if plaform is booked or train leaving
-						bool platformBooked = false;
-						std::vector<std::string> stationsToProtect = {"Alm", "Asd", "Asdz"};
-						if (std::find(stationsToProtect.begin(), stationsToProtect.end(), regional_train[k].Stations[regional_train[k].numStations - 1].stationName) != stationsToProtect.end()) {
-							if (!stationBoundarySections[s].exit) {
-								for (int tr = 0; tr < numRegions; tr++) {
-									if (regional_train[tr].ID == regional_train[k].ID && regional_train[tr].type == regional_train[k].type) {
-										continue;
-									}
-									if (regional_train[tr].Stations[regional_train[tr].numStations - 1].stationName == regional_train[k].Stations[regional_train[k].numStations - 1].stationName && regional_train[tr].reservedPlatform == regional_train[k].arrivalPlatform) {
-										platformBooked = true;
-										break;
-									}
-									// wait for trains leaving the station to prevent deadlocks
-									if (regional_train[tr].Stations[0].stationName == regional_train[k].Stations[regional_train[k].numStations - 1].stationName) {
-										if (train_route[regional_train[tr].indexOfRoute].reversed_direction != train_route[regional_train[k].indexOfRoute].reversed_direction) {
-											// if the other train is not booking a platform, it is not at the platform - enough to check position
-											if (train_route[regional_train[k].indexOfRoute].reversed_direction == false && regional_train[tr].trainXPosition(i) > regional_train[k].trainXPosition(i) && regional_train[tr].numStations > 1) {
-												platformBooked = true;
-												break;
-											} else if (train_route[regional_train[k].indexOfRoute].reversed_direction == true && regional_train[tr].trainXPosition(i) < regional_train[k].trainXPosition(i) && regional_train[tr].numStations > 1) {
-												platformBooked = true;
-												break;
-											}
-										}
-									}
-								}
+					if (!stationBoundarySections[s].entrance)
+						continue;
+					bool stationAreaHandled = false;
+					for (int offset : {1, 2}) {
+						if (hHead + offset >= route.N_Block_Sections ||
+							stationBoundarySections[s].entrance->ID != route.sequence_of_block_sections[hHead + offset].ID)
+							continue;
+
+						if (offset == 2) {
+							// do not protect if section before entrance is occupied by another train, otherwise it will be blocked
+							if (std::find(BlocksOccupied.begin(), BlocksOccupied.end(),
+									route.sequence_of_block_sections[hHead + 1].ID) != BlocksOccupied.end()) {
+								stationAreaHandled = true;
+								break; // preserve the occupied-intermediate-section exception
 							}
 						}
 
-						stationBoundarySections[s].protectEntrance(hHead + 1, regional_train[k].indexOfRoute, platformBooked);
-						break; // train occupies at most one station area
+						stationBoundarySections[s].protectEntrance(hHead + offset, regional_train[k].indexOfRoute,
+							platformBookedFor(stationBoundarySections[s]));
+						stationAreaHandled = true;
+						break;
 					}
-					// check if section ahead of train is section before entrance of station
-					else if (stationBoundarySections[s].entrance->ID == train_route[regional_train[k].indexOfRoute].sequence_of_block_sections[hHead + 2].ID) {
-						// do not protect if section before entrance is occupied by another train, otherwise it will be blocked
-						bool needToBlock = true;
-						for (auto occ = BlocksOccupied.begin(); occ != BlocksOccupied.end(); ++occ) {
-							if (train_route[regional_train[k].indexOfRoute].sequence_of_block_sections[hHead + 1].ID == *occ) {
-								needToBlock = false;
-								break;
-							}
-						}
-						if (needToBlock) {
-							// check if plaform is booked
-							bool platformBooked = false;
-							std::vector<std::string> stationsToProtect = {"Alm", "Asd", "Asdz"};
-							if (std::find(stationsToProtect.begin(), stationsToProtect.end(), regional_train[k].Stations[regional_train[k].numStations - 1].stationName) != stationsToProtect.end()) {
-								if (!stationBoundarySections[s].exit) {
-									for (int tr = 0; tr < numRegions; tr++) {
-										if (regional_train[tr].ID == regional_train[k].ID && regional_train[tr].type == regional_train[k].type) {
-											continue;
-										}
-										if (regional_train[tr].Stations[regional_train[tr].numStations - 1].stationName == regional_train[k].Stations[regional_train[k].numStations - 1].stationName && regional_train[tr].reservedPlatform == regional_train[k].arrivalPlatform) {
-											platformBooked = true;
-											break;
-										}
-										// wait for trains leaving the station to prevent deadlocks
-										if (regional_train[tr].Stations[0].stationName == regional_train[k].Stations[regional_train[k].numStations - 1].stationName) {
-											if (train_route[regional_train[tr].indexOfRoute].reversed_direction != train_route[regional_train[k].indexOfRoute].reversed_direction) {
-												// if the other train is not booking a platform, it is not at the platform - enough to check position
-												if (train_route[regional_train[k].indexOfRoute].reversed_direction == false && regional_train[tr].trainXPosition(i) > regional_train[k].trainXPosition(i) && regional_train[tr].numStations > 1) {
-													platformBooked = true;
-													break;
-												} else if (train_route[regional_train[k].indexOfRoute].reversed_direction == true && regional_train[tr].trainXPosition(i) < regional_train[k].trainXPosition(i) && regional_train[tr].numStations > 1) {
-													platformBooked = true;
-													break;
-												}
-											}
-										}
-									}
-								}
-							}
+					if (stationAreaHandled)
+						break; // train occupies at most one station area
 
-							stationBoundarySections[s].protectEntrance(hHead + 2, regional_train[k].indexOfRoute, platformBooked);
-						}
-						break; // train occupies at most one station area
-					}
 					// check if train entered station area
-					else if (stationBoundarySections[s].entrance->ID == train_route[regional_train[k].indexOfRoute].sequence_of_block_sections[hHead].ID) {
+					if (stationBoundarySections[s].entrance->ID == route.sequence_of_block_sections[hHead].ID) {
 						// FOR NOW, IGNORE AREAS WITH EXIT SECTION
 						if (stationBoundarySections[s].exit) {
 							continue;

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -3663,6 +3663,16 @@ public:
 	// Function to Simulate the Train Trajectory
 	virtual void trajectoryComputationIncludingMovingBlock(int time_seconds, double signalCode1, double signalCode2, double signalCode3) {
 		if (OutOfSimulation == 0) {
+			if (time_seconds == 0) {
+				CanEnter = false;
+				instant_train_speed[0] = 0.0;
+				instant_spatial_position[0] = Start_Node_X * 1000;
+				instant_block_section_occupied[0] = "-";
+				instant_train_power_consumption[0] = 0.0;
+				instant_train_tractive_effort[0] = 0.0;
+				instant_train_energy_consumption[0] = 0.0;
+				return;
+			}
 			// A broken-down train holds its last state for the whole incident
 			// window; entrance processing is also suspended, so a train whose
 			// window covers its entry time simply enters after the window.
@@ -4451,7 +4461,7 @@ public:
 
 	// Function to compute the arrival and departure of a train from a location with a specific position expressed in [m]
 	void computeArrivalAndDepartureAtLocation(double LocationPosition, TrainEvent& PassingPoint) {
-		int TrainEntryTime = (int)departure_time;
+		const int TrainEntryTime = std::max(1, static_cast<int>(departure_time));
 		double ArrivalTime = -1, DepartureTime = -1;
 		bool IsArrivalFound = false;
 		bool IsDepartureFound = false;
@@ -4542,13 +4552,19 @@ public:
 	virtual void Det_Section_Occupied_By_Train(int i, Section* BS, int Blocks) {
 		if (OutOfSimulation == 0) {
 			if ((i >= departure_time) && (CanEnter == 1)) {
+				if (BS == nullptr || Blocks <= 0 || timestep <= 0)
+					return;
+				const int delayedIndex = i - static_cast<int>(S_delay / timestep);
+				if (delayedIndex < 1 || delayedIndex >= static_cast<int>(instant_spatial_position.size()))
+					return;
+
 				// collect all signalling_block_sections from head to tail
 				int hTail = 0, hHead = 0;
 				for (int h = 0; h < Blocks; h++) {
-					if (((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length) < BS[h].end_node.X * 1000) && ((instant_spatial_position[i - (int)(S_delay / timestep)] - train_length) >= BS[h].start_node.X * 1000)) {
+					if (((instant_spatial_position[delayedIndex] - train_length) < BS[h].end_node.X * 1000) && ((instant_spatial_position[delayedIndex] - train_length) >= BS[h].start_node.X * 1000)) {
 						hTail = h;
 					}
-					if ((instant_spatial_position[i - (int)(S_delay / timestep)] < BS[h].end_node.X * 1000) && (instant_spatial_position[i - (int)(S_delay / timestep)] >= BS[h].start_node.X * 1000)) {
+					if ((instant_spatial_position[delayedIndex] < BS[h].end_node.X * 1000) && (instant_spatial_position[delayedIndex] >= BS[h].start_node.X * 1000)) {
 						hHead = h;
 						break;
 					}
@@ -4579,7 +4595,7 @@ public:
 					int Prev_Block = h - 1;
 					if (h == 0)
 						Prev_Block = 0;
-					occupyBlockAndConnected(BS[h], BS[Prev_Block], (instant_spatial_position[i - (int)(S_delay / timestep)] - train_length), (instant_spatial_position[i - (int)(S_delay / timestep) - 1] - train_length));
+					occupyBlockAndConnected(BS[h], BS[Prev_Block], (instant_spatial_position[delayedIndex] - train_length), (instant_spatial_position[delayedIndex - 1] - train_length));
 					// if the Block Section has a switch in diverging position
 
 					if (BS[h].withSwitchDiv == true) {

--- a/EGTRAIN/QEGTRAIN/simulation/Simulation.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Simulation.cpp
@@ -98,6 +98,8 @@ void calculateDelayStatsAtStation(Stations& S) {
 		}
 	} else {																												// This part is executed only if the station to Analyze is the fittitious one: Final_Delay that describes the statics of the train at their own final station
 		for (int j = 0; j < numRegions; j++) {																					// looping over the total number of trains
+			if (regional_train[j].numStations <= 0)
+				continue;
 			if (regional_train[j].StationDelay[regional_train[j].numStations - 1] != -1) {									// and the train has actually crossed that station within the simulation time
 				TrainDelay.push_back(regional_train[j].StationDelay[regional_train[j].numStations - 1]);			// register its arrival delay
 				TrainConsDelay.push_back(regional_train[j].StationConsecDelay[regional_train[j].numStations - 1]); // register its consecutive delay
@@ -111,6 +113,13 @@ void calculateDelayStatsAtStation(Stations& S) {
 				S.N_Stopped_Trains++; // increase the number of trains that crossed station instant_spatial_position
 			}
 		}
+	}
+	if (TrainDelay.empty()) {
+		S.Av_Arrival_Delay = S.Std_Arrival_Delay = S.Tot_Consec_Delay = -1;
+		S.Perc_Delayed_T = S.Perc_Delayed_T_3min = S.Perc_Delayed_T_5min = -1;
+		S.Max_TotalDelay = S.Max_Cons_Delay = -1;
+		S.totalArrivalDelay = 0;
+		return;
 	}
 	// Calculate the Total and the Average Arrival Delay at station instant_spatial_position
 	for (int r = 0; r < S.N_Stopped_Trains; r++) {
@@ -176,6 +185,8 @@ void calculatePosAndNegDelayStatsAtStation(Stations& S) {
 		}
 	} else {																												// This part is executed only if the station to Analyze is the fittitious one: Final_Delay that describes the statics of the train at their own final station
 		for (int j = 0; j < numRegions; j++) {																					// looping over the total number of trains
+			if (regional_train[j].numStations <= 0)
+				continue;
 			if (regional_train[j].StationDelay[regional_train[j].numStations - 1] != -1) {									// and the train has actually crossed that station within the simulation time
 				TrainDelay.push_back(regional_train[j].StationDelay[regional_train[j].numStations - 1]);			// register its arrival delay
 				TrainConsDelay.push_back(regional_train[j].StationConsecDelay[regional_train[j].numStations - 1]); // register its consecutive delay
@@ -189,6 +200,13 @@ void calculatePosAndNegDelayStatsAtStation(Stations& S) {
 				S.N_Stopped_Trains++; // increase the number of trains that crossed station instant_spatial_position
 			}
 		}
+	}
+	if (TrainDelay.empty()) {
+		S.Av_Arrival_Delay = S.Std_Arrival_Delay = S.Tot_Consec_Delay = -1;
+		S.Perc_Delayed_T = S.Perc_Delayed_T_3min = S.Perc_Delayed_T_5min = -1;
+		S.Max_TotalDelay = S.Max_Cons_Delay = -1;
+		S.totalArrivalDelay = 0;
+		return;
 	}
 	// Calculate the Total and the Average Arrival Delay at station instant_spatial_position
 	for (int r = 0; r < S.N_Stopped_Trains; r++) {

--- a/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
@@ -688,5 +688,70 @@ int main() {
 	}
 	ok &= expect(fullPerformanceEnd >= 0 && reducedPerformanceEnd > fullPerformanceEnd,
 			"reduced performance delays native route completion");
+
+	const auto safetyInfrastructure = buildInfrastructureAndSignallingFromScene(trajectoryPerformance);
+	const auto safetyOperations = buildOperationsFromScene(trajectoryPerformance, "scenario.base");
+	ok &= expect(!hasErrors(safetyInfrastructure) && !hasErrors(safetyOperations) && numRegions == 1,
+			"runtime safety fixture builds one zero-stop through service");
+	if (!hasErrors(safetyInfrastructure) && !hasErrors(safetyOperations) && numRegions == 1) {
+		Train& through = regional_train[0];
+		through.departure_time = 0.0;
+		through.checkTrainArrDep(0, 0);
+		Stations finalProbe;
+		finalProbe.stationName = "Final_Station";
+		finalProbe.totalArrivalDelay = finalProbe.Max_TotalDelay = finalProbe.Max_Cons_Delay = 42.0;
+		calculateDelayStatsAtStation(finalProbe);
+		const bool delayUnavailable = finalProbe.N_Stopped_Trains == 0
+				&& finalProbe.Av_Arrival_Delay == -1.0 && finalProbe.Std_Arrival_Delay == -1.0
+				&& finalProbe.totalArrivalDelay == 0.0 && finalProbe.Max_TotalDelay == -1.0
+				&& finalProbe.Max_Cons_Delay == -1.0;
+		finalProbe.totalArrivalDelay = finalProbe.Max_TotalDelay = finalProbe.Max_Cons_Delay = 42.0;
+		calculatePosAndNegDelayStatsAtStation(finalProbe);
+		ok &= expect(through.numStations == 0 && delayUnavailable && finalProbe.N_Stopped_Trains == 0
+				&& finalProbe.Av_Arrival_Delay == -1.0 && finalProbe.Std_Arrival_Delay == -1.0
+				&& finalProbe.totalArrivalDelay == 0.0 && finalProbe.Max_TotalDelay == -1.0
+				&& finalProbe.Max_Cons_Delay == -1.0,
+				"zero-stop through service has unavailable final-station statistics");
+
+		through.trajectoryComputationIncludingMovingBlock(0, signalCode1, signalCode2, signalCode3);
+		ok &= expect(!through.CanEnter && through.instant_train_speed[0] == 0.0
+				&& through.instant_spatial_position[0] == through.Start_Node_X * 1000,
+				"time zero initializes the live trajectory without entering or advancing");
+
+		Route& route = train_route[through.indexOfRoute];
+		S_delay = 0.0;
+		through.CanEnter = true;
+		through.OutOfSimulation = false;
+		const int nextHead = route.N_Block_Sections - 2;
+		const Section& nextSection = route.sequence_of_block_sections[nextHead];
+		through.instant_spatial_position[1] =
+				(nextSection.start_node.X + nextSection.end_node.X) * 500.0;
+		stationBoundarySections.clear();
+		stationBoundarySections.emplace_back(&route.sequence_of_block_sections[nextHead + 1],
+				route.reversed_direction, nullptr);
+		BlocksOccupied.clear();
+		BlocksConnected.clear();
+		protectStationAreas(1);
+		ok &= expect(std::find(BlocksConnected.begin(), BlocksConnected.end(),
+				route.sequence_of_block_sections[nextHead + 1].ID) != BlocksConnected.end(),
+				"zero-stop train keeps station-boundary route protection without stop indexing");
+
+		const int routeCapacity = static_cast<int>(std::size(route.sequence_of_block_sections));
+		ok &= expect(route.N_Block_Sections < routeCapacity, "route-tail fixture has an unused array slot");
+		if (route.N_Block_Sections < routeCapacity) {
+			Section& outOfRoute = route.sequence_of_block_sections[route.N_Block_Sections];
+			outOfRoute.ID = "out.of.route";
+			const Section& tail = route.sequence_of_block_sections[route.N_Block_Sections - 1];
+			through.instant_spatial_position[1] = (tail.start_node.X + tail.end_node.X) * 500.0;
+			stationBoundarySections.clear();
+			stationBoundarySections.emplace_back(&outOfRoute, route.reversed_direction, nullptr);
+			BlocksOccupied.clear();
+			BlocksConnected.clear();
+			protectStationAreas(1);
+			ok &= expect(std::find(BlocksConnected.begin(), BlocksConnected.end(), outOfRoute.ID)
+					== BlocksConnected.end(),
+					"station lookahead ignores sections beyond the actual route tail");
+		}
+	}
 	return ok ? 0 : 1;
 }

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -6,7 +6,7 @@
 
 | Milestone | Findings | Status | Issue | Pull request | Merge |
 |---|---|---|---|---|---|
-| 1. Runtime memory safety | G-01, G-05, G-06; P-03 | In progress | [#306](https://github.com/Ancientkingg/EGTRAIN/issues/306) | Pending | Pending |
+| 1. Runtime memory safety | G-01, G-05, G-06; P-03 | In review | [#306](https://github.com/Ancientkingg/EGTRAIN/issues/306) | [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307) | Pending |
 | 2. Deterministic simulation state | G-02; P-04 | Blocked on milestone 1 | Pending | Pending | Pending |
 | 3. External communication lifecycle | G-03, G-07; P-05 | Blocked on milestone 2 | Pending | Pending | Pending |
 | 4. Result integrity | G-04; P-02 | Blocked on milestone 3 | Pending | Pending | Pending |
@@ -28,7 +28,7 @@
 - Ponytail findings: accepted the `std::find` replacement for a manual membership loop and the single guarded station-delay log expression; rejected replacing the required bounded +1/+2 loop with duplicated comparisons because P-03 explicitly requires the loop
 - Simplifications made: consolidated duplicated +1/+2 station-area lookahead into one bounded loop, removed the manual occupancy flag/scan, and emitted the guarded station-delay log through one expression
 - Commit SHA: `f1a7e581f9ae618d98818210756276c4a423a155`
-- PR number and URL: pending
+- PR number and URL: [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307)
 - CI status: pending
 - Merge SHA: pending
 - Remaining blockers: milestone 1 remains unmerged; G-02 continues to block release after this milestone
@@ -48,3 +48,4 @@
 - 2026-08-19: Final independent re-review found no remaining issues. Final full CTest passed 46/46; six-case native headless and six-case roundtrip both passed.
 - 2026-08-19: Refreshed the local code knowledge graph after the code and ledger changes.
 - 2026-08-19: Committed the verified implementation as `f1a7e581f9ae618d98818210756276c4a423a155`.
+- 2026-08-19: Pushed `fix/runtime-memory-safety` and opened pull request [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307); required CI is pending.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -27,7 +27,7 @@
 - Fixes made from review: empty final-station samples now reset the complete exported metric set to the existing unavailable/zero semantics, including stale totals and maxima; focused tests cover reused-state values and passed under normal and ASan/UBSan builds
 - Ponytail findings: accepted the `std::find` replacement for a manual membership loop and the single guarded station-delay log expression; rejected replacing the required bounded +1/+2 loop with duplicated comparisons because P-03 explicitly requires the loop
 - Simplifications made: consolidated duplicated +1/+2 station-area lookahead into one bounded loop, removed the manual occupancy flag/scan, and emitted the guarded station-delay log through one expression
-- Commit SHA: pending
+- Commit SHA: `f1a7e581f9ae618d98818210756276c4a423a155`
 - PR number and URL: pending
 - CI status: pending
 - Merge SHA: pending
@@ -47,3 +47,4 @@
 - 2026-08-19: Focused re-review identified stale totals and maxima on a reused empty aggregate. Reset the complete exported metric set, added stale-value assertions for both calculation paths, and passed focused normal and sanitizer CTest again.
 - 2026-08-19: Final independent re-review found no remaining issues. Final full CTest passed 46/46; six-case native headless and six-case roundtrip both passed.
 - 2026-08-19: Refreshed the local code knowledge graph after the code and ledger changes.
+- 2026-08-19: Committed the verified implementation as `f1a7e581f9ae618d98818210756276c4a423a155`.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -1,0 +1,49 @@
+# Stabilization execution ledger
+
+- Initial `origin/main`: `935d94227fa3ebc61de371a52d663e711a3e4805`
+- Release status: blocked by G-01 and G-02
+- Active milestone: 1, runtime memory safety
+
+| Milestone | Findings | Status | Issue | Pull request | Merge |
+|---|---|---|---|---|---|
+| 1. Runtime memory safety | G-01, G-05, G-06; P-03 | In progress | [#306](https://github.com/Ancientkingg/EGTRAIN/issues/306) | Pending | Pending |
+| 2. Deterministic simulation state | G-02; P-04 | Blocked on milestone 1 | Pending | Pending | Pending |
+| 3. External communication lifecycle | G-03, G-07; P-05 | Blocked on milestone 2 | Pending | Pending | Pending |
+| 4. Result integrity | G-04; P-02 | Blocked on milestone 3 | Pending | Pending | Pending |
+| 5. Persistence and validation hardening | G-08, G-09, G-10 | Blocked on milestone 4 | Pending | Pending | Pending |
+| 6. Station platform-booking verification | G-NV-01 | Blocked on release fixes | Pending | Pending | Pending |
+| 7. Dead-code cleanup | P-01, P-06 | Blocked on correctness work | Pending | Pending | Pending |
+
+## Milestone 1: runtime memory safety
+
+- Finding IDs: G-01, G-05, G-06, P-03
+- Branch: `fix/runtime-memory-safety`
+- Worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/runtime-memory-safety`
+- Base SHA: `935d94227fa3ebc61de371a52d663e711a3e4805`
+- Scope: zero-stop through-service runtime handling, bounded station-area lookahead, time-zero initialization, and focused regressions
+- Files changed: `CMakeLists.txt`; `EGTRAIN/QEGTRAIN/app/DispatchController.cpp`; `EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp`; `EGTRAIN/QEGTRAIN/simulation/RollingStock.h`; `EGTRAIN/QEGTRAIN/simulation/Simulation.cpp`; `EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp`; `tools/e2e/runtime_memory_safety_smoke.py`; this ledger
+- Test results: focused normal CTest 2/2 passed; focused ASan/UBSan CTest 2/2 passed; final full CTest 46/46 passed; six-case native headless passed; six-case roundtrip passed
+- Adversarial-review findings: the first review found one P2 empty-sample non-finite result; the focused re-review found one medium stale-total/max error on a reused aggregate; final re-review found no remaining issues; no P0/P1 findings
+- Fixes made from review: empty final-station samples now reset the complete exported metric set to the existing unavailable/zero semantics, including stale totals and maxima; focused tests cover reused-state values and passed under normal and ASan/UBSan builds
+- Ponytail findings: accepted the `std::find` replacement for a manual membership loop and the single guarded station-delay log expression; rejected replacing the required bounded +1/+2 loop with duplicated comparisons because P-03 explicitly requires the loop
+- Simplifications made: consolidated duplicated +1/+2 station-area lookahead into one bounded loop, removed the manual occupancy flag/scan, and emitted the guarded station-delay log through one expression
+- Commit SHA: pending
+- PR number and URL: pending
+- CI status: pending
+- Merge SHA: pending
+- Remaining blockers: milestone 1 remains unmerged; G-02 continues to block release after this milestone
+
+### Execution log
+
+- 2026-08-19: Fetched `origin`; the reviewed SHA remains the latest `origin/main`.
+- 2026-08-19: Confirmed no existing issue owns G-01, G-05, and G-06; opened issue [#306](https://github.com/Ancientkingg/EGTRAIN/issues/306).
+- 2026-08-19: Created the milestone branch and clean isolated worktree from the recorded base SHA.
+- 2026-08-19: Traced the live dispatch path and all compiled callers. The shared fix points are `Train::trajectoryComputationIncludingMovingBlock()`, `Train::checkTrainArrDep()`, `protectStationAreas()`, final-station aggregation, and the dispatch traffic-state lookup.
+- 2026-08-19: Mechanical audit confirmed no upstream partial fix and identified the existing `test_operationsbuilder` runtime fixture plus CTest sanitizer wiring as the smallest regression seams.
+- 2026-08-19: Implemented explicit zero-stop handling, time-zero initialization, delayed-index guards, and route-length-bounded station-area lookahead. Added focused unit coverage and a canonical Milano plus modified Paimpol live-runtime smoke.
+- 2026-08-19: Focused normal and ASan/UBSan CTest each passed 2/2. Full normal CTest passed 46/46, and all six scene roundtrips passed.
+- 2026-08-19: Independent correctness review found one P2 empty-sample statistics gap. The zero-stop final-station path now preserves the existing unavailable sentinel, with a regression assertion; focused normal and sanitizer tests passed again.
+- 2026-08-19: Simplicity review produced three suggestions. Two local reductions were accepted; the proposed duplicated lookahead comparisons were rejected because they would undo P-03.
+- 2026-08-19: Focused re-review identified stale totals and maxima on a reused empty aggregate. Reset the complete exported metric set, added stale-value assertions for both calculation paths, and passed focused normal and sanitizer CTest again.
+- 2026-08-19: Final independent re-review found no remaining issues. Final full CTest passed 46/46; six-case native headless and six-case roundtrip both passed.
+- 2026-08-19: Refreshed the local code knowledge graph after the code and ledger changes.

--- a/tools/e2e/runtime_memory_safety_smoke.py
+++ b/tools/e2e/runtime_memory_safety_smoke.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCENES = ROOT / "EGTRAIN/QEGTRAIN/Scenes"
+
+
+def run(app: Path, scene: Path, output: Path, label: str) -> None:
+    env = os.environ.copy()
+    env["QEGTRAIN_OUTPUT_DIR"] = str(output)
+    proc = subprocess.run(
+        [str(app), "--scene", str(scene), "-h", "3", "-g", "0", "-TSM", "0", "-RC", "0"],
+        cwd=output.parent,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"{label} exited with {proc.returncode}\n{proc.stdout[-4000:]}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: runtime_memory_safety_smoke.py PATH_TO_QEGTRAIN")
+    app = Path(sys.argv[1]).resolve()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        temp = Path(tmp)
+        run(app, SCENES / "Milano_Brescia", temp / "milano-output", "Milano zero-stop runtime")
+
+        paimpol = temp / "Paimpol-time-zero"
+        shutil.copytree(SCENES / "Paimpol", paimpol)
+        services_path = paimpol / "services.json"
+        services = json.loads(services_path.read_text(encoding="utf-8"))
+        services["services"][1]["entry_time_seconds"] = 0.0
+        services_path.write_text(json.dumps(services, indent=2) + "\n", encoding="utf-8")
+        run(app, paimpol, temp / "paimpol-output", "Paimpol time-zero runtime")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- keep valid zero-stop through services out of stop-specific runtime and final-station indexing
- initialize timestep zero without reading the previous timestep
- bound delayed indices and station-area lookahead by the live trajectory and route lengths
- replace duplicate station lookahead branches with one bounded loop
- add a canonical Milano zero-stop run and a live entry-time-zero regression

## Verification

- focused normal CTest: 2/2 passed
- focused ASan/UBSan CTest: 2/2 passed
- full CTest: 46/46 passed
- six-case native headless smoke: passed
- six-case roundtrip smoke: passed
- final independent correctness re-review: no findings

Closes #306