### PR TITLE
Harden scene persistence and validation boundaries

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -165,7 +165,7 @@ DispatchController simulation;
 std::vector<SceneDiagnostic> DispatchController::prepareScene(const SceneModel& scene,
 		const std::string& selectedScenarioId, const SceneRunSelection& selectedOccurrences) {
 	resetState();
-	std::vector<SceneDiagnostic> diagnostics = validateRunnableScene(scene);
+	std::vector<SceneDiagnostic> diagnostics = validateRunnableScene(scene, selectedOccurrences);
 	if (hasErrors(diagnostics))
 		return diagnostics;
 

--- a/EGTRAIN/QEGTRAIN/app/main.cpp
+++ b/EGTRAIN/QEGTRAIN/app/main.cpp
@@ -170,7 +170,7 @@ QString resolveOutputDirectory(const std::string& sceneName) {
 		if (base.isEmpty())
 			base = QDir::homePath() + "/EGTRAIN";
 	}
-	const QString suffix = sceneName.empty() ? QStringLiteral("scene") : QString::fromStdString(sceneName);
+	const QString suffix = QString::fromStdString(sceneOutputDirectoryComponent(sceneName));
 	const QString output = QDir(base).filePath("Output/" + suffix);
 	QDir().mkpath(output);
 	return QDir(output).absolutePath();

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.cpp
@@ -149,6 +149,16 @@ SceneInputSnapshot readSceneDirectorySnapshot(const std::string& sceneDir) {
 	return result;
 }
 
+std::string sceneOutputDirectoryComponent(const std::string& sceneName) {
+	const bool driveQualified = sceneName.size() >= 2
+			&& std::isalpha(static_cast<unsigned char>(sceneName[0]))
+			&& sceneName[1] == ':';
+	if (sceneName.empty() || sceneName == "." || sceneName == ".."
+			|| sceneName.find_first_of("/\\") != std::string::npos || driveQualified)
+		return "scene";
+	return sceneName;
+}
+
 int sceneServiceOccurrenceCount(const SceneService& service, double durationSeconds) {
 	if (!service.hasRepeat)
 		return 1;

--- a/EGTRAIN/QEGTRAIN/scene/SceneModel.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneModel.h
@@ -318,6 +318,7 @@ struct SceneModel {
 
 SceneModel makeNewSceneModel();
 
+std::string sceneOutputDirectoryComponent(const std::string& sceneName);
 int sceneServiceOccurrenceCount(const SceneService& service, double durationSeconds);
 std::string sceneServiceOccurrenceOperatingCode(const SceneService& service, int occurrence);
 bool resolveScenePassengerLegStops(const SceneService& service, const ScenePassengerLeg& leg,

--- a/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
@@ -1,5 +1,6 @@
 #include "scene/SceneValidator.h"
 #include "scene/SectionInventory.h"
+#include "simulation/RuntimeLimits.h"
 
 #include <algorithm>
 #include <cmath>
@@ -122,7 +123,8 @@ void collectIds(const std::vector<T>& items, const std::string& file, const std:
 	}
 }
 
-std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable) {
+std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable,
+		const SceneRunSelection& selectedOccurrences = {}) {
 	std::vector<SceneDiagnostic> result;
 	DiagnosticBuilder diagnostics{result};
 
@@ -1133,6 +1135,10 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 	}
 
 	if (runnable) {
+		if (!scene.name.empty() && sceneOutputDirectoryComponent(scene.name) != scene.name)
+			diagnostics.error("scene.name.path", "Scene name must be a single safe output-directory component",
+				"scene.json", "scene", scene.name, "name", "",
+				"Use a name without path separators, dot components, or drive-qualified prefixes");
 		if (scene.baseTime.empty())
 			diagnostics.error("scene.basetime.missing", "Runnable scene requires base_time", "scene.json",
 					"scene", "", "base_time", "", "Set scene.json base_time to HH:MM:SS");
@@ -1187,13 +1193,44 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 			diagnostics.error("scene.scenario.default.missing", "Runnable scene requires a default scenario",
 					"scenarios.json", "scene", "", "default_scenario_id");
 
+		auto runtimeCapacity = [&](const std::string& message, const std::string& file,
+				const std::string& itemType, const std::string& itemId, const std::string& path,
+				const std::string& relatedId = "", const std::string& suggestedFix = "") {
+			diagnostics.error("scene.capacity.runtime", message, file, itemType, itemId, path,
+					relatedId, suggestedFix);
+		};
+		std::size_t expandedServiceOccurrences = 0;
+		const std::size_t maxExpandedTrains = static_cast<std::size_t>(RuntimeLimits::kMaxExpandedTrains);
+		const double durationSeconds = scene.settings.hasDuration ? scene.settings.durationSeconds : 0.0;
+		for (const SceneService& service : scene.services) {
+			const std::string servicePath = "services[" + service.id + "]";
+			if (service.stops.size() > static_cast<std::size_t>(RuntimeLimits::kMaxTimetableStops))
+				runtimeCapacity("Service stops exceed the native timetable capacity of "
+						+ std::to_string(RuntimeLimits::kMaxTimetableStops), "services.json", "service", service.id,
+						servicePath + ".stops", std::to_string(service.stops.size()),
+						"Reduce this service to " + std::to_string(RuntimeLimits::kMaxTimetableStops)
+								+ " or fewer stops");
+			const int occurrences = sceneServiceOccurrenceCount(service, durationSeconds);
+			const std::size_t occurrenceCount = selectedOccurrences.empty()
+					? static_cast<std::size_t>(occurrences)
+					: static_cast<std::size_t>(std::count_if(selectedOccurrences.begin(), selectedOccurrences.end(),
+							[&](const SceneServiceOccurrence& selected) {
+								return selected.serviceId == service.id && selected.occurrence >= 1
+										&& selected.occurrence <= occurrences;
+							}));
+			if (expandedServiceOccurrences > maxExpandedTrains
+					|| occurrenceCount > maxExpandedTrains - expandedServiceOccurrences)
+				expandedServiceOccurrences = maxExpandedTrains + 1;
+			else
+				expandedServiceOccurrences += occurrenceCount;
+		}
+		if (expandedServiceOccurrences > maxExpandedTrains)
+			runtimeCapacity("Expanded service occurrences exceed the native train capacity of "
+					+ std::to_string(RuntimeLimits::kMaxExpandedTrains), "services.json", "scene", scene.name,
+					"services", "", "Reduce repeat counts or headways so total occurrences fit within "
+							+ std::to_string(RuntimeLimits::kMaxExpandedTrains) + " trains");
+
 		if (infrastructureUsableForRuntimeChecks) {
-			auto runtimeCapacity = [&](const std::string& message, const std::string& file,
-					const std::string& itemType, const std::string& itemId, const std::string& path,
-					const std::string& relatedId = "", const std::string& suggestedFix = "") {
-				diagnostics.error("scene.capacity.runtime", message, file, itemType, itemId, path,
-						relatedId, suggestedFix);
-			};
 
 			if (scene.tracks.size() > kNativeMaxTracks)
 				runtimeCapacity("Scene has more than " + std::to_string(kNativeMaxTracks)
@@ -1362,8 +1399,9 @@ std::vector<SceneDiagnostic> validateScene(const SceneModel& scene) {
 	return validateCore(scene, false);
 }
 
-std::vector<SceneDiagnostic> validateRunnableScene(const SceneModel& scene) {
-	return validateCore(scene, true);
+std::vector<SceneDiagnostic> validateRunnableScene(const SceneModel& scene,
+		const SceneRunSelection& selectedOccurrences) {
+	return validateCore(scene, true, selectedOccurrences);
 }
 
 std::vector<SceneDiagnostic> validateSceneDirectory(const std::string& sceneDir) {

--- a/EGTRAIN/QEGTRAIN/scene/SceneValidator.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneValidator.h
@@ -14,7 +14,8 @@ std::vector<SceneDiagnostic> validateSceneStructure(const std::string& sceneDir)
 std::vector<SceneDiagnostic> validateScene(const SceneModel& scene);
 
 // Validate the minimum complete model needed by a runnable simulation.
-std::vector<SceneDiagnostic> validateRunnableScene(const SceneModel& scene);
+std::vector<SceneDiagnostic> validateRunnableScene(const SceneModel& scene,
+		const SceneRunSelection& selectedOccurrences = {});
 
 // Load, then validate ONLY if loading produced no Error diagnostics. Structural
 // errors must be fixed first to avoid semantic cascades from a partial model.

--- a/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp
@@ -1,9 +1,11 @@
 #include "scene/SceneWriter.h"
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <set>
+#include <system_error>
 #include <utility>
 
 using json = nlohmann::json;
@@ -27,9 +29,103 @@ static void addWriteError(SceneSaveResult& result, const std::string& file,
 	result.diagnostics.push_back(diagnostic);
 }
 
+static void addCleanupWarning(SceneSaveResult& result, const fs::path& path,
+		const std::string& message) {
+	SceneDiagnostic diagnostic;
+	diagnostic.severity = SceneSeverity::Warning;
+	diagnostic.code = "scene.save.cleanup";
+	diagnostic.file = path.string();
+	diagnostic.message = message;
+	result.diagnostics.push_back(std::move(diagnostic));
+}
+
+struct StagingDirectory {
+	fs::path path;
+
+	~StagingDirectory() {
+		if (path.empty())
+			return;
+		std::error_code ec;
+		fs::remove_all(path, ec);
+	}
+
+	void release() { path.clear(); }
+};
+
+static bool createUniqueDirectory(const fs::path& parent, const std::string& prefix,
+		fs::path& result) {
+	std::error_code ec;
+	for (unsigned int attempt = 0; attempt < 100; ++attempt) {
+		const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+		const fs::path candidate = parent / (prefix + std::to_string(stamp) + "-"
+				+ std::to_string(attempt));
+		ec.clear();
+		if (fs::create_directory(candidate, ec)) {
+			ec.clear();
+			fs::permissions(candidate, fs::perms::owner_all, fs::perm_options::replace, ec);
+			if (ec) {
+				std::error_code cleanupError;
+				fs::remove_all(candidate, cleanupError);
+				return false;
+			}
+			result = candidate;
+			return true;
+		}
+		if (ec && ec != std::errc::file_exists)
+			return false;
+	}
+	return false;
+}
+
+static bool uniqueSiblingPath(const fs::path& parent, const std::string& prefix,
+		fs::path& result) {
+	std::error_code ec;
+	for (unsigned int attempt = 0; attempt < 100; ++attempt) {
+		const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+		const fs::path candidate = parent / (prefix + std::to_string(stamp) + "-"
+				+ std::to_string(attempt));
+		ec.clear();
+		const auto status = fs::symlink_status(candidate, ec);
+		if (!ec && status.type() == fs::file_type::not_found) {
+			result = candidate;
+			return true;
+		}
+		if (ec == std::errc::no_such_file_or_directory) {
+			result = candidate;
+			return true;
+		}
+		if (ec && ec != std::errc::no_such_file_or_directory)
+			return false;
+	}
+	return false;
+}
+
+static bool inspectDestination(const fs::path& destination, bool& exists,
+		SceneSaveResult& result) {
+	std::error_code ec;
+	const auto status = fs::symlink_status(destination, ec);
+	if (ec && ec != std::errc::no_such_file_or_directory) {
+		addWriteError(result, destination.string(), "Cannot inspect scene destination: " + ec.message());
+		return false;
+	}
+	exists = !ec && status.type() != fs::file_type::not_found;
+	if (exists && status.type() != fs::file_type::directory) {
+		addWriteError(result, destination.string(),
+				"Scene destination must be a directory and cannot be a symlink");
+		return false;
+	}
+	return true;
+}
+
 static bool writeJsonFile(SceneSaveResult& result, const fs::path& scenePath,
-		const std::string& filename, const json& value, std::string* writtenBytes = nullptr) {
-	const std::string bytes = value.dump(4) + "\n";
+		const std::string& filename, const json& value) {
+	std::string bytes;
+	try {
+		bytes = value.dump(4) + "\n";
+	} catch (const json::exception& error) {
+		addWriteError(result, filename, "Cannot serialize " + filename + ": " + error.what());
+		return false;
+	}
 	std::ofstream output(scenePath / filename, std::ios::binary);
 	if (!output) {
 		addWriteError(result, filename, "Cannot open " + filename + " for writing");
@@ -40,8 +136,27 @@ static bool writeJsonFile(SceneSaveResult& result, const fs::path& scenePath,
 		addWriteError(result, filename, "Cannot write " + filename);
 		return false;
 	}
-	if (writtenBytes)
-		*writtenBytes = bytes;
+	return true;
+}
+
+static bool copyExistingSceneContents(const fs::path& source, const fs::path& staging,
+		SceneSaveResult& result) {
+	std::error_code ec;
+	fs::copy(source, staging, fs::copy_options::recursive | fs::copy_options::copy_symlinks, ec);
+	if (ec) {
+		addWriteError(result, source.string(), "Cannot stage the previous scene contents: " + ec.message());
+		return false;
+	}
+	for (const char* filename : {"scene.json", "infrastructure.json", "stations.json",
+			"signalling.json", "rolling_stock.json", "services.json", "scenarios.json",
+			"passengers.json", "views.json", "incidents.json"}) {
+		ec.clear();
+		fs::remove_all(staging / filename, ec);
+		if (ec) {
+			addWriteError(result, filename, "Cannot prepare staged scene file: " + ec.message());
+			return false;
+		}
+	}
 	return true;
 }
 
@@ -436,15 +551,8 @@ static json writeViews(const SceneModel& scene) {
 	return {{"tracks", tracks}, {"stations", stations}};
 }
 
-SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) {
+static SceneSaveResult writeSceneGeneration(const SceneModel& scene, const fs::path& scenePath) {
 	SceneSaveResult result;
-	const fs::path scenePath(sceneDir);
-	std::error_code ec;
-	fs::create_directories(scenePath, ec);
-	if (ec) {
-		addWriteError(result, "", "Cannot create scene directory: " + ec.message());
-		return result;
-	}
 
 	json sceneJson = {
 		{"schema_version", scene.schemaVersion},
@@ -596,13 +704,8 @@ SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) 
 		signalling["station_boundaries"].push_back(value);
 	}
 
-	std::vector<std::pair<std::string, std::string>> inputFiles;
 	const auto writeCanonical = [&](const std::string& filename, const json& value) {
-		std::string bytes;
-		const bool written = writeJsonFile(result, scenePath, filename, value, &bytes);
-		if (written)
-			inputFiles.emplace_back(filename, std::move(bytes));
-		return written;
+		return writeJsonFile(result, scenePath, filename, value);
 	};
 	bool wroteAll = true;
 	wroteAll = writeCanonical("scene.json", sceneJson) && wroteAll;
@@ -620,35 +723,106 @@ SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) 
 		wroteAll = writeCanonical("passengers.json", writePassengers(scene)) && wroteAll;
 	}
 
-	// Keep the old flat file until every new canonical file was persisted.
-	if (wroteAll) {
+	result.wroteAll = wroteAll && !hasErrors(result.diagnostics);
+	return result;
+}
+
+SceneSaveResult saveScene(const SceneModel& scene, const std::string& sceneDir) {
+	SceneSaveResult result;
+	const fs::path destination(sceneDir);
+	const std::string destinationName = destination.filename().string();
+	if (destination.empty() || destinationName.empty() || destinationName == "."
+			|| destinationName == "..") {
+		addWriteError(result, sceneDir, "Scene destination must be a named directory");
+		return result;
+	}
+
+	const fs::path parent = destination.parent_path().empty() ? fs::path(".")
+			: destination.parent_path();
+	std::error_code ec;
+	fs::create_directories(parent, ec);
+	if (ec) {
+		addWriteError(result, parent.string(), "Cannot create scene parent directory: " + ec.message());
+		return result;
+	}
+	ec.clear();
+	const auto parentStatus = fs::symlink_status(parent, ec);
+	if (ec || parentStatus.type() != fs::file_type::directory) {
+		addWriteError(result, parent.string(), "Scene destination parent must be a directory");
+		return result;
+	}
+
+	bool hadDestination = false;
+	if (!inspectDestination(destination, hadDestination, result))
+		return result;
+
+	StagingDirectory staging;
+	if (!createUniqueDirectory(parent, destinationName + ".staging-", staging.path)) {
+		addWriteError(result, destination.string(), "Cannot create a private scene staging directory");
+		return result;
+	}
+	if (hadDestination && !copyExistingSceneContents(destination, staging.path, result))
+		return result;
+	result = writeSceneGeneration(scene, staging.path);
+	if (!result.wroteAll || hasErrors(result.diagnostics))
+		return result;
+
+	const SceneLoadResult staged = loadScene(staging.path.string());
+	result.diagnostics.insert(result.diagnostics.end(), staged.diagnostics.begin(), staged.diagnostics.end());
+	if (hasErrors(staged.diagnostics)) {
+		result.wroteAll = false;
+		return result;
+	}
+	const std::string stagedSnapshot = staged.inputSnapshot;
+
+	if (!inspectDestination(destination, hadDestination, result)) {
+		result.wroteAll = false;
+		return result;
+	}
+
+	fs::path backup;
+	if (hadDestination) {
+		if (!uniqueSiblingPath(parent, destinationName + ".backup-", backup)) {
+			addWriteError(result, destination.string(), "Cannot reserve a private scene backup path");
+			result.wroteAll = false;
+			return result;
+		}
 		ec.clear();
-		fs::remove(scenePath / "incidents.json", ec);
+		fs::rename(destination, backup, ec);
 		if (ec) {
-			addWriteError(result, "incidents.json", "Cannot remove incidents.json: " + ec.message());
-			wroteAll = false;
-		}
-		if (scene.passengers.empty()) {
-			ec.clear();
-			fs::remove(scenePath / "passengers.json", ec);
-			if (ec) {
-				addWriteError(result, "passengers.json",
-						"Cannot remove passengers.json: " + ec.message());
-				wroteAll = false;
-			}
-		}
-		if (!hasViews) {
-			ec.clear();
-			fs::remove(scenePath / "views.json", ec);
-			if (ec) {
-				addWriteError(result, "views.json", "Cannot remove views.json: " + ec.message());
-				wroteAll = false;
-			}
+			addWriteError(result, destination.string(), "Cannot move the previous scene generation: "
+					+ ec.message());
+			result.wroteAll = false;
+			return result;
 		}
 	}
 
-	result.wroteAll = wroteAll && !hasErrors(result.diagnostics);
+	ec.clear();
+	fs::rename(staging.path, destination, ec);
+	if (ec) {
+		addWriteError(result, destination.string(), "Cannot publish scene generation: " + ec.message());
+		if (hadDestination) {
+			std::error_code restoreError;
+			fs::rename(backup, destination, restoreError);
+			if (restoreError)
+				addWriteError(result, destination.string(), "Cannot restore the previous scene generation: "
+						+ restoreError.message());
+		}
+		result.wroteAll = false;
+		return result;
+	}
+	staging.release();
+
+	if (hadDestination) {
+		ec.clear();
+		fs::remove_all(backup, ec);
+		if (ec)
+			addCleanupWarning(result, backup,
+					"Cannot remove the previous scene generation: " + ec.message());
+	}
+
+	result.wroteAll = !hasErrors(result.diagnostics);
 	if (result.wroteAll)
-		result.inputSnapshot = buildSceneDirectorySnapshot(inputFiles);
+		result.inputSnapshot = stagedSnapshot;
 	return result;
 }

--- a/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RollingStock.h
@@ -10,6 +10,7 @@
 #undef EGTRAIN_RESTORE_SIGNALS_KEYWORD
 #endif
 #include "simulation/Signalling.h"
+#include "simulation/RuntimeLimits.h"
 #include "util/TrajectoryUtil.h"
 
 // GUI - Virtual Coupling notifications
@@ -554,8 +555,9 @@ extern int numRegions; /*Number of Speed ranges in the characteristic Tractive e
 
 extern int N_Train, N_TrainD; /*Number of Trains with even path, Number of Trains with odd path*/
 
-// extern const int Max_N_Reg;
-#define Max_N_Reg 700
+// Keep the historical name for native callers while sharing the limit with
+// scene validation.
+inline constexpr int Max_N_Reg = RuntimeLimits::kMaxExpandedTrains;
 
 extern double VirtualQ[Max_N_Reg], VirtualQD[Max_N_Reg];
 
@@ -609,7 +611,7 @@ public:
 	std::vector<double> BX;
 	Node* Stations = nullptr;
 	int numStations;					   // Station is a dynamic array contating all Station Node for the train and int numStations is the Number of Stations (i.e. the dimension of Stations Array)
-	static constexpr int kMaxTimetableStations = 40; // Capacity of the station-indexed arrays below; stations beyond this cap have no timetable slot
+	static constexpr int kMaxTimetableStations = RuntimeLimits::kMaxTimetableStops; // Capacity of the station-indexed arrays below; stations beyond this cap have no timetable slot
 	static int clampStationCount(int requested, const string& trainId); // Clamps a served-station count to kMaxTimetableStations, warning once per train
 	int stationBlockSection[kMaxTimetableStations];		// Cached block section index for each station (avoids full-route scan every timestep)
 	int stationArc[kMaxTimetableStations];				   // Cached Arc index within block section for each station

--- a/EGTRAIN/QEGTRAIN/simulation/RuntimeLimits.h
+++ b/EGTRAIN/QEGTRAIN/simulation/RuntimeLimits.h
@@ -1,0 +1,11 @@
+#ifndef RUNTIME_LIMITS_H
+#define RUNTIME_LIMITS_H
+
+namespace RuntimeLimits {
+
+inline constexpr int kMaxExpandedTrains = 700;
+inline constexpr int kMaxTimetableStops = 40;
+
+} // namespace RuntimeLimits
+
+#endif // RUNTIME_LIMITS_H

--- a/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp
@@ -156,6 +156,18 @@ int main() {
 
 	const auto diagnostics = buildOperationsFromScene(scene, "scenario.selected");
 	ok &= expect(!hasErrors(diagnostics), "M3 operations builder accepts the complete fixture");
+	SceneModel tooManyStops = completeScene();
+	while (tooManyStops.services[0].stops.size() <= static_cast<std::size_t>(Train::kMaxTimetableStations))
+		tooManyStops.services[0].stops.push_back(tooManyStops.services[0].stops.back());
+	const auto tooManyStopsDiagnostics = buildOperationsFromScene(tooManyStops, "scenario.base");
+	ok &= expect(hasCode(tooManyStopsDiagnostics, "scene.native.capacity.stops"),
+			"native operations rejects one stop above the timetable limit");
+	SceneModel tooManyTrains = completeScene();
+	tooManyTrains.services[0].hasRepeatCount = true;
+	tooManyTrains.services[0].repeatCount = Max_N_Reg + 1;
+	const auto tooManyTrainsDiagnostics = buildOperationsFromScene(tooManyTrains, "scenario.base");
+	ok &= expect(hasCode(tooManyTrainsDiagnostics, "scene.native.capacity.trains"),
+			"native operations rejects one expanded train above the limit");
 	ok &= expect(initial_variables.InputMainFolder == "/__egtrain_nonexistent_native_input__"
 			&& InputMainFolder == initial_variables.InputMainFolder,
 			"native builders do not access or rewrite the legacy input folder");
@@ -551,6 +563,12 @@ int main() {
 				&& numRegions == 1
 				&& regional_train[0].trainDescription == "service.native-999999999",
 				"a sparse selection does not expand every occurrence in a large pattern");
+	const SceneRunSelection invalidSelections{{"service.native", 1000000001}, {"service.missing", 1}};
+	const auto invalidSelectionOperations = buildOperationsFromScene(
+			sparsePattern, "scenario.selected", invalidSelections);
+	ok &= expect(hasCode(invalidSelectionOperations, "scene.native.selection.occurrence")
+				&& hasCode(invalidSelectionOperations, "scene.native.selection.service"),
+				"invalid sparse selections retain native selection diagnostics");
 
 	SceneModel outOfPattern = completeScene();
 	outOfPattern.services[0].hasRepeatCount = true;

--- a/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
@@ -1,7 +1,9 @@
 #include "scene/SceneModel.h"
 #include "scene/SectionInventory.h"
 #include "scene/SceneValidator.h"
+#include "simulation/RuntimeLimits.h"
 
+#include <filesystem>
 #include <iostream>
 #include <limits>
 #include <string>
@@ -132,6 +134,59 @@ int main(int argc, char** argv) {
 			"semantic validation does not reject complete topology");
 	ok &= expect(validateScene(clean).empty(), "complete scene passes semantic validation");
 	ok &= expect(validateRunnableScene(clean).empty(), "complete scene passes runnable validation");
+	const std::filesystem::path outputRoot = "scene-output-root";
+	const std::vector<std::pair<std::string, std::string>> outputNameCases = {
+		{"Readable Scene", "Readable Scene"},
+		{"", "scene"},
+		{"../outside", "scene"},
+		{"..\\outside", "scene"},
+		{".", "scene"},
+		{"..", "scene"},
+		{"/absolute", "scene"},
+		{"\\absolute", "scene"},
+		{"//server/share", "scene"},
+		{"\\\\server\\share", "scene"},
+		{"C:", "scene"},
+		{"C:\\outside", "scene"},
+	};
+	for (const auto& outputName : outputNameCases) {
+		const std::string component = sceneOutputDirectoryComponent(outputName.first);
+		const std::filesystem::path joined = outputRoot / component;
+		ok &= expect(component == outputName.second && joined.lexically_normal().parent_path() == outputRoot,
+				("scene output component is safe for " + outputName.first).c_str());
+	}
+	SceneModel unsafeSceneName = clean;
+	unsafeSceneName.name = "../outside";
+	ok &= expect(hasCodeAndPath(validateRunnableScene(unsafeSceneName), "scene.name.path", "name"),
+			"runnable validation rejects unsafe scene output names");
+	SceneModel stopLimit = clean;
+	while (stopLimit.services[0].stops.size() < static_cast<std::size_t>(RuntimeLimits::kMaxTimetableStops))
+		stopLimit.services[0].stops.push_back(stopLimit.services[0].stops.back());
+	ok &= expect(!hasCode(validateRunnableScene(stopLimit), "scene.capacity.runtime"),
+			"runnable validation accepts the exact timetable stop limit");
+	SceneModel tooManyStops = stopLimit;
+	tooManyStops.services[0].stops.push_back(tooManyStops.services[0].stops.back());
+	ok &= expect(hasCodeAndPath(validateRunnableScene(tooManyStops), "scene.capacity.runtime",
+				"services[service-1].stops"), "runnable validation rejects one stop above the limit");
+	SceneModel trainLimit = clean;
+	trainLimit.services[0].hasRepeat = true;
+	trainLimit.services[0].headwaySeconds = 1.0;
+	trainLimit.services[0].hasRepeatCount = true;
+	trainLimit.services[0].repeatCount = RuntimeLimits::kMaxExpandedTrains;
+	ok &= expect(!hasCode(validateRunnableScene(trainLimit), "scene.capacity.runtime"),
+			"runnable validation accepts the exact expanded train limit");
+	SceneModel tooManyTrains = trainLimit;
+	tooManyTrains.services[0].repeatCount = RuntimeLimits::kMaxExpandedTrains + 1;
+	ok &= expect(hasCodeAndPath(validateRunnableScene(tooManyTrains), "scene.capacity.runtime", "services"),
+			"runnable validation rejects one expanded train above the limit");
+	const SceneRunSelection sparseSelection{{tooManyTrains.services[0].id,
+		RuntimeLimits::kMaxExpandedTrains + 1}};
+	ok &= expect(!hasCode(validateRunnableScene(tooManyTrains, sparseSelection), "scene.capacity.runtime"),
+			"runnable validation applies train capacity to a sparse selected run");
+	const SceneRunSelection invalidSelections{{tooManyTrains.services[0].id,
+		RuntimeLimits::kMaxExpandedTrains + 2}, {"service-missing", 1}};
+	ok &= expect(!hasCode(validateRunnableScene(tooManyTrains, invalidSelections), "scene.capacity.runtime"),
+			"invalid selected rows do not fall back to all-scene train capacity");
 	SceneModel invalidPlatformLength = clean;
 	invalidPlatformLength.stations[0].platforms[0].hasLength = true;
 	invalidPlatformLength.stations[0].platforms[0].lengthM = std::numeric_limits<double>::infinity();

--- a/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <map>
 #include <iostream>
 #include <nlohmann/json.hpp>
 
@@ -19,6 +20,26 @@ static bool expect(bool condition, const char* message) {
 static std::string readBytes(const fs::path& path) {
 	std::ifstream input(path, std::ios::binary);
 	return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
+static std::map<std::string, std::string> readDirectoryBytes(const fs::path& directory) {
+	std::map<std::string, std::string> files;
+	for (const auto& entry : fs::directory_iterator(directory)) {
+		if (entry.is_regular_file())
+			files.emplace(entry.path().filename().string(), readBytes(entry.path()));
+	}
+	return files;
+}
+
+static bool hasSiblingArtifact(const fs::path& destination, const std::string& kind) {
+	const fs::path parent = destination.parent_path().empty() ? fs::path(".")
+			: destination.parent_path();
+	const std::string prefix = destination.filename().string() + "." + kind + "-";
+	for (const auto& entry : fs::directory_iterator(parent)) {
+		if (entry.path().filename().string().rfind(prefix, 0) == 0)
+			return true;
+	}
+	return false;
 }
 
 static void printErrors(const std::vector<SceneDiagnostic>& diagnostics, const char* label) {
@@ -205,6 +226,31 @@ int main() {
 			&& savedSnapshot == onDiskSnapshot.bytes,
 			"successful save retains the exact framed canonical input snapshot");
 	ok &= expect(!fs::exists(temp.path / "incidents.json"), "writer does not emit flat incidents.json");
+	{
+		std::ofstream marker(temp.path / "generation-marker.txt", std::ios::binary);
+		marker << "original generation marker\n";
+	}
+	fs::create_directory(temp.path / "notes");
+	{
+		std::ofstream note(temp.path / "notes" / "operator.txt", std::ios::binary);
+		note << "keep with scene\n";
+	}
+	const auto originalGeneration = readDirectoryBytes(temp.path);
+	SceneModel malformed = source;
+	malformed.passengers[0].journeys[0].activity = std::string("\xC3\x28", 2);
+	const SceneSaveResult failedSave = saveScene(malformed, temp.path.string());
+	ok &= expect(!failedSave.success() && hasErrors(failedSave.diagnostics),
+			"malformed UTF-8 fails without publishing a partial generation");
+	ok &= expect(readDirectoryBytes(temp.path) == originalGeneration,
+			"failed save preserves every byte of the previous generation");
+	ok &= expect(!hasSiblingArtifact(temp.path, "staging")
+			&& !hasSiblingArtifact(temp.path, "backup"),
+			"failed save removes sibling staging and backup artifacts");
+	const SceneSaveResult replacementSave = saveScene(source, temp.path.string());
+	ok &= expect(replacementSave.success()
+			&& fs::exists(temp.path / "generation-marker.txt")
+			&& fs::exists(temp.path / "notes" / "operator.txt"),
+			"successful generation replacement preserves unmanaged scene contents");
 	json stations;
 	{
 		std::ifstream input(temp.path / "stations.json");

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -187,7 +187,7 @@
 - Fixes made from review: copy unmanaged existing contents into staging before replacing writer-managed files, test both file and nested-directory preservation, and pass the selected occurrence set into runnable validation so its train-count check matches the native builder. Added invalid and unknown selected-row coverage across validation and native diagnostics.
 - Ponytail findings: accepted removal of an unused JSON-write out-parameter and the redundant nonpositive occurrence guard
 - Simplifications made: removed obsolete serialized-byte plumbing and relied directly on the occurrence-count helper's positive-result contract
-- Commit SHA: pending
+- Commit SHA: `3c93f9df6b6712eaa657b8775e1041bd335fc5ad`
 - PR number and URL: pending
 - CI status: pending
 - Merge SHA: pending
@@ -212,3 +212,4 @@
 - 2026-08-20: Standalone creator acceptance passed 1/1. All six committed scenes passed folder export, compatibility reimport, and validation roundtrip, including the reimported Assignment runtime check. Six-case native headless smoke passed clean exit and finite-statistics checks for every case plus all applicable structure, movement, runtime-observable, and served-station baselines.
 - 2026-08-20: Refreshed the code knowledge graph after the code and ledger changes. Graphify completed with 4,941 nodes and 11,663 edges, retaining its existing parser and zero-node warnings; removed the generated worktree-local graph copy afterward.
 - 2026-08-20: Final mechanical audit confirmed every folder and bundle caller uses the shared transactional writer, dispatch is the only runnable-validation caller with a selected occurrence set and now forwards it, the two native capacities have one source of truth, the only scene-controlled output-directory construction uses the safe component helper, and the focused tests cover failure rollback, successful sidecar preservation, exact/over/sparse/invalid capacity cases, native parity, and traversal. No dead new symbol or missing production call site was found; final diff checks passed.
+- 2026-08-20: Committed the verified milestone implementation as `3c93f9df6b6712eaa657b8775e1041bd335fc5ad`.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -10,7 +10,7 @@
 | 2. Deterministic simulation state | G-02; P-04 | Complete | [#308](https://github.com/Ancientkingg/EGTRAIN/issues/308) | [#309](https://github.com/Ancientkingg/EGTRAIN/pull/309) | `d029582fcb230c8419e9332bfdb608c792974384` |
 | 3. External communication lifecycle | G-03, G-07; P-05 | Complete | [#310](https://github.com/Ancientkingg/EGTRAIN/issues/310) | [#311](https://github.com/Ancientkingg/EGTRAIN/pull/311) | `d2c8dd761808c45deaa3f44a2348e10c5ba3c37a` |
 | 4. Result integrity | G-04; P-02 | Complete | [#312](https://github.com/Ancientkingg/EGTRAIN/issues/312) | [#313](https://github.com/Ancientkingg/EGTRAIN/pull/313) | `ee59d0fec11ecda65c3acca2acb0e1f76c7723dd` |
-| 5. Persistence and validation hardening | G-08, G-09, G-10 | In progress | [#314](https://github.com/Ancientkingg/EGTRAIN/issues/314) | Pending | Pending |
+| 5. Persistence and validation hardening | G-08, G-09, G-10 | In progress | [#314](https://github.com/Ancientkingg/EGTRAIN/issues/314) | [#315](https://github.com/Ancientkingg/EGTRAIN/pull/315) | Pending |
 | 6. Station platform-booking verification | G-NV-01 | Blocked on release fixes | Pending | Pending | Pending |
 | 7. Dead-code cleanup | P-01, P-06 | Blocked on correctness work | Pending | Pending | Pending |
 
@@ -188,8 +188,8 @@
 - Ponytail findings: accepted removal of an unused JSON-write out-parameter and the redundant nonpositive occurrence guard
 - Simplifications made: removed obsolete serialized-byte plumbing and relied directly on the occurrence-count helper's positive-result contract
 - Commit SHA: `3c93f9df6b6712eaa657b8775e1041bd335fc5ad`
-- PR number and URL: pending
-- CI status: pending
+- PR number and URL: [#315](https://github.com/Ancientkingg/EGTRAIN/pull/315)
+- CI status: running
 - Merge SHA: pending
 - Remaining blockers: G-08, G-09, and G-10
 
@@ -213,3 +213,4 @@
 - 2026-08-20: Refreshed the code knowledge graph after the code and ledger changes. Graphify completed with 4,941 nodes and 11,663 edges, retaining its existing parser and zero-node warnings; removed the generated worktree-local graph copy afterward.
 - 2026-08-20: Final mechanical audit confirmed every folder and bundle caller uses the shared transactional writer, dispatch is the only runnable-validation caller with a selected occurrence set and now forwards it, the two native capacities have one source of truth, the only scene-controlled output-directory construction uses the safe component helper, and the focused tests cover failure rollback, successful sidecar preservation, exact/over/sparse/invalid capacity cases, native parity, and traversal. No dead new symbol or missing production call site was found; final diff checks passed.
 - 2026-08-20: Committed the verified milestone implementation as `3c93f9df6b6712eaa657b8775e1041bd335fc5ad`.
+- 2026-08-20: Pushed `fix/scene-integrity-boundaries` and opened pull request [#315](https://github.com/Ancientkingg/EGTRAIN/pull/315); required CI is running.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -1,16 +1,16 @@
 # Stabilization execution ledger
 
 - Initial `origin/main`: `935d94227fa3ebc61de371a52d663e711a3e4805`
-- Release status: P0 blockers cleared; blocked by remaining P1 findings G-04 and G-08
-- Active milestone: 4, result integrity
+- Release status: P0 blockers cleared; blocked by remaining P1 finding G-08
+- Active milestone: 5, persistence and validation hardening
 
 | Milestone | Findings | Status | Issue | Pull request | Merge |
 |---|---|---|---|---|---|
 | 1. Runtime memory safety | G-01, G-05, G-06; P-03 | Complete | [#306](https://github.com/Ancientkingg/EGTRAIN/issues/306) | [#307](https://github.com/Ancientkingg/EGTRAIN/pull/307) | `743fe85798aef38a6862b989434650dc87106b2b` |
 | 2. Deterministic simulation state | G-02; P-04 | Complete | [#308](https://github.com/Ancientkingg/EGTRAIN/issues/308) | [#309](https://github.com/Ancientkingg/EGTRAIN/pull/309) | `d029582fcb230c8419e9332bfdb608c792974384` |
 | 3. External communication lifecycle | G-03, G-07; P-05 | Complete | [#310](https://github.com/Ancientkingg/EGTRAIN/issues/310) | [#311](https://github.com/Ancientkingg/EGTRAIN/pull/311) | `d2c8dd761808c45deaa3f44a2348e10c5ba3c37a` |
-| 4. Result integrity | G-04; P-02 | In progress | [#312](https://github.com/Ancientkingg/EGTRAIN/issues/312) | Pending | Pending |
-| 5. Persistence and validation hardening | G-08, G-09, G-10 | Blocked on milestone 4 | Pending | Pending | Pending |
+| 4. Result integrity | G-04; P-02 | Complete | [#312](https://github.com/Ancientkingg/EGTRAIN/issues/312) | [#313](https://github.com/Ancientkingg/EGTRAIN/pull/313) | `ee59d0fec11ecda65c3acca2acb0e1f76c7723dd` |
+| 5. Persistence and validation hardening | G-08, G-09, G-10 | In progress | [#314](https://github.com/Ancientkingg/EGTRAIN/issues/314) | Pending | Pending |
 | 6. Station platform-booking verification | G-NV-01 | Blocked on release fixes | Pending | Pending | Pending |
 | 7. Dead-code cleanup | P-01, P-06 | Blocked on correctness work | Pending | Pending | Pending |
 
@@ -145,9 +145,9 @@
 - Simplifications made: collapsed roughly 270 duplicated calculation lines into one private path, then removed the one-use sample record/helper and two input-vector allocations for a further ten-line reduction
 - Commit SHA: `cabb787588c2bf28308931c62cb4749f7716be4e`
 - PR number and URL: [#313](https://github.com/Ancientkingg/EGTRAIN/pull/313)
-- CI status: required checks running
-- Merge SHA: pending
-- Remaining blockers: G-04 remains unresolved until the verified change is merged
+- CI status: passed in 12m04s
+- Merge SHA: `ee59d0fec11ecda65c3acca2acb0e1f76c7723dd`
+- Remaining blockers: G-08
 
 ### Execution log
 
@@ -172,3 +172,43 @@
 - 2026-08-20: Final mechanical audit confirmed both public station-statistics entry points and input aggregation retain their production callers, the duplicated formulas are gone, every sample-variance division is guarded by a population larger than one, both station export variants are scanned, and the zero/singleton/multiple plus exact signed `-1` cases remain covered. Final diff checks passed.
 - 2026-08-20: Committed the verified milestone implementation as `cabb787588c2bf28308931c62cb4749f7716be4e`.
 - 2026-08-20: Pushed `fix/finite-delay-statistics` and opened PR [#313](https://github.com/Ancientkingg/EGTRAIN/pull/313); required CI is running.
+- 2026-08-20: Required CI passed in 12m04s. Squash-merged PR #313 as `ee59d0fec11ecda65c3acca2acb0e1f76c7723dd`, deleted the feature branch, and removed the clean milestone worktree.
+
+## Milestone 5: persistence and validation hardening
+
+- Finding IDs: G-08, G-09, G-10
+- Branch: `fix/scene-integrity-boundaries`
+- Worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/scene-integrity-boundaries`
+- Base SHA: `ee59d0fec11ecda65c3acca2acb0e1f76c7723dd`
+- Scope: transactional folder publication, validator/native capacity parity, and safe scene-controlled output directory names
+- Files changed: `EGTRAIN/QEGTRAIN/app/DispatchController.cpp`; `EGTRAIN/QEGTRAIN/app/main.cpp`; `EGTRAIN/QEGTRAIN/scene/SceneModel.cpp`; `EGTRAIN/QEGTRAIN/scene/SceneModel.h`; `EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp`; `EGTRAIN/QEGTRAIN/scene/SceneValidator.h`; `EGTRAIN/QEGTRAIN/scene/SceneWriter.cpp`; `EGTRAIN/QEGTRAIN/simulation/RollingStock.h`; `EGTRAIN/QEGTRAIN/simulation/RuntimeLimits.h`; `EGTRAIN/QEGTRAIN/tests/test_operationsbuilder.cpp`; `EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp`; `EGTRAIN/QEGTRAIN/tests/test_scenewriter.cpp`; this ledger
+- Test results: focused scene writer, scene bundle, runnable validator, and native operations tests passed 4/4 before review and again after accepted review fixes; full build passed; full CTest passed 48/48; standalone creator acceptance passed; six-case folder/export/reimport roundtrip passed; six-case native headless smoke passed
+- Adversarial-review findings: two high-severity regressions: successful generation replacement discarded unmanaged scene-directory contents, and unconditional expanded-count validation blocked supported sparse selected-occurrence runs; the new shared header was also noted as untracked before commit. Re-review found no implementation defect and one low-severity missing invalid-selection regression.
+- Fixes made from review: copy unmanaged existing contents into staging before replacing writer-managed files, test both file and nested-directory preservation, and pass the selected occurrence set into runnable validation so its train-count check matches the native builder. Added invalid and unknown selected-row coverage across validation and native diagnostics.
+- Ponytail findings: accepted removal of an unused JSON-write out-parameter and the redundant nonpositive occurrence guard
+- Simplifications made: removed obsolete serialized-byte plumbing and relied directly on the occurrence-count helper's positive-result contract
+- Commit SHA: pending
+- PR number and URL: pending
+- CI status: pending
+- Merge SHA: pending
+- Remaining blockers: G-08, G-09, and G-10
+
+### Execution log
+
+- 2026-08-20: Fetched `origin`, confirmed PR #313 as the latest merged `origin/main`, removed the clean Milestone 4 worktree, and created the clean isolated milestone branch and worktree from merge SHA `ee59d0fec11ecda65c3acca2acb0e1f76c7723dd`.
+- 2026-08-20: Confirmed no existing issue owns G-08, G-09, and G-10; opened issue [#314](https://github.com/Ancientkingg/EGTRAIN/issues/314) for the PR-sized milestone.
+- 2026-08-20: Read the scene-model and build/test guidance and traced all three boundaries through the knowledge graph and exact source. Folder saves write directly into the live destination while bundle and importer paths already use sibling staging; runtime builders enforce `Train::kMaxTimetableStations` and `Max_N_Reg` while pure runnable validation omits them; `main.cpp` appends the untrusted scene name directly below `Output/`.
+- 2026-08-20: Fixed the implementation scope. Folder saves will stage, structurally reload, and publish through a sibling backup without a test-only hook. The two native capacities will move to one minimal shared constants header consumed by runtime and validation. A pure scene-name component helper will drive both runnable validation and output resolution, falling back safely if validation is bypassed.
+- 2026-08-20: Implemented transactional folder publication with private sibling staging, structural reload, generation backup/restore, and cleanup. A malformed UTF-8 field now produces a normal serialization failure after earlier staged files are written; the focused regression confirms the previous folder remains byte-for-byte intact with no staging or backup artifact. Focused scene-writer and bundle tests passed.
+- 2026-08-20: Added one shared header for the 700-train and 40-stop runtime capacities, and made runnable validation reject the same limit overflows as native operations without expanding the occurrence set. Added a pure single-component output-name helper, runnable diagnostic, and resolver fallback for traversal, separators, drive prefixes, dot names, and empty names. Focused validator and native-operations tests passed.
+- 2026-08-20: Integration review corrected post-publication backup cleanup from a false save failure to a warning and aligned staging-directory permissions with the existing private bundle staging pattern.
+- 2026-08-20: Independent correctness review found that a successful generation replacement discarded unmanaged files and subdirectories, and that unconditional expanded-count validation rejected supported sparse selected-occurrence runs. The new shared header was also identified as an untracked file that must be included in the commit.
+- 2026-08-20: Preserved unmanaged contents by copying the existing directory into private staging before removing and rewriting only writer-managed paths. Extended the regression to cover a top-level marker and nested operator note across a successful replacement.
+- 2026-08-20: Extended runnable validation with the existing selected-occurrence set and passed it from dispatch, retaining all-scene capacity rejection while matching the native builder for sparse runs. Focused CTest passed 4/4 after both corrections.
+- 2026-08-20: Separate Ponytail review found two safe reductions. Removed the unused JSON serialization out-parameter and a redundant guard around the occurrence helper's guaranteed-positive result.
+- 2026-08-20: Fresh correctness re-review found no implementation defect and one low-severity test gap for invalid selections. Added coverage proving invalid and unknown selected rows neither fall back to all-scene capacity nor bypass native selection diagnostics. Fresh Ponytail re-review found no further simplification.
+- 2026-08-20: Rebuilt the complete application and all test targets after the final review fix; compilation and linking passed with only existing deprecation warnings.
+- 2026-08-20: Full normal CTest passed 48/48 in 167.03 seconds, including creator acceptance, folder and bundle coverage, native startup, runtime memory safety, determinism, no-listener sharing, and GUI smokes.
+- 2026-08-20: Standalone creator acceptance passed 1/1. All six committed scenes passed folder export, compatibility reimport, and validation roundtrip, including the reimported Assignment runtime check. Six-case native headless smoke passed clean exit and finite-statistics checks for every case plus all applicable structure, movement, runtime-observable, and served-station baselines.
+- 2026-08-20: Refreshed the code knowledge graph after the code and ledger changes. Graphify completed with 4,941 nodes and 11,663 edges, retaining its existing parser and zero-node warnings; removed the generated worktree-local graph copy afterward.
+- 2026-08-20: Final mechanical audit confirmed every folder and bundle caller uses the shared transactional writer, dispatch is the only runnable-validation caller with a selected occurrence set and now forwards it, the two native capacities have one source of truth, the only scene-controlled output-directory construction uses the safe component helper, and the focused tests cover failure rollback, successful sidecar preservation, exact/over/sparse/invalid capacity cases, native parity, and traversal. No dead new symbol or missing production call site was found; final diff checks passed.


### PR DESCRIPTION
## Summary

- publish folder saves from a validated sibling staging directory, with rollback and preservation of unmanaged scene contents
- enforce the native train and timetable-stop limits during runnable validation, including selected-occurrence runs
- constrain scene-controlled output directory names to one safe path component

## Verification

- focused scene writer, bundle, validator, and native operations tests: 4/4 passed
- full CTest: 48/48 passed
- creator acceptance smoke passed
- six-case roundtrip smoke passed
- six-case native headless smoke passed

Closes #314