### PR TITLE
Serialize train runtime updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,6 +690,9 @@ if(EGTRAIN_BUILD_TESTS)
 	set_tests_properties(test_runtime_memory_safety PROPERTIES
 		ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 		TIMEOUT 240)
+	add_test(NAME test_simulation_determinism
+		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/simulation_determinism_smoke.py $<TARGET_FILE:QEGTRAIN>)
+	set_tests_properties(test_simulation_determinism PROPERTIES TIMEOUT 300)
 	add_test(NAME test_gui_autostart_smoke
 		COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/e2e/gui_autostart_smoke.py $<TARGET_FILE:QEGTRAIN>)
 	# Release completes in seconds; the ceiling exists for the instrumented

--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -403,10 +403,6 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 		std::cout << "\r Time of simulation is " << t;
 		// logger.Log(" clock at" + to_string(t));
 
-		/*#pragma omp parallel
-		{
-		#pragma omp for*/
-
 		// you can comment it if you are simulating something different
 		/*if (t < 430)
 			regional_train[0].max_train_speed = 16;
@@ -423,8 +419,6 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 		}
 
 		// Simulate train movement at each simulation step
-		//  MULTI-THREAD
-#pragma omp parallel for
 		for (int j = 0; j < numRegions; j++) {
 			// cout << j << "++++----/n";
 
@@ -435,15 +429,10 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 			regional_train[j].recordEarliestActiveTrajectoryIndex(t);
 			regional_train[j].recordStationPassagesAtTime(t);
 
-			// only one thread writing to file at a time
-#pragma omp critical(arrdepwrite)
-			{
-				// check if train arrived at destination or departed from origin
-				regional_train[j].checkTrainArrDep(j, t);
-			}
+			// check if train arrived at destination or departed from origin
+			regional_train[j].checkTrainArrDep(j, t);
 		}
 
-		//}
 		// cout << "Time is : " << t << endl;
 		// for (int n = 0; n < numRegions; n++) {
 

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -7,7 +7,7 @@
 | Milestone | Findings | Status | Issue | Pull request | Merge |
 |---|---|---|---|---|---|
 | 1. Runtime memory safety | G-01, G-05, G-06; P-03 | Complete | [#306](https://github.com/Ancientkingg/EGTRAIN/issues/306) | [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307) | `743fe85798aef38a6862b989434650dc87106b2b` |
-| 2. Deterministic simulation state | G-02; P-04 | In progress | [#308](https://github.com/Ancientkingg/EGTRAIN/issues/308) | Pending | Pending |
+| 2. Deterministic simulation state | G-02; P-04 | In review | [#308](https://github.com/Ancientkingg/EGTRAIN/issues/308) | [#309](https://github.com/Ancientkingg/EGTRAIN/pull/309) | Pending |
 | 3. External communication lifecycle | G-03, G-07; P-05 | Blocked on milestone 2 | Pending | Pending | Pending |
 | 4. Result integrity | G-04; P-02 | Blocked on milestone 3 | Pending | Pending | Pending |
 | 5. Persistence and validation hardening | G-08, G-09, G-10 | Blocked on milestone 4 | Pending | Pending | Pending |
@@ -65,7 +65,7 @@
 - Ponytail findings: accepted removal of redundant CMake environment setup, an unnecessary nested working directory, and vestigial commented OpenMP scaffolding; declined P-04 because the only existing matching record belongs to the GUI layer and a new shared type would add an abstraction after serialization removed the practical need
 - Simplifications made: removed the live OpenMP directive, its redundant critical section, stale multithreading comments, duplicate offscreen environment setup, and one unnecessary test-directory level
 - Commit SHA: `61b0fc3313fbd72cddba0a9d71c2610751840672`
-- PR number and URL: pending
+- PR number and URL: [#309](https://github.com/Ancientkingg/EGTRAIN/pull/309)
 - CI status: pending
 - Merge SHA: pending
 - Remaining blockers: G-02 remains unresolved until this verified change is merged
@@ -85,3 +85,4 @@
 - 2026-08-19: Six-case native headless smoke passed, including the canonical Copenhagen and Milano-Brescia runtime baselines.
 - 2026-08-19: Refreshed the local code knowledge graph after the code and ledger changes.
 - 2026-08-19: Committed the verified implementation as `61b0fc3313fbd72cddba0a9d71c2610751840672`.
+- 2026-08-19: Pushed `fix/serialize-train-runtime` and opened pull request [#309](https://github.com/Ancientkingg/EGTRAIN/pull/309); required CI is pending.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -1,13 +1,13 @@
 # Stabilization execution ledger
 
 - Initial `origin/main`: `935d94227fa3ebc61de371a52d663e711a3e4805`
-- Release status: blocked by G-01 and G-02
-- Active milestone: 1, runtime memory safety
+- Release status: blocked by G-02
+- Active milestone: 2, deterministic simulation state
 
 | Milestone | Findings | Status | Issue | Pull request | Merge |
 |---|---|---|---|---|---|
-| 1. Runtime memory safety | G-01, G-05, G-06; P-03 | In review | [#306](https://github.com/Ancientkingg/EGTRAIN/issues/306) | [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307) | Pending |
-| 2. Deterministic simulation state | G-02; P-04 | Blocked on milestone 1 | Pending | Pending | Pending |
+| 1. Runtime memory safety | G-01, G-05, G-06; P-03 | Complete | [#306](https://github.com/Ancientkingg/EGTRAIN/issues/306) | [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307) | `743fe85798aef38a6862b989434650dc87106b2b` |
+| 2. Deterministic simulation state | G-02; P-04 | In progress | [#308](https://github.com/Ancientkingg/EGTRAIN/issues/308) | Pending | Pending |
 | 3. External communication lifecycle | G-03, G-07; P-05 | Blocked on milestone 2 | Pending | Pending | Pending |
 | 4. Result integrity | G-04; P-02 | Blocked on milestone 3 | Pending | Pending | Pending |
 | 5. Persistence and validation hardening | G-08, G-09, G-10 | Blocked on milestone 4 | Pending | Pending | Pending |
@@ -29,9 +29,9 @@
 - Simplifications made: consolidated duplicated +1/+2 station-area lookahead into one bounded loop, removed the manual occupancy flag/scan, and emitted the guarded station-delay log through one expression
 - Commit SHA: `f1a7e581f9ae618d98818210756276c4a423a155`
 - PR number and URL: [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307)
-- CI status: pending
-- Merge SHA: pending
-- Remaining blockers: milestone 1 remains unmerged; G-02 continues to block release after this milestone
+- CI status: passed in 9m55s
+- Merge SHA: `743fe85798aef38a6862b989434650dc87106b2b`
+- Remaining blockers: G-02
 
 ### Execution log
 
@@ -49,3 +49,38 @@
 - 2026-08-19: Refreshed the local code knowledge graph after the code and ledger changes.
 - 2026-08-19: Committed the verified implementation as `f1a7e581f9ae618d98818210756276c4a423a155`.
 - 2026-08-19: Pushed `fix/runtime-memory-safety` and opened pull request [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307); required CI is pending.
+- 2026-08-19: Pull request #307 passed required CI and was squash-merged as `743fe85798aef38a6862b989434650dc87106b2b`. Deleted the remote and local feature branches and removed the clean milestone worktree.
+
+## Milestone 2: deterministic simulation state
+
+- Finding IDs: G-02, P-04
+- Branch: `fix/serialize-train-runtime`
+- Worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/serialize-train-runtime`
+- Base SHA: `743fe85798aef38a6862b989434650dc87106b2b`
+- Scope: serialize the per-train runtime step, add repeated-run determinism coverage, and assess a local virtual-coupling message-record simplification
+- Files changed: `CMakeLists.txt`; `EGTRAIN/QEGTRAIN/app/DispatchController.cpp`; `tools/e2e/simulation_determinism_smoke.py`; this ledger
+- Test results: focused normal CTest 3/3 passed; full normal CTest 47/47 passed; focused ASan/UBSan CTest 3/3 passed; six-case native headless passed; six-case roundtrip passed
+- Adversarial-review findings: final independent correctness review found no undefined behavior, ordering regression, test weakness, or other actionable issue; no P0/P1/P2 findings
+- Fixes made from review: none required
+- Ponytail findings: accepted removal of redundant CMake environment setup, an unnecessary nested working directory, and vestigial commented OpenMP scaffolding; declined P-04 because the only existing matching record belongs to the GUI layer and a new shared type would add an abstraction after serialization removed the practical need
+- Simplifications made: removed the live OpenMP directive, its redundant critical section, stale multithreading comments, duplicate offscreen environment setup, and one unnecessary test-directory level
+- Commit SHA: pending
+- PR number and URL: pending
+- CI status: pending
+- Merge SHA: pending
+- Remaining blockers: G-02 remains unresolved until this verified change is merged
+
+### Execution log
+
+- 2026-08-19: Confirmed no existing issue owns G-02; opened issue [#308](https://github.com/Ancientkingg/EGTRAIN/issues/308).
+- 2026-08-19: Fetched `origin`, created the clean isolated milestone worktree from the latest merged `origin/main`, and recorded the exact base SHA.
+- 2026-08-19: Traced the live GUI and headless call paths to the single active per-train OpenMP loop in `DispatchController`. Iterations reach shared routes, signalling sections, order lists, infrastructure event lists, and virtual-coupling vectors; serial ascending train order is the bounded root-cause fix.
+- 2026-08-19: Audited P-04. The only existing matching record is the GUI snapshot type, and using it from `RollingStock.h` would create a simulation-to-application dependency. Deferred the optional consolidation rather than add a new shared type or header to this correctness fix.
+- 2026-08-19: Fixed the determinism regression seam as two shortened canonical Milano-Brescia runs with identical seed and inputs, comparing trajectories, timetable events, station statistics, and energy results. Milano directly exercises the shared-route fixture while the bounded horizon keeps normal and sanitizer CTest practical.
+- 2026-08-19: Removed the live per-train parallel directive and its now-redundant arrival/departure critical wrapper. Registered the process-level determinism test; its two Milano-Brescia runs produced byte-identical results in about four seconds.
+- 2026-08-19: Focused normal CTest passed 3/3 and full normal CTest passed 47/47, including the new process-level determinism regression.
+- 2026-08-19: Independent correctness review found no actionable correctness, regression, or test-coverage issue. The reviewer also confirmed that each test run produced non-empty trajectory and energy observations.
+- 2026-08-19: Separate Ponytail review identified three safe local reductions. Removed duplicate test environment setup, an unnecessary nested working directory, and vestigial commented OpenMP scaffolding; no correctness check was weakened.
+- 2026-08-19: Focused ASan/UBSan CTest passed 3/3 and all six committed scene roundtrips passed.
+- 2026-08-19: Six-case native headless smoke passed, including the canonical Copenhagen and Milano-Brescia runtime baselines.
+- 2026-08-19: Refreshed the local code knowledge graph after the code and ledger changes.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -64,7 +64,7 @@
 - Fixes made from review: none required
 - Ponytail findings: accepted removal of redundant CMake environment setup, an unnecessary nested working directory, and vestigial commented OpenMP scaffolding; declined P-04 because the only existing matching record belongs to the GUI layer and a new shared type would add an abstraction after serialization removed the practical need
 - Simplifications made: removed the live OpenMP directive, its redundant critical section, stale multithreading comments, duplicate offscreen environment setup, and one unnecessary test-directory level
-- Commit SHA: pending
+- Commit SHA: `61b0fc3313fbd72cddba0a9d71c2610751840672`
 - PR number and URL: pending
 - CI status: pending
 - Merge SHA: pending
@@ -84,3 +84,4 @@
 - 2026-08-19: Focused ASan/UBSan CTest passed 3/3 and all six committed scene roundtrips passed.
 - 2026-08-19: Six-case native headless smoke passed, including the canonical Copenhagen and Milano-Brescia runtime baselines.
 - 2026-08-19: Refreshed the local code knowledge graph after the code and ledger changes.
+- 2026-08-19: Committed the verified implementation as `61b0fc3313fbd72cddba0a9d71c2610751840672`.

--- a/tools/e2e/simulation_determinism_smoke.py
+++ b/tools/e2e/simulation_determinism_smoke.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCENE = ROOT / "EGTRAIN/QEGTRAIN/Scenes/Milano_Brescia"
+FIXED_SEED = ROOT / "tools/golden_master/fixed_seed.seed"
+SCENE_OUTPUT_FILES = (
+    Path("TrainTrajectories/TrainServicePathDiagram.txt"),
+    Path("TrainTrajectories/TimetablePoints.txt"),
+    Path("TrainTrajectories/Stats_Stations.txt"),
+    Path("EnergyConsumptionPerTrain.txt"),
+)
+RUN_TIMEOUT = 240
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: simulation_determinism_smoke.py PATH_TO_QEGTRAIN")
+
+    app = Path(sys.argv[1]).resolve()
+    if not app.is_file():
+        raise SystemExit(f"QEGTRAIN executable not found: {app}")
+    if not SCENE.is_dir():
+        raise SystemExit(f"canonical scene not found: {SCENE}")
+    if not FIXED_SEED.is_file():
+        raise SystemExit(f"fixed seed not found: {FIXED_SEED}")
+
+    try:
+        scene_name = json.loads((SCENE / "scene.json").read_text(encoding="utf-8"))["name"]
+    except (OSError, KeyError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"cannot read canonical scene name from {SCENE / 'scene.json'}: {exc}") from exc
+
+    with tempfile.TemporaryDirectory(prefix="qegtrain-determinism-") as temp:
+        temp_root = Path(temp)
+        result_roots: list[Path] = []
+        for run_number in (1, 2):
+            run_root = temp_root / f"run_{run_number}"
+            output = run_root / "output"
+            output.mkdir(parents=True)
+            shutil.copyfile(FIXED_SEED, run_root / "rand1.seed")
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "OMP_NUM_THREADS": "4",
+                    "QT_QPA_PLATFORM": "offscreen",
+                    "QEGTRAIN_OUTPUT_DIR": str(output),
+                }
+            )
+            command = [
+                str(app),
+                "--scene",
+                str(SCENE),
+                "-h",
+                "1200",
+                "-g",
+                "0",
+                "-TSM",
+                "0",
+                "-RC",
+                "0",
+            ]
+            try:
+                process = subprocess.run(
+                    command,
+                    cwd=run_root,
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    timeout=RUN_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired as exc:
+                output_text = exc.stdout or ""
+                raise SystemExit(
+                    f"determinism run {run_number} timed out after {RUN_TIMEOUT}s\n{output_text[-4000:]}"
+                ) from exc
+            if process.returncode != 0:
+                raise SystemExit(
+                    f"determinism run {run_number} exited with {process.returncode}\n{process.stdout[-4000:]}"
+                )
+
+            result_root = output / "Output" / scene_name
+            if not result_root.is_dir():
+                raise SystemExit(f"determinism run {run_number} missing output directory: {result_root}")
+            missing = [str(path) for path in SCENE_OUTPUT_FILES if not (result_root / path).is_file()]
+            if missing:
+                raise SystemExit(f"determinism run {run_number} missing output files: {', '.join(missing)}")
+            result_roots.append(result_root)
+            print(f"PASS determinism run {run_number}: {result_root}")
+
+        for relative_path in SCENE_OUTPUT_FILES:
+            expected = (result_roots[0] / relative_path).read_bytes()
+            actual = (result_roots[1] / relative_path).read_bytes()
+            if expected != actual:
+                raise SystemExit(f"simulation determinism mismatch: {relative_path}")
+            print(f"PASS identical output: {relative_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary\n\n- run the live per-train simulation step in stable serial order\n- remove the redundant arrival/departure critical section\n- add a fixed-seed Milano-Brescia repeated-run regression that compares key result files\n\n## Verification\n\n- focused normal CTest: 3/3 passed\n- full normal CTest: 47/47 passed\n- focused ASan/UBSan CTest: 3/3 passed\n- six-case headless smoke: passed\n- six-case roundtrip smoke: passed\n- independent correctness review: no findings\n- separate simplicity review: completed\n\nCloses #308