### PR TITLE
Remove confirmed dead simulation paths

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -249,55 +249,17 @@ void DispatchController::runSimulation() {
 		regional_train[i].departure_time = regional_train[i].scheduled_departure_time;
 	}
 
-	// regional_train[1].indexOfRoute = 76;
-	// lockSwitchesOnAllConnectedSections(272, 240, 30, train_route[0].sequence_of_block_sections[1], "Rooo", train_route[0].reversed_direction,"None");
-
-	// lockSwitchesWhileTrainTraverses(15700, 15520, 30, train_route[1].sequence_of_block_sections[65], "Mambo", train_route[1], signalling_block_sections, Blocks);
-
-	/*  This piece of commented code is to test the function to block switches in Moving Block
-	   elaborateMaOnBlockSectionsWithSwitchDiv(15675, 22, train_route[1].sequence_of_block_sections[66], "Samba", train_route[1]);
-	   lockSwitchesWhileTrainTraverses(15675, 15575, 22, train_route[1].sequence_of_block_sections[66], "Samba", train_route[1]);
-
-	   elaborateMaOnBlockSectionsWithSwitchDiv(15575, 22, train_route[1].sequence_of_block_sections[65], "Samba", train_route[1]);
-	   lockSwitchesWhileTrainTraverses(15675, 15575, 22, train_route[1].sequence_of_block_sections[65], "Samba", train_route[1]);*/
-
-	// trainSimulation(signalCode1,signalCode2,signalCode3);
-
 	Train_Simulation_Mixed_Signalling_With_Passengers(signalCode1, signalCode2, signalCode3); // Function to Launch EGTRAIN considering passenger flow simulation
 
 	ComputeEnergyConsumptionForAllTrains(regional_train, numRegions);
 	ComputeTimetableEnergyConsumption(regional_train, numRegions, initial_variables.OutputMainFolder);
 
-	// Train_Simulation_Integration_With_ROMA(signalCode1,signalCode2,signalCode3);     //Launch EGTRAIN in a closed-loop control with ROMA*/
-
 	clock_t StartRun = clock();
-
-	// TrainSimulationForComputingHW(signalCode1,signalCode2,signalCode3);
-
-	/*//Trials for braking curve
-	double Brak;  Brak = regional_train[0].BrakingDistanceFastComputation_PieceWise(23.5332400554126, 0, 40506.6523452644, 41133.1868, train_route[regional_train[0].indexOfRoute].sequence_of_block_sections, train_route[regional_train[0].indexOfRoute].N_Block_Sections);
-	double Brak1; Brak1= regional_train[0].BrakingDistanceFastComputation(23.5332400554126, 0, 40506.6523452644, 41133.1868, train_route[regional_train[0].indexOfRoute].sequence_of_block_sections, train_route[regional_train[0].indexOfRoute].N_Block_Sections);
-	cout << "Braking distance is " << Brak << " and Classical Computed Braking distance is: " << Brak1<<"\n";
-	*/
-
-	double AccDist = 0;
-
-	// AccDist = regional_train[0].AccelerationDistanceFastComputation(25.1688, 25.5097, 16380.6, 16449.9, train_route[regional_train[0].indexOfRoute].sequence_of_block_sections, train_route[regional_train[0].indexOfRoute].N_Block_Sections);
-
-	// AccDist = regional_train[0].AccelerationTimeFollowingMode(20.1688, 22.5097, 16380.6, 16449.9, train_route[regional_train[0].indexOfRoute].sequence_of_block_sections, train_route[regional_train[0].indexOfRoute].N_Block_Sections);
-
-	// cout << "Acceleration distance is " << AccDist << "\n";
-
-	// Function to compute HW under undisturbed service conditions
-	// ImprovedTrainSimulationForComputingHW(signalCode1, signalCode2, signalCode3);     //Simulating Train trajectories
 
 	// sorting recorded events of all infrastructure elements in chronological order
 	SortRecordedEventsForAllInfrastructureElements(InfraElementsList);
 
 	cout << "Computing Blocking Times....\n";
-
-	// TODO : the following breaks in French case
-	// ComputeEnergyConsumptionForAllTrains(regional_train, numRegions);         //Computing EnergyConsumption with and without regenerative braking
 
 	clock_t EndRun = clock();
 
@@ -305,15 +267,6 @@ void DispatchController::runSimulation() {
 
 	TimeElapsed = (double)((EndRun - StartRun) / CLOCKS_PER_SEC);
 	cout << "TimeElapsed is : " << TimeElapsed;
-
-	// regional_train[0];
-	// PrintCompressedTrainPathDiagramTrial(regional_train, numRegions, -171, Folder_RI_PH);
-
-	// PrintTrainPathDiagramToDebug(regional_train, numRegions, Folder_RI_PH);
-
-	// for (int i = 0; i < regional_train[0].numStations; i++) {
-	//	cout << regional_train[0].Stations[i].stationName << " " << regional_train[0].Stations[i].dwellTime << "\n";
-	// }
 
 	for (int i = 0; i < numRegions; i++)
 		regional_train[i].PrintTrajectory();
@@ -352,17 +305,8 @@ void DispatchController::runSimulation() {
 
 	Print_Computing_Times(Folder_RI_PH); // Printing the total computation time of ROMA and EGTRAIN
 
-	// Printing the trajectories on an Excel Chart and saving them on a PNG image file
-	/*Print_Trajectories_As_Image(InstanceName,0,0);*/
-
 
 	cout << "\n\n Computing Train Blocking Times....\n\n";
-
-	// ComputeBlockingTimesForAllTrains("ETCS2", 7,3,10,Folder_RI_PH,0,0);     //Computing Blocking Time in  ETCS level 2
-
-	// ComputeBlockingTimesETCS3ForAllTrains(7,3,10,Folder_RI_PH, 0,5);     //Computing Blocking Time in ETCS level 3
-
-	// DEVO TESTARE LA NUOVA FUNZIONE PER CONNETTERE I BLOCKING TIMES. PER FARE CIO METTI AL PRIMO TRENO LA ROUTE NUMERO 10 instant_train_energy_consumption CONTROLLA CHE AGLI SWITCH MULTIPLI LA COSA FUNZIONA BENE, CONTROLLA ANCHE CHE IL SETUPTIME TIME APPLICA SOLO SE LO SWITCH NON ERA STATO IMPOSTATO DA UN TRENO PRECEDENTE
 
 	ComputeBlockingTimesInMixedSignallingForAllTrains(5, (3 + bufferTime), 0.5, 50, Folder_RI_PH, 0, recoveryTimePercentage); // Computing Blocking Times in mixed signalling Areas
 
@@ -371,9 +315,6 @@ void DispatchController::runSimulation() {
 	PrintTrainBlockingTimes(Folder_RI_PH);
 
 	PrintTimetablePoints(Folder_RI_PH);
-
-	// Free this line if you want to compute the headway for each block section
-	// ComputeHwMatrixForAllTrainsWithGivenOrder(regional_train,numRegions,Folder_RI_PH,TrainEntranceOrder);
 
 	// print trajectories
 	// before in Regional destructor - moved here because vectors are deleted automatically in the destructor and it is no longer possible to use them there
@@ -398,12 +339,6 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 		}
 		clock_t startEGTRAIN = clock(); // EGTRAIN start time
 		std::cout << "\r Time of simulation is " << t;
-		// logger.Log(" clock at" + to_string(t));
-
-		// you can comment it if you are simulating something different
-		/*if (t < 430)
-			regional_train[0].max_train_speed = 16;
-		else regional_train[0].max_train_speed = 33.61;*/
 
 		// Simulate entrance process of passengers on the railway network according to route choice
 		checkJourneyStartForAllPassengers(t, initial_variables.startingSimulationTime, AllDailyPassengers);
@@ -417,11 +352,6 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 
 		// Simulate train movement at each simulation step
 		for (int j = 0; j < numRegions; j++) {
-			// cout << j << "++++----/n";
-
-			// Rigos added this to see if it works
-			// regional_train[j].Trajectory_Block_Section_Free_Flow(t, v1, v2, v3);
-			// The one that run Rafael is the following
 			regional_train[j].trajectoryComputationIncludingMovingBlock(t, v1, v2, v3); // originally we shall call the function Trajectory_Block_Section_Free_Flow
 			regional_train[j].recordEarliestActiveTrajectoryIndex(t);
 			regional_train[j].recordStationPassagesAtTime(t);
@@ -429,12 +359,6 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 			// check if train arrived at destination or departed from origin
 			regional_train[j].checkTrainArrDep(j, t);
 		}
-
-		// cout << "Time is : " << t << endl;
-		// for (int n = 0; n < numRegions; n++) {
-
-		//	cout << "Train is " << regional_train[n].trainDescription << " at x: " << regional_train[n].trainXPosition(t) <<" and speed: " <<regional_train[n].instant_train_speed[t] * 3.6 <<" km/h  "<< endl;
-		//}
 
 		// Here we prepare the Traffic State data
 		for (int n = 0; n < numRegions; n++) {
@@ -444,7 +368,6 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 			Simulate_Train_Passenger_Interactions(t, initial_variables.startingSimulationTime, regional_train[n], AllDailyPassengers, AllStationPlatforms);
 
 			// round to 2 decimals
-			// cout << "n=" << n << " and train desc is " << regional_train[n].trainDescription << "\n";
 			double xPosition = std::ceil(regional_train[n].trainXPosition(t) * 100.0) / 100.0;
 			double trainSpeed = std::ceil((regional_train[n].instant_train_speed[t] * 3.6) * 100.0) / 100.0;
 			jsmsg["trains"][regional_train[n].trainDescription]["km-point"] = xPosition;
@@ -470,50 +393,6 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 			} else
 				jsmsg["trains"][regional_train[n].trainDescription]["inArea"] = 0;
 
-			// train_route[regional_train[n].indexOfRoute].sequence_of_block_sections[train_route[regional_train[n].indexOfRoute].N_Block_Sections-1].ID ;
-			// regional_train[n].direction; // probably this is the direction
-			// regional_train->TimetablePoints
-			//
-
-			// for (auto it = jsmsg["trains"].begin(); it != jsmsg["trains"].end(); ++it)
-			//{
-			//	std::cout << it.key() << " : " << it.value() << std::endl;
-			// }
-			// regional_train[n].BlockTime
-			// td::cout<<"train desc is " << regional_train[n].trainDescription <<" Bs: "<< regional_train[n].Bs.ID << "\n";
-			// regional_train[n].ComputeBlockingTimesInMixedSignallingAreas(5, (3 + bufferTime), 0.5, 50, 0,1);
-			// std::cout << "StartOccTime " << regional_train[n].trainDescription << " Start: " <<  regional_train[n].BlockTime[regional_train[n].N_BlockTimeComplete].StartOccTime << "\n";
-			// std::cout << "EndOccTime " << regional_train[n].trainDescription << " End: " << regional_train[n].BlockTime[regional_train[n].N_BlockTimeComplete].EndOccTime << "\n";
-			// regional_train[n].ComputeBlockingTimeForSingleLocation
-			// train_route[n].sequence_of_block_sections
-			// std::cout << regional_train[n].Bs.arcs_in_signalling_block_section->startNode.ID << "<<<<---- - \n\n";
-			// regional_train[n].ComputeBlockingTimes("Conventional", 5, (3 + bufferTime), 0.5, 50, 0);
-			// std::cout << "train desc222 is " << regional_train[n].BlockTime[9].StartOccTime;
-			// std::cout << xPosition<<"<<<<-----\n\n";
-
-			int Previous_Block_Index = 0;
-			Section SBs;
-			if (t > 0 && t >= regional_train[n].departure_time) {
-				for (int h = 0; h < train_route[regional_train[n].indexOfRoute].N_Block_Sections; h++) {
-					if ((regional_train[n].instant_spatial_position[t - 1] < train_route[regional_train[n].indexOfRoute].sequence_of_block_sections[h].end_node.X * 1000) &&
-						(regional_train[n].instant_spatial_position[t - 1] >= train_route[regional_train[n].indexOfRoute].sequence_of_block_sections[h].start_node.X * 1000)) {
-						SBs = train_route[regional_train[n].indexOfRoute].sequence_of_block_sections[h];
-
-						if (h == 0)
-							Previous_Block_Index = h;
-						else {
-							Previous_Block_Index = h - 1;
-							break;
-						}
-						// regional_train[n].ComputeBlockingTimeForSingleLocation_real_time(Previous_Block_Index, "Conventional", regional_train[n].scheduled_departure_time, 5,(3 + bufferTime), 0.5, 0,1);
-					}
-					// if ((regional_train[n].instant_spatial_position[t - 1] <= train_route[regional_train[n].indexOfRoute].sequence_of_block_sections[Previous_Block_Index].start_node.X * 1000) && (regional_train[n].instant_spatial_position[t] > train_route[regional_train[n].indexOfRoute].sequence_of_block_sections[Previous_Block_Index].start_node.X * 1000)) {
-					// BlockTime[N_BlockSections].StartRunTime = t - 1;
-					//	std::cout << "Occupation itme : " << t - 1;
-
-					//	}
-				}
-			}
 		}
 
 		// Print Passenger Status after the simulation
@@ -548,8 +427,6 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 		// Only for level>=3
 		ReportAllTrainPositionsToRBC(t, 50);
 
-		// Predict_And_Check_Decoupling_MA_For_All_Train_in_Following_Mode(t);  // Predict and check the Predict_MA_To_DecoupleAt for all trains which are in following mode
-
 		// function to protect all station areas
 		protectStationAreas(t);
 
@@ -566,15 +443,8 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 				t);
 		} // unlock occupied single tracks
 
-		// update output signalling file with aspect changes
-		// saveSignalAspectChanges(t, "Input_EGTRAIN/Rescheduling");
-
-		// showElementInEtcsMa(t);   //Printing the MAs
-		/*showElement(t,BlocksOccupied);*/
 		BlocksOccupied.clear();	 // Clear the list BlocksOccupied
 		BlocksConnected.clear(); // Clear the list BlocksConnected
-
-		/*debugFunctionBlockCodes(t,"@2-B2@-1.314000/@3-B0@-1.339000",train_route[0]);*/
 
 		Detect_Implemented_Order_For_All_OL(); // Detect The order Implemented for all the OLs in the network
 

--- a/EGTRAIN/QEGTRAIN/simulation/Simulation.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Simulation.cpp
@@ -128,15 +128,6 @@ void calculateStationDelayStatistics(Stations& station, bool includeNonPositive)
 }
 } // namespace
 
-// Function to Calculate the arrival delay at each station for each train
-void calculateArrivalDelayAllTrainsOldVersion() {
-	for (int j = 0; j < numRegions; j++) {
-		// regional_train[j].Actual_Arrivals();
-		regional_train[j].Actual_Arrivals_NewVersion();
-		regional_train[j].computeArrivalDelaysAtStations();
-	}
-}
-
 // Updated Function to Calculate the arrival delay at each station for each train
 void calculateArrivalDelayAllTrains() {
 	for (int j = 0; j < numRegions; j++) {
@@ -248,106 +239,6 @@ void ComputeHwMatrixForAllTrains(Train* T, int numTrains, string MainFolder) {
 			T[i].ComputeHwMatrix(T, numTrains);
 			T[i].PrintHeadwayMatrix(MainFolder);
 		}
-	}
-}
-
-// Function to compute the headways of all the trains with the following according to a train order given
-void ComputeHwMatrixForAllTrainsWithGivenOrder(Train* T, int numTrains, string MainFolder, OrderList OrderedTrainArray) {
-
-	// Once the TrainArray has been sort out compute the Headway Matrix
-#pragma omp parallel
-	{
-#pragma omp for
-		for (int i = 0; i < numTrains; i++) {
-			T[i].SetLocationNames();
-			T[i].ComputeHwMatrixForGivenOrder(T, numTrains, OrderedTrainArray);
-			T[i].PrintHeadwayMatrix(MainFolder);
-		}
-	}
-}
-
-// Function to compute the HW matrix of all the trains solving the conflicts among all the trains
-void ComputeHwMatrixWithGivenOrderSolvingAllConflicts(Train* T, int numTrains, string MainFolder, OrderList OrderedTrainArray) {
-	int IndexOfTrains[1000]; // this vector connects the vector of OrderedTrainArray with the Array of Trains, since they are orderedi n a different way
-	int N_IndexOfTrains = 0; // The size of the vector
-							 // Define the array containing the indices of all the trains
-	for (int q = 0; q < OrderedTrainArray.numTeList; q++) {
-		for (int i = 0; i < numTrains; i++) {
-			if (T[i].trainDescription == OrderedTrainArray.TE[q].trainDescription) {
-				IndexOfTrains[q] = i;
-				N_IndexOfTrains++; // Increase the number of trains
-				break;
-			}
-		}
-	}
-	// Create a temporary folder for printing out the shifted train trajectories
-	string TrajectorySubFolder;
-	TrajectorySubFolder = TrajectorySubFolder + MainFolder + "/" + "TEMP_Shifted_Trajectories";
-	_mkdir((char*)TrajectorySubFolder.c_str());
-
-	// Create a temporary folder for printing out the ongoing timetable assignments
-	string TTAssignmentSubFolder;
-	TTAssignmentSubFolder = TTAssignmentSubFolder + MainFolder + "/OnGoing_TT_Assignment";
-	_mkdir((char*)TTAssignmentSubFolder.c_str());
-
-	// Create a file for plotting all the conflicts detected in the Timetable
-	ofstream ConflictOutput;
-	string ConflOutputName;
-	ConflOutputName = ConflOutputName + MainFolder + "/" + "AllTrainConflicts.txt";
-	ConflictOutput.open((char*)ConflOutputName.c_str(), ios::app);
-	ConflictOutput << "\n\n*****************New Conflict Detection*******************\n";
-
-	// Create a File for plotting the blocking times and timetable points when the train has been assigned to a path in the timetable
-	ofstream OnGoingBlockingTimeFile;
-	string BlockingTimeFileName;
-	BlockingTimeFileName = BlockingTimeFileName + TTAssignmentSubFolder + "/BlockingTimes.txt";
-	OnGoingBlockingTimeFile.open((char*)BlockingTimeFileName.c_str(), ios::app);
-
-	// Create a File to plot the timetable points
-	ofstream OnGoingTTPoints;
-	string TTPointsFileName;
-	TTPointsFileName = TTPointsFileName + TTAssignmentSubFolder + "/TimetablePoints.txt";
-	OnGoingTTPoints.open((char*)TTPointsFileName.c_str(), ios::app);
-
-	for (int i = 0; i < N_IndexOfTrains; i++) {
-		T[i].SetLocationNames();
-		int Index = IndexOfTrains[i]; // temporary variable equal to IndexOfTrains[i]
-
-		if (i > 0) { // Compute the headways and the shift only for trains different from the first one
-			// Put a dummy overlap to activate the while loop
-			T[Index].numOverlaps = 1;
-			while (T[Index].numOverlaps > 0) {
-				cout << "Resetting Train " << T[Index].trainDescription << "\n";
-				T[Index].ResetConflictingTrainsAndHwMatrix();
-				cout << "Computing HW for train " << T[Index].trainDescription << "\n";
-				// regional_train[Index].SetLocationNames();
-				T[Index].DepartureMatrixToSolveConflictsForGivenOrderImproved3(T, numTrains, i, IndexOfTrains); // Compute the MAtrix of the departure times that solve conflicts among all trains
-
-				cout << "Shifting Train " << T[Index].trainDescription << "\n";
-				T[Index].ShiftTrain();
-				cout << "Detecting Conflicts for Train " << T[Index].trainDescription << "\n";
-				T[Index].DetectConflictsWithPreviousDepartingTrains(T, numTrains);
-			}
-			// regional_train[Index].DepartureMatrixToSolveConflictsForGivenOrder(regional_train, numTrains,i,IndexOfTrains);
-			// regional_train[Index].ShiftTrainToCompressTT(regional_train,numTrains,TrajectorySubFolder,MainFolder);    //Shift the train to compress the timetable according the UIC code 406
-		} else { // For the first train of the timetable which has i==0 then we need to shift it to 0 and we must simply apply the ShiftTrainCompressTT
-			T[Index].ShiftTrainToCompressTT(T, numTrains, TrajectorySubFolder, MainFolder);
-		}
-
-		if (T[Index].numOverlaps == 0) {
-			T[Index].PrintTrainBlockingTimesForThisTrain(BlockingTimeFileName);
-			OnGoingBlockingTimeFile.close();
-			// Now must print the Timetable points as well
-			T[Index].PrintTimetablePointsForThisTrain(TTPointsFileName);
-			OnGoingTTPoints.close();
-		}
-	}
-
-	// Close the ConflictOutput file
-	ConflictOutput.close();
-	// Printing train Hw Matrices
-	for (int i = 0; i < numTrains; i++) {
-		T[i].PrintHeadwayMatrix(MainFolder);
 	}
 }
 
@@ -537,25 +428,6 @@ void Implement_ROMA_Solution(string InstanceName, int Instant_Sol_Returned, doub
 	Set_OL0_as_OL1();
 }
 
-// Fast way of computing free-flow trajectories for HW and capacity computation
-void ImprovedTrainSimulationForComputingHW(double v1, double v2, double v3) {
-	for (int i = 0; i < numRegions; i++) {
-		if (regional_train[i].ID == 1) {
-			activateSignallingSystem(); // Activate the signalling system
-			for (int t = 0; t < initial_variables.times; t++) {
-				regional_train[i].Trajectory_Block_Section_Free_Flow(t, v1, v2, v3);
-				regional_train[i].recordEarliestActiveTrajectoryIndex(t);
-			}
-		} else {
-			for (int j = 0; j < numRegions; j++) {
-				if ((regional_train[j].type == regional_train[i].type) && (regional_train[j].ID == 1)) { // if the train selected is the first one of that type
-					regional_train[i].ReplicateTrainTrajectory(regional_train[j]);						 // Than replicate this train
-					break;																				 // after having replicated it break the for loop
-				}
-			}
-		}
-	}
-}
 
 // Function to Initialize all the Locations in the Network, i.e. the Location list AllLocations
 void InitializeAndComputeMaxHwForAllLocations(Train* T, int N_Train, string MainFolder) {
@@ -642,73 +514,6 @@ void Load_Entrance_Delay_Disturbed_Scenario(string Folder, string stationName, i
 	Load_Departure_Delay_At_Station((char*)Name_Of_File.c_str(), stationName);
 }
 
-void PrintCompressedTrainPathDiagramTrial(Train* S, int N_S, string FolderName) {
-
-	int StartPrintingTime = 999999999; // this is the time the first train departs
-
-	for (int i = 0; i < N_S; i++) {
-		if (S[i].departure_time < StartPrintingTime) {
-			StartPrintingTime = S[i].departure_time; // finding in this way the minimum train departing time as result from the blocking time compression process
-		}
-	}
-
-	string FileName;
-	string FileSpeedsName;
-	FileName = FolderName + "/CompressedTrainPathDiagram.txt";
-	FileSpeedsName = FolderName + "/CompressedSpeedsDiagram.txt";
-	ofstream FileOutput;
-	ofstream FileSpeedsOutput;
-	// Opening the file of the speeds
-	FileSpeedsOutput.open((char*)FileSpeedsName.c_str(), ios::binary);
-	// Opening the file of the train positions
-	FileOutput.open((char*)FileName.c_str(), ios::binary);
-	// witing on the file of the speeds
-	FileSpeedsOutput << "Train/Time ";
-	// writing on the file of the train positions
-	FileOutput << "Train/Time ";
-
-	for (int t = StartPrintingTime; t <= StartPrintingTime + initial_variables.times; t++) {
-		FileOutput << t * timestep << " ";
-		// writing on the file of the speeds
-		FileSpeedsOutput << t * timestep << " ";
-	}
-	FileOutput << "\n";
-	FileSpeedsOutput << "\n";
-
-	for (int i = 0; i < N_S; i++) {
-		FileOutput << S[i].trainDescription << " ";
-		FileSpeedsOutput << S[i].trainDescription << " ";
-
-		const int departureTime = static_cast<int>(S[i].departure_time);
-		const int outputLast = StartPrintingTime + initial_variables.times;
-		const auto positions = shiftedTrajectoryExportCells(
-				S[i].instant_spatial_position, S[i].earliestActiveTrajectoryIndex,
-				S[i].End_Time, departureTime, StartPrintingTime, outputLast);
-		const auto speeds = shiftedTrajectoryExportCells(
-				S[i].instant_train_speed, S[i].earliestActiveTrajectoryIndex,
-				S[i].End_Time, departureTime, StartPrintingTime, outputLast);
-		for (std::size_t column = 0; column < positions.size(); ++column) {
-			const double position = positions[column];
-			if (position == -9999) {
-				FileOutput << -9999 << " ";
-			} else if (train_route[S[i].indexOfRoute].reversed_direction == 0) {
-				FileOutput << position << " ";
-			} else {
-				FileOutput << train_route[S[i].indexOfRoute].OriginalRefReversedRoute - position << " ";
-			}
-
-			const double speed = column < speeds.size() ? speeds[column] : -9999;
-			FileSpeedsOutput << (position == -9999 || speed == -9999 ? -9999 : speed) << " ";
-		}
-		FileOutput << "\n";
-		FileSpeedsOutput << "\n";
-	}
-	// Close the output file	of positions
-	FileOutput.close();
-	// Close the output file	of speeds
-	FileSpeedsOutput.close();
-}
-
 // Function to print out all the Results of a network Location
 void PrintLocationHeadways(string MainFolder) {
 	string FileName;
@@ -749,39 +554,6 @@ void PrintTrainPathDiagram(Train* S, int N_S, string FolderName) {
 			} else {
 				FileOutput << train_route[S[i].indexOfRoute].OriginalRefReversedRoute - position << " ";
 			}
-		}
-		FileOutput << "\n";
-	}
-
-	FileOutput.close();
-}
-
-// Function to Print all the trajectories
-void PrintTrainPathDiagramToDebug(Train* S, int N_S, string FolderName) {
-	bool NoPrint[300]; // This array has for each train the boolean variable that becomes 1 only if the train has finished its run (i.e. the value -9999 to the instant_spatial_position[i] has been reached)
-	for (int k = 0; k < 300; k++) {
-		NoPrint[k] = false;
-	} // Initializing the NoPrint
-	string FileName;
-	FileName = FolderName + "/TrainPathDiagram.txt";
-	ofstream FileOutput;
-	FileOutput.open((char*)FileName.c_str(), ios::binary);
-	FileOutput << "Train/Time ";
-	for (int t = 0; t < initial_variables.times; t++) {
-		FileOutput << t * timestep << " ";
-	}
-	FileOutput << "\n";
-	for (int i = 0; i < N_S; i++) {
-		FileOutput << S[i].trainDescription << " ";
-		for (int t = 0; t < initial_variables.times; t++) {
-			if ((S[i].instant_spatial_position[t] != -9999) && (NoPrint[i] == 0)) {
-				if (train_route[S[i].indexOfRoute].reversed_direction == 0) {
-					FileOutput << S[i].instant_spatial_position[t] << " ";
-				} else {
-					FileOutput << train_route[S[i].indexOfRoute].OriginalRefReversedRoute - S[i].instant_spatial_position[t] << " ";
-				}
-			} else
-				break;
 		}
 		FileOutput << "\n";
 	}
@@ -897,204 +669,14 @@ void SortOutOrderedTrainArray(Train* T, int numTrains, OrderList& TrainEntranceO
 
 // Function to simulate the trains in free flow to be used for computing the Headways
 void TrainSimulationForComputingHW(double v1, double v2, double v3) {
-	/*#pragma omp parallel
-	{
-	#pragma omp for*/
 	for (int i = 0; i < numRegions; i++) {
 		activateSignallingSystem();
 		for (int t = 0; t < initial_variables.times; t++) {
-			// if (t==2200)
-			// cout<<"Pites";
 			regional_train[i].Trajectory_Block_Section_Free_Flow(t, v1, v2, v3);
 			regional_train[i].recordEarliestActiveTrajectoryIndex(t);
 		}
 	}
-	//}
 }
-
-// Function to Simulate EGTRAIN within a dynamic Interaction with the ROMA tool
-void Train_Simulation_Integration_With_ROMA(double v1, double v2, double v3) {
-	int Instant_Sol_Returned = 0, Instant_Sol_Implemented = 0;
-	for (int t = 0; t <= initial_variables.times; t++) {
-		clock_t startEGTRAIN = clock(); // variable that sets the time in which EGTRAIN starts
-#pragma omp parallel
-		{
-#pragma omp for
-			// Upload for each simulation step: train characteristics
-			for (int j = 0; j < numRegions; j++) {
-				regional_train[j].Trajectory_Block_Section(t, v1, v2, v3);
-				regional_train[j].recordEarliestActiveTrajectoryIndex(t);
-			}
-		}
-
-		Occupy_Block_Sections_Of_Route(t); // Fill in the lists Blocks_Occupied and BlocksConnected
-
-		for (const auto& inc : simulationIncidents) {
-			if (inc.type == "signal_failure" && t >= inc.startSeconds && t <= inc.endSeconds) {
-				for (const auto& secID : inc.resolvedSectionIDs) {
-					bool found = false;
-					for (const auto& occ : BlocksOccupied) {
-						if (occ == secID) { found = true; break; }
-					}
-					if (!found) {
-						BlocksOccupied.push_back(secID);
-					}
-				}
-			}
-		}
-		releaseBlockConnections();	   // Release Blocks connected with the one really occupied by a train
-		activateSignallingSystem();	   // Apply the rules of the signalling system for all the Blocks contained
-		BlocksOccupied.clear();			   // Clear the list BlocksOccupied
-		BlocksConnected.clear();		   // Clear the list BlocksConnected
-
-		Detect_Implemented_Order_For_All_OL(); // Detect The order Implemented for all the OLs in the network
-		clock_t endEGTRAIN = clock();		   // variable that sets the time in which EGTRAIN ends
-
-		Comp_Time_EGTRAIN = Comp_Time_EGTRAIN + double(endEGTRAIN - startEGTRAIN) / CLOCKS_PER_SEC; // computing the cumulated computation time of EGTRAIN
-
-		if (Time_To_Collect_Info == Resched_Interval) { // If the Time instant is equal to the interval to gather the information
-			char Resch_Int[20];
-			snprintf(Resch_Int, sizeof(Resch_Int), "%d", Resched_Interval);
-			string NameOutputFolder;
-			NameOutputFolder = NameOutputFolder + Name_Of_Integ_Folder + initial_variables.OutputMainFolder + "/" + "instance_" + InstanceName + "/" + Resch_Int + "-" + Pred_Hor + "/"; // This is the string in which the outputs of EGTRAIN are saved
-			Print_Trajectories_Of_All_Trains_At_Instant(t, NameOutputFolder);
-			Time_To_Collect_Info = 0;
-
-			// CALL the ROMA tool and compute new rescheduling solution
-			clock_t startROMA = clock();
-			callRoma(InstanceName, t, PH);
-			clock_t endROMA = clock();
-			Comp_Time_ROMA = Comp_Time_ROMA + double(endROMA - startROMA) / CLOCKS_PER_SEC; // computing the cumulated computation time of ROMA
-
-			if (DelayDispatcherImpl > Resched_Interval) // If the DelayDispatcherImpl is larger than the reshceduling interval then the instantSol Returned must be the one calculated at the DelayDispatcher/Resched_Interval Rescheduling intervals ago.
-				Instant_Sol_Returned = t - (int)(DelayDispatcherImpl / Resched_Interval) * Resched_Interval;
-			else
-				Instant_Sol_Returned = t;
-			Instant_Sol_Implemented = Instant_Sol_Returned + DelayDispatcherImpl;
-		}
-
-		// Implement the new rescheduling solution (list OL for each of the Checkpoints) in EGTRAIN
-		if (t == Instant_Sol_Implemented) { // If you suppress these two lines you calculate the ROMA Solution but you will not implement it
-			Implement_ROMA_Solution(InstanceName, Instant_Sol_Returned, PH);
-			// Printing unfeasible orders on a txt file
-			char Resch_Int[20];
-			snprintf(Resch_Int, sizeof(Resch_Int), "%d", Resched_Interval); // Char variables to take the values of the rescheduling interval and the prediction horizon
-			string NameOutputFolder;
-			NameOutputFolder = NameOutputFolder + Name_Of_Integ_Folder + initial_variables.OutputMainFolder + "/" + "instance_" + InstanceName + "/" + Resch_Int + "-" + Pred_Hor + "/";
-			compareImplementedOrderWithRomaSolutionForAllOl(NameOutputFolder, t);
-			/*//Print OL lists on the screen
-			cout<<"time"<<t<<"\n";
-			for(int i=0;i<N_OrderLists;i++){
-			cout<<"OL "<<i<<"\n";
-			for (int j=0;j<OL[i].numTeList;j++){
-			cout<<OL[i].TE[j].trainDescription<<"\n";
-			}
-			}
-			system("pause");*/
-		} // This is the parenthesis that closes the if statement above
-
-		/*
-		//Print OL lists on the screen
-		cout<<"time"<<t<<"\n";
-		for(int i=0;i<N_OrderLists;i++){
-		cout<<"OL "<<i<<"\n";
-		for (int j=0;j<OL[i].numTeList;j++){
-		cout<<OL[i].TE[j].trainDescription<<"\n";
-		}
-		}
-		system("pause");*/
-
-		Time_To_Collect_Info++; // increase Time_To_Collect_Info;
-	}
-}
-
-// Function to Simulate traffic within the observation period and without interactions wth the traffic management system
-void trainSimulation(double v1, double v2, double v3) {
-	for (int t = 0; t < initial_variables.times; t++) {
-		std::cout << "times = " << t << std::endl;
-		clock_t startEGTRAIN = clock(); // variable that sets the time in which EGTRAIN starts
-#pragma omp parallel
-		{
-#pragma omp for
-			// Upload for each simulation step: train characteristics
-			for (int j = 0; j < numRegions; j++) {
-				regional_train[j].Trajectory_Block_Section(t, v1, v2, v3);
-				regional_train[j].recordEarliestActiveTrajectoryIndex(t);
-			}
-		}
-
-
-		Occupy_Block_Sections_Of_Route(t); // Fill in the lists Blocks_Occupied and BlocksConnected
-
-		for (const auto& inc : simulationIncidents) {
-			if (inc.type == "signal_failure" && t >= inc.startSeconds && t <= inc.endSeconds) {
-				for (const auto& secID : inc.resolvedSectionIDs) {
-					bool found = false;
-					for (const auto& occ : BlocksOccupied) {
-						if (occ == secID) { found = true; break; }
-					}
-					if (!found) {
-						BlocksOccupied.push_back(secID);
-					}
-				}
-			}
-		}
-		releaseBlockConnections();	   // Release Blocks connected with the one really occupied by a train
-		activateSignallingSystem();	   // Apply the rules of the signalling system for all the Blocks contained
-		/*showElement(t,BlocksOccupied);*/
-		BlocksOccupied.clear();	 // Clear the list BlocksOccupied
-		BlocksConnected.clear(); // Clear the list BlocksConnected
-		/*debugFunctionBlockCodes(t,"@2-B2@-1.314000/@3-B0@-1.339000",Route[0]);*/
-
-		Detect_Implemented_Order_For_All_OL();														// Detect The order Implemented for all the OLs in the network
-		clock_t endEGTRAIN = clock();																// variable that sets the time in which EGTRAIN ends
-		Comp_Time_EGTRAIN = Comp_Time_EGTRAIN + double(endEGTRAIN - startEGTRAIN) / CLOCKS_PER_SEC; // computing the cumulated computation time of EGTRAIN
-	}
-}
-
-////Function to simulate traffic in networks with a mixed signalling system (e.g. conventional, mixed to ETCS L1, L2 and or L3)
-////Function to Simulate traffic within the observation period and without interactions wth the traffic management system
-// void Train_Simulation_Mixed_Signalling(double v1, double v2, double v3) {
-//	for (int t = 0; t < times; t++) {
-//		clock_t startEGTRAIN = clock();    //variable that sets the time in which EGTRAIN starts
-// #pragma omp parallel
-//		{
-// #pragma omp for
-//			//Upload for each simulation step: train characteristics
-//
-//			for (int j = 0; j < numRegions; j++) {
-//
-//				regional_train[j].trajectoryComputationIncludingMovingBlock(t, v1, v2, v3);  //originally we shall call the function Trajectory_Block_Section_Free_Flow
-//			}
-//		}
-//
-//		/**********************************************************************************************
-//		*                        Update configuration of the network elements at instant t
-//		*
-//		************************************************************************************************/
-//		ETCS_MA.clear();                        //Clear the list containing all the Movement Authorities given to the trains at the previous instant
-//
-//		Occupy_Block_Sections_Of_Route(t);     //Fill in the lists Blocks_Occupied and BlocksConnected
-//		//ReportAllTrainPositionsToRBC(t, 50);    //Reporting the positions of the trains to the RBC considering a safety Margin of 50 metres
-//		//Predict_And_Check_Decoupling_MA_For_All_Train_in_Following_Mode(t);  // Predict and check the Predict_MA_To_DecoupleAt for all trains which are in following mode
-//		releaseMixedSignallingSystem();          //Release Blocks connected with the one really occupied by a train
-//
-//		activateMixedSignallingSystem();          //Apply the rules of the signalling system for all the Blocks contained
-//
-//		//showElementInEtcsMa(t);   //Printing the MAs
-//												  /*showElement(t,BlocksOccupied);*/
-//		BlocksOccupied.clear();                 //Clear the list BlocksOccupied
-//		BlocksConnected.clear();                //Clear the list BlocksConnected
-//
-//												/*debugFunctionBlockCodes(t,"@2-B2@-1.314000/@3-B0@-1.339000",Route[0]);*/
-//
-//		Detect_Implemented_Order_For_All_OL();   //Detect The order Implemented for all the OLs in the network
-//		clock_t endEGTRAIN = clock();              //variable that sets the time in which EGTRAIN ends
-//		Comp_Time_EGTRAIN = Comp_Time_EGTRAIN + double(endEGTRAIN - startEGTRAIN) / CLOCKS_PER_SEC;     //computing the cumulated computation time of EGTRAIN
-//
-//	}
-// }
-
 
 // Function to initialise all StationPlatforms for the simulation of passenger flows
 // The function takes as input all the Array and number of all block sections, the array and number of all trains, the array of all defined rutes, as well as the length and width of the platforms (to be expressed in meters)

--- a/EGTRAIN/QEGTRAIN/simulation/Simulation.h
+++ b/EGTRAIN/QEGTRAIN/simulation/Simulation.h
@@ -43,9 +43,6 @@ void Print_Implemented_Order_For_All_OL(string FolderName);
 // Function to Compute the Arrival and Departure times of at all the timetabling points along their own route
 void Compute_TimetablingPoints_For_All_Trains(Train* Trains, int numTrains);
 
-// Function to Calculate the arrival delay at each station for each train
-void calculateArrivalDelayAllTrainsOldVersion();
-
 // Updated Function to Calculate the arrival delay at each station for each train
 void calculateArrivalDelayAllTrains();
 
@@ -76,18 +73,8 @@ void Print_Trajectories_As_Image(string InstanceName, char* Resch_Int, char* Pre
 
 extern double Comp_Time_EGTRAIN, Comp_Time_ROMA; // variable to measure the computation times of EGTRAIN and ROMA
 
-// Function to Simulate traffic within the observation period and without interactions wth the traffic management system
-void trainSimulation(double v1, double v2, double v3);
-
-////Function to simulate traffic in networks with a mixed signalling system (e.g. conventional, mixed to ETCS L1, L2 and or L3)
-////Function to Simulate traffic within the observation period and without interactions wth the traffic management system
-// void Train_Simulation_Mixed_Signalling(double v1, double v2, double v3);
-
 // Function to simulate the trains in free flow to be used for computing the Headways
 void TrainSimulationForComputingHW(double v1, double v2, double v3);
-
-// Fast way of computing free-flow trajectories for HW and capacity computation
-void ImprovedTrainSimulationForComputingHW(double v1, double v2, double v3);
 
 extern int Resched_Interval;	 // Variable that set the time to gather train information from EGTRAIN to ROMA
 extern int Time_To_Collect_Info; // Variable to measure the time passed from the last information update
@@ -108,21 +95,12 @@ void callRoma(string instancename, double inittime, double PH);
 // Function to Implement the ROMA Solution in EGTRAIN
 void Implement_ROMA_Solution(string InstanceName, int Instant_Sol_Returned, double PH);
 
-// Function to Simulate EGTRAIN within a dynamic Interaction with the ROMA tool
-void Train_Simulation_Integration_With_ROMA(double v1, double v2, double v3);
-
 extern OrderList TrainEntranceOrder;
 
 void SortOutOrderedTrainArray(Train* T, int numTrains, OrderList& TrainEntranceOrder);
 
 // Function to compute the headways of all the trains
 void ComputeHwMatrixForAllTrains(Train* T, int numTrains, string MainFolder);
-
-// Function to compute the headways of all the trains with the following according to a train order given
-void ComputeHwMatrixForAllTrainsWithGivenOrder(Train* T, int numTrains, string MainFolder, OrderList OrderedTrainArray);
-
-// Function to compute the HW matrix of all the trains solving the conflicts among all the trains
-void ComputeHwMatrixWithGivenOrderSolvingAllConflicts(Train* T, int numTrains, string MainFolder, OrderList OrderedTrainArray);
 
 // Function to compute the critical headways for all the trains
 void ComputeCriticalHeadwaysForLocationsForAllTrains(Train* T, int numTrains);
@@ -141,78 +119,6 @@ void InitializeAndComputeMaxHwForAllLocations(Train* T, int N_Train, string Main
 
 // Function to Print all the trajectories
 void PrintTrainPathDiagram(Train* S, int N_S, string FolderName);
-
-// Function to Print all the trajectories
-void PrintTrainPathDiagramToDebug(Train* S, int N_S, string FolderName);
-
-/*
-//Function to Print all the trajectories
-void PrintCompressedTrainPathDiagram(Train *instant_spatial_position, int N_S, string FolderName) {
-
-	int StartPrintingTime = 999999999; // this is the time the first train departs
-	int EndPrintingTime = -10000000;
-	for (int i = 0; i < N_S; i++) {
-		if (instant_spatial_position[i].departure_time < StartPrintingTime) {
-			StartPrintingTime = instant_spatial_position[i].departure_time;  // finding in this way the minimum train departing time as result from the blocking time compression process
-		}
-		if (instant_spatial_position[i].End_Time > EndPrintingTime) {  //finding the latest train exit time from simulation as result from the blocking time compression process
-			EndPrintingTime = instant_spatial_position[i].End_Time+1+instant_spatial_position[i].departure_time-instant_spatial_position[i].RunStartTime;
-		}
-	}
-
-	string FileName;
-	FileName = FolderName + "/CompressedTrainPathDiagram.txt";
-	ofstream FileOutput;
-	FileOutput.open((char*)FileName.c_str(), ios::binary);
-	FileOutput << "Train/Time ";
-	for (int t = StartPrintingTime; t<=EndPrintingTime; t++) {
-		FileOutput << t * timestep << " ";
-	}
-	FileOutput << "\n";
-
-	//Shifting train trajectories
-	for (int i = 0; i < N_S; i++) {
-		//Printing out the names of trains
-		FileOutput << instant_spatial_position[i].trainDescription << " ";
-		int TrainShift = (int) instant_spatial_position[i].departure_time - (int) instant_spatial_position[i].RunStartTime;
-		list<int> ShiftedTimes;
-		list<double> TrainPositions;
-		for (int t = 0; t <= times; t++) {
-			ShiftedTimes.push_back(t + instant_spatial_position[i].departure_time);
-			TrainPositions.push_back(instant_spatial_position[i].instant_spatial_position[t]);
-		}
-
-		bool StopPrinting = false;
-		list<int>::iterator shiftTime = ShiftedTimes.begin();
-		list<double>::iterator pos = TrainPositions.begin();
-		for (int k = StartPrintingTime; k <= EndPrintingTime; k++) {
-			if (ShiftedTimes.size() > 0) {
-				if ((*shiftTime == k)&&(StopPrinting==0)) {
-					if (train_route[instant_spatial_position[i].indexOfRoute].reversed_direction == 0) {
-						FileOutput << *pos << " ";
-					}
-					else {
-						FileOutput << train_route[instant_spatial_position[i].indexOfRoute].OriginalRefReversedRoute - *pos << " ";
-					}
-					shiftTime++;  //advancing the pointers to the lists
-					pos++;
-				}
-				else {
-					FileOutput << " ";
-				}
-				if (shiftTime == ShiftedTimes.end()) {
-					StopPrinting = true; //break the for loop when the cicle reaches the end of the list
-				}
-
-			}
-		}
-		FileOutput << "\n";
-	}
-//Close the output file
-	FileOutput.close();
-}
-*/
-void PrintCompressedTrainPathDiagramTrial(Train* S, int N_S, string FolderName);
 
 // Function to compute Energy consumption for all the trains in the network
 void ComputeEnergyConsumptionForAllTrains(Train* Trains, int numTrains);

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -263,10 +263,10 @@
 - Ponytail findings: none (`Lean already. Ship.`)
 - Simplifications made: removed eight unreachable alternate runtime/headway/debug implementations and declarations, the embedded commented compressed-diagram implementation, obsolete commented experiments, and two executable debug-support residues; retained the tested free-flow headway path and supported APIs
 - Commit SHA: `4d4db065e4e1c226ddcec35141df418d328c4879`
-- PR number and URL: pending
+- PR number and URL: [#319](https://github.com/Ancientkingg/EGTRAIN/pull/319)
 - CI status: pending
 - Merge SHA: pending
-- Remaining blockers: PR, CI, and merge
+- Remaining blockers: required CI and merge
 
 ### Execution log
 
@@ -280,3 +280,4 @@
 - 2026-08-20: Independent correctness review reported no findings. It rechecked the retained `TrainSimulationForComputingHW()` declaration, definition, native setup, free-flow call, and both regression callers, and confirmed the removed local debug-support construction had no external side effects. No fixes or re-review were required.
 - 2026-08-20: Separate Ponytail review reported `Lean already. Ship.` No further simplification was accepted.
 - 2026-08-20: Refreshed the repository knowledge graph after the code change, removed the worktree-local generated graph artifacts, and committed the reviewed milestone as `4d4db065e4e1c226ddcec35141df418d328c4879`.
+- 2026-08-20: Pushed `chore/remove-dead-simulation-code` and opened PR [#319](https://github.com/Ancientkingg/EGTRAIN/pull/319).

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -1,8 +1,8 @@
 # Stabilization execution ledger
 
 - Initial `origin/main`: `935d94227fa3ebc61de371a52d663e711a3e4805`
-- Release status: all confirmed P0/P1 blockers cleared; G-NV-01 verification, cleanup, and the final gate remain
-- Active milestone: 6, station platform-booking verification
+- Release status: all confirmed P0/P1 blockers cleared; dead-code cleanup and the final gate remain
+- Active milestone: 7, dead simulation-code cleanup
 
 | Milestone | Findings | Status | Issue | Pull request | Merge |
 |---|---|---|---|---|---|
@@ -11,8 +11,8 @@
 | 3. External communication lifecycle | G-03, G-07; P-05 | Complete | [#310](https://github.com/Ancientkingg/EGTRAIN/issues/310) | [#311](https://github.com/Ancientkingg/EGTRAIN/pull/311) | `d2c8dd761808c45deaa3f44a2348e10c5ba3c37a` |
 | 4. Result integrity | G-04; P-02 | Complete | [#312](https://github.com/Ancientkingg/EGTRAIN/issues/312) | [#313](https://github.com/Ancientkingg/EGTRAIN/pull/313) | `ee59d0fec11ecda65c3acca2acb0e1f76c7723dd` |
 | 5. Persistence and validation hardening | G-08, G-09, G-10 | Complete | [#314](https://github.com/Ancientkingg/EGTRAIN/issues/314) | [#315](https://github.com/Ancientkingg/EGTRAIN/pull/315) | `73dd9947496011df21145c234b27fe95e5065d46` |
-| 6. Station platform-booking verification | G-NV-01 | In progress | [#316](https://github.com/Ancientkingg/EGTRAIN/issues/316) | [#317](https://github.com/Ancientkingg/EGTRAIN/pull/317) | Pending |
-| 7. Dead-code cleanup | P-01, P-06 | Blocked on correctness work | Pending | Pending | Pending |
+| 6. Station platform-booking verification | G-NV-01 | Complete | [#316](https://github.com/Ancientkingg/EGTRAIN/issues/316) | [#317](https://github.com/Ancientkingg/EGTRAIN/pull/317) | `e4d7434de2c4c039f000851ea69fe3cf63702a18` |
+| 7. Dead-code cleanup | P-01, P-06 | In progress | [#318](https://github.com/Ancientkingg/EGTRAIN/issues/318) | Pending | Pending |
 
 ## Milestone 1: runtime memory safety
 
@@ -224,16 +224,16 @@
 - Base SHA: `73dd9947496011df21145c234b27fe95e5065d46`
 - Scope: determine whether platform-booking rules gated by `Alm`, `Asd`, and `Asdz` are intentional Netherlands-specific behavior or generic behavior that should derive from canonical data
 - Files changed: `EGTRAIN/QEGTRAIN/simulation/RollingStock.cpp`; this ledger
-- Test results: final diff check passed; source audit confirmed the executable diff is one comment, current native code has no `arrivalPlatform` assignment, and current Netherlands services have none of the three stations as endpoints; hosted build pending
+- Test results: final diff check passed; source audit confirmed the executable diff is one comment, current native code has no `arrivalPlatform` assignment, and current Netherlands services have none of the three stations as endpoints; hosted full build and test job passed
 - Adversarial-review findings: independent semantic review agreed the gate belongs to the retired Netherlands dispatcher contract and found no basis for genericizing it; native integer platform state remains `-1`, so generic comparison would create false conflicts
 - Fixes made from review: none; added one provenance comment to prevent the legacy integer booking state from being confused with canonical string platform IDs
 - Ponytail findings: no finding; the one-line comment and evidence ledger are already the minimum useful change
 - Simplifications made: no behavioral code added; retained the existing narrow case-specific gate
 - Commit SHA: `85b2f90d92ce3dd4082fb2c13e6bea69b0bf38e3`
 - PR number and URL: [#317](https://github.com/Ancientkingg/EGTRAIN/pull/317)
-- CI status: running
-- Merge SHA: pending
-- Remaining blockers: documentation PR and required CI
+- CI status: passed in 9m28s
+- Merge SHA: `e4d7434de2c4c039f000851ea69fe3cf63702a18`
+- Remaining blockers: none; conclusion is case-specific by design and behavior remains unchanged
 
 ### Execution log
 
@@ -247,3 +247,35 @@
 - 2026-08-20: Recorded the evidence-backed case-specific conclusion on issue #316; no behavior change or generic platform-allocation rewrite is warranted.
 - 2026-08-20: Committed the verified conclusion and provenance comment as `85b2f90d92ce3dd4082fb2c13e6bea69b0bf38e3`.
 - 2026-08-20: Pushed `docs/verify-platform-booking-rules` and opened pull request [#317](https://github.com/Ancientkingg/EGTRAIN/pull/317); required CI is running.
+- 2026-08-20: Required CI passed in 9m28s. Squash-merged pull request #317 as `e4d7434de2c4c039f000851ea69fe3cf63702a18`, deleted the feature branch, and removed the clean milestone worktree.
+
+## Milestone 7: dead simulation-code cleanup
+
+- Finding IDs: P-01, P-06
+- Branch: `chore/remove-dead-simulation-code`
+- Worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/remove-dead-simulation-code`
+- Base SHA: `e4d7434de2c4c039f000851ea69fe3cf63702a18`
+- Scope: re-confirm and delete only unreachable alternate simulation/headway/debug paths and obsolete commented experiments remaining on current `main`
+- Files changed: `EGTRAIN/QEGTRAIN/simulation/Simulation.cpp`, `Simulation.h`, `EGTRAIN/QEGTRAIN/app/DispatchController.cpp`, and this ledger
+- Test results: fresh Qt 5 configure and full build passed; focused `test_operationsbuilder` passed (1/1); full CTest passed (48/48); six-case native headless smoke passed
+- Adversarial-review findings: none; independent review verified the retained free-flow headway path and confirmed the removed executable debug residue had no side effects
+- Fixes made from review: none required
+- Ponytail findings: none (`Lean already. Ship.`)
+- Simplifications made: removed eight unreachable alternate runtime/headway/debug implementations and declarations, the embedded commented compressed-diagram implementation, obsolete commented experiments, and two executable debug-support residues; retained the tested free-flow headway path and supported APIs
+- Commit SHA: pending
+- PR number and URL: pending
+- CI status: pending
+- Merge SHA: pending
+- Remaining blockers: graph refresh, commit, PR, CI, and merge
+
+### Execution log
+
+- 2026-08-20: Confirmed no existing issue owns the remaining P-01/P-06 work; opened issue [#318](https://github.com/Ancientkingg/EGTRAIN/issues/318).
+- 2026-08-20: Fetched `origin`, created the clean isolated milestone branch and worktree from the latest merged `origin/main`, and recorded merge SHA `e4d7434de2c4c039f000851ea69fe3cf63702a18`.
+- 2026-08-20: Re-ran repository-wide exact symbol searches on current `main`. The eight P-01 candidates occur only as definitions, declarations, or commented calls. `TrainSimulationForComputingHW()` remains live in `test_operationsbuilder` and is excluded from deletion. The cleanup boundary remains deletion-only; supported RollingStock APIs are out of scope.
+- 2026-08-20: Independent mechanical audit confirmed the same eight functions have no live repository callers and found no CMake, tool, product-documentation, or test references. It also confirmed the P-06 comment blocks and two small executable debug-support residues in `DispatchController` have no effect on supported runtime behavior. The tested `TrainSimulationForComputingHW()` path, timing output, RollingStock APIs, and trajectory utilities remain out of scope.
+- 2026-08-20: Deleted the confirmed P-01/P-06 surface: 642 product lines removed and no product lines added across `Simulation.cpp`, `Simulation.h`, and `DispatchController.cpp`. A post-edit exact symbol audit found none of the eight dead candidates and retained the live `TrainSimulationForComputingHW()` definition, declaration, and both regression-test callers. `git diff --check` passed.
+- 2026-08-20: Fresh Qt 5 configure and full build passed. The focused `test_operationsbuilder` regression, including both live `TrainSimulationForComputingHW()` calls, passed (1/1).
+- 2026-08-20: Full CTest passed (48/48). The six-case native headless smoke passed for Netherlands, Paimpol, Copenhagen, Brescia, Assignment, and Lebanon; all cases exited cleanly, produced finite station statistics, and retained their expected trajectory/runtime observables.
+- 2026-08-20: Independent correctness review reported no findings. It rechecked the retained `TrainSimulationForComputingHW()` declaration, definition, native setup, free-flow call, and both regression callers, and confirmed the removed local debug-support construction had no external side effects. No fixes or re-review were required.
+- 2026-08-20: Separate Ponytail review reported `Lean already. Ship.` No further simplification was accepted.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -262,11 +262,11 @@
 - Fixes made from review: none required
 - Ponytail findings: none (`Lean already. Ship.`)
 - Simplifications made: removed eight unreachable alternate runtime/headway/debug implementations and declarations, the embedded commented compressed-diagram implementation, obsolete commented experiments, and two executable debug-support residues; retained the tested free-flow headway path and supported APIs
-- Commit SHA: pending
+- Commit SHA: `4d4db065e4e1c226ddcec35141df418d328c4879`
 - PR number and URL: pending
 - CI status: pending
 - Merge SHA: pending
-- Remaining blockers: graph refresh, commit, PR, CI, and merge
+- Remaining blockers: PR, CI, and merge
 
 ### Execution log
 
@@ -279,3 +279,4 @@
 - 2026-08-20: Full CTest passed (48/48). The six-case native headless smoke passed for Netherlands, Paimpol, Copenhagen, Brescia, Assignment, and Lebanon; all cases exited cleanly, produced finite station statistics, and retained their expected trajectory/runtime observables.
 - 2026-08-20: Independent correctness review reported no findings. It rechecked the retained `TrainSimulationForComputingHW()` declaration, definition, native setup, free-flow call, and both regression callers, and confirmed the removed local debug-support construction had no external side effects. No fixes or re-review were required.
 - 2026-08-20: Separate Ponytail review reported `Lean already. Ship.` No further simplification was accepted.
+- 2026-08-20: Refreshed the repository knowledge graph after the code change, removed the worktree-local generated graph artifacts, and committed the reviewed milestone as `4d4db065e4e1c226ddcec35141df418d328c4879`.


### PR DESCRIPTION
Closes #318

## What changed

- remove eight simulation, headway, ROMA, and debug paths with no live callers
- delete their stale declarations and commented launch sites
- remove obsolete experiment blocks and local debug-only residue
- retain the tested `TrainSimulationForComputingHW` path and supported RollingStock APIs

## Verification

- fresh Qt 5 configure and full build
- focused `test_operationsbuilder` regression
- CTest: 48/48 passed
- six-case native headless smoke passed
- exact before/after symbol audit
- `git diff --check`