### PR TITLE
Add consent-based stable release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,7 @@ jobs:
           test -d "$APP/Contents/Frameworks/QtCore.framework"
           test -d "$APP/Contents/Frameworks/QtCharts.framework"
           test -d "$APP/Contents/Frameworks/QtSvg.framework"
+          test -d "$APP/Contents/Frameworks/QtNetwork.framework"
           test -f "$APP/Contents/PlugIns/imageformats/libqsvg.dylib"
           test -f "$APP/Contents/Resources/egtrain.icns"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIconFile' "$APP/Contents/Info.plist")" = "egtrain.icns"
@@ -348,7 +349,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           $dist = "dist/QEGTRAIN"
           if (-not (Test-Path "$dist/QEGTRAIN.exe")) { throw "missing QEGTRAIN.exe" }
-          foreach ($dll in @("Qt5Core.dll","Qt5Gui.dll","Qt5Widgets.dll","Qt5Charts.dll","Qt5Svg.dll")) {
+          foreach ($dll in @("Qt5Core.dll","Qt5Gui.dll","Qt5Widgets.dll","Qt5Charts.dll","Qt5Svg.dll","Qt5Network.dll")) {
             if (-not (Test-Path "$dist/$dll")) { throw "missing $dll" }
           }
           if (-not (Test-Path "$dist/platforms/qwindows.dll")) { throw "missing platforms/qwindows.dll" }
@@ -382,7 +383,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential cmake patchelf wget file desktop-file-utils \
-            qtbase5-dev qttools5-dev qttools5-dev-tools libqt5charts5-dev libqt5svg5-dev \
+            qtbase5-dev qttools5-dev qttools5-dev-tools libqt5charts5-dev libqt5svg5-dev libqt5network5 \
             libzmq3-dev cppzmq-dev nlohmann-json3-dev libomp-dev
 
       - name: Configure
@@ -468,6 +469,7 @@ jobs:
           test -f squashfs-root/AppRun
           find squashfs-root -name 'libQt5Core.so*' -print -quit | grep -q .
           find squashfs-root -name 'libQt5Svg.so*' -print -quit | grep -q .
+          find squashfs-root -name 'libQt5Network.so*' -print -quit | grep -q .
           find squashfs-root -path '*/imageformats/libqsvg.so' -print -quit | grep -q .
           echo "OK: AppImage contains executable, Qt runtime, and canonical Scenes"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ set_target_properties(egtrain_miniz PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED
 include_directories(${SRC_DIR})
 
 # --- Dependencies ---
-find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Charts Svg)
+find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Charts Svg Network)
 
 # OpenMP is required because project headers include omp.h.
 if(APPLE)
@@ -123,7 +123,10 @@ set(EGTRAIN_SOURCES
     ${SRC_DIR}/simulation/Simulation.cpp
     ${SRC_DIR}/simulation/SimulationWorker.cpp
     ${SRC_DIR}/util/TimeFormat.cpp
-	${SRC_DIR}/util/Version.cpp
+    ${SRC_DIR}/util/Version.cpp
+	${SRC_DIR}/update/ReleaseInfo.cpp
+	${SRC_DIR}/update/UpdateChecker.cpp
+	${SRC_DIR}/update/UpdateSettings.cpp
 	${SRC_DIR}/scene/SceneDiagnostic.cpp
 	${SRC_DIR}/scene/SceneModel.cpp
 	${SRC_DIR}/scene/SectionInventory.cpp
@@ -184,6 +187,9 @@ set(EGTRAIN_HEADERS
     ${SRC_DIR}/simulation/SimulationWorker.h
     ${SRC_DIR}/util/TimeFormat.h
     ${SRC_DIR}/util/Version.h
+	${SRC_DIR}/update/ReleaseInfo.h
+	${SRC_DIR}/update/UpdateChecker.h
+	${SRC_DIR}/update/UpdateSettings.h
     ${SRC_DIR}/scene/SceneDiagnostic.h
 	${SRC_DIR}/scene/SceneModel.h
 	${SRC_DIR}/scene/SectionInventory.h
@@ -259,6 +265,7 @@ target_link_libraries(QEGTRAIN PRIVATE
     Qt5::Widgets
     Qt5::Charts
     Qt5::Svg
+    Qt5::Network
 )
 
 if(EGTRAIN_OPENMP_COMPILE_OPTIONS)
@@ -350,6 +357,14 @@ if(EGTRAIN_BUILD_TESTS)
         ${SRC_DIR}/tests/test_version.cpp
         ${SRC_DIR}/util/Version.cpp)
     add_test(NAME test_version COMMAND test_version)
+
+    add_executable(test_updatechecker
+        ${SRC_DIR}/tests/test_updatechecker.cpp
+        ${SRC_DIR}/update/ReleaseInfo.cpp
+        ${SRC_DIR}/update/UpdateSettings.cpp
+        ${SRC_DIR}/util/Version.cpp)
+    target_link_libraries(test_updatechecker PRIVATE Qt5::Core Qt5::Network)
+    add_test(NAME test_updatechecker COMMAND test_updatechecker)
 
     add_executable(test_guisimulationsnapshot
         ${SRC_DIR}/tests/test_guisimulationsnapshot.cpp)

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -21,6 +21,9 @@
 #include "scene/SectionInventory.h"
 #include "scene/TrackPreview.h"
 #include "simulation/Passengers.h"
+#include "update/ReleaseInfo.h"
+#include "update/UpdateChecker.h"
+#include "update/UpdateSettings.h"
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
 #include <QtCharts/QLegendMarker>
@@ -50,6 +53,7 @@
 #include <QSignalBlocker>
 #include <QSettings>
 #include <QIcon>
+#include <QDesktopServices>
 #include <QToolButton>
 #include <QTreeWidgetItemIterator>
 #include <QStringList>
@@ -1445,6 +1449,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 		qApp->setStyleSheet(QString::fromUtf8(themeFile.readAll()));
 
 	ui->setupUi(this);
+	setupUpdateActions();
 	m_startOffsetSeconds = initial_variables.startingSimulationTime;
 
 	cout << "\n...PREPARING GUI...\n\n";
@@ -3768,6 +3773,141 @@ void MainWindow::updateSceneActions() {
 	if (m_recentScenesMenu) {
 		QSettings settings;
 		m_recentScenesMenu->setEnabled(!settings.value(kRecentScenesKey).toStringList().isEmpty());
+	}
+}
+
+void MainWindow::setupUpdateActions() {
+	if (!ui->menuHelp || updatesSuppressedByEnvironment())
+		return;
+
+	m_checkForUpdatesAction = new QAction(QStringLiteral("Check for Updates..."), this);
+	m_checkForUpdatesAction->setObjectName(QStringLiteral("actionCheckForUpdates"));
+	m_automaticUpdateChecksAction = new QAction(
+		QStringLiteral("Automatically Check for Updates"), this);
+	m_automaticUpdateChecksAction->setObjectName(QStringLiteral("actionAutomaticallyCheckForUpdates"));
+	m_automaticUpdateChecksAction->setCheckable(true);
+	QSettings settings;
+	{
+		const QSignalBlocker blocker(m_automaticUpdateChecksAction);
+		m_automaticUpdateChecksAction->setChecked(
+			readUpdateCheckState(settings) == UpdateCheckState::Enabled);
+	}
+	ui->menuHelp->addSeparator();
+	ui->menuHelp->addAction(m_checkForUpdatesAction);
+	ui->menuHelp->addAction(m_automaticUpdateChecksAction);
+
+	m_updateChecker = new UpdateChecker(this);
+	connect(m_checkForUpdatesAction, &QAction::triggered, this,
+		[this]() { startUpdateCheck(true); });
+	connect(m_automaticUpdateChecksAction, &QAction::toggled, this, [this](bool checked) {
+		QSettings preferences;
+		writeUpdateCheckState(preferences, checked ? UpdateCheckState::Enabled
+			: UpdateCheckState::Disabled);
+		preferences.sync();
+	});
+	connect(m_updateChecker, &UpdateChecker::finished, this, &MainWindow::handleUpdateCheckFinished);
+}
+
+void MainWindow::maybePromptForUpdateChecks() {
+	if (!m_updateChecker || updatesSuppressedByEnvironment())
+		return;
+	QSettings settings;
+	const UpdateCheckState state = readUpdateCheckState(settings);
+	if (state == UpdateCheckState::Unknown) {
+		QMessageBox dialog(QMessageBox::Question,
+			QStringLiteral("Automatically Check for EGTRAIN Updates?"),
+			QStringLiteral("EGTRAIN can check GitHub Releases when the application starts and notify you "
+				"when a newer stable version is available."), QMessageBox::NoButton, this);
+		dialog.setInformativeText(QStringLiteral("You can change this later from Help."));
+		QPushButton* enableButton = dialog.addButton(QStringLiteral("Check Automatically"),
+			QMessageBox::AcceptRole);
+		dialog.addButton(QStringLiteral("Don't Check Automatically"), QMessageBox::RejectRole);
+		dialog.setDefaultButton(enableButton);
+		dialog.exec();
+		const UpdateCheckState chosen = dialog.clickedButton() == enableButton
+			? UpdateCheckState::Enabled : UpdateCheckState::Disabled;
+		writeUpdateCheckState(settings, chosen);
+		settings.sync();
+		if (m_automaticUpdateChecksAction) {
+			const QSignalBlocker blocker(m_automaticUpdateChecksAction);
+			m_automaticUpdateChecksAction->setChecked(chosen == UpdateCheckState::Enabled);
+		}
+		if (chosen == UpdateCheckState::Enabled)
+			startUpdateCheck(false);
+		return;
+	}
+	if (state == UpdateCheckState::Enabled)
+		startUpdateCheck(false);
+}
+
+void MainWindow::startUpdateCheck(bool manual) {
+	if (!m_updateChecker || updatesSuppressedByEnvironment())
+		return;
+	QSettings settings;
+	if (!shouldCheckForUpdates(readUpdateCheckState(settings), manual))
+		return;
+	if (!manual && m_updateChecker->isChecking())
+		return;
+	m_manualUpdateCheck = manual;
+	m_updateChecker->check();
+}
+
+void MainWindow::handleUpdateCheckFinished(const UpdateCheckResult& result) {
+	const bool manual = m_manualUpdateCheck;
+	m_manualUpdateCheck = false;
+	if (!result.success || !result.release) {
+		if (manual) {
+			QMessageBox::warning(this, QStringLiteral("Check for Updates"),
+				result.error.isEmpty() ? QStringLiteral("Could not check for updates.") : result.error);
+		} else {
+			qWarning().noquote() << "Automatic update check failed:"
+				<< (result.error.isEmpty() ? QStringLiteral("unknown error") : result.error);
+		}
+		return;
+	}
+
+	const std::optional<SemanticVersion> current =
+		parseStableVersion(QCoreApplication::applicationVersion().toStdString());
+	if (!current) {
+		const QString error = QStringLiteral("The installed application version is invalid.");
+		if (manual)
+			QMessageBox::warning(this, QStringLiteral("Check for Updates"), error);
+		else
+			qWarning().noquote() << "Automatic update check failed:" << error;
+		return;
+	}
+	if (!isUpdateAvailable(*current, *result.release)) {
+		if (manual)
+			QMessageBox::information(this, QStringLiteral("Check for Updates"),
+				QStringLiteral("EGTRAIN %1 is up to date.").arg(formatSemanticVersion(*current)));
+		return;
+	}
+
+	const StableRelease& release = *result.release;
+	QMessageBox dialog(QMessageBox::Information,
+		QStringLiteral("EGTRAIN %1 is Available").arg(formatSemanticVersion(release.version)),
+		QStringLiteral("You are currently using %1.").arg(formatSemanticVersion(*current)),
+		QMessageBox::NoButton, this);
+	dialog.setInformativeText(release.notes.isEmpty()
+		? QStringLiteral("No release notes were provided.") : release.notes);
+	QPushButton* openButton = dialog.addButton(QStringLiteral("Open Release Page"),
+		QMessageBox::AcceptRole);
+	dialog.addButton(QStringLiteral("Later"), QMessageBox::RejectRole);
+	QPushButton* stopButton = dialog.addButton(QStringLiteral("Stop Checking"),
+		QMessageBox::DestructiveRole);
+	dialog.exec();
+	if (dialog.clickedButton() == stopButton) {
+		QSettings settings;
+		writeUpdateCheckState(settings, UpdateCheckState::Disabled);
+		settings.sync();
+		if (m_automaticUpdateChecksAction) {
+			const QSignalBlocker blocker(m_automaticUpdateChecksAction);
+			m_automaticUpdateChecksAction->setChecked(false);
+		}
+	} else if (dialog.clickedButton() == openButton
+		&& !QDesktopServices::openUrl(release.releasePage)) {
+		QMessageBox::warning(this, QStringLiteral("Open Release Page"),
+			QStringLiteral("Could not open the release page:\n%1").arg(release.releasePage.toString()));
 	}
 }
 
@@ -17311,9 +17451,13 @@ void MainWindow::showEvent(QShowEvent* e) {
 		QTimer::singleShot(0, this, &MainWindow::runCreatorAcceptanceE2E);
 		return;
 	}
-	// skip the chooser when -n was given so scripted runs load directly
-	if (!initial_variables.nArgProvided)
-		QTimer::singleShot(0, this, &MainWindow::showStartupChooser);
+	// Keep update consent behind the startup chooser. Scripted launches have no
+	// chooser, so the same queued callback runs after the initial window shows.
+	QTimer::singleShot(0, this, [this]() {
+		if (!initial_variables.nArgProvided)
+			showStartupChooser();
+		maybePromptForUpdateChecks();
+	});
 
 	// verification hook: auto-start the simulation when QEGTRAIN_AUTOSTART is set
 	if (qEnvironmentVariableIsSet("QEGTRAIN_AUTOSTART"))

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -98,6 +98,8 @@ QT_CHARTS_USE_NAMESPACE
 
 class ConsoleWidget; // forward declaration for m_logPane
 class DiagramWindow;
+class UpdateChecker;
+struct UpdateCheckResult;
 
 // custom GUI files
 #include "graphics/NetworkView.h"
@@ -381,6 +383,10 @@ private:
 	QToolBar* m_toolBar;
 	QAction* m_openCaseAction = nullptr;
 	QAction* m_newSceneAction = nullptr;
+	QAction* m_checkForUpdatesAction = nullptr;
+	QAction* m_automaticUpdateChecksAction = nullptr;
+	UpdateChecker* m_updateChecker = nullptr;
+	bool m_manualUpdateCheck = false;
 
 	bool m_promptedLoad = false; // ensures the load prompt only fires once
 
@@ -596,6 +602,10 @@ private:
 	void refreshFollowTrainChoices();
 	void updateSpeedModeDisplay(int value);
 	void updateSceneActions();
+	void setupUpdateActions();
+	void maybePromptForUpdateChecks();
+	void startUpdateCheck(bool manual);
+	void handleUpdateCheckFinished(const UpdateCheckResult& result);
 	void showSceneContextMenu(QGraphicsItem* item, const QPointF& scenePos, const QPoint& screenPos, bool keyboard);
 	void centerSceneItem(QGraphicsItem* item);
 	void setFollowTrain(int trainIndex);

--- a/EGTRAIN/QEGTRAIN/tests/test_updatechecker.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_updatechecker.cpp
@@ -1,0 +1,84 @@
+#include "update/ReleaseInfo.h"
+#include "update/UpdateSettings.h"
+
+#include <QCoreApplication>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+static QByteArray releaseJson(const char* tag, bool draft = false, bool prerelease = false) {
+	return QByteArray("[{\"tag_name\":\"") + tag
+		+ "\",\"draft\":" + (draft ? "true" : "false")
+		+ ",\"prerelease\":" + (prerelease ? "true" : "false")
+		+ ",\"html_url\":\"https://github.com/Ancientkingg/EGTRAIN/releases/tag/"
+		+ tag + "\",\"body\":\"Notes\"}]";
+}
+
+int main(int argc, char** argv) {
+	QCoreApplication application(argc, argv);
+	QTemporaryDir temp;
+	if (!temp.isValid())
+		return 1;
+	QSettings settings(temp.filePath(QStringLiteral("updates.ini")), QSettings::IniFormat);
+	settings.clear();
+
+	bool ok = true;
+	ok &= expect(readUpdateCheckState(settings) == UpdateCheckState::Unknown,
+		"missing preference is unknown");
+	writeUpdateCheckState(settings, UpdateCheckState::Enabled);
+	ok &= expect(readUpdateCheckState(settings) == UpdateCheckState::Enabled,
+		"enabled preference round-trips");
+	writeUpdateCheckState(settings, UpdateCheckState::Disabled);
+	ok &= expect(readUpdateCheckState(settings) == UpdateCheckState::Disabled,
+		"stop checking persists disabled");
+	writeUpdateCheckState(settings, UpdateCheckState::Enabled);
+	ok &= expect(readUpdateCheckState(settings) == UpdateCheckState::Enabled,
+		"automatic checking can be re-enabled");
+	ok &= expect(!shouldCheckForUpdates(UpdateCheckState::Disabled, false)
+		&& shouldCheckForUpdates(UpdateCheckState::Disabled, true),
+		"manual checks remain available while automatic checks are disabled");
+	const QByteArray previousSuppression = qgetenv("QEGTRAIN_DISABLE_UPDATES");
+	qputenv("QEGTRAIN_DISABLE_UPDATES", "1");
+	ok &= expect(updatesSuppressedByEnvironment(), "automation can suppress update UI and network");
+	if (previousSuppression.isNull())
+		qunsetenv("QEGTRAIN_DISABLE_UPDATES");
+	else
+		qputenv("QEGTRAIN_DISABLE_UPDATES", previousSuppression);
+
+	const auto current = parseStableVersion("1.9.0");
+	const auto release = parseLatestStableRelease(releaseJson("v1.10.0"));
+	ok &= expect(current && release && isUpdateAvailable(*current, *release),
+		"release comparison uses numeric version components");
+	ok &= expect(release && !isUpdateAvailable(release->version, *release), "same version is up to date");
+
+	for (const QByteArray& malformed : {QByteArray("not json"), QByteArray("{}"),
+		QByteArray("[{\"tag_name\":\"v1.0.0\",\"draft\":false,\"prerelease\":true}]"),
+		QByteArray("[{\"tag_name\":\"v1.0.0\",\"draft\":true,\"prerelease\":false}]"),
+		QByteArray("[{\"tag_name\":\"1.0.0\",\"draft\":false,\"prerelease\":false}]"),
+		QByteArray("[{\"tag_name\":\"v1.0\",\"draft\":false,\"prerelease\":false}]"),
+		QByteArray("[{\"tag_name\":\"v1.0.0\",\"draft\":false}]")}) {
+		ok &= expect(!parseLatestStableRelease(malformed), "invalid release is ignored");
+	}
+
+	QByteArray releaseList = releaseJson("v1.9.9");
+	releaseList.chop(1);
+	releaseList += ',';
+	releaseList += releaseJson("v1.10.0").mid(1);
+	const auto releases = parseLatestStableRelease(releaseList);
+	ok &= expect(releases && releases->version.major == 1 && releases->version.minor == 10,
+		"latest stable release is selected without package information");
+	const auto wrongPage = parseLatestStableRelease(
+		QByteArray("[{\"tag_name\":\"v1.10.0\",\"draft\":false,\"prerelease\":false,"
+			"\"html_url\":\"https://example.com/phishing\"}]") );
+	ok &= expect(wrongPage && wrongPage->releasePage.host() == QStringLiteral("github.com")
+		&& wrongPage->releasePage.path().startsWith(QStringLiteral("/Ancientkingg/EGTRAIN/")),
+		"release page is constrained to the expected GitHub repository");
+	return ok ? 0 : 1;
+}

--- a/EGTRAIN/QEGTRAIN/update/ReleaseInfo.cpp
+++ b/EGTRAIN/QEGTRAIN/update/ReleaseInfo.cpp
@@ -1,0 +1,79 @@
+#include "update/ReleaseInfo.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+
+namespace {
+
+void setError(QString* error, const QString& message) {
+	if (error)
+		*error = message;
+}
+
+QString releaseNotes(const QJsonObject& object) {
+	QString notes = object.value(QStringLiteral("body")).toString().simplified();
+	if (notes.size() > 360)
+		notes = notes.left(357) + QStringLiteral("...");
+	return notes;
+}
+
+} // namespace
+
+std::optional<StableRelease> parseLatestStableRelease(const QByteArray& json, QString* error) {
+	QJsonParseError parseError;
+	const QJsonDocument document = QJsonDocument::fromJson(json, &parseError);
+	if (parseError.error != QJsonParseError::NoError) {
+		setError(error, QStringLiteral("Invalid GitHub release JSON: %1").arg(parseError.errorString()));
+		return std::nullopt;
+	}
+
+	if (!document.isArray()) {
+		setError(error, QStringLiteral("GitHub returned an invalid release list."));
+		return std::nullopt;
+	}
+	const QJsonArray releases = document.array();
+	if (releases.isEmpty()) {
+		if (error && error->isEmpty())
+			*error = QStringLiteral("GitHub returned no releases.");
+		return std::nullopt;
+	}
+
+	std::optional<StableRelease> latest;
+	for (const QJsonValue& value : releases) {
+		if (!value.isObject())
+			continue;
+		const QJsonObject object = value.toObject();
+		if (!object.value(QStringLiteral("draft")).isBool()
+			|| !object.value(QStringLiteral("prerelease")).isBool())
+			continue;
+		if (object.value(QStringLiteral("draft")).toBool()
+			|| object.value(QStringLiteral("prerelease")).toBool())
+			continue;
+		const QString tag = object.value(QStringLiteral("tag_name")).toString();
+		const std::optional<SemanticVersion> version = parseStableTag(tag.toStdString());
+		if (!version || (latest && !((*latest).version < *version)))
+			continue;
+
+		QUrl releasePage(object.value(QStringLiteral("html_url")).toString());
+		if (!releasePage.isValid() || releasePage.scheme() != QStringLiteral("https")
+			|| releasePage.host().compare(QStringLiteral("github.com"), Qt::CaseInsensitive) != 0
+			|| !releasePage.path().startsWith(QStringLiteral("/Ancientkingg/EGTRAIN/releases/tag/")))
+			releasePage = QUrl(QStringLiteral("https://github.com/Ancientkingg/EGTRAIN/releases/tag/") + tag);
+		latest = StableRelease{*version, tag, releaseNotes(object), releasePage};
+	}
+
+	if (!latest)
+		setError(error, QStringLiteral("No stable vX.Y.Z GitHub release was found."));
+	return latest;
+}
+
+bool isUpdateAvailable(const SemanticVersion& current, const StableRelease& release) {
+	return current < release.version;
+}
+
+QString formatSemanticVersion(const SemanticVersion& version) {
+	return QStringLiteral("%1.%2.%3")
+		.arg(version.major).arg(version.minor).arg(version.patch);
+}

--- a/EGTRAIN/QEGTRAIN/update/ReleaseInfo.h
+++ b/EGTRAIN/QEGTRAIN/update/ReleaseInfo.h
@@ -1,0 +1,23 @@
+#ifndef EGTRAIN_RELEASE_INFO_H
+#define EGTRAIN_RELEASE_INFO_H
+
+#include "util/Version.h"
+
+#include <QByteArray>
+#include <QString>
+#include <QUrl>
+#include <optional>
+
+struct StableRelease {
+	SemanticVersion version;
+	QString tag;
+	QString notes;
+	QUrl releasePage;
+};
+
+std::optional<StableRelease> parseLatestStableRelease(const QByteArray& json,
+	QString* error = nullptr);
+bool isUpdateAvailable(const SemanticVersion& current, const StableRelease& release);
+QString formatSemanticVersion(const SemanticVersion& version);
+
+#endif

--- a/EGTRAIN/QEGTRAIN/update/UpdateChecker.cpp
+++ b/EGTRAIN/QEGTRAIN/update/UpdateChecker.cpp
@@ -1,0 +1,80 @@
+#include "update/UpdateChecker.h"
+
+#include <QCoreApplication>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+
+namespace {
+constexpr int kUpdateCheckTimeoutMs = 10000;
+}
+
+UpdateChecker::UpdateChecker(QObject* parent)
+	: QObject(parent), m_network(this), m_timeout(this) {
+	m_timeout.setSingleShot(true);
+	connect(&m_timeout, &QTimer::timeout, this, [this]() {
+		QNetworkReply* reply = m_reply;
+		if (!reply)
+			return;
+		m_reply = nullptr;
+		reply->abort();
+		reply->deleteLater();
+		emit finished(UpdateCheckResult{false, std::nullopt,
+			QStringLiteral("The update check timed out.")});
+	});
+}
+
+QUrl UpdateChecker::releasesUrl() {
+	// Keep startup traffic bounded to one request; paginate if stable tags can fall behind 100 prereleases.
+	return QUrl(QStringLiteral("https://api.github.com/repos/Ancientkingg/EGTRAIN/releases?per_page=100"));
+}
+
+void UpdateChecker::check() {
+	if (m_reply) {
+		QNetworkReply* previous = m_reply;
+		m_reply = nullptr;
+		m_timeout.stop();
+		previous->abort();
+		previous->deleteLater();
+	}
+
+	QNetworkRequest request(releasesUrl());
+	request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("EGTRAIN/%1")
+		.arg(QCoreApplication::applicationVersion()));
+	request.setRawHeader("Accept", "application/vnd.github+json");
+	request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+		QNetworkRequest::NoLessSafeRedirectPolicy);
+	QNetworkReply* reply = m_network.get(request);
+	m_reply = reply;
+	m_timeout.start(kUpdateCheckTimeoutMs);
+	connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+		if (reply != m_reply)
+			return;
+		m_reply = nullptr;
+		m_timeout.stop();
+
+		if (reply->error() != QNetworkReply::NoError) {
+			const QString error = reply->errorString();
+			reply->deleteLater();
+			emit finished(UpdateCheckResult{false, std::nullopt,
+				error.isEmpty() ? QStringLiteral("GitHub update check failed.") : error});
+			return;
+		}
+		const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+		if (status < 200 || status >= 300) {
+			reply->deleteLater();
+			emit finished(UpdateCheckResult{false, std::nullopt,
+				QStringLiteral("GitHub returned HTTP %1.").arg(status)});
+			return;
+		}
+
+		QString parseError;
+		const std::optional<StableRelease> release = parseLatestStableRelease(reply->readAll(), &parseError);
+		reply->deleteLater();
+		if (!release) {
+			emit finished(UpdateCheckResult{false, std::nullopt,
+				parseError.isEmpty() ? QStringLiteral("No stable release was found.") : parseError});
+			return;
+		}
+		emit finished(UpdateCheckResult{true, release, QString()});
+	});
+}

--- a/EGTRAIN/QEGTRAIN/update/UpdateChecker.h
+++ b/EGTRAIN/QEGTRAIN/update/UpdateChecker.h
@@ -1,0 +1,36 @@
+#ifndef EGTRAIN_UPDATE_CHECKER_H
+#define EGTRAIN_UPDATE_CHECKER_H
+
+#include "update/ReleaseInfo.h"
+
+#include <QNetworkAccessManager>
+#include <QPointer>
+#include <QTimer>
+#include <QObject>
+
+struct UpdateCheckResult {
+	bool success = false;
+	std::optional<StableRelease> release;
+	QString error;
+};
+
+class UpdateChecker : public QObject {
+	Q_OBJECT
+
+public:
+	explicit UpdateChecker(QObject* parent = nullptr);
+
+	void check();
+	bool isChecking() const { return !m_reply.isNull(); }
+	static QUrl releasesUrl();
+
+signals:
+	void finished(const UpdateCheckResult& result);
+
+private:
+	QNetworkAccessManager m_network;
+	QPointer<QNetworkReply> m_reply;
+	QTimer m_timeout;
+};
+
+#endif

--- a/EGTRAIN/QEGTRAIN/update/UpdateSettings.cpp
+++ b/EGTRAIN/QEGTRAIN/update/UpdateSettings.cpp
@@ -1,0 +1,39 @@
+#include "update/UpdateSettings.h"
+
+#include <QProcessEnvironment>
+#include <QSettings>
+
+namespace {
+constexpr char kAutomaticUpdateChecksKey[] = "updates/automaticCheck";
+}
+
+UpdateCheckState readUpdateCheckState(const QSettings& settings) {
+	if (!settings.contains(QString::fromLatin1(kAutomaticUpdateChecksKey)))
+		return UpdateCheckState::Unknown;
+	return settings.value(QString::fromLatin1(kAutomaticUpdateChecksKey)).toBool()
+		? UpdateCheckState::Enabled : UpdateCheckState::Disabled;
+}
+
+void writeUpdateCheckState(QSettings& settings, UpdateCheckState state) {
+	const QString key = QString::fromLatin1(kAutomaticUpdateChecksKey);
+	if (state == UpdateCheckState::Unknown) {
+		settings.remove(key);
+		return;
+	}
+	settings.setValue(key, state == UpdateCheckState::Enabled);
+}
+
+bool shouldCheckForUpdates(UpdateCheckState state, bool manual) {
+	return manual || state == UpdateCheckState::Enabled;
+}
+
+bool updatesSuppressedByEnvironment() {
+	const QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+	if (environment.contains(QStringLiteral("QEGTRAIN_DISABLE_UPDATES"))
+		|| environment.contains(QStringLiteral("QEGTRAIN_AUTOSTART")))
+		return true;
+	for (const QString& key : environment.keys())
+		if (key.startsWith(QStringLiteral("QEGTRAIN_E2E_")))
+			return true;
+	return false;
+}

--- a/EGTRAIN/QEGTRAIN/update/UpdateSettings.h
+++ b/EGTRAIN/QEGTRAIN/update/UpdateSettings.h
@@ -1,0 +1,17 @@
+#ifndef EGTRAIN_UPDATE_SETTINGS_H
+#define EGTRAIN_UPDATE_SETTINGS_H
+
+class QSettings;
+
+enum class UpdateCheckState {
+	Unknown,
+	Enabled,
+	Disabled
+};
+
+UpdateCheckState readUpdateCheckState(const QSettings& settings);
+void writeUpdateCheckState(QSettings& settings, UpdateCheckState state);
+bool shouldCheckForUpdates(UpdateCheckState state, bool manual);
+bool updatesSuppressedByEnvironment();
+
+#endif

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -193,6 +193,12 @@ def main() -> None:
         for name in scene_names
     ) or "artifacts/EGTRAIN-scenes/*.egscene" not in release_workflow:
         missing.append("scene bundles in published release assets")
+    if '"$APP/Contents/Frameworks/QtNetwork.framework"' not in release_workflow:
+        missing.append("macOS Qt Network package verification")
+    if '"Qt5Network.dll"' not in release_workflow:
+        missing.append("Windows Qt Network package verification")
+    if "libqt5network5" not in release_workflow or "libQt5Network.so*" not in release_workflow:
+        missing.append("Linux Qt Network package verification")
     if missing:
         raise SystemExit("CI workflows are missing: " + ", ".join(missing))
 

--- a/tools/e2e/test_qt_resources.py
+++ b/tools/e2e/test_qt_resources.py
@@ -49,7 +49,7 @@ def main() -> None:
     if not any(f'":/{alias}"' in source_text for alias in ENTITY_ASSETS):
         raise SystemExit("application and graphics source do not reference an SVG resource")
 
-    if "find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Charts Svg)" not in cmake:
+    if not re.search(r"find_package\(Qt5 REQUIRED COMPONENTS [^)]*\bSvg\b", cmake):
         raise SystemExit("CMake does not require Qt5 Svg")
     if "Qt5::Svg" not in cmake:
         raise SystemExit("CMake does not link Qt5::Svg")


### PR DESCRIPTION
## Summary
- ask first-time GUI users before making automatic GitHub release requests
- add manual and configurable startup checks in the Help menu
- select the newest stable semantic release asynchronously and verify Qt Network packaging

Part of #155. The issue should close when #341 lands on main.

## Verification
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` (50/50)
- `tools/e2e/visual_polish_smoke.sh`
