### PR TITLE
Keep delay statistics finite

### DIFF
--- a/EGTRAIN/QEGTRAIN/simulation/Infrastructure.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Infrastructure.cpp
@@ -174,14 +174,18 @@ void Print_Station_Delay_Stats(string Name_StationDelay, string kindofdelay) {
 
 	// Computing Totals over the stations
 	double TotalAV = 0, TotalStd = 0, TOTDelay = 0, MAX_TOTDelay = 0, TOTCONSDelay = 0, MAX_CONSDelay = 0, AV_Punct = 0, AV_Punct_3min = 0, AV_Punct_5min = 0;
+	int stationsWithSamples = 0;
 	for (int s = 1; s < numStations; s++) {								// Calculate it for every station but the first, if you want it also for the first station just start the loop with s=0
+		if (StationArray[s].N_Stopped_Trains <= 0)
+			continue;
+		++stationsWithSamples;
 		TotalAV = TotalAV + StationArray[s].Av_Arrival_Delay;			// Calculating the Average Delay over the stations
 		TotalStd = TotalStd + StationArray[s].Std_Arrival_Delay;		// Calculating the Average Std over the stations
 		TOTDelay = TOTDelay + StationArray[s].totalArrivalDelay;		// Calculating the Total Delay over all stations
 		TOTCONSDelay = TOTCONSDelay + StationArray[s].Tot_Consec_Delay; // Calculating the Total consecutive delay over all stations
-		if (StationArray[s].Max_TotalDelay > MAX_TOTDelay)
+		if (stationsWithSamples == 1 || StationArray[s].Max_TotalDelay > MAX_TOTDelay)
 			MAX_TOTDelay = StationArray[s].Max_TotalDelay; // Calculating the MAX TOTAL DELAY
-		if (StationArray[s].Max_Cons_Delay > MAX_CONSDelay)
+		if (stationsWithSamples == 1 || StationArray[s].Max_Cons_Delay > MAX_CONSDelay)
 			MAX_CONSDelay = StationArray[s].Max_Cons_Delay;					 // Calculating the MAX CONSECUTIVE DELAY
 		AV_Punct = AV_Punct + StationArray[s].Perc_Delayed_T;				 // Calculating the  Avergae Punctuality at stations
 		AV_Punct_3min = AV_Punct_3min + StationArray[s].Perc_Delayed_T_3min; // Calculating the  Avergae Punctuality at 3 min at stations
@@ -195,12 +199,17 @@ void Print_Station_Delay_Stats(string Name_StationDelay, string kindofdelay) {
 	AV_Punct_3min=AV_Punct_3min/numStations;          //Calculating the  Average Punctuality at 3 min at stations
 	AV_Punct_5min=AV_Punct_5min/numStations;          //Calculating the  Average Punctuality at 5 min at stations*/
 
-	// Calculating the averages over all stations but the first
-	TotalAV = TotalAV / (numStations - 1);
-	TotalStd = TotalStd / (numStations - 1);
-	AV_Punct = AV_Punct / (numStations - 1);			  // Calculating the  Avergae Punctuality at stations
-	AV_Punct_3min = AV_Punct_3min / (numStations - 1); // Calculating the  Avergae Punctuality at 3 min at stations
-	AV_Punct_5min = AV_Punct_5min / (numStations - 1); // Calculating the  Avergae Punctuality at 5 min at stations
+	if (stationsWithSamples > 0) {
+		TotalAV /= stationsWithSamples;
+		TotalStd /= stationsWithSamples;
+		AV_Punct /= stationsWithSamples;
+		AV_Punct_3min /= stationsWithSamples;
+		AV_Punct_5min /= stationsWithSamples;
+	} else {
+		TotalAV = TotalStd = MAX_TOTDelay = MAX_CONSDelay = -1;
+		AV_Punct = AV_Punct_3min = AV_Punct_5min = -1;
+		TOTCONSDelay = -1;
+	}
 
 	FileOutput << "TOTALS" << " " << TotalAV << " " << TotalStd << " " << TOTDelay << " " << MAX_TOTDelay << " " << TOTCONSDelay << " " << MAX_CONSDelay << " " << AV_Punct << " " << AV_Punct_3min << " " << AV_Punct_5min << "\n";
 	// Printing the Final_Delay fittitious station

--- a/EGTRAIN/QEGTRAIN/simulation/Simulation.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Simulation.cpp
@@ -1,7 +1,9 @@
 #include "simulation/Simulation.h"
 #include "diagrams/RunResults.h"
+#include <algorithm>
 #include <cstdio>
 #include <cmath>
+#include <numeric>
 #include <vector>
 
 double Comp_Time_EGTRAIN = 0, Comp_Time_ROMA = 0; // variable to measure the computation times of EGTRAIN and ROMA
@@ -46,6 +48,84 @@ bool canComputeTrainEnergy(Train& train) {
 									 train.earliestActiveTrajectoryIndex, train.End_Time)
 			.empty();
 }
+
+void calculateDelayStatistics(Stations& result, const std::vector<double>& delays,
+		const std::vector<double>& consecutive, bool includeNonPositive) {
+	result.N_Stopped_Trains = static_cast<int>(delays.size());
+	result.N_Delayed_Arr = result.N_Delayed_Arr_3min = result.N_Delayed_Arr_5min = 0;
+	result.Av_Arrival_Delay = result.Std_Arrival_Delay = 0;
+	result.Perc_Delayed_T = result.Perc_Delayed_T_3min = result.Perc_Delayed_T_5min = 0;
+	result.totalArrivalDelay = result.Tot_Consec_Delay = 0;
+	result.Max_TotalDelay = result.Max_Cons_Delay = -1;
+	if (delays.empty()) {
+		result.Av_Arrival_Delay = result.Std_Arrival_Delay = result.Tot_Consec_Delay = -1;
+		result.Perc_Delayed_T = result.Perc_Delayed_T_3min = result.Perc_Delayed_T_5min = -1;
+		return;
+	}
+
+	std::vector<double> population;
+	population.reserve(delays.size());
+	for (double delay : delays) {
+		if (delay > 0) {
+			++result.N_Delayed_Arr;
+			if (delay > 3 * 60 / timestep)
+				++result.N_Delayed_Arr_3min;
+			if (delay > 5 * 60 / timestep)
+				++result.N_Delayed_Arr_5min;
+		}
+		if (includeNonPositive || delay > 0)
+			population.push_back(delay);
+	}
+
+	result.totalArrivalDelay = std::accumulate(delays.begin(), delays.end(), 0.0);
+	if (!population.empty()) {
+		result.Av_Arrival_Delay =
+			std::accumulate(population.begin(), population.end(), 0.0) / population.size();
+		if (population.size() > 1) {
+			double squaredDifference = 0;
+			for (double delay : population)
+				squaredDifference += std::pow(delay - result.Av_Arrival_Delay, 2);
+			result.Std_Arrival_Delay = std::sqrt(squaredDifference / (population.size() - 1));
+		}
+	}
+
+	result.Perc_Delayed_T = static_cast<double>(result.N_Delayed_Arr) / delays.size() * 100;
+	result.Perc_Delayed_T_3min = static_cast<double>(result.N_Delayed_Arr_3min) / delays.size() * 100;
+	result.Perc_Delayed_T_5min = static_cast<double>(result.N_Delayed_Arr_5min) / delays.size() * 100;
+	result.Max_TotalDelay = *std::max_element(delays.begin(), delays.end());
+	if (!consecutive.empty()) {
+		result.Tot_Consec_Delay = std::accumulate(consecutive.begin(), consecutive.end(), 0.0);
+		result.Max_Cons_Delay = *std::max_element(consecutive.begin(), consecutive.end());
+	}
+}
+
+void calculateStationDelayStatistics(Stations& station, bool includeNonPositive) {
+	std::vector<double> arrivals;
+	std::vector<double> consecutive;
+	const auto append = [&arrivals, &consecutive, includeNonPositive](const Train& train, int index) {
+		const bool recorded = includeNonPositive
+			? train.StationArrivals[index] != -1
+			: train.StationDelay[index] != -1;
+		if (!recorded)
+			return;
+		arrivals.push_back(train.StationDelay[index]);
+		consecutive.push_back(train.StationConsecDelay[index]);
+	};
+
+	for (int trainIndex = 0; trainIndex < numRegions; ++trainIndex) {
+		const Train& train = regional_train[trainIndex];
+		if (station.stationName == "Final_Station") {
+			if (train.numStations > 0)
+				append(train, train.numStations - 1);
+			continue;
+		}
+		for (int stationIndex = 0; stationIndex < train.numStations; ++stationIndex) {
+			if (train.stationNameForArrivalStats(stationIndex) == station.stationName)
+				append(train, stationIndex);
+		}
+	}
+	calculateDelayStatistics(station, arrivals, consecutive, includeNonPositive);
+}
 } // namespace
 
 // Function to Calculate the arrival delay at each station for each train
@@ -69,288 +149,27 @@ void calculateArrivalDelayAllTrains() {
 
 // Function to calculate the train delay statistics for a single station instant_spatial_position
 void calculateDelayStatsAtStation(Stations& S) {
-	std::vector<double> TrainDelay;
-	std::vector<double> TrainConsDelay;
-	S.N_Stopped_Trains = 0;						// Number of trains that passed station instant_spatial_position during the simulation
-	S.Av_Arrival_Delay = S.Std_Arrival_Delay = 0;
-	S.N_Delayed_Arr = S.N_Delayed_Arr_3min = S.N_Delayed_Arr_5min = 0; // Initializing Station parameters to 0 since these values will be calculated for station instant_spatial_position
-	S.Perc_Delayed_T = S.Perc_Delayed_T_3min = S.Perc_Delayed_T_5min = 0;
-	S.Tot_Consec_Delay = 0;
-
-	if (S.stationName != "Final_Station") {
-		for (int j = 0; j < numRegions; j++) {															  // looping over the total number of trains
-			for (int s = 0; s < regional_train[j].numStations; s++) {									  // looping over their stations
-				if (regional_train[j].stationNameForArrivalStats(s) == S.stationName) {					  // if the train has a stop at station instant_spatial_position
-					if (regional_train[j].StationDelay[s] != -1) {									  // and the train has actually crossed that station within the simulation time
-						TrainDelay.push_back(regional_train[j].StationDelay[s]);			  // register its arrival delay
-						TrainConsDelay.push_back(regional_train[j].StationConsecDelay[s]); // register its consecutive delay
-						if (TrainDelay[S.N_Stopped_Trains] > 0)
-							S.N_Delayed_Arr++; // increase the number of delayed trains if it is delayed
-						if (TrainDelay[S.N_Stopped_Trains] > 3 * 60 / timestep)
-							S.N_Delayed_Arr_3min++; // increase this number if its delay>3 min
-						if (TrainDelay[S.N_Stopped_Trains] > 5 * 60 / timestep)
-							S.N_Delayed_Arr_5min++; // increase this number if its delay>5 min
-
-						S.N_Stopped_Trains++; // increase the number of trains that crossed station instant_spatial_position
-					}
-				}
-			}
-		}
-	} else {																												// This part is executed only if the station to Analyze is the fittitious one: Final_Delay that describes the statics of the train at their own final station
-		for (int j = 0; j < numRegions; j++) {																					// looping over the total number of trains
-			if (regional_train[j].numStations <= 0)
-				continue;
-			if (regional_train[j].StationDelay[regional_train[j].numStations - 1] != -1) {									// and the train has actually crossed that station within the simulation time
-				TrainDelay.push_back(regional_train[j].StationDelay[regional_train[j].numStations - 1]);			// register its arrival delay
-				TrainConsDelay.push_back(regional_train[j].StationConsecDelay[regional_train[j].numStations - 1]); // register its consecutive delay
-				if (TrainDelay[S.N_Stopped_Trains] > 0)
-					S.N_Delayed_Arr++; // increase the number of delayed trains if it is delayed
-				if (TrainDelay[S.N_Stopped_Trains] > 3 * 60 / timestep)
-					S.N_Delayed_Arr_3min++; // increase this number if its delay>3 min
-				if (TrainDelay[S.N_Stopped_Trains] > 5 * 60 / timestep)
-					S.N_Delayed_Arr_5min++; // increase this number if its delay>5 min
-
-				S.N_Stopped_Trains++; // increase the number of trains that crossed station instant_spatial_position
-			}
-		}
-	}
-	if (TrainDelay.empty()) {
-		S.Av_Arrival_Delay = S.Std_Arrival_Delay = S.Tot_Consec_Delay = -1;
-		S.Perc_Delayed_T = S.Perc_Delayed_T_3min = S.Perc_Delayed_T_5min = -1;
-		S.Max_TotalDelay = S.Max_Cons_Delay = -1;
-		S.totalArrivalDelay = 0;
-		return;
-	}
-	// Calculate the Total and the Average Arrival Delay at station instant_spatial_position
-	for (int r = 0; r < S.N_Stopped_Trains; r++) {
-		S.Av_Arrival_Delay = S.Av_Arrival_Delay + TrainDelay[r];
-	}
-	S.totalArrivalDelay = S.Av_Arrival_Delay;				   // Calculating the total arrival delay (sum of train delays over all trains stopping at station instant_spatial_position)
-	S.Av_Arrival_Delay = S.Av_Arrival_Delay / S.N_Delayed_Arr; // Calculating the average arrival delay over the delayed trains
-
-	// Calculate the Standard Deviation of Delay at station instant_spatial_position over the delayed trains
-	for (int r = 0; r < S.N_Stopped_Trains; r++) {
-		if (TrainDelay[r] != 0) {
-			S.Std_Arrival_Delay = S.Std_Arrival_Delay + pow((TrainDelay[r] - S.Av_Arrival_Delay), 2);
-		}
-	}
-	S.Std_Arrival_Delay = sqrt(S.Std_Arrival_Delay / (S.N_Delayed_Arr - 1));
-
-	// Calculate the Percentages of Delayed trains and Total Consecutive delay at that station
-	for (int r = 0; r < S.N_Stopped_Trains; r++) {
-		S.Perc_Delayed_T = (double)S.N_Delayed_Arr / S.N_Stopped_Trains * 100;			 // Percentage of delayed trains
-		S.Perc_Delayed_T_3min = (double)S.N_Delayed_Arr_3min / S.N_Stopped_Trains * 100; // Percentage of delayed trains more than 3 min
-		S.Perc_Delayed_T_5min = (double)S.N_Delayed_Arr_5min / S.N_Stopped_Trains * 100; // Percentage of delayed trains more than 5 min
-		S.Tot_Consec_Delay = S.Tot_Consec_Delay + TrainConsDelay[r];					 // Calculate Total consecutive delay
-	}
-
-	// Calculate the MaxConsecutive Delay and the Max Total Delay
-	for (int r = 0; r < S.N_Stopped_Trains; r++) {
-		if (TrainDelay[r] > S.Max_TotalDelay)
-			S.Max_TotalDelay = TrainDelay[r];
-		if (TrainConsDelay[r] > S.Max_Cons_Delay)
-			S.Max_Cons_Delay = TrainConsDelay[r];
-	}
-
+	calculateStationDelayStatistics(S, false);
 }
 
 // Function to Calculate the positive and negative delays stats at station instant_spatial_position
 void calculatePosAndNegDelayStatsAtStation(Stations& S) {
-	std::vector<double> TrainDelay;
-	std::vector<double> TrainConsDelay;
-	S.N_Stopped_Trains = 0;						// Number of trains that passed station instant_spatial_position during the simulation
-	S.Av_Arrival_Delay = S.Std_Arrival_Delay = 0;
-	S.N_Delayed_Arr = S.N_Delayed_Arr_3min = S.N_Delayed_Arr_5min = 0; // Initializing Station parameters to 0 since these values will be calculated for station instant_spatial_position
-	S.Perc_Delayed_T = S.Perc_Delayed_T_3min = S.Perc_Delayed_T_5min = 0;
-	S.Tot_Consec_Delay = 0;
-
-	if (S.stationName != "Final_Station") {
-		for (int j = 0; j < numRegions; j++) {															  // looping over the total number of trains
-			for (int s = 0; s < regional_train[j].numStations; s++) {									  // looping over their stations
-				if (regional_train[j].stationNameForArrivalStats(s) == S.stationName) {					  // if the train has a stop at station instant_spatial_position
-					if (regional_train[j].StationDelay[s] != -1) {									  // and the train has actually crossed that station within the simulation time
-						TrainDelay.push_back(regional_train[j].StationDelay[s]);			  // register its arrival delay
-						TrainConsDelay.push_back(regional_train[j].StationConsecDelay[s]); // register its consecutive delay
-						if (TrainDelay[S.N_Stopped_Trains] > 0)
-							S.N_Delayed_Arr++; // increase the number of delayed trains if it is delayed
-						if (TrainDelay[S.N_Stopped_Trains] > 3 * 60 / timestep)
-							S.N_Delayed_Arr_3min++; // increase this number if its delay>3 min
-						if (TrainDelay[S.N_Stopped_Trains] > 5 * 60 / timestep)
-							S.N_Delayed_Arr_5min++; // increase this number if its delay>5 min
-
-						S.N_Stopped_Trains++; // increase the number of trains that crossed station instant_spatial_position
-					}
-				}
-			}
-		}
-	} else {																												// This part is executed only if the station to Analyze is the fittitious one: Final_Delay that describes the statics of the train at their own final station
-		for (int j = 0; j < numRegions; j++) {																					// looping over the total number of trains
-			if (regional_train[j].numStations <= 0)
-				continue;
-			if (regional_train[j].StationDelay[regional_train[j].numStations - 1] != -1) {									// and the train has actually crossed that station within the simulation time
-				TrainDelay.push_back(regional_train[j].StationDelay[regional_train[j].numStations - 1]);			// register its arrival delay
-				TrainConsDelay.push_back(regional_train[j].StationConsecDelay[regional_train[j].numStations - 1]); // register its consecutive delay
-				if (TrainDelay[S.N_Stopped_Trains] > 0)
-					S.N_Delayed_Arr++; // increase the number of delayed trains if it is delayed
-				if (TrainDelay[S.N_Stopped_Trains] > 3 * 60 / timestep)
-					S.N_Delayed_Arr_3min++; // increase this number if its delay>3 min
-				if (TrainDelay[S.N_Stopped_Trains] > 5 * 60 / timestep)
-					S.N_Delayed_Arr_5min++; // increase this number if its delay>5 min
-
-				S.N_Stopped_Trains++; // increase the number of trains that crossed station instant_spatial_position
-			}
-		}
-	}
-	if (TrainDelay.empty()) {
-		S.Av_Arrival_Delay = S.Std_Arrival_Delay = S.Tot_Consec_Delay = -1;
-		S.Perc_Delayed_T = S.Perc_Delayed_T_3min = S.Perc_Delayed_T_5min = -1;
-		S.Max_TotalDelay = S.Max_Cons_Delay = -1;
-		S.totalArrivalDelay = 0;
-		return;
-	}
-	// Calculate the Total and the Average Arrival Delay at station instant_spatial_position
-	for (int r = 0; r < S.N_Stopped_Trains; r++) {
-		S.Av_Arrival_Delay = S.Av_Arrival_Delay + TrainDelay[r];
-	}
-	S.totalArrivalDelay = S.Av_Arrival_Delay;					  // Calculating the total arrival delay (sum of train delays over all trains stopping at station instant_spatial_position)
-	S.Av_Arrival_Delay = S.Av_Arrival_Delay / S.N_Stopped_Trains; // Calculating the average arrival delay over the delayed trains
-
-	// Calculate the Standard Deviation of Delay at station instant_spatial_position over the delayed trains
-	for (int r = 0; r < S.N_Stopped_Trains; r++) {
-		S.Std_Arrival_Delay = S.Std_Arrival_Delay + pow((TrainDelay[r] - S.Av_Arrival_Delay), 2);
-	}
-	S.Std_Arrival_Delay = sqrt(S.Std_Arrival_Delay / (S.N_Stopped_Trains - 1));
-
-	// Calculate the Percentages of Delayed trains and Total Consecutive delay at that station
-	for (int r = 0; r < S.N_Stopped_Trains; r++) {
-		S.Perc_Delayed_T = (double)S.N_Delayed_Arr / S.N_Stopped_Trains * 100;			 // Percentage of delayed trains
-		S.Perc_Delayed_T_3min = (double)S.N_Delayed_Arr_3min / S.N_Stopped_Trains * 100; // Percentage of delayed trains more than 3 min
-		S.Perc_Delayed_T_5min = (double)S.N_Delayed_Arr_5min / S.N_Stopped_Trains * 100; // Percentage of delayed trains more than 5 min
-		S.Tot_Consec_Delay = S.Tot_Consec_Delay + TrainConsDelay[r];					 // Calculate Total consecutive delay
-	}
-
-	// Calculate the MaxConsecutive Delay and the Max Total Delay
-	for (int r = 0; r < S.N_Stopped_Trains; r++) {
-		if (TrainDelay[r] > S.Max_TotalDelay)
-			S.Max_TotalDelay = TrainDelay[r];
-		if (TrainConsDelay[r] > S.Max_Cons_Delay)
-			S.Max_Cons_Delay = TrainConsDelay[r];
-	}
-
+	calculateStationDelayStatistics(S, true);
 }
 
 // Function to Compute the amount of Disturbances set as input: Entrance delays, Cumulative disturbances to dwell times and Total delays (sum of entrance delays and disturbances to dwell times)
 void Compute_Input_Delays() {
-	std::vector<double> TrainDelay(numRegions);
-	std::vector<double> TrainEntDelay(numRegions);
-	std::vector<double> Disturb(numRegions);
-										 // Initializing parameters for Total input delays
-	TotalInputDelays.N_Stopped_Trains = numRegions; // Initializing the number of trains to consider: in this case they are all the trains considered in the network
-	TotalInputDelays.Av_Arrival_Delay = TotalInputDelays.Std_Arrival_Delay = 0;
-	TotalInputDelays.N_Delayed_Arr = TotalInputDelays.N_Delayed_Arr_3min = TotalInputDelays.N_Delayed_Arr_5min = 0; // Initializing Station parameters to 0 since these values will be calculated for station instant_spatial_position
-	TotalInputDelays.Perc_Delayed_T = TotalInputDelays.Perc_Delayed_T_3min = TotalInputDelays.Perc_Delayed_T_5min = 0;
-	TotalInputDelays.Tot_Consec_Delay = 0;
-
-	// Initializing parameters for Entrance input delays
-	EntranceInputDelays.N_Stopped_Trains = numRegions; // Initializing the number of trains to consider: in this case they are all the trains considered in the network
-	EntranceInputDelays.Av_Arrival_Delay = EntranceInputDelays.Std_Arrival_Delay = 0;
-	EntranceInputDelays.N_Delayed_Arr = EntranceInputDelays.N_Delayed_Arr_3min = EntranceInputDelays.N_Delayed_Arr_5min = 0; // Initializing Station parameters to 0 since these values will be calculated for station instant_spatial_position
-	EntranceInputDelays.Perc_Delayed_T = EntranceInputDelays.Perc_Delayed_T_3min = EntranceInputDelays.Perc_Delayed_T_5min = 0;
-	EntranceInputDelays.Tot_Consec_Delay = 0;
-
-	// Initializing parameters for Disturbances to dwell times input delays
-	DisturbanceInput.N_Stopped_Trains = numRegions; // Initializing the number of trains to consider: in this case they are all the trains considered in the network
-	DisturbanceInput.Av_Arrival_Delay = DisturbanceInput.Std_Arrival_Delay = 0;
-	DisturbanceInput.N_Delayed_Arr = DisturbanceInput.N_Delayed_Arr_3min = DisturbanceInput.N_Delayed_Arr_5min = 0; // Initializing Station parameters to 0 since these values will be calculated for station instant_spatial_position
-	DisturbanceInput.Perc_Delayed_T = DisturbanceInput.Perc_Delayed_T_3min = DisturbanceInput.Perc_Delayed_T_5min = 0;
-	DisturbanceInput.Tot_Consec_Delay = 0;
-
-	for (int j = 0; j < numRegions; j++) {													   // looping over the total number of trains
-		TrainDelay[j] = regional_train[j].TotalInputDelays;								   // recording the total delay in input: Entrance + Disturbances to dwell times
-		TrainEntDelay[j] = regional_train[j].EntranceDelay;								   // recording the delay at the entrance set in input
-		Disturb[j] = regional_train[j].TotalInputDelays - regional_train[j].EntranceDelay; // recording the disturbances to dwell times cumulated over all stations
-
-		// Setting the Number of trains that are delayed because they have total input delay positive:Entrance delays+disturbances to dwell times
-		if (TrainDelay[j] > 0)
-			TotalInputDelays.N_Delayed_Arr++; // increase the number of delayed trains if it is delayed
-		if (TrainDelay[j] > 3 * 60 / timestep)
-			TotalInputDelays.N_Delayed_Arr_3min++; // increase this number if its delay>3 min
-		if (TrainDelay[j] > 5 * 60 / timestep)
-			TotalInputDelays.N_Delayed_Arr_5min++; // increase this number if its delay>5 min
-
-		// Setting the Number of trains that are delayed because they have entrance input delay positive
-		if (TrainEntDelay[j] > 0)
-			EntranceInputDelays.N_Delayed_Arr++; // increase the number of delayed trains if it is delayed
-		if (TrainEntDelay[j] > 3 * 60 / timestep)
-			EntranceInputDelays.N_Delayed_Arr_3min++; // increase this number if its delay>3 min
-		if (TrainEntDelay[j] > 5 * 60 / timestep)
-			EntranceInputDelays.N_Delayed_Arr_5min++; // increase this number if its delay>5 min
-
-		// Setting the Number of trains that are delayed because they have disturbances to dwell times positive
-		if (Disturb[j] > 0)
-			DisturbanceInput.N_Delayed_Arr++; // increase the number of delayed trains if it is delayed
-		if (Disturb[j] > 3 * 60 / timestep)
-			DisturbanceInput.N_Delayed_Arr_3min++; // increase this number if its delay>3 min
-		if (Disturb[j] > 5 * 60 / timestep)
-			DisturbanceInput.N_Delayed_Arr_5min++; // increase this number if its delay>5 min
-	}
-
-	// Calculate the Total and the Average Input Delays
-	for (int r = 0; r < numRegions; r++) {
-		TotalInputDelays.Av_Arrival_Delay = TotalInputDelays.Av_Arrival_Delay + TrainDelay[r];			// Calculating the sum of total input delays
-		EntranceInputDelays.Av_Arrival_Delay = EntranceInputDelays.Av_Arrival_Delay + TrainEntDelay[r]; // Calculating the sum of entrance input delays
-		DisturbanceInput.Av_Arrival_Delay = DisturbanceInput.Av_Arrival_Delay + Disturb[r];				// Calculating the sum of disturbances to dwell times
-	}
-	TotalInputDelays.totalArrivalDelay = TotalInputDelays.Av_Arrival_Delay;		// Calculating the total input delay
-	EntranceInputDelays.totalArrivalDelay = EntranceInputDelays.Av_Arrival_Delay; // Calculating the total entrance delay in input
-	DisturbanceInput.totalArrivalDelay = DisturbanceInput.Av_Arrival_Delay;		// Calculating the total entrance delay in input
-
-	TotalInputDelays.Av_Arrival_Delay = TotalInputDelays.Av_Arrival_Delay / TotalInputDelays.N_Delayed_Arr;			 // Calculating the average total delay in input
-	EntranceInputDelays.Av_Arrival_Delay = EntranceInputDelays.Av_Arrival_Delay / EntranceInputDelays.N_Delayed_Arr; // Calculating the average entrance delay in input
-	DisturbanceInput.Av_Arrival_Delay = DisturbanceInput.Av_Arrival_Delay / DisturbanceInput.N_Delayed_Arr;			 // Calculating the average disturbance in input
-
-	// Calculate the Standard Deviation of Entrance delays and disturbances in input
-	for (int r = 0; r < numRegions; r++) {
-		if (TrainDelay[r] != 0) { // Std for Total delays in input
-			TotalInputDelays.Std_Arrival_Delay = TotalInputDelays.Std_Arrival_Delay + pow((TrainDelay[r] - TotalInputDelays.Av_Arrival_Delay), 2);
-		}
-		if (TrainEntDelay[r] != 0) { // Std for entrance delays in input
-			EntranceInputDelays.Std_Arrival_Delay = EntranceInputDelays.Std_Arrival_Delay + pow((TrainEntDelay[r] - EntranceInputDelays.Av_Arrival_Delay), 2);
-		}
-		if (Disturb[r] != 0) { // Std for disturbances to dwell time in input
-			DisturbanceInput.Std_Arrival_Delay = DisturbanceInput.Std_Arrival_Delay + pow((Disturb[r] - DisturbanceInput.Av_Arrival_Delay), 2);
-		}
-	}
-	TotalInputDelays.Std_Arrival_Delay = sqrt(TotalInputDelays.Std_Arrival_Delay / (TotalInputDelays.N_Delayed_Arr - 1));
-	EntranceInputDelays.Std_Arrival_Delay = sqrt(EntranceInputDelays.Std_Arrival_Delay / (EntranceInputDelays.N_Delayed_Arr - 1));
-	DisturbanceInput.Std_Arrival_Delay = sqrt(DisturbanceInput.Std_Arrival_Delay / (DisturbanceInput.N_Delayed_Arr - 1));
-
-	// Calculate the Percentages of Delayed trains in input
-	for (int r = 0; r < numRegions; r++) {
-		// For Total Delay in input
-		TotalInputDelays.Perc_Delayed_T = (double)TotalInputDelays.N_Delayed_Arr / TotalInputDelays.N_Stopped_Trains * 100;			  // Percentage of delayed trains
-		TotalInputDelays.Perc_Delayed_T_3min = (double)TotalInputDelays.N_Delayed_Arr_3min / TotalInputDelays.N_Stopped_Trains * 100; // Percentage of delayed trains more than 3 min
-		TotalInputDelays.Perc_Delayed_T_5min = (double)TotalInputDelays.N_Delayed_Arr_5min / TotalInputDelays.N_Stopped_Trains * 100; // Percentage of delayed trains more than 5 min
-																																	  // For Entrance Delay in input
-		EntranceInputDelays.Perc_Delayed_T = (double)EntranceInputDelays.N_Delayed_Arr / EntranceInputDelays.N_Stopped_Trains * 100;		   // Percentage of delayed trains
-		EntranceInputDelays.Perc_Delayed_T_3min = (double)EntranceInputDelays.N_Delayed_Arr_3min / EntranceInputDelays.N_Stopped_Trains * 100; // Percentage of delayed trains more than 3 min
-		EntranceInputDelays.Perc_Delayed_T_5min = (double)EntranceInputDelays.N_Delayed_Arr_5min / EntranceInputDelays.N_Stopped_Trains * 100; // Percentage of delayed trains more than 5 min
-																																			   // For Disturbances in input
-		DisturbanceInput.Perc_Delayed_T = (double)DisturbanceInput.N_Delayed_Arr / DisturbanceInput.N_Stopped_Trains * 100;			  // Percentage of delayed trains
-		DisturbanceInput.Perc_Delayed_T_3min = (double)DisturbanceInput.N_Delayed_Arr_3min / DisturbanceInput.N_Stopped_Trains * 100; // Percentage of delayed trains more than 3 min
-		DisturbanceInput.Perc_Delayed_T_5min = (double)DisturbanceInput.N_Delayed_Arr_5min / DisturbanceInput.N_Stopped_Trains * 100; // Percentage of delayed trains more than 5 min
-	}
-
-	// Calculate the Max Total, Entrance and Disturbance Delay in input
-	for (int r = 0; r < numRegions; r++) {
-		if (TrainDelay[r] > TotalInputDelays.Max_TotalDelay)
-			TotalInputDelays.Max_TotalDelay = TrainDelay[r]; // Max Total Delay in input
-		if (TrainEntDelay[r] > EntranceInputDelays.Max_TotalDelay)
-			EntranceInputDelays.Max_TotalDelay = TrainEntDelay[r]; // Max Entrance Delay in input
-		if (Disturb[r] > DisturbanceInput.Max_TotalDelay)
-			DisturbanceInput.Max_TotalDelay = Disturb[r]; // Max Disturbance in input
-	}
-
+	std::vector<double> delays(numRegions);
+	for (int trainIndex = 0; trainIndex < numRegions; ++trainIndex)
+		delays[trainIndex] = regional_train[trainIndex].TotalInputDelays;
+	calculateDelayStatistics(TotalInputDelays, delays, {}, false);
+	for (int trainIndex = 0; trainIndex < numRegions; ++trainIndex)
+		delays[trainIndex] = regional_train[trainIndex].EntranceDelay;
+	calculateDelayStatistics(EntranceInputDelays, delays, {}, false);
+	for (int trainIndex = 0; trainIndex < numRegions; ++trainIndex)
+		delays[trainIndex] = regional_train[trainIndex].TotalInputDelays
+			- regional_train[trainIndex].EntranceDelay;
+	calculateDelayStatistics(DisturbanceInput, delays, {}, false);
 }
 
 // Function to calculate the train delay statistics for all the station considered in the network

--- a/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
@@ -8,9 +8,12 @@
 #undef signals
 #endif
 
+#include <QTemporaryDir>
+
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <iterator>
 #include <limits>
@@ -763,6 +766,119 @@ int main() {
 					== BlocksConnected.end(),
 					"station lookahead ignores sections beyond the actual route tail");
 		}
+	}
+
+	SceneModel statisticsScene = completeScene();
+	statisticsScene.services[0].hasRepeatCount = true;
+	statisticsScene.services[0].repeatCount = 3;
+	const auto statisticsInfrastructure = buildInfrastructureAndSignallingFromScene(statisticsScene);
+	const auto statisticsOperations = buildOperationsFromScene(statisticsScene, "scenario.base");
+	ok &= expect(!hasErrors(statisticsInfrastructure) && !hasErrors(statisticsOperations)
+			&& numRegions == 3, "station statistics fixture builds three trains");
+	if (!hasErrors(statisticsInfrastructure) && !hasErrors(statisticsOperations) && numRegions == 3) {
+		Stations statistics;
+		statistics.stationName = "Final_Station";
+		for (int trainIndex = 0; trainIndex < 3; ++trainIndex) {
+			regional_train[trainIndex].numStations = 1;
+			regional_train[trainIndex].StationArrivals[0] = -1;
+			regional_train[trainIndex].StationDelay[0] = -1;
+			regional_train[trainIndex].StationConsecDelay[0] = -1;
+		}
+
+		numRegions = 0;
+		calculateDelayStatsAtStation(statistics);
+		Compute_Input_Delays();
+		ok &= expect(statistics.N_Stopped_Trains == 0 && statistics.Av_Arrival_Delay == -1
+				&& statistics.Std_Arrival_Delay == -1 && statistics.totalArrivalDelay == 0
+				&& TotalInputDelays.Av_Arrival_Delay == -1
+				&& EntranceInputDelays.Std_Arrival_Delay == -1
+				&& DisturbanceInput.Perc_Delayed_T == -1,
+				"empty delay populations keep the unavailable representation");
+
+		numRegions = 1;
+		regional_train[0].StationArrivals[0] = 100;
+		regional_train[0].StationDelay[0] = 12;
+		regional_train[0].StationConsecDelay[0] = 3;
+		calculateDelayStatsAtStation(statistics);
+		ok &= expect(statistics.Av_Arrival_Delay == 12 && statistics.Std_Arrival_Delay == 0
+				&& statistics.totalArrivalDelay == 12 && statistics.Max_TotalDelay == 12
+				&& std::isfinite(statistics.Perc_Delayed_T),
+				"one positive station-delay sample has zero deviation");
+
+		regional_train[0].StationDelay[0] = -1;
+		calculatePosAndNegDelayStatsAtStation(statistics);
+		ok &= expect(statistics.N_Stopped_Trains == 1 && statistics.Av_Arrival_Delay == -1
+				&& statistics.Std_Arrival_Delay == 0 && statistics.totalArrivalDelay == -1,
+				"a one-second early arrival is not confused with the delay sentinel");
+
+		regional_train[0].StationDelay[0] = -12;
+		regional_train[0].StationConsecDelay[0] = -3;
+		calculatePosAndNegDelayStatsAtStation(statistics);
+		ok &= expect(statistics.Av_Arrival_Delay == -12 && statistics.Std_Arrival_Delay == 0
+				&& statistics.Max_TotalDelay == -12 && statistics.Max_Cons_Delay == -3,
+				"one negative station-delay sample remains valid with zero deviation");
+
+		const double positiveDelays[] = {10, 20, 0};
+		const double mixedDelays[] = {-10, 0, 20};
+		for (int trainIndex = 0; trainIndex < 3; ++trainIndex) {
+			regional_train[trainIndex].StationArrivals[0] = 100;
+			regional_train[trainIndex].StationDelay[0] = positiveDelays[trainIndex];
+			regional_train[trainIndex].StationConsecDelay[0] = trainIndex;
+		}
+		numRegions = 3;
+		calculateDelayStatsAtStation(statistics);
+		ok &= expect(std::abs(statistics.Av_Arrival_Delay - 15) < 1e-9
+				&& std::abs(statistics.Std_Arrival_Delay - std::sqrt(50.0)) < 1e-9
+				&& statistics.N_Stopped_Trains == 3 && statistics.N_Delayed_Arr == 2
+				&& std::isfinite(statistics.Perc_Delayed_T),
+				"multiple positive delays retain the delayed-train sample denominator");
+
+		for (int trainIndex = 0; trainIndex < 3; ++trainIndex)
+			regional_train[trainIndex].StationDelay[0] = mixedDelays[trainIndex];
+		calculatePosAndNegDelayStatsAtStation(statistics);
+		ok &= expect(std::abs(statistics.Av_Arrival_Delay - (10.0 / 3.0)) < 1e-9
+				&& std::abs(statistics.Std_Arrival_Delay - std::sqrt(700.0 / 3.0)) < 1e-9
+				&& statistics.Max_TotalDelay == 20 && std::isfinite(statistics.totalArrivalDelay),
+				"mixed early and late arrivals use the all-sample denominator");
+
+		const double totalInputs[] = {0, 10, 20};
+		const double entranceInputs[] = {0, 4, 8};
+		for (int trainIndex = 0; trainIndex < 3; ++trainIndex) {
+			regional_train[trainIndex].TotalInputDelays = totalInputs[trainIndex];
+			regional_train[trainIndex].EntranceDelay = entranceInputs[trainIndex];
+		}
+		Compute_Input_Delays();
+		ok &= expect(std::abs(TotalInputDelays.Av_Arrival_Delay - 15) < 1e-9
+				&& std::abs(TotalInputDelays.Std_Arrival_Delay - std::sqrt(50.0)) < 1e-9
+				&& std::abs(EntranceInputDelays.Av_Arrival_Delay - 6) < 1e-9
+				&& std::abs(DisturbanceInput.Av_Arrival_Delay - 9) < 1e-9
+				&& std::isfinite(EntranceInputDelays.Std_Arrival_Delay)
+				&& std::isfinite(DisturbanceInput.Std_Arrival_Delay),
+				"multiple input-delay populations remain finite");
+
+		numRegions = 1;
+		regional_train[0].TotalInputDelays = 0;
+		regional_train[0].EntranceDelay = 0;
+		Compute_Input_Delays();
+		ok &= expect(TotalInputDelays.Av_Arrival_Delay == 0
+				&& TotalInputDelays.Std_Arrival_Delay == 0
+				&& EntranceInputDelays.Std_Arrival_Delay == 0
+				&& DisturbanceInput.Std_Arrival_Delay == 0,
+				"one all-punctual input population reports finite zeros");
+
+		QTemporaryDir statisticsOutput;
+		numStations = 1;
+		Final_Station = statistics;
+		Print_Station_Delay_Stats(statisticsOutput.path().toStdString(), "pos");
+		std::ifstream exported(statisticsOutput.filePath("Stats_Stations.txt").toStdString());
+		bool finiteExport = exported.good();
+		for (std::string token; exported >> token;) {
+			char* end = nullptr;
+			const double value = std::strtod(token.c_str(), &end);
+			if (end != token.c_str() && *end == '\0' && !std::isfinite(value))
+				finiteExport = false;
+		}
+		ok &= expect(finiteExport, "one-station statistics export contains no non-finite values");
 	}
 	return ok ? 0 : 1;
 }

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -1,15 +1,15 @@
 # Stabilization execution ledger
 
 - Initial `origin/main`: `935d94227fa3ebc61de371a52d663e711a3e4805`
-- Release status: P0 blockers cleared; blocked by remaining P1 findings G-03, G-04, G-07, and G-08
-- Active milestone: 3, external communication lifecycle
+- Release status: P0 blockers cleared; blocked by remaining P1 findings G-04 and G-08
+- Active milestone: 4, result integrity
 
 | Milestone | Findings | Status | Issue | Pull request | Merge |
 |---|---|---|---|---|---|
 | 1. Runtime memory safety | G-01, G-05, G-06; P-03 | Complete | [#306](https://github.com/Ancientkingg/EGTRAIN/issues/306) | [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307) | `743fe85798aef38a6862b989434650dc87106b2b` |
 | 2. Deterministic simulation state | G-02; P-04 | Complete | [#308](https://github.com/Ancientkingg/EGTRAIN/issues/308) | [#309](https://github.com/Ancientkingg/EGTRAIN/pull/309) | `d029582fcb230c8419e9332bfdb608c792974384` |
-| 3. External communication lifecycle | G-03, G-07; P-05 | In review | [#310](https://github.com/Ancientkingg/EGTRAIN/issues/310) | [#311](https://github.com/Ancientkingg/EGTRAIN/pull/311) | Pending |
-| 4. Result integrity | G-04; P-02 | Blocked on milestone 3 | Pending | Pending | Pending |
+| 3. External communication lifecycle | G-03, G-07; P-05 | Complete | [#310](https://github.com/Ancientkingg/EGTRAIN/issues/310) | [#311](https://github.com/Ancientkingg/EGTRAIN/pull/311) | `d2c8dd761808c45deaa3f44a2348e10c5ba3c37a` |
+| 4. Result integrity | G-04; P-02 | In progress | [#312](https://github.com/Ancientkingg/EGTRAIN/issues/312) | Pending | Pending |
 | 5. Persistence and validation hardening | G-08, G-09, G-10 | Blocked on milestone 4 | Pending | Pending | Pending |
 | 6. Station platform-booking verification | G-NV-01 | Blocked on release fixes | Pending | Pending | Pending |
 | 7. Dead-code cleanup | P-01, P-06 | Blocked on correctness work | Pending | Pending | Pending |
@@ -103,9 +103,9 @@
 - Simplifications made: replaced the two detached port-specific senders with one shared sender, deleted the duplicated hard-coded XML example bodies, computed each XML document once, and applied the three accepted Ponytail reductions for a further five-line reduction
 - Commit SHA: implementation `1d94c3c62126535d4826d0f2674aa57fbdd9fe44`; CI correction `b60af2da27f8587291d1667f498f775ea0db96e4`
 - PR number and URL: [#311](https://github.com/Ancientkingg/EGTRAIN/pull/311)
-- CI status: initial run 32351657448 failed only `test_railmlparser`; the failure was reproduced and corrected, and a replacement run is pending
-- Merge SHA: pending
-- Remaining blockers: G-03 and G-07 remain unresolved until the verified change is merged
+- CI status: replacement run 32353585680 passed in 10m53s after the initial flaky test-harness failure was corrected
+- Merge SHA: `d2c8dd761808c45deaa3f44a2348e10c5ba3c37a`
+- Remaining blockers: G-04 and G-08
 
 ### Execution log
 
@@ -128,3 +128,45 @@
 - 2026-08-20: Removed the mock server's zero-linger shutdown and added an explicit client-completion handshake so the server remains alive until the request/reply call returns. Retained the 100 ms production transport bound. The corrected test passed 100 consecutive runs, and the focused milestone set passed 4/4.
 - 2026-08-20: Focused independent review of the CI correction found no issue and confirmed all failure paths remain bounded. Full normal CTest then passed 48/48 in 149.02 seconds. The existing Ponytail reductions remain intact; the completion handshake is the minimum synchronization needed for a reliable request/reply test.
 - 2026-08-20: Committed the verified CI correction as `b60af2da27f8587291d1667f498f775ea0db96e4`; replacement CI is pending.
+- 2026-08-20: Replacement CI run 32353585680 passed in 10m53s. Squash-merged pull request #311 as `d2c8dd761808c45deaa3f44a2348e10c5ba3c37a`, deleted the feature branch, and removed the clean milestone worktree.
+
+## Milestone 4: result integrity
+
+- Finding IDs: G-04, P-02
+- Branch: `fix/finite-delay-statistics`
+- Worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/finite-delay-statistics`
+- Base SHA: `d2c8dd761808c45deaa3f44a2348e10c5ba3c37a`
+- Scope: finite station-delay statistics for zero, one, and multiple samples, with shared aggregation where scientifically equivalent
+- Files changed: `EGTRAIN/QEGTRAIN/simulation/Infrastructure.cpp`; `EGTRAIN/QEGTRAIN/simulation/Simulation.cpp`; `EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp`; `tools/e2e/headless_smoke.py`; `tools/memory/test_raii_contract.py`; this ledger
+- Test results: focused operations and RAII contract tests passed 2/2; Python export-scan syntax check passed; full build and post-simplification application rebuild passed; focused Paimpol and Milano native headless runs passed their existing runtime baselines and both finite-statistics export scans; full CTest passed 48/48; six-case native headless smoke passed with finite station-statistics exports; six-case roundtrip passed
+- Adversarial-review findings: one medium sentinel collision in signed statistics: a valid one-second early arrival had `StationDelay == -1` and was mistaken for the positive-mode unavailable marker
+- Fixes made from review: signed-mode collection now derives availability from the actual-arrival array while positive-only mode retains its delay sentinel; an exact `-1` signed-delay regression passes
+- Ponytail findings: accepted inlining the one-caller station sample collector and reusing one input vector sequentially instead of allocating three
+- Simplifications made: collapsed roughly 270 duplicated calculation lines into one private path, then removed the one-use sample record/helper and two input-vector allocations for a further ten-line reduction
+- Commit SHA: pending
+- PR number and URL: pending
+- CI status: pending
+- Merge SHA: pending
+- Remaining blockers: G-04 remains unresolved until the verified change is merged
+
+### Execution log
+
+- 2026-08-20: Confirmed no existing issue owns G-04; opened issue [#312](https://github.com/Ancientkingg/EGTRAIN/issues/312).
+- 2026-08-20: Fetched `origin`, created the clean isolated milestone worktree from the latest merged `origin/main`, and recorded the exact base SHA.
+- 2026-08-20: Traced the complete result path. Both station modes duplicate collection and calculation, while `Compute_Input_Delays()` repeats the same unsafe positive-delay mean and sample-deviation logic for three input populations; all six values flow directly into `Print_Station_Delay_Stats()` and its totals.
+- 2026-08-20: Fixed the semantics before implementation: no recorded arrivals retain the existing unavailable marker; a non-empty all-punctual positive-only population reports zero mean and deviation; singleton statistical populations report zero deviation; larger populations retain the sample denominator. Positive-only means remain based on positive delays, while positive/negative means include every recorded arrival.
+- 2026-08-20: Replaced the duplicated station bodies and three input calculations with one private collection/calculation path. Added direct zero, singleton, multi-sample, positive, negative, and input-population assertions plus a canonical output scan that rejects non-finite numeric tokens in both station-statistics files.
+- 2026-08-20: Configured a clean Qt 5 test build. The focused `test_operationsbuilder` regression passed 1/1 in 2.86 seconds, and the Python export-scan syntax check passed.
+- 2026-08-20: Completed the full application build. Native Paimpol and Milano-Brescia headless checks passed their structure, movement, served-arrival, and pre-cutover runtime baselines; both generated station-statistics files contained only finite numeric values.
+- 2026-08-20: Root review found the exported `TOTALS` row could still divide by `numStations - 1` when no reportable station followed the excluded first station. Totals now aggregate only rows with recorded samples and use the established unavailable marker when none exist. A one-station export regression passed with no non-finite numeric token; focused CTest passed again 1/1.
+- 2026-08-20: Independent correctness review found that signed delay `-1` is a valid one-second early arrival but collided with the positive-mode unavailable marker. Signed collection now checks the actual-arrival sentinel instead; positive-only collection retains the legacy delay sentinel. Added an exact `-1` regression, and focused CTest passed 1/1 in 2.71 seconds.
+- 2026-08-20: Fresh correctness re-review found no remaining issue. Separate Ponytail review identified two local reductions: inlined the one-caller station collector and reused one vector across the three input populations, removing ten lines and two allocations. Focused CTest passed 1/1 after simplification in 2.63 seconds.
+- 2026-08-20: Rebuilt the complete `QEGTRAIN` target after the accepted simplifications; compilation and linking passed.
+- 2026-08-20: Re-ran the canonical Paimpol and Milano-Brescia native headless cases against the final executable. Both passed clean exit, structure, movement, served-station, runtime-observable, and finite-statistics checks.
+- 2026-08-20: Final independent correctness review of the simplified diff found no issue. The reviewer traced current callers and delay producers; residual risk is limited to legacy paths that bypass native validation and supply non-finite inputs.
+- 2026-08-20: The first full CTest run passed 47/48. The only failure was the source-level RAII contract, whose literal checks still expected the four duplicated `TrainDelay`/`TrainConsDelay` append sites removed by consolidation. Updated that contract to verify the shared `arrivals` and `consecutive` vectors grow together and that the one reusable input vector remains RAII-managed. The contract and focused operations regression then passed 2/2.
+- 2026-08-20: Re-ran full CTest after correcting the stale source contract; all 48 tests passed in 147.67 seconds.
+- 2026-08-20: Six-case native headless smoke passed. Every case exited cleanly and produced finite station-statistics exports; all applicable structure, movement, runtime-observable, and served-station baselines also passed.
+- 2026-08-20: Six-case folder export, compatibility reimport, and validation roundtrip passed, including the reimported Assignment scene runtime check. Existing scene diagnostics remained warnings or informational messages.
+- 2026-08-20: Refreshed the repository knowledge graph after the code and guidance changes. Graphify reported its existing parser warnings for four files and zero-node warnings for data files; the graph rebuild completed with 4,923 nodes and 11,600 edges.
+- 2026-08-20: Final mechanical audit confirmed both public station-statistics entry points and input aggregation retain their production callers, the duplicated formulas are gone, every sample-variance division is guarded by a population larger than one, both station export variants are scanned, and the zero/singleton/multiple plus exact signed `-1` cases remain covered. Final diff checks passed.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -144,8 +144,8 @@
 - Ponytail findings: accepted inlining the one-caller station sample collector and reusing one input vector sequentially instead of allocating three
 - Simplifications made: collapsed roughly 270 duplicated calculation lines into one private path, then removed the one-use sample record/helper and two input-vector allocations for a further ten-line reduction
 - Commit SHA: `cabb787588c2bf28308931c62cb4749f7716be4e`
-- PR number and URL: pending
-- CI status: pending
+- PR number and URL: [#313](https://github.com/Ancientkingg/EGTRAIN/pull/313)
+- CI status: required checks running
 - Merge SHA: pending
 - Remaining blockers: G-04 remains unresolved until the verified change is merged
 
@@ -171,3 +171,4 @@
 - 2026-08-20: Refreshed the repository knowledge graph after the code and guidance changes. Graphify reported its existing parser warnings for four files and zero-node warnings for data files; the graph rebuild completed with 4,923 nodes and 11,600 edges.
 - 2026-08-20: Final mechanical audit confirmed both public station-statistics entry points and input aggregation retain their production callers, the duplicated formulas are gone, every sample-variance division is guarded by a population larger than one, both station export variants are scanned, and the zero/singleton/multiple plus exact signed `-1` cases remain covered. Final diff checks passed.
 - 2026-08-20: Committed the verified milestone implementation as `cabb787588c2bf28308931c62cb4749f7716be4e`.
+- 2026-08-20: Pushed `fix/finite-delay-statistics` and opened PR [#313](https://github.com/Ancientkingg/EGTRAIN/pull/313); required CI is running.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -143,7 +143,7 @@
 - Fixes made from review: signed-mode collection now derives availability from the actual-arrival array while positive-only mode retains its delay sentinel; an exact `-1` signed-delay regression passes
 - Ponytail findings: accepted inlining the one-caller station sample collector and reusing one input vector sequentially instead of allocating three
 - Simplifications made: collapsed roughly 270 duplicated calculation lines into one private path, then removed the one-use sample record/helper and two input-vector allocations for a further ten-line reduction
-- Commit SHA: pending
+- Commit SHA: `cabb787588c2bf28308931c62cb4749f7716be4e`
 - PR number and URL: pending
 - CI status: pending
 - Merge SHA: pending
@@ -170,3 +170,4 @@
 - 2026-08-20: Six-case folder export, compatibility reimport, and validation roundtrip passed, including the reimported Assignment scene runtime check. Existing scene diagnostics remained warnings or informational messages.
 - 2026-08-20: Refreshed the repository knowledge graph after the code and guidance changes. Graphify reported its existing parser warnings for four files and zero-node warnings for data files; the graph rebuild completed with 4,923 nodes and 11,600 edges.
 - 2026-08-20: Final mechanical audit confirmed both public station-statistics entry points and input aggregation retain their production callers, the duplicated formulas are gone, every sample-variance division is guarded by a population larger than one, both station export variants are scanned, and the zero/singleton/multiple plus exact signed `-1` cases remain covered. Final diff checks passed.
+- 2026-08-20: Committed the verified milestone implementation as `cabb787588c2bf28308931c62cb4749f7716be4e`.

--- a/tools/e2e/headless_smoke.py
+++ b/tools/e2e/headless_smoke.py
@@ -253,6 +253,21 @@ def check_station_arrivals(case_id: int = 3, out_base: Path = RUN_DIR) -> None:
     print(f"PASS case {case_id} has {rows} served station rows")
 
 
+def check_finite_station_statistics(case_id: int, out_base: Path = RUN_DIR) -> None:
+    output = scene_output_dir(case_id, out_base) / "TrainTrajectories"
+    for name in ("Stats_Stations.txt", "Pos&Neg_Stats_Stations.txt"):
+        path = output / name
+        for line_number, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            for token in line.split():
+                try:
+                    value = float(token)
+                except ValueError:
+                    continue
+                if not math.isfinite(value):
+                    raise SystemExit(f"case {case_id} has non-finite station statistics at {path}:{line_number}")
+    print(f"PASS case {case_id} station statistics are finite")
+
+
 def check_original_case_runtime(case_id: int, out_base: Path = RUN_DIR) -> None:
     expected = ORIGINAL_CASE_PARITY[case_id]
     output_dir = scene_output_dir(case_id, out_base)
@@ -313,6 +328,7 @@ def main() -> None:
         if case_id in ORIGINAL_CASE_PARITY:
             check_scene_structure(case_id)
         run_case(case_id)
+        check_finite_station_statistics(case_id)
         if case_id in ASSERT_MOVEMENT:
             check_movement(case_id)
         if case_id in ORIGINAL_CASE_PARITY:

--- a/tools/memory/test_raii_contract.py
+++ b/tools/memory/test_raii_contract.py
@@ -11,21 +11,16 @@ def main() -> None:
 
     delay_functions = simulation[: simulation.index("void calculateDelayStatsForAllStations")]
     station_delay_functions = simulation[
-        simulation.index("void calculateDelayStatsAtStation") : simulation.index("void Compute_Input_Delays")
+        simulation.index("void calculateStationDelayStatistics") : simulation.index("} // namespace")
     ]
-    for name in ("TrainDelay", "TrainConsDelay"):
-        if station_delay_functions.count(f"{name}.push_back(") != 4:
-            raise SystemExit(f"{name} must grow at every matching stop")
+    for name in ("arrivals", "consecutive"):
+        if station_delay_functions.count(f"{name}.push_back(") != 1:
+            raise SystemExit(f"{name} must grow at every recorded stop")
     if re.search(r"new\s+double\s*\[\s*numRegions\s*\]", delay_functions):
         raise SystemExit("delay statistics still use owning raw arrays")
     if re.search(r"delete\s*\[\s*\]\s*(?:TrainDelay|TrainConsDelay|TrainEntDelay|Disturb)", delay_functions):
         raise SystemExit("delay statistics still delete raw arrays")
-    expected_vectors = {
-        "TrainDelay": 1,
-        "TrainConsDelay": 0,
-        "TrainEntDelay": 1,
-        "Disturb": 1,
-    }
+    expected_vectors = {"delays": 1}
     for name, count in expected_vectors.items():
         pattern = rf"std::vector<double>\s+{name}\s*\(\s*numRegions\s*\)"
         if len(re.findall(pattern, delay_functions)) != count:


### PR DESCRIPTION
## Summary

- define finite zero-, one-, and multi-sample station-delay statistics
- preserve positive-only and signed-delay populations while sharing their calculation path
- keep empty aggregates unavailable and prevent non-finite station totals
- scan both exported station-statistics files during canonical headless runs

## Verification

- focused operations and source-contract tests: 2/2 passed
- full CTest: 48/48 passed
- Paimpol and Milano reproducer runs: passed
- six-case native headless smoke: passed
- six-case roundtrip smoke: passed
- independent correctness review and final re-review: no findings
- separate simplicity review: completed

Closes #312