### PR TITLE
Fix schematic track spacing scale

### DIFF
--- a/EGTRAIN/QEGTRAIN/scene/TrackPreview.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/TrackPreview.cpp
@@ -219,9 +219,13 @@ TrackPreviewResult loadTrackPreview(const SceneModel& scene) {
 					}
 					displayXs.push_back(displayX);
 				}
-				if (valid)
+				if (valid) {
 					for (std::size_t index = 0; index < line.points.size(); ++index)
 						line.points[index].x = displayXs[index];
+					line.displayOffset *= 8.0 * std::fabs((uniqueXAnchors.back().second
+							- uniqueXAnchors.front().second) / (uniqueXAnchors.back().first
+							- uniqueXAnchors.front().first));
+				}
 				continue;
 			}
 			if (valid && uniqueXAnchors.size() >= 2 && uniqueYAnchors.size() >= 2) {

--- a/EGTRAIN/QEGTRAIN/tests/test_trackpreview.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_trackpreview.cpp
@@ -107,8 +107,8 @@ int main() {
 			&& schematicResult.lines[0].points[0].y == 0.0
 			&& schematicResult.lines[1].points[0].y == 0.0
 			&& schematicResult.lines[0].displayOffset == 0.0
-			&& std::fabs(schematicResult.lines[1].displayOffset - 0.015) < 1e-9,
-			"constant-latitude display anchors retain schematic track levels");
+			&& std::fabs(schematicResult.lines[1].displayOffset - 0.0012) < 1e-9,
+			"constant-latitude display anchors scale schematic track levels with mapped x");
 	SceneModel hidden = scene;
 	hidden.trackViews[1].visible = false;
 	hidden.stations.front().platforms.insert(hidden.stations.front().platforms.begin(),


### PR DESCRIPTION
## Summary

- scale schematic track-level offsets with the scene coordinate remapping
- keep constant-latitude case studies readable without vertical line artifacts
- update the track-preview regression expectation

## Testing

- `cmake --build build -j4`
- `ctest --test-dir build --output-on-failure` (48/48 passed)
- `tools/e2e/visual_polish_smoke.sh`
- visually checked Copenhagen, Netherlands, Paimpol, and Milano–Brescia at Fit view