### PR TITLE
Fix runtime map geometry drift

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -1287,36 +1287,18 @@ bool copyDirectoryRecursively(const QString& sourcePath, const QString& targetPa
 }
 
 bool previewPointAtNode(const TrackPreviewLine& line, const std::string& nodeId, qreal offset, QPointF& point) {
-	for (const auto& candidate : line.points) {
-		if (candidate.nodeId == nodeId) {
-			point = QPointF(candidate.x, candidate.y + offset);
-			return true;
-		}
-	}
-	return false;
+	TrackPreviewPoint candidate;
+	if (!trackPreviewPointAtNode(line, nodeId, candidate))
+		return false;
+	point = QPointF(candidate.x, candidate.y + offset);
+	return true;
 }
 
 bool previewPointAtX(const TrackPreviewLine& line, double x, qreal offset, QPointF& point) {
-	if (line.points.empty())
+	TrackPreviewPoint candidate;
+	if (!trackPreviewPointAtX(line, x, candidate))
 		return false;
-
-	for (std::size_t index = 1; index < line.points.size(); ++index) {
-		const auto& first = line.points[index - 1];
-		const auto& second = line.points[index];
-		if (x < std::min(first.rawX, second.rawX) || x > std::max(first.rawX, second.rawX))
-			continue;
-
-		const double span = second.rawX - first.rawX;
-		const double ratio = span == 0.0 ? 0.0 : (x - first.rawX) / span;
-		point = QPointF(first.x + ratio * (second.x - first.x),
-			first.y + ratio * (second.y - first.y) + offset);
-		return true;
-	}
-
-	const auto closest = std::min_element(line.points.begin(), line.points.end(), [x](const auto& left, const auto& right) {
-		return std::abs(left.rawX - x) < std::abs(right.rawX - x);
-	});
-	point = QPointF(closest->x, closest->y + offset);
+	point = QPointF(candidate.x, candidate.y + offset);
 	return true;
 }
 
@@ -3247,6 +3229,16 @@ bool MainWindow::openSceneDirectory(const QString& dir) {
 	return true;
 }
 
+const TrackPreviewLine* MainWindow::cachedTrackLine(int track) const {
+	if (track < 0 || track >= numTrackLines || blockSets[track].sceneTrackId.empty())
+		return nullptr;
+	const auto line = std::find_if(m_cachedTrackPreview.lines.begin(),
+			m_cachedTrackPreview.lines.end(), [track](const TrackPreviewLine& candidate) {
+				return candidate.id == blockSets[track].sceneTrackId;
+			});
+	return line == m_cachedTrackPreview.lines.end() ? nullptr : &*line;
+}
+
 void MainWindow::renderTrackPreview(const SceneModel& sceneModel) {
 	m_previewFitBounds = QRectF();
 	m_previewHasSelectedTrack = false;
@@ -3338,7 +3330,8 @@ void MainWindow::renderTrackPreview(const SceneModel& sceneModel) {
 		}
 	}
 	m_previewHasSelectedTrack = !selectedTrackIds.empty();
-	const TrackPreviewResult preview = loadTrackPreview(sceneModel);
+	m_cachedTrackPreview = normalizeTrackPreview(loadTrackPreview(sceneModel));
+	const TrackPreviewResult& preview = m_cachedTrackPreview;
 	if (preview.lines.empty()) {
 		if (scene)
 			scene->setSceneRect(QRectF());
@@ -10166,7 +10159,7 @@ void MainWindow::runStationOverlayE2E() {
 		QApplication::processEvents();
 		const QRectF topologyBounds = networkView->topologyBounds();
 		const auto checkZoom = [&](qreal ratio, const char* label) {
-			networkView->fitToTopology();
+			fitView();
 			if (ratio > 1.0)
 				networkView->zoomBy(ratio);
 			updateViewportOverlays();
@@ -16973,11 +16966,50 @@ void MainWindow::setupGUI() {
 
 	// calculate screen coordinates and shifts for each station (graphical levels)
 	calculateStationCoordAndShift(geo_scale);
+	const bool hasSharedPreview = !m_cachedTrackPreview.lines.empty();
+	const auto sharedStationPoint = [this, hasSharedPreview](int stationIndex, QPointF& point) {
+		if (!hasSharedPreview || stationIndex < 0
+				|| stationIndex >= static_cast<int>(m_sceneModel.stations.size()))
+			return false;
+		const auto& source = m_sceneModel.stations[static_cast<std::size_t>(stationIndex)];
+		const auto station = std::find_if(m_cachedTrackPreview.stations.begin(),
+				m_cachedTrackPreview.stations.end(), [&source](const TrackPreviewStation& candidate) {
+					return (!source.id.empty() && candidate.id == source.id)
+						|| (source.id.empty() && candidate.name == source.name);
+				});
+		if (station == m_cachedTrackPreview.stations.end())
+			return false;
+		for (const auto& line : m_cachedTrackPreview.lines) {
+			if (!station->nodeId.empty()) {
+				if (previewPointAtNode(line, station->nodeId,
+						static_cast<qreal>(line.displayOffset), point))
+					return true;
+				continue;
+			}
+			if (line.points.empty())
+				continue;
+			const double minX = std::min(line.points.front().rawX, line.points.back().rawX);
+			const double maxX = std::max(line.points.front().rawX, line.points.back().rawX);
+			if (station->x < minX || station->x > maxX)
+				continue;
+			if (previewPointAtX(line, station->x,
+					static_cast<qreal>(line.displayOffset), point))
+				return true;
+		}
+		return false;
+	};
 
 	// draw station icons and print names
 	for (int i = 0; i < numStations; i++) {
 		// ignore virtual stations (name contains "virtual")
 		if (StationArray[i].stationName.find("virtual") != std::string::npos) {
+			continue;
+		}
+		QPointF sharedPoint;
+		if (sharedStationPoint(i, sharedPoint)) {
+			paintStationOverlay(sharedPoint,
+				classifyStation(StationArray[i].N_StationPlatforms > 0, 0),
+				StationArray[i].stationName, 0.75);
 			continue;
 		}
 
@@ -17107,6 +17139,9 @@ void MainWindow::setupGUI() {
 	int st_index;
 	QPointF ptc1, ptc2;
 	for (int c = 0; c < numConnections; c++) {
+		if (hasSharedPreview && (!cachedTrackLine(connections[c].idFirstTrackLine)
+				|| !cachedTrackLine(connections[c].idSecondTrackLine)))
+			continue;
 		// get shifted connections
 		egtrainPoint2Screen(&connections[c], connections[c].idFirstTrackLine, connections[c].idSecondTrackLine, track_separation);
 		ptc1.setX(connections[c].graphXFirstNode);
@@ -17119,6 +17154,8 @@ void MainWindow::setupGUI() {
 
 	// draw tracklines
 	for (int track = 0; track < numTrackLines; track++) {
+		if (hasSharedPreview && !cachedTrackLine(track))
+			continue;
 		// run over all arcs
 		for (int i = 0; i < blockSets[track].len; i++) {
 			// get shifted nodes
@@ -17184,6 +17221,8 @@ void MainWindow::setupGUI() {
 	for (int i = 0; i < Blocks; i++) {
 		// draw signal
 		if (signalling_block_sections[i].trackLineId != -1) { // compound signalling_block_sections are not drawn
+			if (hasSharedPreview && !cachedTrackLine(signalling_block_sections[i].trackLineId))
+				continue;
 
 			// -----------------------------------------------------------------------
 			// London Waterloo manual drawing
@@ -17208,7 +17247,8 @@ void MainWindow::setupGUI() {
 	buildSignalIndex();
 	buildTrackIndexes();
 
-	updateStationOverlayDegrees();
+	if (!hasSharedPreview)
+		updateStationOverlayDegrees();
 	updateViewportOverlays();
 
 	refreshFollowTrainChoices();
@@ -17985,7 +18025,11 @@ void MainWindow::runScene() {
 	statusBar()->showMessage("Preparing scene simulation...");
 	QApplication::processEvents();
 
+	const QRectF previewFitBounds = m_previewFitBounds;
+	const QPointF previewZoomFocus = m_previewZoomFocus;
 	teardownGUI();
+	m_previewFitBounds = previewFitBounds;
+	m_previewZoomFocus = previewZoomFocus;
 	QString outputPath = QString::fromStdString(initial_variables.OutputMainFolder);
 	if (outputPath.isEmpty() || QDir(outputPath).isRelative()) {
 		QString base = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
@@ -18424,9 +18468,9 @@ void MainWindow::paintConnection(QPointF start, QPointF end, int pen_width, Conn
 
 // draws trackside signals (X is the beginning of the block section - except for the last signal of each trackline)
 void MainWindow::paintSignal(double X, int size, int pen_width, int track, int track_separation, int sectionIndex) {
-	if (!hasTrackGeometry(track))
+	const TrackPreviewLine* previewLine = cachedTrackLine(track);
+	if (!previewLine && !hasTrackGeometry(track))
 		return;
-	int graphID = blockSets[track].graphID;
 
 	// positions
 	double postStartX, postStartY;
@@ -18442,20 +18486,31 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	egtrainPoint2Screen(X - 0.008, track, track_separation, postEndX, postEndY);
 
 	// place signal on trackside (with signal deltas)
-	// last segment
-	int stationIdx[2];
-	neighbourStations(X, track, stationIdx);
-	int index = stationIdx[1];
+	double signalDeltaX = 0.0;
+	double signalDeltaY = 0.0;
+	if (previewLine) {
+		QPointF normal;
+		if (!previewSignalNormal(*previewLine, X, normal))
+			return;
+		signalDeltaX = normal.x();
+		signalDeltaY = normal.y();
+	} else {
+		int stationIdx[2];
+		neighbourStations(X, track, stationIdx);
+		const int index = stationIdx[1];
+		signalDeltaX = StationArray[index].signalDeltaX[blockSets[track].region];
+		signalDeltaY = StationArray[index].signalDeltaY[blockSets[track].region];
+	}
 
-	basisStartX -= StationArray[index].signalDeltaX[blockSets[track].region] * 0.10 * track_separation;
-	basisStartY -= StationArray[index].signalDeltaY[blockSets[track].region] * 0.10 * track_separation;
-	basisEndX = basisStartX - StationArray[index].signalDeltaX[blockSets[track].region] * 0.20 * track_separation;
-	basisEndY = basisStartY - StationArray[index].signalDeltaY[blockSets[track].region] * 0.20 * track_separation;
+	basisStartX -= signalDeltaX * 0.10 * track_separation;
+	basisStartY -= signalDeltaY * 0.10 * track_separation;
+	basisEndX = basisStartX - signalDeltaX * 0.20 * track_separation;
+	basisEndY = basisStartY - signalDeltaY * 0.20 * track_separation;
 
-	postStartX -= StationArray[index].signalDeltaX[blockSets[track].region] * 0.20 * track_separation;
-	postStartY -= StationArray[index].signalDeltaY[blockSets[track].region] * 0.20 * track_separation;
-	postEndX -= StationArray[index].signalDeltaX[blockSets[track].region] * 0.20 * track_separation;
-	postEndY -= StationArray[index].signalDeltaY[blockSets[track].region] * 0.20 * track_separation;
+	postStartX -= signalDeltaX * 0.20 * track_separation;
+	postStartY -= signalDeltaY * 0.20 * track_separation;
+	postEndX -= signalDeltaX * 0.20 * track_separation;
+	postEndY -= signalDeltaY * 0.20 * track_separation;
 
 	// post/basis
 	QPen penPost = QPen(Qt::white);
@@ -18512,17 +18567,17 @@ void MainWindow::paintSignal(double X, int size, int pen_width, int track, int t
 	basis1->setPen(penPost);
 
 	// basis #2
-	basisStartX += 2 * StationArray[index].signalDeltaX[blockSets[track].region] * 0.10 * track_separation;
-	basisStartY += 2 * StationArray[index].signalDeltaY[blockSets[track].region] * 0.10 * track_separation;
-	basisEndX = basisStartX + StationArray[index].signalDeltaX[blockSets[track].region] * 0.20 * track_separation;
-	basisEndY = basisStartY + StationArray[index].signalDeltaY[blockSets[track].region] * 0.20 * track_separation;
+	basisStartX += 2 * signalDeltaX * 0.10 * track_separation;
+	basisStartY += 2 * signalDeltaY * 0.10 * track_separation;
+	basisEndX = basisStartX + signalDeltaX * 0.20 * track_separation;
+	basisEndY = basisStartY + signalDeltaY * 0.20 * track_separation;
 
 	// post #2
 	egtrainPoint2Screen(X + 0.008, track, track_separation, postEndX, postEndY);
-	postStartX += 2 * StationArray[index].signalDeltaX[blockSets[track].region] * 0.20 * track_separation;
-	postStartY += 2 * StationArray[index].signalDeltaY[blockSets[track].region] * 0.20 * track_separation;
-	postEndX += StationArray[index].signalDeltaX[blockSets[track].region] * 0.20 * track_separation;
-	postEndY += StationArray[index].signalDeltaY[blockSets[track].region] * 0.20 * track_separation;
+	postStartX += 2 * signalDeltaX * 0.20 * track_separation;
+	postStartY += 2 * signalDeltaY * 0.20 * track_separation;
+	postEndX += signalDeltaX * 0.20 * track_separation;
+	postEndY += signalDeltaY * 0.20 * track_separation;
 
 	QGraphicsLineItem* post2 = new QGraphicsLineItem(QLineF(postStartX, postStartY, postEndX, postEndY));
 	post2->setPen(penPost);
@@ -18616,6 +18671,10 @@ void MainWindow::paintTrain(const GuiTrainState& train, int size, int pen_width)
 		// add item to list
 		trainPolygonItemList->push_back(trainItem);
 	}
+	const bool hasVisibleGeometry = std::any_of(trainPolygonItemList->cbegin(),
+			trainPolygonItemList->cend(), [](const TrainBodyItem* item) {
+				return item && !item->polygon().isEmpty();
+			});
 
 	// add train pointer and index to the item
 	trainPolygonGroup->index = train.index;
@@ -18631,7 +18690,7 @@ void MainWindow::paintTrain(const GuiTrainState& train, int size, int pen_width)
 
 	// add train to scene
 	scene->addItem(trainPolygonGroup);
-	trainPolygonGroup->setVisible(m_trainLayerVisible && !train.outOfSimulation);
+	trainPolygonGroup->setVisible(m_trainLayerVisible && !train.outOfSimulation && hasVisibleGeometry);
 
 	// add train to allTrains list
 	allTrains.push_back(trainPolygonGroup);
@@ -18645,7 +18704,7 @@ void MainWindow::paintTrain(const GuiTrainState& train, int size, int pen_width)
 	badge->setCompact(!networkView || networkView->zoomRatio() < kDenseDetailZoom);
 	badge->setAcceptedMouseButtons(Qt::NoButton);
 	scene->addItem(badge);
-	badge->setVisible(m_trainLayerVisible && !train.outOfSimulation);
+	badge->setVisible(m_trainLayerVisible && !train.outOfSimulation && hasVisibleGeometry);
 	badge->setPos(trainPolygonGroup->sceneBoundingRect().center() + QPointF(8.0, -24.0));
 	m_trainBadges[train.index] = badge;
 }
@@ -19538,6 +19597,14 @@ void MainWindow::neighbourStations(double X, int tracklineID, int* stationIdx) {
 
 // get shifted screen coordinates of a point (given 1D X coordinate)
 void MainWindow::egtrainPoint2Screen(double X, int track, double separation, double& graphX, double& graphY) {
+	if (const auto* line = cachedTrackLine(track)) {
+		TrackPreviewPoint point;
+		if (trackPreviewPointAtX(*line, X, point)) {
+			graphX = point.x;
+			graphY = point.y + line->displayOffset;
+			return;
+		}
+	}
 	if (!hasTrackGeometry(track)) {
 		graphX = X * 1000.0;
 		graphY = static_cast<double>(blockSets[track].graphID) * separation;
@@ -19564,6 +19631,16 @@ void MainWindow::egtrainPoint2Screen(double X, int track, double separation, dou
 
 // get shifted screen coordinates of a Node
 void MainWindow::egtrainPoint2Screen(Node* Node, int track, double separation) {
+	if (const auto* line = cachedTrackLine(track)) {
+		TrackPreviewPoint point;
+		if ((!Node->sceneNodeId.empty()
+				&& trackPreviewPointAtNode(*line, Node->sceneNodeId, point))
+				|| trackPreviewPointAtX(*line, Node->X, point)) {
+			Node->graphX = point.x;
+			Node->graphY = point.y + line->displayOffset;
+			return;
+		}
+	}
 	if (!hasTrackGeometry(track)) {
 		Node->graphX = Node->X * 1000.0;
 		Node->graphY = Node->Y * 1000.0 + static_cast<double>(blockSets[track].graphID) * separation;
@@ -19588,6 +19665,25 @@ void MainWindow::egtrainPoint2Screen(Node* Node, int track, double separation) {
 
 // get shifted screen coordinates of a Node
 void MainWindow::egtrainPoint2Screen(Connections* connections, int track1, int track2, double separation) {
+	if (const auto* firstLine = cachedTrackLine(track1)) {
+		if (const auto* secondLine = cachedTrackLine(track2)) {
+			TrackPreviewPoint first;
+			TrackPreviewPoint second;
+			const bool hasFirst = (!connections->sceneFirstNodeId.empty()
+					&& trackPreviewPointAtNode(*firstLine, connections->sceneFirstNodeId, first))
+				|| trackPreviewPointAtX(*firstLine, connections->xFirstNode, first);
+			const bool hasSecond = (!connections->sceneSecondNodeId.empty()
+					&& trackPreviewPointAtNode(*secondLine, connections->sceneSecondNodeId, second))
+				|| trackPreviewPointAtX(*secondLine, connections->xSecondNode, second);
+			if (hasFirst && hasSecond) {
+				connections->graphXFirstNode = first.x;
+				connections->graphYFirstNode = first.y + firstLine->displayOffset;
+				connections->graphXSecondNode = second.x;
+				connections->graphYSecondNode = second.y + secondLine->displayOffset;
+				return;
+			}
+		}
+	}
 	if (!hasTrackGeometry(track1) || !hasTrackGeometry(track2)) {
 		connections->graphXFirstNode = connections->xFirstNode * 1000.0;
 		connections->graphYFirstNode = static_cast<double>(blockSets[track1].graphID) * separation;
@@ -19890,7 +19986,9 @@ void MainWindow::updateTrainPosition(int t) {
 				else
 					oldCenter = trainItem->sceneBoundingRect().center();
 
-				getTrainPolygonItemList(trainItem->trainPolygonItemList, state);
+				const bool hasVisibleGeometry = getTrainPolygonItemList(
+					trainItem->trainPolygonItemList, state);
+				trainItem->setVisible(m_trainLayerVisible && hasVisibleGeometry);
 				checkVCouplingMsg(trainItem, state, t);
 
 				// animate smooth transition from old position to new position
@@ -19903,7 +20001,7 @@ void MainWindow::updateTrainPosition(int t) {
 					badge->setSpeedVisible(m_trainSpeedLabelsVisible);
 					badge->setTrainVisual(classifyTrainType(state.type, state.description));
 					badge->setReversed(state.reversedDirection);
-					badge->setVisible(m_trainLayerVisible);
+					badge->setVisible(m_trainLayerVisible && hasVisibleGeometry);
 				}
 				m_prevTrainPositions[train] = newCenter;
 				QPointF delta = oldCenter - newCenter;
@@ -19937,7 +20035,8 @@ void MainWindow::updateTrainPosition(int t) {
 					if (badge)
 						badge->setPos(badgeBase);
 				}
-				if (m_followAction && m_followAction->isChecked() && m_followTrainIndex == train)
+				if (hasVisibleGeometry && m_followAction && m_followAction->isChecked()
+						&& m_followTrainIndex == train)
 					networkView->centerOn(newCenter);
 			}
 			// hide train whose simulation is finished
@@ -19957,9 +20056,10 @@ void MainWindow::updateTrainPosition(int t) {
 			const bool firstTrain = allTrains.isEmpty();
 			paintTrain(state, node_size, line_width);
 			legendNeedsUpdate = true;
-			if (firstTrain && !allTrains.isEmpty())
+			if (firstTrain && !allTrains.isEmpty() && allTrains.last()->isVisible())
 				networkView->centerOn(allTrains.last()->sceneBoundingRect().center());
-			if (m_followAction && m_followAction->isChecked() && m_followTrainIndex == train && !allTrains.isEmpty())
+			if (m_followAction && m_followAction->isChecked() && m_followTrainIndex == train
+					&& !allTrains.isEmpty() && allTrains.last()->isVisible())
 				networkView->centerOn(allTrains.last());
 		}
 	}
@@ -19972,17 +20072,20 @@ void MainWindow::updateTrainPosition(int t) {
 }
 
 // returns the full train shape (list of polygons)
-void MainWindow::getTrainPolygonItemList(QList<TrainBodyItem*>* trainPolygonItemList, const GuiTrainState& train) {
+bool MainWindow::getTrainPolygonItemList(QList<TrainBodyItem*>* trainPolygonItemList, const GuiTrainState& train) {
 	if (!trainPolygonItemList)
-		return;
+		return false;
+	bool hasVisibleGeometry = false;
 	// get the polygon of each wagon
 	for (int wagon = 0; wagon <= train.wagonCount; wagon++) {
 		if (wagon >= trainPolygonItemList->size())
-			return;
+			return hasVisibleGeometry;
 		QPolygonF trainPolygon;
 		getTrainPolygon(&trainPolygon, wagon, train);
 		trainPolygonItemList->at(wagon)->setPolygon(trainPolygon);
+		hasVisibleGeometry = hasVisibleGeometry || !trainPolygon.isEmpty();
 	}
+	return hasVisibleGeometry;
 }
 
 // returns the shape of an one-wagon train (polygon)
@@ -20069,7 +20172,8 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 
 				// get station index to extract shifts
 				int stationIdx[2];
-				if (!hasTrackGeometry(currBS->trackLineId)) {
+				if ((!m_cachedTrackPreview.lines.empty() && !cachedTrackLine(currBS->trackLineId))
+						|| !hasTrackGeometry(currBS->trackLineId)) {
 					continue;
 				}
 				neighbourStations(posX[j], currBS->trackLineId, stationIdx);
@@ -20112,7 +20216,9 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 					}
 					if (!BS1 || !BS2)
 						continue;
-					if (!hasTrackGeometry(BS1->trackLineId) || !hasTrackGeometry(BS2->trackLineId))
+					if ((!m_cachedTrackPreview.lines.empty()
+							&& (!cachedTrackLine(BS1->trackLineId) || !cachedTrackLine(BS2->trackLineId)))
+							|| !hasTrackGeometry(BS1->trackLineId) || !hasTrackGeometry(BS2->trackLineId))
 						continue;
 
 					// get beginning and end of connection to interpolate

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -20096,7 +20096,6 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 	double headX, tailX, connectionX1, connectionX2, x0, x1, x2, x3, y0, y1, y2, y3;
 	double dot, det, beta, alpha, gamma;
 	std::vector<double> posX, routeX;
-	int prevIndex, index, revPrevIndex;
 	QPointF ptTrainEdge, ptConnection1, ptConnection2, ptBegin1, ptEnd2;
 	std::string ID1, ID2, connection1, connection2;
 	const Section* currBS = nullptr;
@@ -20106,6 +20105,39 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 	QVector<int> trainPointsStIndex, trainPointsStRegion, trainPointsGraphID;
 	int revStIndex;												  // used to add station points to the polygon (needed for reversed routes)
 	double total_nW = train.wagonCount + 1;
+	const auto addPreviewPoint = [&](const TrackPreviewLine* line, double rawX,
+			const QPointF& point) {
+		QPointF normal;
+		if (!line || !previewSignalNormal(*line, rawX, normal))
+			return false;
+		const QPointF offset = normal * (0.10 * track_separation);
+		trainPointsUp.push_back(point - offset);
+		trainPointsDown.push_front(point + offset);
+		trainPointsStIndex.push_back(-1);
+		trainPointsStRegion.push_back(-1);
+		trainPointsGraphID.push_back(INT_MIN);
+		return true;
+	};
+	const auto addTrackPoint = [&](const QPointF& point, int track, double rawX) {
+		if (const auto* line = cachedTrackLine(track))
+			return addPreviewPoint(line, rawX, point);
+		int stationIdx[2];
+		neighbourStations(rawX, track, stationIdx);
+		const int prevIndex = stationIdx[0];
+		const int index = stationIdx[1];
+		const int revPrevIndex = index * (1 - revStIndex) + prevIndex * revStIndex;
+		const int region = blockSets[track].region;
+		trainPointsUp.push_back(QPointF(point.x()
+				- StationArray[index].signalDeltaX[region] * 0.10 * track_separation,
+				point.y() - StationArray[index].signalDeltaY[region] * 0.10 * track_separation));
+		trainPointsDown.push_front(QPointF(point.x()
+				+ StationArray[index].signalDeltaX[region] * 0.10 * track_separation,
+				point.y() + StationArray[index].signalDeltaY[region] * 0.10 * track_separation));
+		trainPointsStIndex.push_back(revPrevIndex);
+		trainPointsStRegion.push_back(region);
+		trainPointsGraphID.push_back(blockSets[track].graphID);
+		return true;
+	};
 
 	// train position on X axis
 	// reversed route
@@ -20170,26 +20202,16 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 					continue;
 				} // single section in between (no relevant points)
 
-				// get station index to extract shifts
-				int stationIdx[2];
-				if ((!m_cachedTrackPreview.lines.empty() && !cachedTrackLine(currBS->trackLineId))
-						|| !hasTrackGeometry(currBS->trackLineId)) {
+				const TrackPreviewLine* previewLine = cachedTrackLine(currBS->trackLineId);
+				if ((!m_cachedTrackPreview.lines.empty() && !previewLine)
+						|| (!previewLine && !hasTrackGeometry(currBS->trackLineId))) {
 					continue;
 				}
-				neighbourStations(posX[j], currBS->trackLineId, stationIdx);
-				prevIndex = stationIdx[0];
-				index = stationIdx[1];
-				revPrevIndex = index * (1 - revStIndex) + prevIndex * revStIndex; // if reversed route, gives previous station
 
 				// get point
 				egtrainPoint2Screen(posX[j], currBS->trackLineId, track_separation, ptTrainEdge.rx(), ptTrainEdge.ry());
-
-				// add points to vectors
-				trainPointsUp.push_back(QPointF(ptTrainEdge.x() - StationArray[index].signalDeltaX[blockSets[currBS->trackLineId].region] * 0.10 * track_separation, ptTrainEdge.y() - StationArray[index].signalDeltaY[blockSets[currBS->trackLineId].region] * 0.10 * track_separation));
-				trainPointsDown.push_front(QPointF(ptTrainEdge.x() + StationArray[index].signalDeltaX[blockSets[currBS->trackLineId].region] * 0.10 * track_separation, ptTrainEdge.y() + StationArray[index].signalDeltaY[blockSets[currBS->trackLineId].region] * 0.10 * track_separation));
-				trainPointsStIndex.push_back(revPrevIndex);
-				trainPointsStRegion.push_back(blockSets[currBS->trackLineId].region);
-				trainPointsGraphID.push_back(blockSets[currBS->trackLineId].graphID);
+				if (!addTrackPoint(ptTrainEdge, currBS->trackLineId, posX[j]))
+					return;
 			}
 			// compound signalling_block_sections -> get connection points and/or tail or head
 			else {
@@ -20216,9 +20238,12 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 					}
 					if (!BS1 || !BS2)
 						continue;
-					if ((!m_cachedTrackPreview.lines.empty()
-							&& (!cachedTrackLine(BS1->trackLineId) || !cachedTrackLine(BS2->trackLineId)))
-							|| !hasTrackGeometry(BS1->trackLineId) || !hasTrackGeometry(BS2->trackLineId))
+					const TrackPreviewLine* previewLine1 = cachedTrackLine(BS1->trackLineId);
+					const TrackPreviewLine* previewLine2 = cachedTrackLine(BS2->trackLineId);
+					const bool hasPreview = !m_cachedTrackPreview.lines.empty();
+					if ((hasPreview && (!previewLine1 || !previewLine2))
+							|| (!hasPreview && (!hasTrackGeometry(BS1->trackLineId)
+									|| !hasTrackGeometry(BS2->trackLineId))))
 						continue;
 
 					// get beginning and end of connection to interpolate
@@ -20229,16 +20254,16 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 					egtrainPoint2Screen(BS1->start_node.X, BS1->trackLineId, track_separation, ptBegin1.rx(), ptBegin1.ry());
 					egtrainPoint2Screen(BS2->end_node.X, BS2->trackLineId, track_separation, ptEnd2.rx(), ptEnd2.ry());
 
-					// get station indexes (used to add station points)
-					int stationIdx[2];
-					neighbourStations(connectionX1, BS1->trackLineId, stationIdx);
-					int prevIndexConnection1 = stationIdx[0];
-					int indexConnection1 = stationIdx[1];
-					int revPrevIndexConnection1 = indexConnection1 * (1 - revStIndex) + prevIndexConnection1 * revStIndex; // if reversed route, gives previous sation
-					neighbourStations(connectionX2, BS2->trackLineId, stationIdx);
-					int prevIndexConnection2 = stationIdx[0];
-					int indexConnection2 = stationIdx[1];
-					int revPrevIndexConnection2 = indexConnection2 * (1 - revStIndex) + prevIndexConnection2 * revStIndex; // if reversed route, gives previous sation
+					int revPrevIndexConnection1 = -1;
+					int revPrevIndexConnection2 = -1;
+					if (!hasPreview) {
+						// get station indexes (used to add station points)
+						int stationIdx[2];
+						neighbourStations(connectionX1, BS1->trackLineId, stationIdx);
+						revPrevIndexConnection1 = stationIdx[1] * (1 - revStIndex) + stationIdx[0] * revStIndex;
+						neighbourStations(connectionX2, BS2->trackLineId, stationIdx);
+						revPrevIndexConnection2 = stationIdx[1] * (1 - revStIndex) + stationIdx[0] * revStIndex;
+					}
 
 					// linear interpolation of geodetic coordinates using known coordinates of closest stations
 					x0 = ptBegin1.x();
@@ -20273,6 +20298,17 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 					gamma = alpha / 2 - beta;
 					double connectionEndShiftX = cos(gamma);
 					double connectionEndShiftY = sin(gamma);
+					if (hasPreview) {
+						QPointF normal;
+						if (!previewSignalNormal(*previewLine1, connectionX1, normal))
+							return;
+						connectionStartShiftX = normal.x();
+						connectionStartShiftY = normal.y();
+						if (!previewSignalNormal(*previewLine2, connectionX2, normal))
+							return;
+						connectionEndShiftX = normal.x();
+						connectionEndShiftY = normal.y();
+					}
 
 					// calculate connection deltas (inside connection)
 					beta = atan2(-(y1 - y2), (x1 - x2));
@@ -20320,19 +20356,9 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 
 					// head/tail in the 1st track and before connection
 					if (routeX[j] >= currBS->start_node.X && posX[j] <= connectionX1) {
-						// get station index to extract shifts
-						int stationIdx[2];
-						neighbourStations(posX[j], BS1->trackLineId, stationIdx);
-						prevIndex = stationIdx[0];
-						index = stationIdx[1];
-						revPrevIndex = index * (1 - revStIndex) + prevIndex * revStIndex; // if reversed route, gives previous station
-
 						egtrainPoint2Screen(posX[j], BS1->trackLineId, track_separation, ptTrainEdge.rx(), ptTrainEdge.ry());
-						trainPointsUp.push_back(QPointF(ptTrainEdge.x() - StationArray[index].signalDeltaX[blockSets[BS1->trackLineId].region] * 0.10 * track_separation, ptTrainEdge.y() - StationArray[index].signalDeltaY[blockSets[BS1->trackLineId].region] * 0.10 * track_separation));
-						trainPointsDown.push_front(QPointF(ptTrainEdge.x() + StationArray[index].signalDeltaX[blockSets[BS1->trackLineId].region] * 0.10 * track_separation, ptTrainEdge.y() + StationArray[index].signalDeltaY[blockSets[BS1->trackLineId].region] * 0.10 * track_separation));
-						trainPointsStIndex.push_back(revPrevIndex);
-						trainPointsStRegion.push_back(blockSets[BS1->trackLineId].region);
-						trainPointsGraphID.push_back(blockSets[BS1->trackLineId].graphID);
+						if (!addTrackPoint(ptTrainEdge, BS1->trackLineId, posX[j]))
+							return;
 					}
 					// head/tail inside the connection
 					else if (posX[j] > connectionX1 && posX[j] < connectionX2) {
@@ -20348,19 +20374,9 @@ void MainWindow::getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTr
 					}
 					// head/tail in the 2nd track and after connection
 					else if (posX[j] >= connectionX2 && routeX[j] < currBS->end_node.X) {
-						// get station index to extract shifts
-						int stationIdx[2];
-						neighbourStations(posX[j], BS2->trackLineId, stationIdx);
-						prevIndex = stationIdx[0];
-						index = stationIdx[1];
-						revPrevIndex = index * (1 - revStIndex) + prevIndex * revStIndex; // if reversed route, gives previous station
-
 						egtrainPoint2Screen(posX[j], BS2->trackLineId, track_separation, ptTrainEdge.rx(), ptTrainEdge.ry());
-						trainPointsUp.push_back(QPointF(ptTrainEdge.x() - StationArray[index].signalDeltaX[blockSets[BS2->trackLineId].region] * 0.10 * track_separation, ptTrainEdge.y() - StationArray[index].signalDeltaY[blockSets[BS2->trackLineId].region] * 0.10 * track_separation));
-						trainPointsDown.push_front(QPointF(ptTrainEdge.x() + StationArray[index].signalDeltaX[blockSets[BS2->trackLineId].region] * 0.10 * track_separation, ptTrainEdge.y() + StationArray[index].signalDeltaY[blockSets[BS2->trackLineId].region] * 0.10 * track_separation));
-						trainPointsStIndex.push_back(revPrevIndex);
-						trainPointsStRegion.push_back(blockSets[BS2->trackLineId].region);
-						trainPointsGraphID.push_back(blockSets[BS2->trackLineId].graphID);
+						if (!addTrackPoint(ptTrainEdge, BS2->trackLineId, posX[j]))
+							return;
 					}
 
 					// add connection points if it is head section and tail is in another signalling_block_sections

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -88,6 +88,7 @@
 
 #include "scene/SceneDiagnostic.h"
 #include "scene/SceneValidator.h"
+#include "scene/TrackPreview.h"
 
 // charts
 #include <QtCharts/QChartView>
@@ -212,7 +213,7 @@ public:
 	void updateSignalAspect(const std::string& ID, double code, bool reversed);
 
 	// get train polygon (list)
-	void getTrainPolygonItemList(QList<TrainBodyItem*>* trainPolygonItemList, const GuiTrainState& train);
+	bool getTrainPolygonItemList(QList<TrainBodyItem*>* trainPolygonItemList, const GuiTrainState& train);
 	void getTrainPolygon(QPolygonF* trainPolygon, int wagon, const GuiTrainState& train);
 
 	// train path diagram
@@ -390,6 +391,7 @@ private:
 	QString m_sceneDir;
 	std::string m_savedSceneSha256;
 	SceneModel m_sceneModel;
+	TrackPreviewResult m_cachedTrackPreview;
 	bool m_sceneLoaded = false;
 	bool m_sceneIsBundle = false;
 	bool m_sceneDirty = false;
@@ -607,6 +609,7 @@ private:
 	void addRecentScene(const QString& path);
 	void rebuildRecentScenesMenu();
 	bool maybeSaveScene();
+	const TrackPreviewLine* cachedTrackLine(int track) const;
 	void renderTrackPreview(const SceneModel& sceneModel);
 	bool finishSceneSave(const SceneSaveResult& result);
 	bool saveSceneToCurrentDir();

--- a/EGTRAIN/QEGTRAIN/scene/TrackPreview.cpp
+++ b/EGTRAIN/QEGTRAIN/scene/TrackPreview.cpp
@@ -306,9 +306,9 @@ TrackPreviewResult loadTrackPreview(const SceneModel& scene) {
 			}
 		}
 		if (anchor != nullptr)
-			result.stations.push_back({name, anchor->id, anchor->xKm, true});
+			result.stations.push_back({name, anchor->id, anchor->xKm, true, station.id});
 		else if (station.hasPosition && std::isfinite(station.positionKm)) {
-			result.stations.push_back({name, {}, station.positionKm, false});
+			result.stations.push_back({name, {}, station.positionKm, false, station.id});
 		}
 	}
 
@@ -344,4 +344,84 @@ TrackPreviewResult loadTrackPreview(const SceneModel& scene) {
 	if (result.lines.empty())
 		result.warnings.push_back("no valid scene track preview is available");
 	return result;
+}
+
+bool trackPreviewPointAtNode(const TrackPreviewLine& line, const std::string& nodeId,
+		TrackPreviewPoint& point) {
+	for (const auto& candidate : line.points) {
+		if (candidate.nodeId == nodeId) {
+			point = candidate;
+			return true;
+		}
+	}
+	return false;
+}
+
+bool trackPreviewPointAtX(const TrackPreviewLine& line, double rawX,
+		TrackPreviewPoint& point) {
+	if (line.points.empty() || !std::isfinite(rawX))
+		return false;
+
+	for (std::size_t index = 1; index < line.points.size(); ++index) {
+		const auto& first = line.points[index - 1];
+		const auto& second = line.points[index];
+		if (rawX < std::min(first.rawX, second.rawX)
+				|| rawX > std::max(first.rawX, second.rawX))
+			continue;
+		const double span = second.rawX - first.rawX;
+		const double ratio = span == 0.0 ? 0.0 : (rawX - first.rawX) / span;
+		point = first;
+		point.nodeId.clear();
+		point.rawX = rawX;
+		point.x = first.x + ratio * (second.x - first.x);
+		point.y = first.y + ratio * (second.y - first.y);
+		return std::isfinite(point.x) && std::isfinite(point.y);
+	}
+
+	const auto closest = std::min_element(line.points.begin(), line.points.end(),
+			[rawX](const auto& left, const auto& right) {
+				return std::abs(left.rawX - rawX) < std::abs(right.rawX - rawX);
+			});
+	point = *closest;
+	return std::isfinite(point.x) && std::isfinite(point.y);
+}
+
+TrackPreviewResult normalizeTrackPreview(const TrackPreviewResult& preview) {
+	TrackPreviewResult normalized = preview;
+	double rawChainageSpan = 0.0;
+	double minX = std::numeric_limits<double>::infinity();
+	double maxX = -std::numeric_limits<double>::infinity();
+	double minY = std::numeric_limits<double>::infinity();
+	double maxY = -std::numeric_limits<double>::infinity();
+	for (const auto& line : preview.lines) {
+		double lineMinRawX = std::numeric_limits<double>::infinity();
+		double lineMaxRawX = -std::numeric_limits<double>::infinity();
+		for (const auto& point : line.points) {
+			if (!std::isfinite(point.rawX) || !std::isfinite(point.x)
+					|| !std::isfinite(point.y))
+				continue;
+			lineMinRawX = std::min(lineMinRawX, point.rawX);
+			lineMaxRawX = std::max(lineMaxRawX, point.rawX);
+			minX = std::min(minX, point.x);
+			maxX = std::max(maxX, point.x);
+			minY = std::min(minY, point.y + line.displayOffset);
+			maxY = std::max(maxY, point.y + line.displayOffset);
+		}
+		if (std::isfinite(lineMinRawX) && std::isfinite(lineMaxRawX))
+			rawChainageSpan = std::max(rawChainageSpan, lineMaxRawX - lineMinRawX);
+	}
+	const double projectedSpan = std::max(maxX - minX, maxY - minY);
+	const double scale = rawChainageSpan > 0.0 && projectedSpan > 0.0
+		? rawChainageSpan * 1000.0 / projectedSpan
+		: 1000.0;
+	if (!std::isfinite(scale) || scale <= 0.0)
+		return normalized;
+	for (auto& line : normalized.lines) {
+		line.displayOffset *= scale;
+		for (auto& point : line.points) {
+			point.x *= scale;
+			point.y *= scale;
+		}
+	}
+	return normalized;
 }

--- a/EGTRAIN/QEGTRAIN/scene/TrackPreview.h
+++ b/EGTRAIN/QEGTRAIN/scene/TrackPreview.h
@@ -29,6 +29,7 @@ struct TrackPreviewStation {
 	std::string nodeId;
 	double x = 0.0;
 	bool hasPlatform = false;
+	std::string id;
 };
 
 struct TrackPreviewSignal {
@@ -49,5 +50,13 @@ struct TrackPreviewResult {
 struct SceneModel;
 
 TrackPreviewResult loadTrackPreview(const SceneModel& scene);
+
+// These helpers operate on projected scene coordinates only; rawX remains the
+// canonical chainage used to interpolate runtime positions.
+bool trackPreviewPointAtNode(const TrackPreviewLine& line, const std::string& nodeId,
+		TrackPreviewPoint& point);
+bool trackPreviewPointAtX(const TrackPreviewLine& line, double rawX,
+		TrackPreviewPoint& point);
+TrackPreviewResult normalizeTrackPreview(const TrackPreviewResult& preview);
 
 #endif

--- a/EGTRAIN/QEGTRAIN/simulation/Infrastructure.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Infrastructure.cpp
@@ -34,6 +34,7 @@ InfraElement::InfraElement() {
 
 // Node Default Values
 Node::Node() {
+	sceneNodeId.clear();
 	X = Y = dwellTime = 0;
 	ID = 0;
 	isSignalled = virtualCouplingNode = false;
@@ -92,6 +93,7 @@ void Arc::arcLength() {
 
 BlockSet::BlockSet() {
 	ID = len = arcs = numNodes = 0;
+	sceneTrackId.clear();
 	region = 0;
 	graphID = -1;
 	hasGraphLayout = false;
@@ -104,6 +106,8 @@ BlockSet blockSets[268];
 int numConnections = 0;
 
 Connections::Connections() {
+	sceneFirstNodeId.clear();
+	sceneSecondNodeId.clear();
 	idFirstTrackLine = idSecondTrackLine = 0;
 	xFirstNode = xSecondNode = 0;
 	speedlimit = 16.667; // by default the speedlimit on a switch is set to 16.667 m /s; i.e. 60 km/h

--- a/EGTRAIN/QEGTRAIN/simulation/Infrastructure.h
+++ b/EGTRAIN/QEGTRAIN/simulation/Infrastructure.h
@@ -76,6 +76,7 @@ public:
 
 class Node {
 public:
+	string sceneNodeId; // Canonical scene node identity, when built from a SceneModel.
 	double ID;
 	double X, Y;
 	bool isSignalled;
@@ -102,6 +103,7 @@ public:
 	Node();
 
 	Node& operator=(const Node& ob2) {
+		sceneNodeId = ob2.sceneNodeId;
 		ID = ob2.ID;
 		X = ob2.X;
 		Y = ob2.Y;
@@ -192,6 +194,7 @@ public:
 class BlockSet {
 public:
 	int ID;
+	string sceneTrackId;              // Canonical scene track identity, when built from a SceneModel.
 	int len;
 	int arcs, numNodes;              // Number of arcs and nodes in this track line
 	Arc A[1500];                     // Runtime arcs populated from the scene model
@@ -214,6 +217,7 @@ extern int numConnections;
 class Connections {
 public:
 	string ID;
+	string sceneFirstNodeId, sceneSecondNodeId;
 	int idFirstTrackLine, idSecondTrackLine;
 	double xFirstNode, xSecondNode;
 	double speedlimit; // Speed limit in m/s (default 16.67 m/s)

--- a/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
+++ b/EGTRAIN/QEGTRAIN/simulation/Signalling.cpp
@@ -2804,6 +2804,7 @@ std::vector<SceneDiagnostic> buildInfrastructureAndSignallingFromScene(const Sce
 		NativeTrack& track = nativeTracks[slot];
 		BlockSet& runtimeTrack = blockSets[slot];
 		runtimeTrack.ID = static_cast<int>(slot);
+		runtimeTrack.sceneTrackId = track.id;
 		runtimeTrack.numNodes = static_cast<int>(track.chainNodes.size());
 		runtimeTrack.arcs = static_cast<int>(track.chainArcs.size());
 		runtimeTrack.len = static_cast<int>(track.chainArcs.size());
@@ -2816,6 +2817,7 @@ std::vector<SceneDiagnostic> buildInfrastructureAndSignallingFromScene(const Sce
 		}
 		for (std::size_t index = 0; index < track.chainNodes.size(); ++index) {
 			Node node;
+			node.sceneNodeId = track.chainNodes[index]->id;
 			node.ID = static_cast<double>(slot * 1000000 + index + 1);
 			node.X = track.chainNodes[index]->xKm;
 			node.Y = track.chainNodes[index]->yKm;
@@ -2874,6 +2876,8 @@ std::vector<SceneDiagnostic> buildInfrastructureAndSignallingFromScene(const Sce
 		const bool fromFirst = fromNode.X <= toNode.X;
 		connection.idFirstTrackLine = fromFirst ? firstSlot : secondSlot;
 		connection.idSecondTrackLine = fromFirst ? secondSlot : firstSlot;
+		connection.sceneFirstNodeId = fromFirst ? source.fromNodeId : source.toNodeId;
+		connection.sceneSecondNodeId = fromFirst ? source.toNodeId : source.fromNodeId;
 		connection.xFirstNode = fromFirst ? fromNode.X : toNode.X;
 		connection.xSecondNode = fromFirst ? toNode.X : fromNode.X;
 		connection.speedlimit = source.hasSpeedLimit ? source.speedLimitMs : 16.667;

--- a/EGTRAIN/QEGTRAIN/tests/test_trackpreview.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_trackpreview.cpp
@@ -54,6 +54,37 @@ int main() {
 
 	const TrackPreviewResult result = loadTrackPreview(scene);
 	bool ok = true;
+	const TrackPreviewResult normalized = normalizeTrackPreview(result);
+	ok &= expect(normalized.lines.size() == result.lines.size(),
+			"normalization retains every projected line");
+	if (normalized.lines.size() == result.lines.size()) {
+		const auto& sourcePoint = result.lines[0].points[1];
+		const auto& normalizedPoint = normalized.lines[0].points[1];
+		ok &= expect(sourcePoint.rawX == normalizedPoint.rawX,
+				"normalization preserves raw chainage");
+		const double scaleX = (normalized.lines[0].points[2].x - normalized.lines[0].points[0].x)
+			/ (result.lines[0].points[2].x - result.lines[0].points[0].x);
+		const double scaleY = (normalized.lines[0].points[2].y - normalized.lines[0].points[0].y)
+			/ (result.lines[0].points[2].y - result.lines[0].points[0].y);
+		ok &= expect(std::fabs(scaleX - scaleY) < 1e-9 && scaleX > 1000.0,
+				"normalization applies one stable uniform projected scale");
+		TrackPreviewPoint nodePoint;
+		ok &= expect(trackPreviewPointAtNode(normalized.lines[0], "B0.Gdg", nodePoint)
+				&& std::fabs(nodePoint.x - normalized.lines[0].points[1].x) < 1e-9
+				&& std::fabs(nodePoint.y - normalized.lines[0].points[1].y) < 1e-9,
+				"point lookup resolves normalized node anchors");
+		TrackPreviewLine duplicateChainage = normalized.lines[0];
+		duplicateChainage.points[2].rawX = duplicateChainage.points[1].rawX;
+		ok &= expect(trackPreviewPointAtNode(duplicateChainage, "B0.Ut", nodePoint)
+				&& nodePoint.nodeId == "B0.Ut",
+				"node identity disambiguates equal-chainage runtime anchors");
+		TrackPreviewPoint interpolated;
+		ok &= expect(trackPreviewPointAtX(normalized.lines[0], 32.0, interpolated)
+				&& interpolated.rawX == 32.0
+				&& std::fabs(interpolated.x - (normalized.lines[0].points[1].x
+					+ (normalized.lines[0].points[2].x - normalized.lines[0].points[1].x) * 4.0 / 36.0)) < 1e-9,
+				"point lookup interpolates by raw chainage");
+	}
 	ok &= expect(result.lines.size() == 2, "preview renders both in-memory tracks without legacy files");
 	if (result.lines.size() == 2) {
 		const auto& first = result.lines[0];
@@ -102,6 +133,7 @@ int main() {
 	for (auto& node : schematic.nodes)
 		node.yKm = 0.0;
 	const TrackPreviewResult schematicResult = loadTrackPreview(schematic);
+	const TrackPreviewResult normalizedSchematic = normalizeTrackPreview(schematicResult);
 	ok &= expect(schematicResult.lines.size() == 2
 			&& std::fabs(schematicResult.lines[0].points[1].x - 0.28) < 1e-9
 			&& schematicResult.lines[0].points[0].y == 0.0
@@ -109,6 +141,14 @@ int main() {
 			&& schematicResult.lines[0].displayOffset == 0.0
 			&& std::fabs(schematicResult.lines[1].displayOffset - 0.0012) < 1e-9,
 			"constant-latitude display anchors scale schematic track levels with mapped x");
+	ok &= expect(normalizedSchematic.lines.size() == 2
+			&& std::fabs(normalizedSchematic.lines[0].points[1].x - 28000.0) < 1e-9
+			&& std::fabs(normalizedSchematic.lines[1].displayOffset - 120.0) < 1e-9,
+			"schematic normalization keeps two-level spacing in runtime units");
+	TrackPreviewPoint schematicStationPoint;
+	ok &= expect(trackPreviewPointAtNode(normalizedSchematic.lines[1], "B1.Ut", schematicStationPoint)
+			&& std::fabs(schematicStationPoint.x - normalizedSchematic.lines[1].points[0].x) < 1e-9,
+			"schematic point lookup resolves the second-level station anchor");
 	SceneModel hidden = scene;
 	hidden.trackViews[1].visible = false;
 	hidden.stations.front().platforms.insert(hidden.stations.front().platforms.begin(),
@@ -127,7 +167,8 @@ int main() {
 	if (!result.stations.empty()) {
 		const auto& stationAnchor = result.stations.front();
 		ok &= expect(stationAnchor.name == "Gvc" && stationAnchor.nodeId == "B0.Gvc"
-				&& stationAnchor.x == 0.0 && stationAnchor.hasPlatform,
+				&& stationAnchor.x == 0.0 && stationAnchor.hasPlatform
+				&& stationAnchor.id == "Gvc",
 				"station preview prefers the platform node anchor");
 	}
 	ok &= expect(result.previewSignals.size() == 2,


### PR DESCRIPTION
## Summary
- reuse canonical preview geometry when rendering a running scene
- preserve fit, station anchors, signals, and hidden-track visibility
- cover normalized interpolation and equal-chainage node anchors

## Verification
- `cmake --build build -j4`
- `ctest --test-dir build --output-on-failure`
- `tools/e2e/visual_polish_smoke.sh`
- `tools/e2e/headless_smoke.py`
- `tools/e2e/roundtrip_smoke.py`
- visual before/after comparison for all six bundled case studies