### PR TITLE
Fix schematic case study preview layout

### DIFF
--- a/EGTRAIN/QEGTRAIN/scene/TrackPreview.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/TrackPreview.cpp
@@ -202,6 +202,28 @@ TrackPreviewResult loadTrackPreview(const SceneModel& scene) {
 				}
 				uniqueYAnchors.push_back(anchor);
 			}
+			const bool schematicLayout = valid && uniqueYAnchors.size() >= 2
+					&& std::all_of(uniqueYAnchors.begin() + 1, uniqueYAnchors.end(),
+							[&uniqueYAnchors](const auto& anchor) {
+								return std::fabs(anchor.second - uniqueYAnchors.front().second) <= 1e-9;
+							});
+			if (schematicLayout && uniqueXAnchors.size() >= 2) {
+				std::vector<double> displayXs;
+				displayXs.reserve(line.points.size());
+				for (const auto& point : line.points) {
+					double displayX = 0.0;
+					if (!std::isfinite(point.rawX)
+							|| !mapPreviewX(point.rawX, uniqueXAnchors, displayX)) {
+						valid = false;
+						break;
+					}
+					displayXs.push_back(displayX);
+				}
+				if (valid)
+					for (std::size_t index = 0; index < line.points.size(); ++index)
+						line.points[index].x = displayXs[index];
+				continue;
+			}
 			if (valid && uniqueXAnchors.size() >= 2 && uniqueYAnchors.size() >= 2) {
 				const double separation = static_cast<double>(view->level)
 						* kGeographicTrackSeparation;

--- a/EGTRAIN/QEGTRAIN/tests/test_trackpreview.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_trackpreview.cpp
@@ -96,6 +96,19 @@ int main() {
 				&& connection.secondTrackId == "B1" && connection.secondNodeId == "B1.Ut",
 				"connection endpoints resolve through canonical node references");
 	}
+	SceneModel schematic = scene;
+	for (auto& station : schematic.stationViews)
+		station.latitude = 1.0;
+	for (auto& node : schematic.nodes)
+		node.yKm = 0.0;
+	const TrackPreviewResult schematicResult = loadTrackPreview(schematic);
+	ok &= expect(schematicResult.lines.size() == 2
+			&& std::fabs(schematicResult.lines[0].points[1].x - 0.28) < 1e-9
+			&& schematicResult.lines[0].points[0].y == 0.0
+			&& schematicResult.lines[1].points[0].y == 0.0
+			&& schematicResult.lines[0].displayOffset == 0.0
+			&& std::fabs(schematicResult.lines[1].displayOffset - 0.015) < 1e-9,
+			"constant-latitude display anchors retain schematic track levels");
 	SceneModel hidden = scene;
 	hidden.trackViews[1].visible = false;
 	hidden.stations.front().platforms.insert(hidden.stations.front().platforms.begin(),


### PR DESCRIPTION
## Summary
- preserve authored schematic track levels for constant-latitude case studies
- retain geographic projection for case studies with real latitude variation
- add regression coverage for schematic coordinate mapping and spacing

## Verification
- `cmake --build build -j4`
- `ctest --test-dir build --output-on-failure` (48/48 passed)
- `tools/e2e/visual_polish_smoke.sh`
- live Copenhagen inspection at fit and detail zoom