### PR TITLE
Honor duration overrides in runnable validation

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <memory>
 #include <map>
+#include <optional>
 
 namespace {
 void ensureDirectory(const string& path) {
@@ -165,7 +166,10 @@ DispatchController simulation;
 std::vector<SceneDiagnostic> DispatchController::prepareScene(const SceneModel& scene,
 		const std::string& selectedScenarioId, const SceneRunSelection& selectedOccurrences) {
 	resetState();
-	std::vector<SceneDiagnostic> diagnostics = validateRunnableScene(scene, selectedOccurrences);
+	const std::optional<double> effectiveDurationOverride = initial_variables.durationOverride
+			? std::optional<double>(initial_variables.times) : std::nullopt;
+	std::vector<SceneDiagnostic> diagnostics = validateRunnableScene(scene, selectedOccurrences,
+			effectiveDurationOverride);
 	if (hasErrors(diagnostics))
 		return diagnostics;
 

--- a/EGTRAIN/QEGTRAIN/app/main.cpp
+++ b/EGTRAIN/QEGTRAIN/app/main.cpp
@@ -4,6 +4,7 @@
 #include "scene/SceneBundle.h"
 #include "scene/SceneValidator.h"
 #include <algorithm>
+#include <optional>
 #include "util/portability.h"
 #include <QDir>
 #include <QFileInfo>
@@ -203,6 +204,8 @@ int main(int argc, char* argv[]) {
 		initial_variables.nArgProvided = true;
 
 	const bool gui = initial_variables.GUI != 0;
+	const std::optional<double> effectiveDurationOverride = initial_variables.durationOverride
+			? std::optional<double>(initial_variables.times) : std::nullopt;
 	if (gui)
 		std::cout << "Graphical user interface (GUI): 1\n";
 	else
@@ -231,7 +234,8 @@ int main(int argc, char* argv[]) {
 			sceneOption ? QString::fromLocal8Bit(sceneArgument) : QString(), defaultName);
 		SceneLoadResult loaded = loadScenePath(scenePath.toStdString());
 		if (!hasErrors(loaded.diagnostics)) {
-			const std::vector<SceneDiagnostic> runnable = validateRunnableScene(loaded.scene);
+			const std::vector<SceneDiagnostic> runnable = validateRunnableScene(loaded.scene, {},
+				effectiveDurationOverride);
 			loaded.diagnostics.insert(loaded.diagnostics.end(), runnable.begin(), runnable.end());
 		}
 		if (hasErrors(loaded.diagnostics)) {
@@ -255,7 +259,8 @@ int main(int argc, char* argv[]) {
 		sceneOption ? QString::fromLocal8Bit(sceneArgument) : QString(), defaultName);
 	SceneLoadResult loaded = loadScenePath(scenePath.toStdString());
 	if (!hasErrors(loaded.diagnostics)) {
-		const std::vector<SceneDiagnostic> runnable = validateRunnableScene(loaded.scene);
+		const std::vector<SceneDiagnostic> runnable = validateRunnableScene(loaded.scene, {},
+			effectiveDurationOverride);
 		loaded.diagnostics.insert(loaded.diagnostics.end(), runnable.begin(), runnable.end());
 	}
 	if (hasErrors(loaded.diagnostics)) {

--- a/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/SceneValidator.cpp
@@ -124,9 +124,12 @@ void collectIds(const std::vector<T>& items, const std::string& file, const std:
 }
 
 std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable,
-		const SceneRunSelection& selectedOccurrences = {}) {
+		const SceneRunSelection& selectedOccurrences = {},
+		std::optional<double> effectiveDurationOverride = std::nullopt) {
 	std::vector<SceneDiagnostic> result;
 	DiagnosticBuilder diagnostics{result};
+	const double effectiveDurationSeconds = effectiveDurationOverride.value_or(
+			scene.settings.hasDuration ? scene.settings.durationSeconds : 0.0);
 
 	if (!scene.baseTime.empty()) {
 		static const std::regex timePattern("^([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$");
@@ -797,8 +800,7 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 					"repeat.operating_code_step must be nonzero and use a decimal operating code base",
 					"services.json", "service", service.id, path + ".repeat.operating_code_step", "",
 					"Use a nonzero step with a decimal operating_code");
-		const int occurrences = sceneServiceOccurrenceCount(service,
-				scene.settings.hasDuration ? scene.settings.durationSeconds : 0.0);
+		const int occurrences = sceneServiceOccurrenceCount(service, effectiveDurationSeconds);
 		if (service.hasRepeat && service.hasOperatingCodeStep
 				&& !sceneServiceOccurrenceOperatingCode(service, 1).empty()
 				&& sceneServiceOccurrenceOperatingCode(service, occurrences).empty())
@@ -1201,7 +1203,6 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 		};
 		std::size_t expandedServiceOccurrences = 0;
 		const std::size_t maxExpandedTrains = static_cast<std::size_t>(RuntimeLimits::kMaxExpandedTrains);
-		const double durationSeconds = scene.settings.hasDuration ? scene.settings.durationSeconds : 0.0;
 		for (const SceneService& service : scene.services) {
 			const std::string servicePath = "services[" + service.id + "]";
 			if (service.stops.size() > static_cast<std::size_t>(RuntimeLimits::kMaxTimetableStops))
@@ -1210,7 +1211,7 @@ std::vector<SceneDiagnostic> validateCore(const SceneModel& scene, bool runnable
 						servicePath + ".stops", std::to_string(service.stops.size()),
 						"Reduce this service to " + std::to_string(RuntimeLimits::kMaxTimetableStops)
 								+ " or fewer stops");
-			const int occurrences = sceneServiceOccurrenceCount(service, durationSeconds);
+			const int occurrences = sceneServiceOccurrenceCount(service, effectiveDurationSeconds);
 			const std::size_t occurrenceCount = selectedOccurrences.empty()
 					? static_cast<std::size_t>(occurrences)
 					: static_cast<std::size_t>(std::count_if(selectedOccurrences.begin(), selectedOccurrences.end(),
@@ -1400,8 +1401,8 @@ std::vector<SceneDiagnostic> validateScene(const SceneModel& scene) {
 }
 
 std::vector<SceneDiagnostic> validateRunnableScene(const SceneModel& scene,
-		const SceneRunSelection& selectedOccurrences) {
-	return validateCore(scene, true, selectedOccurrences);
+		const SceneRunSelection& selectedOccurrences, std::optional<double> effectiveDurationOverride) {
+	return validateCore(scene, true, selectedOccurrences, effectiveDurationOverride);
 }
 
 std::vector<SceneDiagnostic> validateSceneDirectory(const std::string& sceneDir) {

--- a/EGTRAIN/QEGTRAIN/scene/SceneValidator.h
+++ b/EGTRAIN/QEGTRAIN/scene/SceneValidator.h
@@ -2,6 +2,7 @@
 #define SCENEVALIDATOR_H
 
 #include "scene/SceneModel.h"
+#include <optional>
 #include <vector>
 #include <string>
 
@@ -15,7 +16,8 @@ std::vector<SceneDiagnostic> validateScene(const SceneModel& scene);
 
 // Validate the minimum complete model needed by a runnable simulation.
 std::vector<SceneDiagnostic> validateRunnableScene(const SceneModel& scene,
-		const SceneRunSelection& selectedOccurrences = {});
+		const SceneRunSelection& selectedOccurrences = {},
+		std::optional<double> effectiveDurationOverride = std::nullopt);
 
 // Load, then validate ONLY if loading produced no Error diagnostics. Structural
 // errors must be fixed first to avoid semantic cascades from a partial model.

--- a/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp
@@ -179,6 +179,14 @@ int main(int argc, char** argv) {
 	tooManyTrains.services[0].repeatCount = RuntimeLimits::kMaxExpandedTrains + 1;
 	ok &= expect(hasCodeAndPath(validateRunnableScene(tooManyTrains), "scene.capacity.runtime", "services"),
 			"runnable validation rejects one expanded train above the limit");
+	SceneModel horizonTrainLimit = clean;
+	horizonTrainLimit.services[0].hasRepeat = true;
+	horizonTrainLimit.services[0].headwaySeconds = 1.0;
+	ok &= expect(hasCode(validateRunnableScene(horizonTrainLimit), "scene.capacity.runtime"),
+			"runnable validation rejects saved-horizon train expansion above the limit");
+	ok &= expect(!hasCode(validateRunnableScene(horizonTrainLimit, {}, std::optional<double>(1.0)),
+				"scene.capacity.runtime"),
+			"runnable validation uses an effective duration override for train capacity");
 	const SceneRunSelection sparseSelection{{tooManyTrains.services[0].id,
 		RuntimeLimits::kMaxExpandedTrains + 1}};
 	ok &= expect(!hasCode(validateRunnableScene(tooManyTrains, sparseSelection), "scene.capacity.runtime"),
@@ -650,6 +658,21 @@ int main(int argc, char** argv) {
 	reducedIncident.occurrence = 1;
 	ok &= expect(validateRunnableScene(reducedBreakdown).empty(),
 			"reduced-speed breakdown may omit recovery end");
+	SceneModel extendedOccurrence = reducedBreakdown;
+	extendedOccurrence.settings.durationSeconds = 1.0;
+	extendedOccurrence.services[0].hasRepeat = true;
+	extendedOccurrence.services[0].headwaySeconds = 10.0;
+	extendedOccurrence.scenarios[0].incidents[0].occurrence = 2;
+	extendedOccurrence.scenarios[0].entranceDelays[0].occurrence = 2;
+	const auto savedHorizonDiagnostics = validateRunnableScene(extendedOccurrence);
+	ok &= expect(hasCode(savedHorizonDiagnostics, "scene.occurrence.invalid")
+			&& hasCode(savedHorizonDiagnostics, "scene.entrance.occurrence.out_of_horizon"),
+			"saved horizon rejects occurrence-specific rows outside its repeat pattern");
+	const auto extendedHorizonDiagnostics = validateRunnableScene(
+			extendedOccurrence, {}, std::optional<double>(20.0));
+	ok &= expect(!hasCode(extendedHorizonDiagnostics, "scene.occurrence.invalid")
+			&& !hasCode(extendedHorizonDiagnostics, "scene.entrance.occurrence.out_of_horizon"),
+			"duration override applies to breakdown and entrance-delay occurrences");
 
 	SceneModel fullHoldWithoutEnd = reducedBreakdown;
 	fullHoldWithoutEnd.scenarios[0].incidents[0].hasReducedSpeed = false;

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -297,8 +297,8 @@
 - Ponytail findings: none (`Lean already. Ship.`); the separate review inspected the full 26-file stabilization diff and current tracked state
 - Simplifications made: none at the final gate; the reviewed stabilization range was already lean and no safety or correctness check was removed
 - Commit SHA: `d132c2442430609f57589f12eb14e031da8fea2a`
-- PR number and URL: pending
-- CI status: pending
+- PR number and URL: [#322](https://github.com/Ancientkingg/EGTRAIN/pull/322)
+- CI status: required `build` check running
 - Merge SHA: pending
 - Remaining blockers: correct the accepted P2 duration-override capacity mismatch, merge it, and repeat the final gate from the resulting `origin/main`
 
@@ -342,3 +342,4 @@
 - 2026-08-20: Fresh correctness re-review of all effective-duration consumers and runtime call sites reported no findings. The separate final Ponytail re-review inspected all seven changed files and reported `Lean already. Ship.`
 - 2026-08-20: Rebuilt the final corrected diff. Full normal CTest passed (48/48), including the live high-repeat short-override path; the six-case native headless matrix passed with finite statistics and expected train/trajectory observables. Focused ASan/UBSan `test_scenevalidator` and `test_runtime_memory_safety` passed (2/2). Refreshed the repository knowledge graph and removed the worktree-local generated graph and alternate sanitizer build artifacts.
 - 2026-08-20: Committed the reviewed corrective implementation and regressions as `d132c2442430609f57589f12eb14e031da8fea2a`.
+- 2026-08-20: Pushed `fix/duration-override-capacity-validation` and opened PR [#322](https://github.com/Ancientkingg/EGTRAIN/pull/322); required CI is running.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -264,9 +264,9 @@
 - Simplifications made: removed eight unreachable alternate runtime/headway/debug implementations and declarations, the embedded commented compressed-diagram implementation, obsolete commented experiments, and two executable debug-support residues; retained the tested free-flow headway path and supported APIs
 - Commit SHA: `4d4db065e4e1c226ddcec35141df418d328c4879`
 - PR number and URL: [#319](https://github.com/Ancientkingg/EGTRAIN/pull/319)
-- CI status: pending
-- Merge SHA: pending
-- Remaining blockers: required CI and merge
+- CI status: required `build` check passed in 12m42s ([run 32370063529](https://github.com/Ancientkingg/EGTRAIN/actions/runs/32370063529))
+- Merge SHA: `e41b3c3621ff3d943454f62f2e211c964a9678b5`
+- Remaining blockers: none for Milestone 7
 
 ### Execution log
 
@@ -281,3 +281,33 @@
 - 2026-08-20: Separate Ponytail review reported `Lean already. Ship.` No further simplification was accepted.
 - 2026-08-20: Refreshed the repository knowledge graph after the code change, removed the worktree-local generated graph artifacts, and committed the reviewed milestone as `4d4db065e4e1c226ddcec35141df418d328c4879`.
 - 2026-08-20: Pushed `chore/remove-dead-simulation-code` and opened PR [#319](https://github.com/Ancientkingg/EGTRAIN/pull/319).
+- 2026-08-20: Required CI passed in 12m42s. Squash-merged PR #319 as `e41b3c3621ff3d943454f62f2e211c964a9678b5`, deleted the feature branch, and removed the clean milestone worktree.
+
+## Final stabilization gate
+
+- Finding IDs: final release gate for G-01 through G-10, G-NV-01, and P-01 through P-06
+- Branch: `chore/final-stabilization-gate`
+- Worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/final-stabilization-gate`
+- Base SHA: `e41b3c3621ff3d943454f62f2e211c964a9678b5`
+- Scope: run the complete stabilization verification matrix from current `main`, perform fresh correctness and Ponytail reviews, record the release decision, and make no unrelated product changes
+- Files changed: this ledger; pending gate results
+- Test results: fresh normal Qt 5 configure and full build passed; full normal CTest passed (48/48); six-case headless, six-scene roundtrip, bundle, Assignment acceptance, incident, editor, and visual/render smokes passed; generated supported outputs contain no `nan`/`inf`; sanitizer checks pending
+- Adversarial-review findings: one P2 validator/runtime mismatch: runnable capacity validation uses the saved scene duration while native operation building honors a shorter command-line duration override, so validation can reject a run that stays within native capacity
+- Fixes made from review: corrective issue [#321](https://github.com/Ancientkingg/EGTRAIN/issues/321) opened; fix and repeated final gate pending
+- Ponytail findings: none (`Lean already. Ship.`); the separate review inspected the full 26-file stabilization diff and current tracked state
+- Simplifications made: none at the final gate; the reviewed stabilization range was already lean and no safety or correctness check was removed
+- Commit SHA: pending
+- PR number and URL: pending
+- CI status: pending
+- Merge SHA: pending
+- Remaining blockers: correct the accepted P2 duration-override capacity mismatch, merge it, and repeat the final gate from the resulting `origin/main`
+
+### Execution log
+
+- 2026-08-20: Confirmed no existing issue owns the final release gate; opened issue [#320](https://github.com/Ancientkingg/EGTRAIN/issues/320).
+- 2026-08-20: Fetched and pruned `origin`, created the clean isolated final-gate branch and worktree from merged `origin/main`, and recorded base SHA `e41b3c3621ff3d943454f62f2e211c964a9678b5`.
+- 2026-08-20: Fresh normal Qt 5 configure and full build passed. Full normal CTest passed (48/48), including runtime-memory, determinism, route-choice, no-listener external sharing, creator acceptance, GUI autostart, scene, ownership, and platform/configuration checks.
+- 2026-08-20: The six-scene folder roundtrip, all six bundle validations, packed Assignment headless run, canonical Assignment timetable check, breakdown and signal-failure incident checks, editor smoke, and visual/render smoke group all passed.
+- 2026-08-20: The full six-case native headless smoke passed. All cases exited cleanly; station statistics remained finite; Netherlands, Paimpol, Copenhagen, and Milano retained their pre-cutover train-count and trajectory observables. A token-aware scan of generated supported text, CSV, and JSON outputs found no `nan` or infinity values.
+- 2026-08-20: The fresh separate Ponytail review inspected the complete 26-file stabilization diff and current tracked state and reported `Lean already. Ship.` No further simplification was accepted.
+- 2026-08-20: Fresh independent correctness review found one P2 regression in G-09. Both startup and `DispatchController::prepareScene` validate expanded trains from the saved scene duration, while `buildOperationsFromScene` uses a shorter `-h` override. Root call-flow verification accepted the finding because this can reject a run that would remain below the 700-train native limit. Opened corrective issue [#321](https://github.com/Ancientkingg/EGTRAIN/issues/321); release-gate completion is paused until the fix is merged and the gate is repeated.

--- a/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
+++ b/docs/planning/STABILIZATION_EXECUTION_LEDGER.md
@@ -296,7 +296,7 @@
 - Fixes made from review: corrective issue [#321](https://github.com/Ancientkingg/EGTRAIN/issues/321) opened; fix and repeated final gate pending
 - Ponytail findings: none (`Lean already. Ship.`); the separate review inspected the full 26-file stabilization diff and current tracked state
 - Simplifications made: none at the final gate; the reviewed stabilization range was already lean and no safety or correctness check was removed
-- Commit SHA: pending
+- Commit SHA: `d132c2442430609f57589f12eb14e031da8fea2a`
 - PR number and URL: pending
 - CI status: pending
 - Merge SHA: pending
@@ -311,3 +311,34 @@
 - 2026-08-20: The full six-case native headless smoke passed. All cases exited cleanly; station statistics remained finite; Netherlands, Paimpol, Copenhagen, and Milano retained their pre-cutover train-count and trajectory observables. A token-aware scan of generated supported text, CSV, and JSON outputs found no `nan` or infinity values.
 - 2026-08-20: The fresh separate Ponytail review inspected the complete 26-file stabilization diff and current tracked state and reported `Lean already. Ship.` No further simplification was accepted.
 - 2026-08-20: Fresh independent correctness review found one P2 regression in G-09. Both startup and `DispatchController::prepareScene` validate expanded trains from the saved scene duration, while `buildOperationsFromScene` uses a shorter `-h` override. Root call-flow verification accepted the finding because this can reject a run that would remain below the 700-train native limit. Opened corrective issue [#321](https://github.com/Ancientkingg/EGTRAIN/issues/321); release-gate completion is paused until the fix is merged and the gate is repeated.
+- 2026-08-20: The pre-correction ASan/UBSan build and full instrumented CTest completed successfully (48/48 in 317.39s). This is retained as diagnostic evidence only; the sanitizer and complete release gate will be repeated after G-09-R1 merges.
+
+## Corrective milestone: duration-override capacity alignment
+
+- Finding IDs: G-09-R1 (P2 final-review regression)
+- Branch: `fix/duration-override-capacity-validation`
+- Worktree: `/Users/samuelbruin/Downloads/EGTRAIN/local/worktrees/duration-override-capacity-validation`
+- Base SHA: `e41b3c3621ff3d943454f62f2e211c964a9678b5`
+- Scope: make runnable expanded-train capacity validation use the same effective command-line duration override as native operation building, without mutating the loaded scene
+- Files changed: `EGTRAIN/QEGTRAIN/scene/SceneValidator.h`, `SceneValidator.cpp`, `EGTRAIN/QEGTRAIN/app/main.cpp`, `DispatchController.cpp`, `EGTRAIN/QEGTRAIN/tests/test_scenevalidator.cpp`, `tools/e2e/runtime_memory_safety_smoke.py`, and this ledger
+- Test results: fresh Qt 5 configure and full build passed; focused normal tests passed (2/2); full CTest passed (48/48); six-case native headless passed; focused ASan/UBSan `test_scenevalidator` and live `test_runtime_memory_safety` passed (2/2)
+- Adversarial-review findings: accepted P1 extension of the original mismatch: occurrence-specific breakdown and entrance-delay validation still used the saved duration when `-h` extended the runnable horizon
+- Fixes made from review: compute one effective duration at runnable-validator entry and use it for the shared service-occurrence map and expanded-train capacity; added focused saved/extended-horizon checks for both occurrence-specific row types; fresh correctness re-review reported no findings
+- Ponytail findings: none (`Lean already. Ship.`) after the final corrected seven-file diff
+- Simplifications made: one shared effective-duration value replaces separate saved/override duration calculations; no further simplification accepted
+- Commit SHA: pending
+- PR number and URL: pending
+- CI status: pending
+- Merge SHA: pending
+- Remaining blockers: commit, push, pass required CI, and merge the corrective fix; then repeat the final stabilization gate
+
+### Execution log
+
+- 2026-08-20: Confirmed no existing issue owns the duration-override validation mismatch and opened issue [#321](https://github.com/Ancientkingg/EGTRAIN/issues/321).
+- 2026-08-20: Fetched `origin`, created the clean isolated corrective branch and worktree from merged `origin/main`, and recorded base SHA `e41b3c3621ff3d943454f62f2e211c964a9678b5`.
+- 2026-08-20: Traced the startup, controller, validator, and native-builder call flow. The saved duration is used at both runnable-validation boundaries, but native expansion switches to `initial_variables.times` when `durationOverride` is true. Accepted the P2 finding and fixed the scope to explicit effective-duration propagation plus one validator regression and one live `-h` path.
+- 2026-08-20: Added one optional effective-duration input to pure runnable validation and passed the command-line override through both startup prevalidation paths and `DispatchController::prepareScene`; the loaded scene remains unchanged. Added a saved-horizon/short-override validator assertion and made the existing Paimpol time-zero live smoke exceed capacity only over its saved horizon. Fresh configure/build and the two focused tests passed (2/2); `git diff --check` passed.
+- 2026-08-20: Independent correctness review found a P1 extension: the shared occurrence map used by breakdown and entrance-delay validation still used the saved horizon when `-h` extended it. Accepted and fixed the finding at the root by computing one effective duration at validator entry and reusing it for both the occurrence map and capacity loop. Added saved-horizon rejection and extended-horizon acceptance checks for both row types; focused `test_scenevalidator` passed. Fresh correctness and Ponytail re-reviews are running.
+- 2026-08-20: Fresh correctness re-review of all effective-duration consumers and runtime call sites reported no findings. The separate final Ponytail re-review inspected all seven changed files and reported `Lean already. Ship.`
+- 2026-08-20: Rebuilt the final corrected diff. Full normal CTest passed (48/48), including the live high-repeat short-override path; the six-case native headless matrix passed with finite statistics and expected train/trajectory observables. Focused ASan/UBSan `test_scenevalidator` and `test_runtime_memory_safety` passed (2/2). Refreshed the repository knowledge graph and removed the worktree-local generated graph and alternate sanitizer build artifacts.
+- 2026-08-20: Committed the reviewed corrective implementation and regressions as `d132c2442430609f57589f12eb14e031da8fea2a`.

--- a/tools/e2e/runtime_memory_safety_smoke.py
+++ b/tools/e2e/runtime_memory_safety_smoke.py
@@ -42,6 +42,7 @@ def main() -> None:
         services_path = paimpol / "services.json"
         services = json.loads(services_path.read_text(encoding="utf-8"))
         services["services"][1]["entry_time_seconds"] = 0.0
+        services["services"][1]["repeat"]["headway_seconds"] = 1.0
         services_path.write_text(json.dumps(services, indent=2) + "\n", encoding="utf-8")
         run(app, paimpol, temp / "paimpol-output", "Paimpol time-zero runtime")
 


### PR DESCRIPTION
## Summary

- use one effective duration for runnable repeat counts, occurrence-specific rows, and expanded-train capacity
- pass the command-line `-h` override through startup and controller validation without changing the loaded scene
- cover saved-horizon rejection, short-override acceptance, and the live Paimpol startup path

## Verification

- full build
- CTest: 48/48
- six-case native headless smoke
- focused ASan/UBSan tests: 2/2

Closes #321