### PR TITLE
Add verified cross-platform self-updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,14 @@ jobs:
         run: >
           cmake -S . -B build
           -DCMAKE_BUILD_TYPE=Release
+          -DEGTRAIN_PACKAGED_BUILD=ON
           -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
 
       - name: Build
         run: cmake --build build --config Release -j
+
+      - name: Verify update helper transaction
+        run: ctest --test-dir build -R '^test_updatehelper$' --output-on-failure
 
       - name: Bundle Qt and dependencies into the app
         run: |
@@ -153,6 +157,8 @@ jobs:
           # into Contents/Frameworks, rewriting every reference to
           # @executable_path so the app runs without Homebrew.
           "$(brew --prefix qt@5)/bin/macdeployqt" build/QEGTRAIN.app -verbose=1
+          cp build/egtrain_update_helper build/QEGTRAIN.app/Contents/MacOS/egtrain_update_helper
+          chmod +x build/QEGTRAIN.app/Contents/MacOS/egtrain_update_helper
 
       - name: Ad-hoc code sign
         # macdeployqt rewrites install names with install_name_tool, which
@@ -209,6 +215,7 @@ jobs:
           set -euo pipefail
           PKG="build/dist/QEGTRAIN-Lebanon"
           test -x "$PKG/QEGTRAIN.app/Contents/MacOS/QEGTRAIN"
+          test -x "$PKG/QEGTRAIN.app/Contents/MacOS/egtrain_update_helper"
           test -x "$PKG/scene_tool"
           test -f "$PKG/Scenes/Lebanon/stations.json"
           test -f "$PKG/Scenes/Lebanon/scene.json"
@@ -314,12 +321,16 @@ jobs:
         shell: pwsh
         run: >
           cmake -S . -B build
+          -DEGTRAIN_PACKAGED_BUILD=ON
           -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
           -DVCPKG_TARGET_TRIPLET=x64-windows
           -DCMAKE_PREFIX_PATH="$env:QT_ROOT_DIR"
 
       - name: Build
         run: cmake --build build --config Release
+
+      - name: Verify update helper transaction
+        run: ctest --test-dir build -C Release -R '^test_updatehelper$' --output-on-failure
 
       - name: Assemble package
         shell: pwsh
@@ -330,6 +341,9 @@ jobs:
           $exe = Get-ChildItem -Path build -Recurse -Filter QEGTRAIN.exe | Select-Object -First 1
           if (-not $exe) { throw "QEGTRAIN.exe not found under build/" }
           Copy-Item $exe.FullName "$dist/QEGTRAIN.exe"
+          $helper = Get-ChildItem -Path build -Recurse -Filter egtrain_update_helper.exe | Select-Object -First 1
+          if (-not $helper) { throw "egtrain_update_helper.exe not found under build/" }
+          Copy-Item $helper.FullName "$dist/egtrain_update_helper.exe"
           # ZeroMQ + libsodium runtime DLLs from vcpkg
           Copy-Item "$env:VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin/*.dll" $dist/ -ErrorAction SilentlyContinue
           # Qt runtime: DLLs + platform/imageformat plugins next to the exe
@@ -349,6 +363,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           $dist = "dist/QEGTRAIN"
           if (-not (Test-Path "$dist/QEGTRAIN.exe")) { throw "missing QEGTRAIN.exe" }
+          if (-not (Test-Path "$dist/egtrain_update_helper.exe")) { throw "missing egtrain_update_helper.exe" }
           foreach ($dll in @("Qt5Core.dll","Qt5Gui.dll","Qt5Widgets.dll","Qt5Charts.dll","Qt5Svg.dll","Qt5Network.dll")) {
             if (-not (Test-Path "$dist/$dll")) { throw "missing $dll" }
           }
@@ -387,10 +402,13 @@ jobs:
             libzmq3-dev cppzmq-dev nlohmann-json3-dev libomp-dev
 
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DEGTRAIN_PACKAGED_BUILD=ON
 
       - name: Build
         run: cmake --build build --config Release -j"$(nproc)"
+
+      - name: Verify update helper transaction
+        run: ctest --test-dir build -R '^test_updatehelper$' --output-on-failure
 
       - name: Assemble AppDir
         run: |
@@ -404,6 +422,9 @@ jobs:
           EXE="$(find build -type f -perm -111 -name QEGTRAIN | head -n 1)"
           test -n "$EXE"
           cp "$EXE" "$APPDIR/usr/bin/QEGTRAIN"
+          HELPER="$(find build -type f -perm -111 -name egtrain_update_helper | head -n 1)"
+          test -n "$HELPER"
+          cp "$HELPER" "$APPDIR/usr/bin/egtrain_update_helper"
 
           # Canonical scenes live beside the executable for packaged defaults.
           cp -R EGTRAIN/QEGTRAIN/Scenes "$APPDIR/usr/bin/Scenes"
@@ -464,6 +485,7 @@ jobs:
           chmod +x QEGTRAIN-linux-x86_64.AppImage
           ./QEGTRAIN-linux-x86_64.AppImage --appimage-extract >/dev/null
           test -x squashfs-root/usr/bin/QEGTRAIN
+          test -x squashfs-root/usr/bin/egtrain_update_helper
           test -f squashfs-root/usr/bin/Scenes/Paimpol/scene.json
           test -f squashfs-root/usr/share/icons/hicolor/256x256/apps/qegtrain.png
           test -f squashfs-root/AppRun
@@ -548,6 +570,30 @@ jobs:
             echo "make_latest=$make_latest"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Generate update manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(sed -nE 's/^project\(EGTRAIN VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt | head -n 1)"
+          test -n "$version"
+          mac_sha="$(sha256sum artifacts/QEGTRAIN-macos-arm64/QEGTRAIN-macos-arm64.zip | cut -d ' ' -f 1)"
+          windows_sha="$(sha256sum artifacts/QEGTRAIN-windows-x64/QEGTRAIN-windows-x64.zip | cut -d ' ' -f 1)"
+          linux_sha="$(sha256sum artifacts/QEGTRAIN-linux-x86_64/QEGTRAIN-linux-x86_64.AppImage | cut -d ' ' -f 1)"
+          mac_size="$(stat -c %s artifacts/QEGTRAIN-macos-arm64/QEGTRAIN-macos-arm64.zip)"
+          windows_size="$(stat -c %s artifacts/QEGTRAIN-windows-x64/QEGTRAIN-windows-x64.zip)"
+          linux_size="$(stat -c %s artifacts/QEGTRAIN-linux-x86_64/QEGTRAIN-linux-x86_64.AppImage)"
+          jq -n \
+            --arg version "$version" \
+            --arg mac_sha "$mac_sha" \
+            --arg windows_sha "$windows_sha" \
+            --arg linux_sha "$linux_sha" \
+            --argjson mac_size "$mac_size" \
+            --argjson windows_size "$windows_size" \
+            --argjson linux_size "$linux_size" \
+            '{version:$version,assets:{"macos-arm64":{name:"QEGTRAIN-macos-arm64.zip",sha256:$mac_sha,size:$mac_size},"windows-x64":{name:"QEGTRAIN-windows-x64.zip",sha256:$windows_sha,size:$windows_size},"linux-x86_64":{name:"QEGTRAIN-linux-x86_64.AppImage",sha256:$linux_sha,size:$linux_size}}}' \
+            > artifacts/update-manifest.json
+          test -s artifacts/update-manifest.json
+
       - name: Verify release assets
         shell: bash
         run: |
@@ -562,6 +608,7 @@ jobs:
             artifacts/EGTRAIN-scenes/Milano_Brescia.egscene
             artifacts/EGTRAIN-scenes/Assignment_Gvc_Gdg_Ut.egscene
             artifacts/EGTRAIN-scenes/Lebanon.egscene
+            artifacts/update-manifest.json
           )
 
           for file in "${expected[@]}"; do
@@ -569,8 +616,8 @@ jobs:
           done
 
           count="$(find artifacts -type f | wc -l | tr -d ' ')"
-          if [[ "$count" != "9" ]]; then
-            echo "Expected exactly 9 release assets, found $count"
+          if [[ "$count" != "10" ]]; then
+            echo "Expected exactly 10 release assets, found $count"
             find artifacts -type f -print
             exit 1
           fi
@@ -586,6 +633,7 @@ jobs:
             artifacts/QEGTRAIN-windows-x64/QEGTRAIN-windows-x64.zip
             artifacts/QEGTRAIN-linux-x86_64/QEGTRAIN-linux-x86_64.AppImage
             artifacts/EGTRAIN-scenes/*.egscene
+            artifacts/update-manifest.json
           prerelease: ${{ steps.release-meta.outputs.prerelease }}
           make_latest: ${{ steps.release-meta.outputs.make_latest }}
           fail_on_unmatched_files: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ if(MSVC)
 endif()
 
 option(EGTRAIN_ENABLE_SANITIZERS "Enable AddressSanitizer/UndefinedBehaviorSanitizer for local debug checks" OFF)
+option(EGTRAIN_PACKAGED_BUILD "Enable self-update support for a release package" OFF)
+
+if(EGTRAIN_PACKAGED_BUILD)
+    add_compile_definitions(EGTRAIN_PACKAGED_BUILD=1)
+else()
+    add_compile_definitions(EGTRAIN_PACKAGED_BUILD=0)
+endif()
 
 if(EGTRAIN_ENABLE_SANITIZERS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
@@ -127,6 +134,7 @@ set(EGTRAIN_SOURCES
 	${SRC_DIR}/update/ReleaseInfo.cpp
 	${SRC_DIR}/update/UpdateChecker.cpp
 	${SRC_DIR}/update/UpdateSettings.cpp
+	${SRC_DIR}/update/SelfUpdater.cpp
 	${SRC_DIR}/scene/SceneDiagnostic.cpp
 	${SRC_DIR}/scene/SceneModel.cpp
 	${SRC_DIR}/scene/SectionInventory.cpp
@@ -190,6 +198,7 @@ set(EGTRAIN_HEADERS
 	${SRC_DIR}/update/ReleaseInfo.h
 	${SRC_DIR}/update/UpdateChecker.h
 	${SRC_DIR}/update/UpdateSettings.h
+	${SRC_DIR}/update/SelfUpdater.h
     ${SRC_DIR}/scene/SceneDiagnostic.h
 	${SRC_DIR}/scene/SceneModel.h
 	${SRC_DIR}/scene/SectionInventory.h
@@ -288,6 +297,21 @@ target_link_libraries(QEGTRAIN PRIVATE cppzmq nlohmann_json::nlohmann_json)
 target_link_libraries(QEGTRAIN PRIVATE egtrain_miniz)
 message(STATUS "ZeroMQ + nlohmann_json found - traffic-state sharing enabled")
 
+add_executable(egtrain_update_helper
+	${SRC_DIR}/update/UpdateHelper.cpp)
+if(MSVC)
+    set_property(TARGET egtrain_update_helper PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
+if(EGTRAIN_PACKAGED_BUILD)
+    enable_testing()
+    add_executable(test_updatehelper
+        ${SRC_DIR}/tests/test_updatehelper.cpp)
+    target_link_libraries(test_updatehelper PRIVATE Qt5::Core)
+    add_test(NAME test_updatehelper COMMAND test_updatehelper $<TARGET_FILE:egtrain_update_helper>)
+endif()
+
 # Platform-specific settings
 if(APPLE)
     set_target_properties(QEGTRAIN PROPERTIES
@@ -365,6 +389,13 @@ if(EGTRAIN_BUILD_TESTS)
         ${SRC_DIR}/util/Version.cpp)
     target_link_libraries(test_updatechecker PRIVATE Qt5::Core Qt5::Network)
     add_test(NAME test_updatechecker COMMAND test_updatechecker)
+
+    if(NOT TARGET test_updatehelper)
+        add_executable(test_updatehelper
+            ${SRC_DIR}/tests/test_updatehelper.cpp)
+        target_link_libraries(test_updatehelper PRIVATE Qt5::Core)
+        add_test(NAME test_updatehelper COMMAND test_updatehelper $<TARGET_FILE:egtrain_update_helper>)
+    endif()
 
     add_executable(test_guisimulationsnapshot
         ${SRC_DIR}/tests/test_guisimulationsnapshot.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,11 @@ if(EGTRAIN_BUILD_TESTS)
     target_link_libraries(test_updatechecker PRIVATE Qt5::Core Qt5::Network)
     add_test(NAME test_updatechecker COMMAND test_updatechecker)
 
+    add_executable(test_updatestaging
+        ${SRC_DIR}/tests/test_updatestaging.cpp)
+    target_link_libraries(test_updatestaging PRIVATE Qt5::Core)
+    add_test(NAME test_updatestaging COMMAND test_updatestaging)
+
     if(NOT TARGET test_updatehelper)
         add_executable(test_updatehelper
             ${SRC_DIR}/tests/test_updatehelper.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(EGTRAIN_SOURCES
 	${SRC_DIR}/update/ReleaseInfo.cpp
 	${SRC_DIR}/update/UpdateChecker.cpp
 	${SRC_DIR}/update/UpdateSettings.cpp
+	${SRC_DIR}/update/UpdatePreparation.cpp
 	${SRC_DIR}/update/SelfUpdater.cpp
 	${SRC_DIR}/scene/SceneDiagnostic.cpp
 	${SRC_DIR}/scene/SceneModel.cpp
@@ -198,6 +199,7 @@ set(EGTRAIN_HEADERS
 	${SRC_DIR}/update/ReleaseInfo.h
 	${SRC_DIR}/update/UpdateChecker.h
 	${SRC_DIR}/update/UpdateSettings.h
+	${SRC_DIR}/update/UpdatePreparation.h
 	${SRC_DIR}/update/SelfUpdater.h
     ${SRC_DIR}/scene/SceneDiagnostic.h
 	${SRC_DIR}/scene/SceneModel.h
@@ -394,6 +396,12 @@ if(EGTRAIN_BUILD_TESTS)
         ${SRC_DIR}/tests/test_updatestaging.cpp)
     target_link_libraries(test_updatestaging PRIVATE Qt5::Core)
     add_test(NAME test_updatestaging COMMAND test_updatestaging)
+
+    add_executable(test_updatepreparation
+        ${SRC_DIR}/tests/test_updatepreparation.cpp
+        ${SRC_DIR}/update/UpdatePreparation.cpp)
+    target_link_libraries(test_updatepreparation PRIVATE Qt5::Core)
+    add_test(NAME test_updatepreparation COMMAND test_updatepreparation)
 
     if(NOT TARGET test_updatehelper)
         add_executable(test_updatehelper

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3821,6 +3821,14 @@ void MainWindow::setupUpdateActions() {
 		}
 	});
 	connect(m_selfUpdater, &SelfUpdater::finished, this, &MainWindow::handleSelfUpdateFinished);
+	connect(m_selfUpdater, &SelfUpdater::preparing, this, [this](const QString& version) {
+		if (!m_updateProgress)
+			return;
+		m_updateProgress->setLabelText(QStringLiteral("Verifying and preparing EGTRAIN %1...")
+			.arg(version));
+		m_updateProgress->setCancelButton(nullptr);
+		m_updateProgress->setRange(0, 0);
+	});
 }
 
 void MainWindow::maybePromptForUpdateChecks() {
@@ -3941,7 +3949,7 @@ void MainWindow::handleUpdateCheckFinished(const UpdateCheckResult& result) {
 void MainWindow::startSelfUpdate(const StableRelease& release) {
 	if (!m_selfUpdater || m_selfUpdater->isBusy() || !maybeSaveScene())
 		return;
-	m_updateProgress = new QProgressDialog(QStringLiteral("Downloading and preparing EGTRAIN %1...")
+	m_updateProgress = new QProgressDialog(QStringLiteral("Downloading EGTRAIN %1...")
 		.arg(formatSemanticVersion(release.version)),
 		QStringLiteral("Cancel"), 0, 0, this);
 	m_updateProgress->setWindowTitle(QStringLiteral("EGTRAIN Update"));
@@ -3950,8 +3958,16 @@ void MainWindow::startSelfUpdate(const StableRelease& release) {
 	m_updateProgress->setAutoReset(false);
 	m_updateProgress->setMinimumDuration(0);
 	connect(m_updateProgress, &QProgressDialog::canceled, this, [this]() {
-		if (m_selfUpdater)
-			m_selfUpdater->cancel();
+		if (!m_selfUpdater)
+			return;
+		if (m_selfUpdater->isPreparing()) {
+			// Preparation cannot be interrupted safely; Esc or a stray cancel
+			// must not hide the dialog while the update is still progressing.
+			if (m_updateProgress && !m_updateProgress->isVisible())
+				m_updateProgress->show();
+			return;
+		}
+		m_selfUpdater->cancel();
 	});
 	m_updateProgress->show();
 	m_selfUpdater->start(release);

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -3929,9 +3929,10 @@ void MainWindow::handleUpdateCheckFinished(const UpdateCheckResult& result) {
 	QPushButton* stopButton = dialog.addButton(QStringLiteral("Stop Checking"),
 		QMessageBox::DestructiveRole);
 	dialog.exec();
-	if (dialog.clickedButton() == updateButton) {
+	QAbstractButton* clickedButton = dialog.clickedButton();
+	if (updateButton && clickedButton == updateButton) {
 		startSelfUpdate(release);
-	} else if (dialog.clickedButton() == stopButton) {
+	} else if (clickedButton == stopButton) {
 		QSettings settings;
 		writeUpdateCheckState(settings, UpdateCheckState::Disabled);
 		settings.sync();
@@ -3939,7 +3940,7 @@ void MainWindow::handleUpdateCheckFinished(const UpdateCheckResult& result) {
 			const QSignalBlocker blocker(m_automaticUpdateChecksAction);
 			m_automaticUpdateChecksAction->setChecked(false);
 		}
-	} else if (dialog.clickedButton() == openButton
+	} else if (clickedButton == openButton
 		&& !QDesktopServices::openUrl(release.releasePage)) {
 		QMessageBox::warning(this, QStringLiteral("Open Release Page"),
 			QStringLiteral("Could not open the release page:\n%1").arg(release.releasePage.toString()));

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -24,6 +24,7 @@
 #include "update/ReleaseInfo.h"
 #include "update/UpdateChecker.h"
 #include "update/UpdateSettings.h"
+#include "update/SelfUpdater.h"
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
 #include <QtCharts/QLegendMarker>
@@ -47,6 +48,7 @@
 #include <QRadioButton>
 #include <QButtonGroup>
 #include <QDialogButtonBox>
+#include <QProgressDialog>
 #include <QInputDialog>
 #include <QCoreApplication>
 #include <QStandardPaths>
@@ -3797,6 +3799,7 @@ void MainWindow::setupUpdateActions() {
 	ui->menuHelp->addAction(m_automaticUpdateChecksAction);
 
 	m_updateChecker = new UpdateChecker(this);
+	m_selfUpdater = new SelfUpdater(this);
 	connect(m_checkForUpdatesAction, &QAction::triggered, this,
 		[this]() { startUpdateCheck(true); });
 	connect(m_automaticUpdateChecksAction, &QAction::toggled, this, [this](bool checked) {
@@ -3806,6 +3809,18 @@ void MainWindow::setupUpdateActions() {
 		preferences.sync();
 	});
 	connect(m_updateChecker, &UpdateChecker::finished, this, &MainWindow::handleUpdateCheckFinished);
+	connect(m_selfUpdater, &SelfUpdater::progress, this, [this](qint64 received, qint64 total) {
+		if (!m_updateProgress)
+			return;
+		if (total > 0) {
+			const qint64 maxValue = std::numeric_limits<int>::max();
+			m_updateProgress->setRange(0, total > maxValue ? static_cast<int>(maxValue) : static_cast<int>(total));
+			m_updateProgress->setValue(received > maxValue ? static_cast<int>(maxValue) : static_cast<int>(received));
+		} else {
+			m_updateProgress->setRange(0, 0);
+		}
+	});
+	connect(m_selfUpdater, &SelfUpdater::finished, this, &MainWindow::handleSelfUpdateFinished);
 }
 
 void MainWindow::maybePromptForUpdateChecks() {
@@ -3884,19 +3899,31 @@ void MainWindow::handleUpdateCheckFinished(const UpdateCheckResult& result) {
 	}
 
 	const StableRelease& release = *result.release;
+	QString availability;
+	if (m_selfUpdater && !m_selfUpdater->canSelfUpdate(release)) {
+		const SelfUpdateCapability capability = m_selfUpdater->capability();
+		availability = capability.supported
+			? QStringLiteral("\n\nNo automatic update package is available for this platform. Use the release page to update manually.")
+			: QStringLiteral("\n\n%1 Use the release page to update manually.").arg(capability.reason);
+	}
 	QMessageBox dialog(QMessageBox::Information,
 		QStringLiteral("EGTRAIN %1 is Available").arg(formatSemanticVersion(release.version)),
 		QStringLiteral("You are currently using %1.").arg(formatSemanticVersion(*current)),
 		QMessageBox::NoButton, this);
-	dialog.setInformativeText(release.notes.isEmpty()
-		? QStringLiteral("No release notes were provided.") : release.notes);
+	dialog.setInformativeText((release.notes.isEmpty()
+		? QStringLiteral("No release notes were provided.") : release.notes) + availability);
+	QPushButton* updateButton = nullptr;
+	if (m_selfUpdater && m_selfUpdater->canSelfUpdate(release))
+		updateButton = dialog.addButton(QStringLiteral("Update and Restart"), QMessageBox::AcceptRole);
 	QPushButton* openButton = dialog.addButton(QStringLiteral("Open Release Page"),
 		QMessageBox::AcceptRole);
 	dialog.addButton(QStringLiteral("Later"), QMessageBox::RejectRole);
 	QPushButton* stopButton = dialog.addButton(QStringLiteral("Stop Checking"),
 		QMessageBox::DestructiveRole);
 	dialog.exec();
-	if (dialog.clickedButton() == stopButton) {
+	if (dialog.clickedButton() == updateButton) {
+		startSelfUpdate(release);
+	} else if (dialog.clickedButton() == stopButton) {
 		QSettings settings;
 		writeUpdateCheckState(settings, UpdateCheckState::Disabled);
 		settings.sync();
@@ -3909,6 +3936,46 @@ void MainWindow::handleUpdateCheckFinished(const UpdateCheckResult& result) {
 		QMessageBox::warning(this, QStringLiteral("Open Release Page"),
 			QStringLiteral("Could not open the release page:\n%1").arg(release.releasePage.toString()));
 	}
+}
+
+void MainWindow::startSelfUpdate(const StableRelease& release) {
+	if (!m_selfUpdater || m_selfUpdater->isBusy() || !maybeSaveScene())
+		return;
+	m_updateProgress = new QProgressDialog(QStringLiteral("Downloading and preparing EGTRAIN %1...")
+		.arg(formatSemanticVersion(release.version)),
+		QStringLiteral("Cancel"), 0, 0, this);
+	m_updateProgress->setWindowTitle(QStringLiteral("EGTRAIN Update"));
+	m_updateProgress->setWindowModality(Qt::WindowModal);
+	m_updateProgress->setAutoClose(false);
+	m_updateProgress->setAutoReset(false);
+	m_updateProgress->setMinimumDuration(0);
+	connect(m_updateProgress, &QProgressDialog::canceled, this, [this]() {
+		if (m_selfUpdater)
+			m_selfUpdater->cancel();
+	});
+	m_updateProgress->show();
+	m_selfUpdater->start(release);
+}
+
+void MainWindow::handleSelfUpdateFinished(bool success, const QString& error) {
+	if (m_updateProgress) {
+		m_updateProgress->close();
+		m_updateProgress->deleteLater();
+		m_updateProgress = nullptr;
+	}
+	if (!success) {
+		QMessageBox::warning(this, QStringLiteral("EGTRAIN Update"),
+			error.isEmpty() ? QStringLiteral("The update was not installed. EGTRAIN is unchanged.") : error);
+		return;
+	}
+	QMessageBox::information(this, QStringLiteral("EGTRAIN Update"),
+		QStringLiteral("The update is ready. EGTRAIN will restart now."));
+	if (!m_selfUpdater || !m_selfUpdater->restart()) {
+		QMessageBox::warning(this, QStringLiteral("EGTRAIN Update"),
+			QStringLiteral("Could not start the update installer. EGTRAIN is unchanged."));
+		return;
+	}
+	QCoreApplication::quit();
 }
 
 void MainWindow::refreshValidationPanel() {

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -99,7 +99,10 @@ QT_CHARTS_USE_NAMESPACE
 class ConsoleWidget; // forward declaration for m_logPane
 class DiagramWindow;
 class UpdateChecker;
+class SelfUpdater;
+class QProgressDialog;
 struct UpdateCheckResult;
+struct StableRelease;
 
 // custom GUI files
 #include "graphics/NetworkView.h"
@@ -386,6 +389,8 @@ private:
 	QAction* m_checkForUpdatesAction = nullptr;
 	QAction* m_automaticUpdateChecksAction = nullptr;
 	UpdateChecker* m_updateChecker = nullptr;
+	SelfUpdater* m_selfUpdater = nullptr;
+	QProgressDialog* m_updateProgress = nullptr;
 	bool m_manualUpdateCheck = false;
 
 	bool m_promptedLoad = false; // ensures the load prompt only fires once
@@ -606,6 +611,8 @@ private:
 	void maybePromptForUpdateChecks();
 	void startUpdateCheck(bool manual);
 	void handleUpdateCheckFinished(const UpdateCheckResult& result);
+	void startSelfUpdate(const StableRelease& release);
+	void handleSelfUpdateFinished(bool success, const QString& error);
 	void showSceneContextMenu(QGraphicsItem* item, const QPointF& scenePos, const QPoint& screenPos, bool keyboard);
 	void centerSceneItem(QGraphicsItem* item);
 	void setFollowTrain(int trainIndex);

--- a/EGTRAIN/QEGTRAIN/tests/test_updatechecker.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_updatechecker.cpp
@@ -80,5 +80,35 @@ int main(int argc, char** argv) {
 	ok &= expect(wrongPage && wrongPage->releasePage.host() == QStringLiteral("github.com")
 		&& wrongPage->releasePage.path().startsWith(QStringLiteral("/Ancientkingg/EGTRAIN/")),
 		"release page is constrained to the expected GitHub repository");
+	const QByteArray packagedRelease = QByteArray(
+		"[{\"tag_name\":\"v1.10.0\",\"draft\":false,\"prerelease\":false,"
+		"\"html_url\":\"https://github.com/Ancientkingg/EGTRAIN/releases/tag/v1.10.0\","
+		"\"assets\":["
+		"{\"name\":\"update-manifest.json\",\"browser_download_url\":\"https://github.com/Ancientkingg/EGTRAIN/releases/download/v1.10.0/update-manifest.json\"},"
+		"{\"name\":\"QEGTRAIN-linux-x86_64.AppImage\",\"browser_download_url\":\"https://github.com/Ancientkingg/EGTRAIN/releases/download/v1.10.0/QEGTRAIN-linux-x86_64.AppImage\"},"
+		"{\"name\":\"untrusted.zip\",\"browser_download_url\":\"https://example.com/untrusted.zip\"}]}]");
+	const auto packaged = parseLatestStableRelease(packagedRelease);
+	ok &= expect(packaged && packaged->asset(updateManifestAssetName())
+		&& packaged->asset(updatePackageName(QStringLiteral("linux-x86_64"))),
+		"only exact release package assets are retained");
+	ok &= expect(packaged && !packaged->asset(QStringLiteral("untrusted.zip")),
+		"untrusted release assets are ignored");
+	const QByteArray validHash(64, 'a');
+	const QByteArray manifest = QByteArray("{\"version\":\"1.10.0\",\"assets\":{\"linux-x86_64\":{\"name\":\"QEGTRAIN-linux-x86_64.AppImage\",\"sha256\":\"")
+		+ validHash + QByteArray("\",\"size\":12345}}}");
+	const auto parsedManifest = parseUpdateManifest(manifest, QStringLiteral("v1.10.0"),
+		QStringLiteral("linux-x86_64"));
+	ok &= expect(parsedManifest && parsedManifest->sha256 == QString::fromLatin1(validHash),
+		"valid update manifest parses");
+	ok &= expect(parsedManifest && parsedManifest->assetSize == 12345,
+		"manifest package size is retained");
+	ok &= expect(!parseUpdateManifest(manifest, QStringLiteral("v1.10.1"),
+		QStringLiteral("linux-x86_64")), "manifest version must equal the stable tag");
+	QByteArray uppercaseManifest = manifest;
+	uppercaseManifest.replace("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+	ok &= expect(!parseUpdateManifest(uppercaseManifest,
+		QStringLiteral("v1.10.0"), QStringLiteral("linux-x86_64")),
+		"manifest hash must be lowercase hexadecimal");
 	return ok ? 0 : 1;
 }

--- a/EGTRAIN/QEGTRAIN/tests/test_updatehelper.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_updatehelper.cpp
@@ -1,0 +1,95 @@
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QProcess>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+static bool writeFile(const QString& path, const QByteArray& contents) {
+	QFile file(path);
+	return file.open(QIODevice::WriteOnly) && file.write(contents) == contents.size();
+}
+
+static QByteArray readFile(const QString& path) {
+	QFile file(path);
+	if (!file.open(QIODevice::ReadOnly))
+		return {};
+	return file.readAll();
+}
+
+int main(int argc, char** argv) {
+	QCoreApplication application(argc, argv);
+	if (argc == 1)
+		return 0;
+	if (argc != 2)
+		return 2;
+	const QString helper = QString::fromLocal8Bit(argv[1]);
+	QTemporaryDir temp;
+	if (!temp.isValid())
+		return 1;
+
+	bool ok = true;
+	const QString current = QDir(temp.path()).filePath("current.bin");
+	const QString staged = QDir(temp.path()).filePath("staged.bin");
+	const QString backup = QDir(temp.path()).filePath("backup.bin");
+	ok &= expect(writeFile(current, "old"), "fixture current file is writable");
+	ok &= expect(writeFile(staged, "new"), "fixture staged file is writable");
+	const QStringList successArguments = {
+		"--parent-pid", "0", "--current", current, "--staged", staged,
+		"--backup", backup, "--launch", QCoreApplication::applicationFilePath()};
+	ok &= expect(QProcess::execute(helper, successArguments) == 0,
+		"helper installs a staged file");
+	ok &= expect(readFile(current) == QByteArray("new"), "new file is active after helper success");
+	ok &= expect(readFile(backup) == QByteArray("old"),
+		"successful helper retains a recoverable backup");
+
+	const QString missingStage = QDir(temp.path()).filePath("missing.bin");
+	const QString rollbackBackup = QDir(temp.path()).filePath("rollback.bin");
+	ok &= expect(QProcess::execute(helper, {
+		"--parent-pid", "0", "--current", current, "--staged", missingStage,
+		"--backup", rollbackBackup, "--launch", QCoreApplication::applicationFilePath()}) != 0,
+		"helper rejects a missing staged file");
+	ok &= expect(readFile(current) == QByteArray("new"),
+		"failed helper leaves the active file untouched");
+	const QString rollbackStage = QDir(temp.path()).filePath("rollback-stage.bin");
+	const QString launchFailureBackup = QDir(temp.path()).filePath("launch-failure.bin");
+	ok &= expect(writeFile(current, "old-again") && writeFile(rollbackStage, "new-again"),
+		"rollback fixture is writable");
+	ok &= expect(QProcess::execute(helper, {
+		"--parent-pid", "0", "--current", current, "--staged", rollbackStage,
+		"--backup", launchFailureBackup, "--launch", QDir(temp.path()).filePath("missing-launch")}) != 0,
+		"helper rolls back when relaunch fails");
+	ok &= expect(readFile(current) == QByteArray("old-again"),
+		"launch failure restores the previous file");
+
+	const QString currentDir = QDir(temp.path()).filePath("current-dir");
+	const QString stagedDir = QDir(temp.path()).filePath("staged-dir");
+	const QString backupDir = QDir(temp.path()).filePath("backup-dir");
+	QDir().mkpath(currentDir);
+	QDir().mkpath(stagedDir);
+	ok &= expect(writeFile(QDir(currentDir).filePath("marker"), "old"),
+		"directory fixture current is writable");
+	ok &= expect(writeFile(QDir(stagedDir).filePath("marker"), "new"),
+		"directory fixture staged is writable");
+	QProcess directoryUpdate;
+	directoryUpdate.setProgram(helper);
+	directoryUpdate.setArguments({
+		"--parent-pid", "0", "--current", currentDir, "--staged", stagedDir,
+		"--backup", backupDir, "--launch", QCoreApplication::applicationFilePath()});
+	directoryUpdate.setWorkingDirectory(currentDir);
+	directoryUpdate.start();
+	directoryUpdate.waitForFinished();
+	ok &= expect(directoryUpdate.exitStatus() == QProcess::NormalExit
+		&& directoryUpdate.exitCode() == 0,
+		"helper installs a staged directory");
+	ok &= expect(readFile(QDir(currentDir).filePath("marker")) == QByteArray("new"),
+		"new directory is active after helper success");
+	return ok ? 0 : 1;
+}

--- a/EGTRAIN/QEGTRAIN/tests/test_updatepreparation.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_updatepreparation.cpp
@@ -1,0 +1,137 @@
+#include "update/UpdatePreparation.h"
+
+#include <QCryptographicHash>
+#include <QCoreApplication>
+#include <QDir>
+#include <QEventLoop>
+#include <QFile>
+#include <QTemporaryDir>
+#include <QThread>
+#include <QTimer>
+
+#include <functional>
+#include <iostream>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+static bool writeFile(const QString& path, const QByteArray& contents) {
+	QFile file(path);
+	return file.open(QIODevice::WriteOnly) && file.write(contents) == contents.size();
+}
+
+struct PreparationOutcome {
+	UpdatePreparationResult result;
+	QThread* stagerThread = nullptr;
+	QThread* deliveryThread = nullptr;
+	bool stagerRan = false;
+	int heartbeatTicks = 0;
+};
+
+static PreparationOutcome runPreparation(const UpdatePreparationInput& input,
+	const std::function<QString(const UpdatePreparationInput&, QString*)>& stager) {
+	PreparationOutcome outcome;
+	const QThread* mainThread = QCoreApplication::instance()->thread();
+	QEventLoop loop;
+	auto* thread = new QThread;
+	auto* worker = new UpdatePreparationWorker;
+	worker->setPlatformStager([&outcome, stager](const UpdatePreparationInput& stagerInput,
+		QString* error) {
+		outcome.stagerRan = true;
+		outcome.stagerThread = QThread::currentThread();
+		QThread::msleep(150);
+		return stager ? stager(stagerInput, error) : QString();
+	});
+	worker->moveToThread(thread);
+	QObject::connect(thread, &QThread::started, worker,
+		[worker, input]() { worker->prepare(input); });
+	QObject::connect(worker, &UpdatePreparationWorker::finished, &loop,
+		[&outcome, &loop, mainThread](const UpdatePreparationResult& result) {
+			outcome.result = result;
+			outcome.deliveryThread = QThread::currentThread();
+			loop.quit();
+		});
+	QObject::connect(thread, &QThread::finished, worker, &QObject::deleteLater);
+
+	QTimer heartbeat;
+	heartbeat.setInterval(10);
+	QObject::connect(&heartbeat, &QTimer::timeout, &heartbeat,
+		[&outcome]() { ++outcome.heartbeatTicks; });
+	QTimer watchdog;
+	watchdog.setSingleShot(true);
+	QObject::connect(&watchdog, &QTimer::timeout, &loop, &QEventLoop::quit);
+
+	heartbeat.start();
+	watchdog.start(15000);
+	thread->start();
+	loop.exec();
+	heartbeat.stop();
+	thread->quit();
+	if (!thread->wait(5000))
+		std::cerr << "failed: preparation thread stopped\n";
+	delete thread;
+	return outcome;
+}
+
+int main(int argc, char** argv) {
+	QCoreApplication application(argc, argv);
+	qRegisterMetaType<UpdatePreparationInput>("UpdatePreparationInput");
+	qRegisterMetaType<UpdatePreparationResult>("UpdatePreparationResult");
+	QTemporaryDir temp;
+	if (!temp.isValid())
+		return 1;
+
+	bool ok = true;
+	QByteArray packageContents(3 * 1024 * 1024, 'p');
+	for (int offset = 0; offset < packageContents.size(); offset += 4096)
+		packageContents[offset] = static_cast<char>(offset % 251);
+	const QString packagePath = QDir(temp.path()).filePath(QStringLiteral("package.zip"));
+	ok &= expect(writeFile(packagePath, packageContents), "package fixture is writable");
+	const QString expectedSha = QString::fromLatin1(
+		QCryptographicHash::hash(packageContents, QCryptographicHash::Sha256).toHex());
+	const QThread* mainThread = QCoreApplication::instance()->thread();
+
+	const auto baseInput = [&](const QString& sha256) {
+		UpdatePreparationInput input;
+		input.packagePath = packagePath;
+		input.stagingRoot = QDir(temp.path()).filePath(QStringLiteral("staging"));
+		input.currentPath = QDir(temp.path()).filePath(QStringLiteral("current"));
+		input.manifest.version = QStringLiteral("1.2.3");
+		input.manifest.assetName = QStringLiteral("package.zip");
+		input.manifest.sha256 = sha256;
+		input.manifest.assetSize = packageContents.size();
+		return input;
+	};
+
+	PreparationOutcome failedHash = runPreparation(
+		baseInput(QString(64, '0')), [](const UpdatePreparationInput&, QString*) {
+			return QStringLiteral("should-not-stage");
+		});
+	ok &= expect(!failedHash.result.success && !failedHash.stagerRan,
+		"a failed hash never proceeds to staging");
+	ok &= expect(failedHash.result.error
+		== QStringLiteral("The downloaded update failed its SHA-256 check."),
+		"hash failure reports the SHA-256 mismatch");
+	ok &= expect(failedHash.result.stagedPath.isEmpty(),
+		"a failed hash publishes no staged path");
+
+	const QString stagedPath = QDir(temp.path()).filePath(QStringLiteral("staged"));
+	PreparationOutcome prepared = runPreparation(baseInput(expectedSha),
+		[stagedPath](const UpdatePreparationInput&, QString*) { return stagedPath; });
+	ok &= expect(prepared.result.success && prepared.result.error.isEmpty(),
+		"successful preparation completes without an error");
+	ok &= expect(prepared.result.stagedPath == stagedPath,
+		"successful preparation publishes only the resulting staged path");
+	ok &= expect(prepared.stagerRan && prepared.stagerThread
+		&& prepared.stagerThread != mainThread,
+		"preparation work runs off the application thread");
+	ok &= expect(prepared.deliveryThread == mainThread,
+		"preparation completion is delivered on the application thread");
+	ok &= expect(prepared.heartbeatTicks >= 4,
+		"the event loop keeps processing events while preparation runs");
+
+	return ok ? 0 : 1;
+}

--- a/EGTRAIN/QEGTRAIN/tests/test_updatestaging.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_updatestaging.cpp
@@ -1,0 +1,93 @@
+#include "update/WindowsStaging.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+static bool expect(bool condition, const char* message) {
+	if (!condition)
+		std::cerr << "failed: " << message << "\n";
+	return condition;
+}
+
+static bool writeFile(const QString& path, const QByteArray& contents) {
+	QFile file(path);
+	return file.open(QIODevice::WriteOnly) && file.write(contents) == contents.size();
+}
+
+static QByteArray readFile(const QString& path) {
+	QFile file(path);
+	if (!file.open(QIODevice::ReadOnly))
+		return {};
+	return file.readAll();
+}
+
+static void populateInstallation(const QString& directory, const char* marker,
+	const char* executableContents) {
+	QDir().mkpath(QDir(directory).filePath(QStringLiteral("platforms")));
+	QDir().mkpath(QDir(directory).filePath(QStringLiteral("Scenes")));
+	writeFile(QDir(directory).filePath(QStringLiteral("QEGTRAIN.exe")), executableContents);
+	writeFile(QDir(directory).filePath(QStringLiteral("egtrain_update_helper.exe")),
+		executableContents);
+	writeFile(QDir(directory).filePath(QStringLiteral("Qt5Network.dll")), executableContents);
+	writeFile(QDir(directory).filePath(QStringLiteral("platforms/qwindows.dll")),
+		executableContents);
+	writeFile(QDir(directory).filePath(QStringLiteral("Scenes/marker.txt")), marker);
+}
+
+int main(int argc, char** argv) {
+	QCoreApplication application(argc, argv);
+	QTemporaryDir temp;
+	if (!temp.isValid())
+		return 1;
+
+	bool ok = true;
+	const QString current = QDir(temp.path()).filePath(QStringLiteral("current"));
+	populateInstallation(current, "old", "old");
+	ok &= expect(writeFile(QDir(current).filePath(QStringLiteral("obsolete-runtime-file.dll")),
+		"old-dll"), "old installation fixture is writable");
+
+	const QString extract = QDir(temp.path()).filePath(QStringLiteral("extract"));
+	populateInstallation(extract, "new", "new");
+
+	QString error;
+	const QString staged = QDir(temp.path()).filePath(QStringLiteral("QEGTRAIN"));
+	ok &= expect(!QFileInfo(staged).exists(), "staging starts without an installation");
+	ok &= expect(WindowsStaging::buildStage(extract, staged, &error),
+		"staging builds from the extracted release package");
+	ok &= expect(readFile(QDir(staged).filePath(QStringLiteral("Scenes/marker.txt")))
+		== QByteArray("new"), "the new package owns the shipped Scenes");
+	ok &= expect(!QFileInfo(QDir(staged).filePath(
+		QStringLiteral("obsolete-runtime-file.dll"))).exists(),
+		"stale old installation files are dropped");
+	ok &= expect(readFile(QDir(staged).filePath(QStringLiteral("QEGTRAIN.exe")))
+		== QByteArray("new"), "staged runtime files come from the new package");
+
+	error.clear();
+	ok &= expect(!WindowsStaging::buildStage(extract, staged, &error)
+		&& error == QStringLiteral("The Windows update staging location is not empty."),
+		"staging refuses to merge into an existing installation");
+
+	const QString incomplete = QDir(temp.path()).filePath(QStringLiteral("incomplete"));
+	populateInstallation(incomplete, "new", "new");
+	QFile::remove(QDir(incomplete).filePath(QStringLiteral("Qt5Network.dll")));
+	error.clear();
+	ok &= expect(!WindowsStaging::buildStage(incomplete,
+		QDir(temp.path()).filePath(QStringLiteral("staged-incomplete")), &error)
+		&& error == QStringLiteral("The Windows update package is missing required runtime files."),
+		"staging rejects a package with missing runtime files");
+
+	const QString noExecutable = QDir(temp.path()).filePath(QStringLiteral("no-executable"));
+	QDir().mkpath(noExecutable);
+	error.clear();
+	ok &= expect(!WindowsStaging::buildStage(noExecutable,
+		QDir(temp.path()).filePath(QStringLiteral("staged-no-executable")), &error)
+		&& error == QStringLiteral("The Windows update package does not contain QEGTRAIN.exe."),
+		"staging rejects a package without QEGTRAIN.exe");
+
+	return ok ? 0 : 1;
+}

--- a/EGTRAIN/QEGTRAIN/update/ReleaseInfo.cpp
+++ b/EGTRAIN/QEGTRAIN/update/ReleaseInfo.cpp
@@ -4,6 +4,10 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
+#include <QRegularExpression>
+#include <QSysInfo>
+#include <QStringList>
+#include <cmath>
 
 namespace {
 
@@ -19,7 +23,68 @@ QString releaseNotes(const QJsonObject& object) {
 	return notes;
 }
 
+QString expectedAssetName(const QString& platform) {
+	if (platform == QStringLiteral("macos-arm64"))
+		return QStringLiteral("QEGTRAIN-macos-arm64.zip");
+	if (platform == QStringLiteral("windows-x64"))
+		return QStringLiteral("QEGTRAIN-windows-x64.zip");
+	if (platform == QStringLiteral("linux-x86_64"))
+		return QStringLiteral("QEGTRAIN-linux-x86_64.AppImage");
+	return {};
+}
+
+bool validHttpsGitHubUrl(const QUrl& url) {
+	return url.isValid() && url.scheme() == QStringLiteral("https")
+		&& url.host().compare(QStringLiteral("github.com"), Qt::CaseInsensitive) == 0
+		&& url.userInfo().isEmpty() && url.port(-1) == -1
+		&& url.query().isEmpty() && url.fragment().isEmpty();
+}
+
+void setManifestError(QString* error, const QString& message) {
+	if (error)
+		*error = message;
+}
+
 } // namespace
+
+const ReleaseAsset* StableRelease::asset(const QString& name) const {
+	for (const ReleaseAsset& candidate : assets)
+		if (candidate.name == name)
+			return &candidate;
+	return nullptr;
+}
+
+QString updatePlatformKey() {
+#if defined(Q_OS_MACOS)
+	const QString architecture = QSysInfo::currentCpuArchitecture().toLower();
+	return architecture == QStringLiteral("arm64") || architecture == QStringLiteral("aarch64")
+		? QStringLiteral("macos-arm64") : QString();
+#elif defined(Q_OS_WIN)
+	const QString architecture = QSysInfo::currentCpuArchitecture().toLower();
+	return architecture == QStringLiteral("x86_64") || architecture == QStringLiteral("amd64")
+		? QStringLiteral("windows-x64") : QString();
+#elif defined(Q_OS_LINUX)
+	const QString architecture = QSysInfo::currentCpuArchitecture().toLower();
+	return architecture == QStringLiteral("x86_64") || architecture == QStringLiteral("amd64")
+		? QStringLiteral("linux-x86_64") : QString();
+#else
+	return {};
+#endif
+}
+
+QString updatePackageName(const QString& platform) {
+	return expectedAssetName(platform);
+}
+
+QString updateManifestAssetName() {
+	return QStringLiteral("update-manifest.json");
+}
+
+bool isExpectedReleaseAssetUrl(const QString& tag, const QString& name, const QUrl& url) {
+	return validHttpsGitHubUrl(url)
+		&& url.path() == QStringLiteral("/Ancientkingg/EGTRAIN/releases/download/%1/%2")
+			.arg(tag, name);
+}
 
 std::optional<StableRelease> parseLatestStableRelease(const QByteArray& json, QString* error) {
 	QJsonParseError parseError;
@@ -57,16 +122,79 @@ std::optional<StableRelease> parseLatestStableRelease(const QByteArray& json, QS
 			continue;
 
 		QUrl releasePage(object.value(QStringLiteral("html_url")).toString());
-		if (!releasePage.isValid() || releasePage.scheme() != QStringLiteral("https")
-			|| releasePage.host().compare(QStringLiteral("github.com"), Qt::CaseInsensitive) != 0
-			|| !releasePage.path().startsWith(QStringLiteral("/Ancientkingg/EGTRAIN/releases/tag/")))
-			releasePage = QUrl(QStringLiteral("https://github.com/Ancientkingg/EGTRAIN/releases/tag/") + tag);
-		latest = StableRelease{*version, tag, releaseNotes(object), releasePage};
+		const QUrl expectedPage(QStringLiteral("https://github.com/Ancientkingg/EGTRAIN/releases/tag/") + tag);
+		if (!validHttpsGitHubUrl(releasePage) || releasePage.path() != expectedPage.path())
+			releasePage = expectedPage;
+
+		QList<ReleaseAsset> assets;
+		const QJsonValue rawAssets = object.value(QStringLiteral("assets"));
+		if (rawAssets.isArray()) {
+			for (const QJsonValue& rawAsset : rawAssets.toArray()) {
+				if (!rawAsset.isObject())
+					continue;
+				const QJsonObject asset = rawAsset.toObject();
+				const QString name = asset.value(QStringLiteral("name")).toString();
+				const QStringList allowedNames = {
+					updateManifestAssetName(),
+					updatePackageName(QStringLiteral("macos-arm64")),
+					updatePackageName(QStringLiteral("windows-x64")),
+					updatePackageName(QStringLiteral("linux-x86_64"))};
+				if (!allowedNames.contains(name))
+					continue;
+				const QUrl downloadUrl(asset.value(QStringLiteral("browser_download_url")).toString());
+				if (isExpectedReleaseAssetUrl(tag, name, downloadUrl))
+					assets.append({name, downloadUrl});
+			}
+		}
+		latest = StableRelease{*version, tag, releaseNotes(object), releasePage, assets};
 	}
 
 	if (!latest)
 		setError(error, QStringLiteral("No stable vX.Y.Z GitHub release was found."));
 	return latest;
+}
+
+std::optional<UpdateManifest> parseUpdateManifest(const QByteArray& json,
+	const QString& expectedTag, const QString& platform, QString* error) {
+	QJsonParseError parseError;
+	const QJsonDocument document = QJsonDocument::fromJson(json, &parseError);
+	if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+		setManifestError(error, QStringLiteral("Invalid update manifest JSON."));
+		return std::nullopt;
+	}
+	if (!parseStableTag(expectedTag.toStdString())) {
+		setManifestError(error, QStringLiteral("Update manifest release tag is invalid."));
+		return std::nullopt;
+	}
+	const QJsonObject root = document.object();
+	const QString expectedVersion = expectedTag.mid(1);
+	if (root.value(QStringLiteral("version")).toString() != expectedVersion
+		|| !parseStableVersion(root.value(QStringLiteral("version")).toString().toStdString())) {
+		setManifestError(error, QStringLiteral("Update manifest version does not match the release tag."));
+		return std::nullopt;
+	}
+	const QJsonObject assets = root.value(QStringLiteral("assets")).toObject();
+	const QJsonObject entry = assets.value(platform).toObject();
+	const QString expectedName = expectedAssetName(platform);
+	const QString asset = entry.value(QStringLiteral("name")).toString();
+	const QString sha256 = entry.value(QStringLiteral("sha256")).toString();
+	const double rawSize = entry.value(QStringLiteral("size")).toDouble(-1.0);
+	if (expectedName.isEmpty() || asset != expectedName) {
+		setManifestError(error, QStringLiteral("Update manifest has no valid package for this platform."));
+		return std::nullopt;
+	}
+	static const QRegularExpression hashPattern(QStringLiteral("^[0-9a-f]{64}$"));
+	if (!hashPattern.match(sha256).hasMatch()) {
+		setManifestError(error, QStringLiteral("Update manifest has an invalid SHA-256."));
+		return std::nullopt;
+	}
+	constexpr qint64 kMaxPackageBytes = 2LL * 1024 * 1024 * 1024;
+	if (!std::isfinite(rawSize) || rawSize < 1.0 || rawSize > kMaxPackageBytes
+		|| std::floor(rawSize) != rawSize) {
+		setManifestError(error, QStringLiteral("Update manifest has an invalid package size."));
+		return std::nullopt;
+	}
+	return UpdateManifest{expectedVersion, platform, asset, sha256, static_cast<qint64>(rawSize)};
 }
 
 bool isUpdateAvailable(const SemanticVersion& current, const StableRelease& release) {

--- a/EGTRAIN/QEGTRAIN/update/ReleaseInfo.h
+++ b/EGTRAIN/QEGTRAIN/update/ReleaseInfo.h
@@ -4,18 +4,43 @@
 #include "util/Version.h"
 
 #include <QByteArray>
+#include <QList>
 #include <QString>
 #include <QUrl>
 #include <optional>
+
+struct ReleaseAsset {
+	QString name;
+	QUrl downloadUrl;
+};
 
 struct StableRelease {
 	SemanticVersion version;
 	QString tag;
 	QString notes;
 	QUrl releasePage;
+	QList<ReleaseAsset> assets;
+
+	const ReleaseAsset* asset(const QString& name) const;
 };
 
+struct UpdateManifest {
+	QString version;
+	QString platform;
+	QString assetName;
+	QString sha256;
+	qint64 assetSize = 0;
+};
+
+QString updatePlatformKey();
+QString updatePackageName(const QString& platform = updatePlatformKey());
+QString updateManifestAssetName();
+bool isExpectedReleaseAssetUrl(const QString& tag, const QString& name, const QUrl& url);
+
 std::optional<StableRelease> parseLatestStableRelease(const QByteArray& json,
+	QString* error = nullptr);
+std::optional<UpdateManifest> parseUpdateManifest(const QByteArray& json,
+	const QString& expectedTag, const QString& platform = updatePlatformKey(),
 	QString* error = nullptr);
 bool isUpdateAvailable(const SemanticVersion& current, const StableRelease& release);
 QString formatSemanticVersion(const SemanticVersion& version);

--- a/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
+++ b/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
@@ -1,5 +1,7 @@
 #include "update/SelfUpdater.h"
 
+#include "update/WindowsStaging.h"
+
 #include <QCoreApplication>
 #include <QCryptographicHash>
 #include <QDir>
@@ -40,53 +42,6 @@ bool writableParent(const QString& path) {
 	const QFileInfo info(path);
 	const QFileInfo parent(info.absolutePath());
 	return parent.exists() && parent.isDir() && parent.isWritable();
-}
-
-bool copyTree(const QString& sourcePath, const QString& destinationPath) {
-	const QFileInfo source(sourcePath);
-	if (!source.isDir() || source.isSymLink())
-		return false;
-	if (!QDir().mkpath(destinationPath))
-		return false;
-	const QDir sourceDir(sourcePath);
-	const QFileInfoList entries = sourceDir.entryInfoList(
-		QDir::NoDotAndDotDot | QDir::AllEntries | QDir::Hidden | QDir::System,
-		QDir::DirsFirst | QDir::Name);
-	for (const QFileInfo& entry : entries) {
-		if (entry.isSymLink())
-			return false;
-		const QString destination = QDir(destinationPath).filePath(entry.fileName());
-		if (entry.isDir()) {
-			if (!copyTree(entry.absoluteFilePath(), destination))
-				return false;
-			continue;
-		}
-		if (!entry.isFile())
-			return false;
-		QFile::remove(destination);
-		if (!QFile::copy(entry.absoluteFilePath(), destination))
-			return false;
-	}
-	return true;
-}
-
-bool cleanWindowsRuntime(const QString& directory) {
-	QDir root(directory);
-	for (const QFileInfo& dll : root.entryInfoList({QStringLiteral("*.dll")}, QDir::Files))
-		if (!QFile::remove(dll.absoluteFilePath()))
-			return false;
-	for (const QString& executable : {QStringLiteral("QEGTRAIN.exe"),
-		QStringLiteral("scene_tool.exe"), QStringLiteral("egtrain_update_helper.exe")})
-		if (QFileInfo::exists(root.filePath(executable)) && !QFile::remove(root.filePath(executable)))
-			return false;
-	for (const QString& pluginDirectory : {QStringLiteral("platforms"), QStringLiteral("imageformats"),
-		QStringLiteral("iconengines"), QStringLiteral("styles"), QStringLiteral("tls"),
-		QStringLiteral("bearer")}) {
-		const QString path = root.filePath(pluginDirectory);
-		if (QFileInfo::exists(path) && !QDir(path).removeRecursively())
-			return false;
-	}
-	return true;
 }
 
 bool runProcess(const QString& program, const QStringList& arguments, int timeoutMs,
@@ -526,42 +481,8 @@ bool SelfUpdater::stageWindowsPackage(const QString& packagePath, QString* error
 		{QStringLiteral("-NoProfile"), QStringLiteral("-NonInteractive"), QStringLiteral("-Command"), script},
 		60000, error, &environment))
 		return false;
-	if (!QFileInfo(QDir(extract).filePath(executableName())).isFile()) {
-		if (error)
-			*error = QStringLiteral("The Windows update package does not contain QEGTRAIN.exe.");
-		return false;
-	}
 	m_stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN"));
-	if (!copyTree(m_currentPath, m_stagedPath) || !cleanWindowsRuntime(m_stagedPath)) {
-		if (error)
-			*error = QStringLiteral("Could not stage the Windows update without touching user files.");
-		return false;
-	}
-	// Keep any case studies stored beside the portable application. Application
-	// binaries and runtime plugins still come exclusively from the new package.
-	if (QFileInfo(QDir(m_currentPath).filePath(QStringLiteral("Scenes"))).isDir()) {
-		const QString packagedScenes = QDir(extract).filePath(QStringLiteral("Scenes"));
-		const QFileInfo packagedScenesInfo(packagedScenes);
-		if (packagedScenesInfo.isSymLink()
-			|| (packagedScenesInfo.exists() && !QDir(packagedScenes).removeRecursively())) {
-			if (error)
-				*error = QStringLiteral("Could not preserve portable case studies while staging the update.");
-			return false;
-		}
-	}
-	if (!copyTree(extract, m_stagedPath)) {
-		if (error)
-			*error = QStringLiteral("Could not finish staging the Windows update.");
-		return false;
-	}
-	if (!QFileInfo(QDir(m_stagedPath).filePath(executableName())).isFile()
-		|| !QFileInfo(QDir(m_stagedPath).filePath(QStringLiteral("Qt5Network.dll"))).isFile()
-		|| !QFileInfo(QDir(m_stagedPath).filePath(QStringLiteral("platforms/qwindows.dll"))).isFile()) {
-		if (error)
-			*error = QStringLiteral("The Windows update package is missing required runtime files.");
-		return false;
-	}
-	return true;
+	return WindowsStaging::buildStage(extract, m_stagedPath, error);
 }
 
 bool SelfUpdater::stageLinuxPackage(const QString& packagePath, QString* error) {

--- a/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
+++ b/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
@@ -122,7 +122,6 @@ bool validElf(const QString& path) {
 	return file.read(4) == QByteArray::fromHex("7f454c46");
 }
 
-#if defined(Q_OS_MACOS)
 std::optional<QString> macBundleVersion(const QString& bundlePath) {
 	QFile plist(QDir(bundlePath).filePath(QStringLiteral("Contents/Info.plist")));
 	if (!plist.open(QIODevice::ReadOnly | QIODevice::Text))
@@ -142,7 +141,6 @@ std::optional<QString> macBundleVersion(const QString& bundlePath) {
 	}
 	return std::nullopt;
 }
-#endif
 
 } // namespace
 

--- a/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
+++ b/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
@@ -1,0 +1,627 @@
+#include "update/SelfUpdater.h"
+
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFileInfo>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QTemporaryDir>
+#include <QXmlStreamReader>
+
+#ifndef EGTRAIN_PACKAGED_BUILD
+#define EGTRAIN_PACKAGED_BUILD 0
+#endif
+
+namespace {
+
+constexpr int kDownloadTimeoutMs = 30000;
+constexpr qint64 kMaxManifestBytes = 128 * 1024;
+
+QString executableName() {
+#if defined(Q_OS_WIN)
+	return QStringLiteral("QEGTRAIN.exe");
+#else
+	return QStringLiteral("QEGTRAIN");
+#endif
+}
+
+QString helperName() {
+#if defined(Q_OS_WIN)
+	return QStringLiteral("egtrain_update_helper.exe");
+#else
+	return QStringLiteral("egtrain_update_helper");
+#endif
+}
+
+bool writableParent(const QString& path) {
+	const QFileInfo info(path);
+	const QFileInfo parent(info.absolutePath());
+	return parent.exists() && parent.isDir() && parent.isWritable();
+}
+
+bool copyTree(const QString& sourcePath, const QString& destinationPath) {
+	const QFileInfo source(sourcePath);
+	if (!source.isDir() || source.isSymLink())
+		return false;
+	if (!QDir().mkpath(destinationPath))
+		return false;
+	const QDir sourceDir(sourcePath);
+	const QFileInfoList entries = sourceDir.entryInfoList(
+		QDir::NoDotAndDotDot | QDir::AllEntries | QDir::Hidden | QDir::System,
+		QDir::DirsFirst | QDir::Name);
+	for (const QFileInfo& entry : entries) {
+		if (entry.isSymLink())
+			return false;
+		const QString destination = QDir(destinationPath).filePath(entry.fileName());
+		if (entry.isDir()) {
+			if (!copyTree(entry.absoluteFilePath(), destination))
+				return false;
+			continue;
+		}
+		if (!entry.isFile())
+			return false;
+		QFile::remove(destination);
+		if (!QFile::copy(entry.absoluteFilePath(), destination))
+			return false;
+	}
+	return true;
+}
+
+bool cleanWindowsRuntime(const QString& directory) {
+	QDir root(directory);
+	for (const QFileInfo& dll : root.entryInfoList({QStringLiteral("*.dll")}, QDir::Files))
+		if (!QFile::remove(dll.absoluteFilePath()))
+			return false;
+	for (const QString& executable : {QStringLiteral("QEGTRAIN.exe"),
+		QStringLiteral("scene_tool.exe"), QStringLiteral("egtrain_update_helper.exe")})
+		if (QFileInfo::exists(root.filePath(executable)) && !QFile::remove(root.filePath(executable)))
+			return false;
+	for (const QString& pluginDirectory : {QStringLiteral("platforms"), QStringLiteral("imageformats"),
+		QStringLiteral("iconengines"), QStringLiteral("styles"), QStringLiteral("tls"),
+		QStringLiteral("bearer")}) {
+		const QString path = root.filePath(pluginDirectory);
+		if (QFileInfo::exists(path) && !QDir(path).removeRecursively())
+			return false;
+	}
+	return true;
+}
+
+bool runProcess(const QString& program, const QStringList& arguments, int timeoutMs,
+	QString* error = nullptr, const QProcessEnvironment* environment = nullptr) {
+	QProcess process;
+	if (environment)
+		process.setProcessEnvironment(*environment);
+	process.start(program, arguments);
+	if (!process.waitForStarted(5000)) {
+		if (error)
+			*error = QStringLiteral("Could not start %1.").arg(program);
+		return false;
+	}
+	if (!process.waitForFinished(timeoutMs)) {
+		process.kill();
+		process.waitForFinished(1000);
+		if (error)
+			*error = QStringLiteral("%1 timed out.").arg(program);
+		return false;
+	}
+	if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
+		if (error)
+			*error = QStringLiteral("%1 could not prepare the update package.").arg(program);
+		return false;
+	}
+	return true;
+}
+
+bool validElf(const QString& path) {
+	QFile file(path);
+	if (!file.open(QIODevice::ReadOnly))
+		return false;
+	return file.read(4) == QByteArray::fromHex("7f454c46");
+}
+
+#if defined(Q_OS_MACOS)
+std::optional<QString> macBundleVersion(const QString& bundlePath) {
+	QFile plist(QDir(bundlePath).filePath(QStringLiteral("Contents/Info.plist")));
+	if (!plist.open(QIODevice::ReadOnly | QIODevice::Text))
+		return std::nullopt;
+	QXmlStreamReader xml(&plist);
+	QString key;
+	while (!xml.atEnd()) {
+		xml.readNext();
+		if (!xml.isStartElement())
+			continue;
+		if (xml.name() == QStringLiteral("key")) {
+			key = xml.readElementText();
+		} else if (xml.name() == QStringLiteral("string")
+			&& key == QStringLiteral("CFBundleShortVersionString")) {
+			return xml.readElementText();
+		}
+	}
+	return std::nullopt;
+}
+#endif
+
+} // namespace
+
+SelfUpdater::SelfUpdater(QObject* parent)
+	: QObject(parent), m_network(this), m_timeout(this) {
+	m_timeout.setSingleShot(true);
+	connect(&m_timeout, &QTimer::timeout, this, [this]() {
+		if (!m_reply)
+			return;
+		m_cancelRequested = false;
+		QNetworkReply* reply = m_reply;
+		m_reply = nullptr;
+		reply->abort();
+		reply->deleteLater();
+		fail(QStringLiteral("The update download timed out."));
+	});
+}
+
+SelfUpdateCapability SelfUpdater::capability() const {
+	SelfUpdateCapability result;
+#if !EGTRAIN_PACKAGED_BUILD
+	result.reason = QStringLiteral("Self-update is available only in packaged release builds.");
+	return result;
+#else
+	const QString applicationPath = QFileInfo(QCoreApplication::applicationFilePath()).absoluteFilePath();
+	result.launchPath = applicationPath;
+	result.helperPath = QDir(QCoreApplication::applicationDirPath()).filePath(helperName());
+
+#if defined(Q_OS_MACOS)
+	const QString applicationDirectory = QFileInfo(applicationPath).absolutePath();
+	const QString bundlePath = QDir(applicationDirectory).filePath("../..");
+	const QFileInfo bundleInfo(QDir(bundlePath).absolutePath());
+	result.currentPath = bundleInfo.absoluteFilePath();
+	if (!bundleInfo.isDir() || bundleInfo.fileName() != QStringLiteral("QEGTRAIN.app")) {
+		result.reason = QStringLiteral("The running application is not a packaged macOS app.");
+		return result;
+	}
+	if (!QFileInfo(QDir(result.currentPath).filePath("Contents/MacOS/QEGTRAIN")).isFile()
+		|| !QFileInfo(QDir(result.currentPath).filePath("Contents/Info.plist")).isFile()) {
+		result.reason = QStringLiteral("The packaged macOS app is incomplete.");
+		return result;
+	}
+#elif defined(Q_OS_WIN)
+	result.currentPath = QFileInfo(applicationPath).absolutePath();
+	if (QFileInfo(applicationPath).fileName().compare(executableName(), Qt::CaseInsensitive) != 0
+		|| !QFileInfo(applicationPath).isFile()) {
+		result.reason = QStringLiteral("The running application is not a packaged Windows release.");
+		return result;
+	}
+#elif defined(Q_OS_LINUX)
+	const QString appImage = qEnvironmentVariable("APPIMAGE");
+	const QFileInfo appImageInfo(appImage);
+	const QString resolved = appImageInfo.canonicalFilePath();
+	if (resolved.isEmpty() || !QFileInfo(resolved).isFile()) {
+		result.reason = QStringLiteral("The application is not running from an AppImage.");
+		return result;
+	}
+	result.currentPath = resolved;
+	result.launchPath = resolved;
+#else
+	result.reason = QStringLiteral("Self-update is not supported on this platform.");
+	return result;
+#endif
+
+	if (!QFileInfo(result.helperPath).isFile()) {
+		result.reason = QStringLiteral("The packaged update helper is missing.");
+		return result;
+	}
+	if (!writableParent(result.currentPath)) {
+		result.reason = QStringLiteral("The packaged installation is not writable.");
+		return result;
+	}
+	result.supported = true;
+	return result;
+#endif
+}
+
+bool SelfUpdater::canSelfUpdate(const StableRelease& release) const {
+	const SelfUpdateCapability current = capability();
+	return current.supported && release.asset(updateManifestAssetName())
+		&& release.asset(updatePackageName());
+}
+
+void SelfUpdater::start(const StableRelease& release) {
+	if (m_busy)
+		return;
+	const SelfUpdateCapability current = capability();
+	if (!current.supported) {
+		emit finished(false, current.reason);
+		return;
+	}
+	if (!release.asset(updateManifestAssetName()) || !release.asset(updatePackageName())) {
+		emit finished(false, QStringLiteral("This release does not provide a verified update package."));
+		return;
+	}
+	m_busy = true;
+	m_ready = false;
+	m_cancelRequested = false;
+	m_release = release;
+	m_currentPath = current.currentPath;
+	m_launchPath = current.launchPath;
+	m_helperPath = current.helperPath;
+	m_stagingRoot.clear();
+	m_stagedPath.clear();
+	m_manifestData.clear();
+	requestManifest();
+}
+
+void SelfUpdater::requestManifest() {
+	const ReleaseAsset* asset = m_release.asset(updateManifestAssetName());
+	if (!asset) {
+		fail(QStringLiteral("The release manifest is missing."));
+		return;
+	}
+	QNetworkRequest request(asset->downloadUrl);
+	request.setHeader(QNetworkRequest::UserAgentHeader,
+		QStringLiteral("EGTRAIN/%1").arg(QCoreApplication::applicationVersion()));
+	request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+		QNetworkRequest::NoLessSafeRedirectPolicy);
+	m_manifestData.clear();
+	QNetworkReply* reply = m_network.get(request);
+	m_reply = reply;
+	m_timeout.start(kDownloadTimeoutMs);
+	connect(reply, &QNetworkReply::readyRead, this, [this, reply]() {
+		if (reply != m_reply)
+			return;
+		m_timeout.start(kDownloadTimeoutMs);
+		m_manifestData += reply->readAll();
+		if (m_manifestData.size() > kMaxManifestBytes)
+			fail(QStringLiteral("The update manifest is too large."));
+	});
+	connect(reply, &QNetworkReply::downloadProgress, this,
+		[this, reply](qint64, qint64) {
+			if (reply == m_reply)
+				m_timeout.start(kDownloadTimeoutMs);
+		});
+	connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+		if (reply == m_reply)
+			handleReply(reply, true);
+	});
+}
+
+void SelfUpdater::requestPackage(const UpdateManifest& manifest) {
+	const ReleaseAsset* asset = m_release.asset(manifest.assetName);
+	if (!asset || !isExpectedReleaseAssetUrl(m_release.tag, manifest.assetName, asset->downloadUrl)) {
+		fail(QStringLiteral("The release package URL is not trusted."));
+		return;
+	}
+	QTemporaryDir staging(QDir(QFileInfo(m_currentPath).absolutePath()).filePath(
+		QStringLiteral(".qegtrain-update-XXXXXX")));
+	if (!staging.isValid()) {
+		fail(QStringLiteral("Could not create update staging storage."));
+		return;
+	}
+	staging.setAutoRemove(false);
+	m_stagingRoot = staging.path();
+	const QString packagePath = QDir(m_stagingRoot).filePath(manifest.assetName);
+	m_packageFile.setFileName(packagePath);
+	if (!m_packageFile.open(QIODevice::WriteOnly)) {
+		fail(QStringLiteral("Could not create the update download file."));
+		return;
+	}
+	m_manifest = manifest;
+	m_packageBytes = 0;
+	QNetworkRequest request(asset->downloadUrl);
+	request.setHeader(QNetworkRequest::UserAgentHeader,
+		QStringLiteral("EGTRAIN/%1").arg(QCoreApplication::applicationVersion()));
+	request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+		QNetworkRequest::NoLessSafeRedirectPolicy);
+	QNetworkReply* reply = m_network.get(request);
+	m_reply = reply;
+	m_timeout.start(kDownloadTimeoutMs);
+	connect(reply, &QNetworkReply::readyRead, this, [this, reply]() {
+		if (reply != m_reply)
+			return;
+		m_timeout.start(kDownloadTimeoutMs);
+		const QByteArray data = reply->readAll();
+		if (data.size() > m_manifest.assetSize - m_packageBytes) {
+			fail(QStringLiteral("The update package is larger than the release manifest."));
+			return;
+		}
+		if (m_packageFile.write(data) != data.size()) {
+			fail(QStringLiteral("Could not save the downloaded update."));
+			return;
+		}
+		m_packageBytes += data.size();
+	});
+	connect(reply, &QNetworkReply::downloadProgress, this,
+		[this, reply](qint64 received, qint64 total) {
+			if (reply != m_reply)
+				return;
+			m_timeout.start(kDownloadTimeoutMs);
+			emit progress(received, total);
+		});
+	connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+		if (reply == m_reply)
+			handleReply(reply, false);
+	});
+}
+
+void SelfUpdater::handleReply(QNetworkReply* reply, bool manifestReply) {
+	if (reply != m_reply)
+		return;
+	m_reply = nullptr;
+	m_timeout.stop();
+	if (m_cancelRequested) {
+		reply->deleteLater();
+		fail(QStringLiteral("Update cancelled."));
+		return;
+	}
+	if (reply->error() != QNetworkReply::NoError) {
+		const QString error = reply->errorString();
+		reply->deleteLater();
+		fail(error.isEmpty() ? QStringLiteral("The update download failed.") : error);
+		return;
+	}
+	const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+	if (status < 200 || status >= 300) {
+		reply->deleteLater();
+		fail(QStringLiteral("GitHub returned HTTP %1 while downloading the update.").arg(status));
+		return;
+	}
+	if (manifestReply) {
+		const qint64 contentLength = reply->header(QNetworkRequest::ContentLengthHeader).toLongLong();
+		if (contentLength > kMaxManifestBytes) {
+			reply->deleteLater();
+			fail(QStringLiteral("The update manifest is too large."));
+			return;
+		}
+		m_manifestData += reply->readAll();
+		if (m_manifestData.size() > kMaxManifestBytes) {
+			reply->deleteLater();
+			fail(QStringLiteral("The update manifest is too large."));
+			return;
+		}
+		QString error;
+		const std::optional<UpdateManifest> manifest = parseUpdateManifest(
+			m_manifestData, m_release.tag, updatePlatformKey(), &error);
+		m_manifestData.clear();
+		reply->deleteLater();
+		if (!manifest) {
+			fail(error.isEmpty() ? QStringLiteral("The update manifest is invalid.") : error);
+			return;
+		}
+		requestPackage(*manifest);
+		return;
+	}
+	const QByteArray tail = reply->readAll();
+	if (tail.size() > m_manifest.assetSize - m_packageBytes) {
+		reply->deleteLater();
+		fail(QStringLiteral("The update package is larger than the release manifest."));
+		return;
+	}
+	if (m_packageFile.write(tail) != tail.size()) {
+		reply->deleteLater();
+		fail(QStringLiteral("Could not save the downloaded update."));
+		return;
+	}
+	m_packageBytes += tail.size();
+	m_packageFile.close();
+	reply->deleteLater();
+	if (m_packageBytes != m_manifest.assetSize) {
+		fail(QStringLiteral("The update package size does not match the release manifest."));
+		return;
+	}
+	QFile package(m_packageFile.fileName());
+	if (!package.open(QIODevice::ReadOnly)) {
+		fail(QStringLiteral("Could not read the downloaded update."));
+		return;
+	}
+	QCryptographicHash hash(QCryptographicHash::Sha256);
+	if (!hash.addData(&package)) {
+		fail(QStringLiteral("Could not verify the downloaded update."));
+		return;
+	}
+	if (QString::fromLatin1(hash.result().toHex()) != m_manifest.sha256) {
+		fail(QStringLiteral("The downloaded update failed its SHA-256 check."));
+		return;
+	}
+	QString error;
+	if (!stagePackage(package.fileName(), &error)) {
+		fail(error.isEmpty() ? QStringLiteral("The update package is incomplete.") : error);
+		return;
+	}
+	m_busy = false;
+	m_ready = true;
+	emit finished(true, QString());
+}
+
+void SelfUpdater::fail(const QString& error) {
+	if (m_reply) {
+		QNetworkReply* reply = m_reply;
+		m_reply = nullptr;
+		reply->abort();
+		reply->deleteLater();
+	}
+	m_timeout.stop();
+	if (m_packageFile.isOpen())
+		m_packageFile.close();
+	clearStaging();
+	m_busy = false;
+	m_ready = false;
+	m_cancelRequested = false;
+	emit finished(false, error);
+}
+
+void SelfUpdater::cancel() {
+	if (!m_busy)
+		return;
+	m_cancelRequested = true;
+	if (m_reply) {
+		m_reply->abort();
+		return;
+	}
+	fail(QStringLiteral("Update cancelled."));
+}
+
+bool SelfUpdater::stagePackage(const QString& packagePath, QString* error) {
+	if (m_stagingRoot.isEmpty()) {
+		if (error)
+			*error = QStringLiteral("Update staging storage is unavailable.");
+		return false;
+	}
+#if defined(Q_OS_MACOS)
+	return stageMacPackage(packagePath, error);
+#elif defined(Q_OS_WIN)
+	return stageWindowsPackage(packagePath, error);
+#elif defined(Q_OS_LINUX)
+	return stageLinuxPackage(packagePath, error);
+#else
+	Q_UNUSED(packagePath);
+	if (error)
+		*error = QStringLiteral("Self-update is not supported on this platform.");
+	return false;
+#endif
+}
+
+bool SelfUpdater::stageMacPackage(const QString& packagePath, QString* error) {
+	const QString& root = m_stagingRoot;
+	const QString extract = QDir(root).filePath(QStringLiteral("extract"));
+	if (!QDir().mkpath(extract))
+		return false;
+	if (!runProcess(QStringLiteral("/usr/bin/ditto"),
+		{QStringLiteral("-x"), QStringLiteral("-k"), packagePath, extract}, 60000, error))
+		return false;
+	const QString source = QDir(extract).filePath(QStringLiteral("QEGTRAIN-Lebanon/QEGTRAIN.app"));
+	const QFileInfo app(source);
+	if (!app.isDir() || app.fileName() != QStringLiteral("QEGTRAIN.app")
+		|| !QFileInfo(QDir(source).filePath("Contents/MacOS/QEGTRAIN")).isFile()
+		|| !QFileInfo(QDir(source).filePath("Contents/Info.plist")).isFile()) {
+		if (error)
+			*error = QStringLiteral("The macOS update package has an invalid app bundle.");
+		return false;
+	}
+	m_stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN.app"));
+	if (!runProcess(QStringLiteral("/usr/bin/ditto"), {source, m_stagedPath}, 60000, error))
+		return false;
+	if (!runProcess(QStringLiteral("/usr/bin/codesign"),
+		{QStringLiteral("--verify"), QStringLiteral("--deep"), QStringLiteral("--strict"), m_stagedPath},
+		60000, error))
+		return false;
+	const std::optional<QString> version = macBundleVersion(m_stagedPath);
+	if (!version || *version != m_manifest.version) {
+		if (error)
+			*error = QStringLiteral("The macOS update app version does not match the release manifest.");
+		return false;
+	}
+	return true;
+}
+
+bool SelfUpdater::stageWindowsPackage(const QString& packagePath, QString* error) {
+	const QString& root = m_stagingRoot;
+	const QString extract = QDir(root).filePath(QStringLiteral("extract"));
+	if (!QDir().mkpath(extract))
+		return false;
+	QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+	environment.insert(QStringLiteral("EGTRAIN_UPDATE_ZIP"), packagePath);
+	environment.insert(QStringLiteral("EGTRAIN_UPDATE_DEST"), extract);
+	const QString script = QStringLiteral(
+		"$ErrorActionPreference='Stop'; Expand-Archive -LiteralPath $env:EGTRAIN_UPDATE_ZIP "
+		"-DestinationPath $env:EGTRAIN_UPDATE_DEST -Force");
+	if (!runProcess(QStringLiteral("powershell.exe"),
+		{QStringLiteral("-NoProfile"), QStringLiteral("-NonInteractive"), QStringLiteral("-Command"), script},
+		60000, error, &environment))
+		return false;
+	if (!QFileInfo(QDir(extract).filePath(executableName())).isFile()) {
+		if (error)
+			*error = QStringLiteral("The Windows update package does not contain QEGTRAIN.exe.");
+		return false;
+	}
+	m_stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN"));
+	if (!copyTree(m_currentPath, m_stagedPath) || !cleanWindowsRuntime(m_stagedPath)) {
+		if (error)
+			*error = QStringLiteral("Could not stage the Windows update without touching user files.");
+		return false;
+	}
+	// Keep any case studies stored beside the portable application. Application
+	// binaries and runtime plugins still come exclusively from the new package.
+	if (QFileInfo(QDir(m_currentPath).filePath(QStringLiteral("Scenes"))).isDir()) {
+		const QString packagedScenes = QDir(extract).filePath(QStringLiteral("Scenes"));
+		const QFileInfo packagedScenesInfo(packagedScenes);
+		if (packagedScenesInfo.isSymLink()
+			|| (packagedScenesInfo.exists() && !QDir(packagedScenes).removeRecursively())) {
+			if (error)
+				*error = QStringLiteral("Could not preserve portable case studies while staging the update.");
+			return false;
+		}
+	}
+	if (!copyTree(extract, m_stagedPath)) {
+		if (error)
+			*error = QStringLiteral("Could not finish staging the Windows update.");
+		return false;
+	}
+	if (!QFileInfo(QDir(m_stagedPath).filePath(executableName())).isFile()
+		|| !QFileInfo(QDir(m_stagedPath).filePath(QStringLiteral("Qt5Network.dll"))).isFile()
+		|| !QFileInfo(QDir(m_stagedPath).filePath(QStringLiteral("platforms/qwindows.dll"))).isFile()) {
+		if (error)
+			*error = QStringLiteral("The Windows update package is missing required runtime files.");
+		return false;
+	}
+	return true;
+}
+
+bool SelfUpdater::stageLinuxPackage(const QString& packagePath, QString* error) {
+	const QString& root = m_stagingRoot;
+	m_stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN-linux-x86_64.AppImage"));
+	if (!QFile::copy(packagePath, m_stagedPath)) {
+		if (error)
+			*error = QStringLiteral("Could not stage the AppImage.");
+		return false;
+	}
+	QFile::Permissions permissions = QFileInfo(m_currentPath).permissions();
+	permissions |= QFile::ExeOwner;
+	if (!QFile::setPermissions(m_stagedPath, permissions) || !validElf(m_stagedPath)) {
+		if (error)
+			*error = QStringLiteral("The downloaded AppImage is structurally invalid.");
+		return false;
+	}
+	return true;
+}
+
+void SelfUpdater::clearStaging() {
+	if (!m_stagingRoot.isEmpty())
+		QDir(m_stagingRoot).removeRecursively();
+	m_stagingRoot.clear();
+	m_stagedPath.clear();
+}
+
+bool SelfUpdater::restart() {
+	if (!m_ready || m_stagedPath.isEmpty())
+		return false;
+	const QString helperCopy = QDir(m_stagingRoot).filePath(helperName());
+	QFile::remove(helperCopy);
+	if (!QFile::copy(m_helperPath, helperCopy))
+		return false;
+#if !defined(Q_OS_WIN)
+	QFile::setPermissions(helperCopy, QFileInfo(m_helperPath).permissions()
+		| QFile::ExeOwner | QFile::ExeGroup | QFile::ExeOther);
+#endif
+	QString backup = m_currentPath + QStringLiteral(".egtrain-old");
+	const QFileInfo previousBackup(backup);
+	if (previousBackup.isSymLink())
+		return false;
+	if (previousBackup.exists()) {
+		const bool removed = previousBackup.isDir()
+			? QDir(backup).removeRecursively() : QFile::remove(backup);
+		if (!removed)
+			return false;
+	}
+	const QStringList arguments = {
+		QStringLiteral("--parent-pid"), QString::number(QCoreApplication::applicationPid()),
+		QStringLiteral("--current"), m_currentPath,
+		QStringLiteral("--staged"), m_stagedPath,
+		QStringLiteral("--backup"), backup,
+		QStringLiteral("--launch"), m_launchPath};
+	if (!QProcess::startDetached(helperCopy, arguments)) {
+		clearStaging();
+		m_ready = false;
+		return false;
+	}
+	return true;
+}

--- a/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
+++ b/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
@@ -370,7 +370,9 @@ void SelfUpdater::startPreparation() {
 
 void SelfUpdater::handlePreparationFinished(const UpdatePreparationResult& result) {
 	if (m_preparationThread) {
-		m_preparationThread->quit();
+		QThread* thread = m_preparationThread;
+		thread->quit();
+		thread->wait();
 		m_preparationThread = nullptr;
 	}
 	if (!result.success) {

--- a/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
+++ b/EGTRAIN/QEGTRAIN/update/SelfUpdater.cpp
@@ -1,17 +1,12 @@
 #include "update/SelfUpdater.h"
 
-#include "update/WindowsStaging.h"
-
 #include <QCoreApplication>
-#include <QCryptographicHash>
 #include <QDir>
 #include <QFileInfo>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QProcess>
-#include <QProcessEnvironment>
 #include <QTemporaryDir>
-#include <QXmlStreamReader>
 
 #ifndef EGTRAIN_PACKAGED_BUILD
 #define EGTRAIN_PACKAGED_BUILD 0
@@ -44,63 +39,12 @@ bool writableParent(const QString& path) {
 	return parent.exists() && parent.isDir() && parent.isWritable();
 }
 
-bool runProcess(const QString& program, const QStringList& arguments, int timeoutMs,
-	QString* error = nullptr, const QProcessEnvironment* environment = nullptr) {
-	QProcess process;
-	if (environment)
-		process.setProcessEnvironment(*environment);
-	process.start(program, arguments);
-	if (!process.waitForStarted(5000)) {
-		if (error)
-			*error = QStringLiteral("Could not start %1.").arg(program);
-		return false;
-	}
-	if (!process.waitForFinished(timeoutMs)) {
-		process.kill();
-		process.waitForFinished(1000);
-		if (error)
-			*error = QStringLiteral("%1 timed out.").arg(program);
-		return false;
-	}
-	if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
-		if (error)
-			*error = QStringLiteral("%1 could not prepare the update package.").arg(program);
-		return false;
-	}
-	return true;
-}
-
-bool validElf(const QString& path) {
-	QFile file(path);
-	if (!file.open(QIODevice::ReadOnly))
-		return false;
-	return file.read(4) == QByteArray::fromHex("7f454c46");
-}
-
-std::optional<QString> macBundleVersion(const QString& bundlePath) {
-	QFile plist(QDir(bundlePath).filePath(QStringLiteral("Contents/Info.plist")));
-	if (!plist.open(QIODevice::ReadOnly | QIODevice::Text))
-		return std::nullopt;
-	QXmlStreamReader xml(&plist);
-	QString key;
-	while (!xml.atEnd()) {
-		xml.readNext();
-		if (!xml.isStartElement())
-			continue;
-		if (xml.name() == QStringLiteral("key")) {
-			key = xml.readElementText();
-		} else if (xml.name() == QStringLiteral("string")
-			&& key == QStringLiteral("CFBundleShortVersionString")) {
-			return xml.readElementText();
-		}
-	}
-	return std::nullopt;
-}
-
 } // namespace
 
 SelfUpdater::SelfUpdater(QObject* parent)
 	: QObject(parent), m_network(this), m_timeout(this) {
+	qRegisterMetaType<UpdatePreparationInput>("UpdatePreparationInput");
+	qRegisterMetaType<UpdatePreparationResult>("UpdatePreparationResult");
 	m_timeout.setSingleShot(true);
 	connect(&m_timeout, &QTimer::timeout, this, [this]() {
 		if (!m_reply)
@@ -112,6 +56,13 @@ SelfUpdater::SelfUpdater(QObject* parent)
 		reply->deleteLater();
 		fail(QStringLiteral("The update download timed out."));
 	});
+}
+
+SelfUpdater::~SelfUpdater() {
+	if (m_preparationThread) {
+		m_preparationThread->quit();
+		m_preparationThread->wait();
+	}
 }
 
 SelfUpdateCapability SelfUpdater::capability() const {
@@ -361,28 +312,7 @@ void SelfUpdater::handleReply(QNetworkReply* reply, bool manifestReply) {
 		fail(QStringLiteral("The update package size does not match the release manifest."));
 		return;
 	}
-	QFile package(m_packageFile.fileName());
-	if (!package.open(QIODevice::ReadOnly)) {
-		fail(QStringLiteral("Could not read the downloaded update."));
-		return;
-	}
-	QCryptographicHash hash(QCryptographicHash::Sha256);
-	if (!hash.addData(&package)) {
-		fail(QStringLiteral("Could not verify the downloaded update."));
-		return;
-	}
-	if (QString::fromLatin1(hash.result().toHex()) != m_manifest.sha256) {
-		fail(QStringLiteral("The downloaded update failed its SHA-256 check."));
-		return;
-	}
-	QString error;
-	if (!stagePackage(package.fileName(), &error)) {
-		fail(error.isEmpty() ? QStringLiteral("The update package is incomplete.") : error);
-		return;
-	}
-	m_busy = false;
-	m_ready = true;
-	emit finished(true, QString());
+	startPreparation();
 }
 
 void SelfUpdater::fail(const QString& error) {
@@ -403,7 +333,7 @@ void SelfUpdater::fail(const QString& error) {
 }
 
 void SelfUpdater::cancel() {
-	if (!m_busy)
+	if (!m_busy || m_preparationThread)
 		return;
 	m_cancelRequested = true;
 	if (m_reply) {
@@ -413,94 +343,45 @@ void SelfUpdater::cancel() {
 	fail(QStringLiteral("Update cancelled."));
 }
 
-bool SelfUpdater::stagePackage(const QString& packagePath, QString* error) {
-	if (m_stagingRoot.isEmpty()) {
-		if (error)
-			*error = QStringLiteral("Update staging storage is unavailable.");
-		return false;
+void SelfUpdater::startPreparation() {
+	if (m_stagingRoot.isEmpty() || m_preparationThread) {
+		fail(QStringLiteral("Update staging storage is unavailable."));
+		return;
 	}
-#if defined(Q_OS_MACOS)
-	return stageMacPackage(packagePath, error);
-#elif defined(Q_OS_WIN)
-	return stageWindowsPackage(packagePath, error);
-#elif defined(Q_OS_LINUX)
-	return stageLinuxPackage(packagePath, error);
-#else
-	Q_UNUSED(packagePath);
-	if (error)
-		*error = QStringLiteral("Self-update is not supported on this platform.");
-	return false;
-#endif
+	UpdatePreparationInput input;
+	input.packagePath = m_packageFile.fileName();
+	input.stagingRoot = m_stagingRoot;
+	input.currentPath = m_currentPath;
+	input.manifest = m_manifest;
+
+	emit preparing(m_manifest.version);
+	auto* thread = new QThread(this);
+	auto* worker = new UpdatePreparationWorker;
+	worker->moveToThread(thread);
+	connect(thread, &QThread::started, worker,
+		[worker, input]() { worker->prepare(input); });
+	connect(worker, &UpdatePreparationWorker::finished,
+		this, &SelfUpdater::handlePreparationFinished);
+	connect(thread, &QThread::finished, worker, &QObject::deleteLater);
+	connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+	m_preparationThread = thread;
+	thread->start(QThread::LowPriority);
 }
 
-bool SelfUpdater::stageMacPackage(const QString& packagePath, QString* error) {
-	const QString& root = m_stagingRoot;
-	const QString extract = QDir(root).filePath(QStringLiteral("extract"));
-	if (!QDir().mkpath(extract))
-		return false;
-	if (!runProcess(QStringLiteral("/usr/bin/ditto"),
-		{QStringLiteral("-x"), QStringLiteral("-k"), packagePath, extract}, 60000, error))
-		return false;
-	const QString source = QDir(extract).filePath(QStringLiteral("QEGTRAIN-Lebanon/QEGTRAIN.app"));
-	const QFileInfo app(source);
-	if (!app.isDir() || app.fileName() != QStringLiteral("QEGTRAIN.app")
-		|| !QFileInfo(QDir(source).filePath("Contents/MacOS/QEGTRAIN")).isFile()
-		|| !QFileInfo(QDir(source).filePath("Contents/Info.plist")).isFile()) {
-		if (error)
-			*error = QStringLiteral("The macOS update package has an invalid app bundle.");
-		return false;
+void SelfUpdater::handlePreparationFinished(const UpdatePreparationResult& result) {
+	if (m_preparationThread) {
+		m_preparationThread->quit();
+		m_preparationThread = nullptr;
 	}
-	m_stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN.app"));
-	if (!runProcess(QStringLiteral("/usr/bin/ditto"), {source, m_stagedPath}, 60000, error))
-		return false;
-	if (!runProcess(QStringLiteral("/usr/bin/codesign"),
-		{QStringLiteral("--verify"), QStringLiteral("--deep"), QStringLiteral("--strict"), m_stagedPath},
-		60000, error))
-		return false;
-	const std::optional<QString> version = macBundleVersion(m_stagedPath);
-	if (!version || *version != m_manifest.version) {
-		if (error)
-			*error = QStringLiteral("The macOS update app version does not match the release manifest.");
-		return false;
+	if (!result.success) {
+		fail(result.error.isEmpty()
+			? QStringLiteral("The update package is incomplete.") : result.error);
+		return;
 	}
-	return true;
-}
-
-bool SelfUpdater::stageWindowsPackage(const QString& packagePath, QString* error) {
-	const QString& root = m_stagingRoot;
-	const QString extract = QDir(root).filePath(QStringLiteral("extract"));
-	if (!QDir().mkpath(extract))
-		return false;
-	QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
-	environment.insert(QStringLiteral("EGTRAIN_UPDATE_ZIP"), packagePath);
-	environment.insert(QStringLiteral("EGTRAIN_UPDATE_DEST"), extract);
-	const QString script = QStringLiteral(
-		"$ErrorActionPreference='Stop'; Expand-Archive -LiteralPath $env:EGTRAIN_UPDATE_ZIP "
-		"-DestinationPath $env:EGTRAIN_UPDATE_DEST -Force");
-	if (!runProcess(QStringLiteral("powershell.exe"),
-		{QStringLiteral("-NoProfile"), QStringLiteral("-NonInteractive"), QStringLiteral("-Command"), script},
-		60000, error, &environment))
-		return false;
-	m_stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN"));
-	return WindowsStaging::buildStage(extract, m_stagedPath, error);
-}
-
-bool SelfUpdater::stageLinuxPackage(const QString& packagePath, QString* error) {
-	const QString& root = m_stagingRoot;
-	m_stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN-linux-x86_64.AppImage"));
-	if (!QFile::copy(packagePath, m_stagedPath)) {
-		if (error)
-			*error = QStringLiteral("Could not stage the AppImage.");
-		return false;
-	}
-	QFile::Permissions permissions = QFileInfo(m_currentPath).permissions();
-	permissions |= QFile::ExeOwner;
-	if (!QFile::setPermissions(m_stagedPath, permissions) || !validElf(m_stagedPath)) {
-		if (error)
-			*error = QStringLiteral("The downloaded AppImage is structurally invalid.");
-		return false;
-	}
-	return true;
+	m_stagedPath = result.stagedPath;
+	m_busy = false;
+	m_ready = true;
+	emit finished(true, QString());
 }
 
 void SelfUpdater::clearStaging() {

--- a/EGTRAIN/QEGTRAIN/update/SelfUpdater.h
+++ b/EGTRAIN/QEGTRAIN/update/SelfUpdater.h
@@ -2,11 +2,13 @@
 #define EGTRAIN_SELF_UPDATER_H
 
 #include "update/ReleaseInfo.h"
+#include "update/UpdatePreparation.h"
 
 #include <QByteArray>
 #include <QFile>
 #include <QNetworkAccessManager>
 #include <QPointer>
+#include <QThread>
 #include <QTimer>
 #include <QObject>
 
@@ -25,27 +27,30 @@ class SelfUpdater : public QObject {
 
 public:
 	explicit SelfUpdater(QObject* parent = nullptr);
+	~SelfUpdater() override;
 
 	SelfUpdateCapability capability() const;
 	bool canSelfUpdate(const StableRelease& release) const;
 	bool isBusy() const { return m_busy; }
+	bool isPreparing() const { return m_preparationThread != nullptr; }
 	void start(const StableRelease& release);
 	void cancel();
 	bool restart();
 
 signals:
 	void progress(qint64 received, qint64 total);
+	void preparing(const QString& version);
 	void finished(bool success, const QString& error);
+
+private slots:
+	void handlePreparationFinished(const UpdatePreparationResult& result);
 
 private:
 	void requestManifest();
 	void requestPackage(const UpdateManifest& manifest);
 	void handleReply(QNetworkReply* reply, bool manifestReply);
 	void fail(const QString& error);
-	bool stagePackage(const QString& packagePath, QString* error);
-	bool stageMacPackage(const QString& packagePath, QString* error);
-	bool stageWindowsPackage(const QString& packagePath, QString* error);
-	bool stageLinuxPackage(const QString& packagePath, QString* error);
+	void startPreparation();
 	void clearStaging();
 
 	QNetworkAccessManager m_network;
@@ -60,6 +65,7 @@ private:
 	QString m_currentPath;
 	QString m_launchPath;
 	QString m_helperPath;
+	QThread* m_preparationThread = nullptr;
 	qint64 m_packageBytes = 0;
 	bool m_busy = false;
 	bool m_cancelRequested = false;

--- a/EGTRAIN/QEGTRAIN/update/SelfUpdater.h
+++ b/EGTRAIN/QEGTRAIN/update/SelfUpdater.h
@@ -1,0 +1,69 @@
+#ifndef EGTRAIN_SELF_UPDATER_H
+#define EGTRAIN_SELF_UPDATER_H
+
+#include "update/ReleaseInfo.h"
+
+#include <QByteArray>
+#include <QFile>
+#include <QNetworkAccessManager>
+#include <QPointer>
+#include <QTimer>
+#include <QObject>
+
+class QNetworkReply;
+
+struct SelfUpdateCapability {
+	bool supported = false;
+	QString reason;
+	QString currentPath;
+	QString launchPath;
+	QString helperPath;
+};
+
+class SelfUpdater : public QObject {
+	Q_OBJECT
+
+public:
+	explicit SelfUpdater(QObject* parent = nullptr);
+
+	SelfUpdateCapability capability() const;
+	bool canSelfUpdate(const StableRelease& release) const;
+	bool isBusy() const { return m_busy; }
+	void start(const StableRelease& release);
+	void cancel();
+	bool restart();
+
+signals:
+	void progress(qint64 received, qint64 total);
+	void finished(bool success, const QString& error);
+
+private:
+	void requestManifest();
+	void requestPackage(const UpdateManifest& manifest);
+	void handleReply(QNetworkReply* reply, bool manifestReply);
+	void fail(const QString& error);
+	bool stagePackage(const QString& packagePath, QString* error);
+	bool stageMacPackage(const QString& packagePath, QString* error);
+	bool stageWindowsPackage(const QString& packagePath, QString* error);
+	bool stageLinuxPackage(const QString& packagePath, QString* error);
+	void clearStaging();
+
+	QNetworkAccessManager m_network;
+	QPointer<QNetworkReply> m_reply;
+	QTimer m_timeout;
+	QFile m_packageFile;
+	QByteArray m_manifestData;
+	StableRelease m_release;
+	UpdateManifest m_manifest;
+	QString m_stagingRoot;
+	QString m_stagedPath;
+	QString m_currentPath;
+	QString m_launchPath;
+	QString m_helperPath;
+	qint64 m_packageBytes = 0;
+	bool m_busy = false;
+	bool m_cancelRequested = false;
+	bool m_ready = false;
+};
+
+#endif

--- a/EGTRAIN/QEGTRAIN/update/UpdateHelper.cpp
+++ b/EGTRAIN/QEGTRAIN/update/UpdateHelper.cpp
@@ -1,0 +1,187 @@
+#include <cerrno>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#if defined(_WIN32)
+#include <windows.h>
+using ArgumentChar = wchar_t;
+using ArgumentString = std::wstring;
+#define EGTRAIN_HELPER_MAIN wmain
+#else
+#include <csignal>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+using ArgumentChar = char;
+using ArgumentString = std::string;
+#define EGTRAIN_HELPER_MAIN main
+#endif
+
+namespace {
+
+struct Arguments {
+	unsigned long long parentPid = 0;
+	std::filesystem::path current;
+	std::filesystem::path staged;
+	std::filesystem::path backup;
+	std::filesystem::path launch;
+};
+
+bool parseArguments(int argc, ArgumentChar** argv, Arguments& result) {
+	for (int i = 1; i < argc; ++i) {
+		const ArgumentString name(argv[i]);
+		if (i + 1 >= argc)
+			return false;
+		const ArgumentString value(argv[++i]);
+#if defined(_WIN32)
+		if (name == L"--parent-pid") {
+			wchar_t* end = nullptr;
+			result.parentPid = std::wcstoull(value.c_str(), &end, 10);
+#else
+		if (name == "--parent-pid") {
+			char* end = nullptr;
+			result.parentPid = std::strtoull(value.c_str(), &end, 10);
+#endif
+			if (!end || *end != '\0')
+				return false;
+#if defined(_WIN32)
+		} else if (name == L"--current") {
+			result.current = value;
+		} else if (name == L"--staged") {
+			result.staged = value;
+		} else if (name == L"--backup") {
+			result.backup = value;
+		} else if (name == L"--launch") {
+#else
+		} else if (name == "--current") {
+			result.current = value;
+		} else if (name == "--staged") {
+			result.staged = value;
+		} else if (name == "--backup") {
+			result.backup = value;
+		} else if (name == "--launch") {
+#endif
+			result.launch = value;
+		} else {
+			return false;
+		}
+	}
+	return result.current.has_filename() && result.staged.has_filename()
+		&& result.backup.has_filename() && result.launch.has_filename();
+}
+
+bool waitForParent(unsigned long long pid) {
+	if (pid == 0)
+		return true;
+#if defined(_WIN32)
+	HANDLE process = OpenProcess(SYNCHRONIZE, FALSE, static_cast<DWORD>(pid));
+	if (!process)
+		return GetLastError() == ERROR_INVALID_PARAMETER;
+	const DWORD status = WaitForSingleObject(process, 5 * 60 * 1000);
+	CloseHandle(process);
+	return status == WAIT_OBJECT_0;
+#else
+	for (int attempt = 0; attempt < 6000; ++attempt) {
+		if (kill(static_cast<pid_t>(pid), 0) == -1 && errno == ESRCH)
+			return true;
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+	return false;
+#endif
+}
+
+bool removePath(const std::filesystem::path& path) {
+	std::error_code error;
+	std::filesystem::remove_all(path, error);
+	return !error;
+}
+
+bool movePath(const std::filesystem::path& from, const std::filesystem::path& to) {
+	std::error_code error;
+	std::filesystem::rename(from, to, error);
+	return !error;
+}
+
+#if defined(_WIN32)
+bool launch(const std::filesystem::path& executable) {
+	const std::wstring path = executable.wstring();
+	STARTUPINFOW startup{};
+	startup.cb = sizeof(startup);
+	PROCESS_INFORMATION process{};
+	if (!CreateProcessW(path.c_str(), nullptr, nullptr, nullptr, FALSE,
+		CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS, nullptr, nullptr, &startup, &process))
+		return false;
+	CloseHandle(process.hThread);
+	CloseHandle(process.hProcess);
+	return true;
+}
+#else
+bool launch(const std::filesystem::path& executable) {
+	const pid_t child = fork();
+	if (child < 0)
+		return false;
+	if (child == 0) {
+		execl(executable.c_str(), executable.c_str(), static_cast<char*>(nullptr));
+		_exit(127);
+	}
+	for (int attempt = 0; attempt < 20; ++attempt) {
+		int status = 0;
+		const pid_t result = waitpid(child, &status, WNOHANG);
+		if (result == child)
+			return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+		if (result < 0)
+			return false;
+		std::this_thread::sleep_for(std::chrono::milliseconds(25));
+	}
+	return true;
+}
+#endif
+
+bool transactionalInstall(const Arguments& arguments) {
+	std::error_code error;
+	if (!std::filesystem::exists(arguments.current, error)
+		|| error || !std::filesystem::exists(arguments.staged, error) || error)
+		return false;
+	if (std::filesystem::exists(arguments.backup, error) || error)
+		return false;
+
+	if (!movePath(arguments.current, arguments.backup)) {
+		launch(arguments.launch);
+		return false;
+	}
+	if (!movePath(arguments.staged, arguments.current)) {
+		movePath(arguments.backup, arguments.current);
+		launch(arguments.launch);
+		return false;
+	}
+	if (!launch(arguments.launch)) {
+		removePath(arguments.current);
+		if (movePath(arguments.backup, arguments.current))
+			launch(arguments.launch);
+		return false;
+	}
+	// Keep one recoverable installation until a later update proves this one usable.
+	return true;
+}
+
+} // namespace
+
+int EGTRAIN_HELPER_MAIN(int argc, ArgumentChar** argv) {
+	Arguments arguments;
+	if (!parseArguments(argc, argv, arguments)) {
+		std::cerr << "usage: egtrain_update_helper --parent-pid PID --current PATH "
+			"--staged PATH --backup PATH --launch PATH\n";
+		return 2;
+	}
+	std::error_code workingDirectoryError;
+	std::filesystem::current_path(arguments.staged.parent_path(), workingDirectoryError);
+	if (workingDirectoryError)
+		return 1;
+	if (!waitForParent(arguments.parentPid))
+		return 1;
+	return transactionalInstall(arguments) ? 0 : 1;
+}

--- a/EGTRAIN/QEGTRAIN/update/UpdatePreparation.cpp
+++ b/EGTRAIN/QEGTRAIN/update/UpdatePreparation.cpp
@@ -1,0 +1,195 @@
+#include "update/UpdatePreparation.h"
+
+#include "update/WindowsStaging.h"
+
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QXmlStreamReader>
+
+namespace {
+
+constexpr qint64 kHashChunkBytes = 1024 * 1024;
+
+bool runProcess(const QString& program, const QStringList& arguments, int timeoutMs,
+	QString* error = nullptr, const QProcessEnvironment* environment = nullptr) {
+	QProcess process;
+	if (environment)
+		process.setProcessEnvironment(*environment);
+	process.start(program, arguments);
+	if (!process.waitForStarted(5000)) {
+		if (error)
+			*error = QStringLiteral("Could not start %1.").arg(program);
+		return false;
+	}
+	if (!process.waitForFinished(timeoutMs)) {
+		process.kill();
+		process.waitForFinished(1000);
+		if (error)
+			*error = QStringLiteral("%1 timed out.").arg(program);
+		return false;
+	}
+	if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
+		if (error)
+			*error = QStringLiteral("%1 could not prepare the update package.").arg(program);
+		return false;
+	}
+	return true;
+}
+
+bool validElf(const QString& path) {
+	QFile file(path);
+	if (!file.open(QIODevice::ReadOnly))
+		return false;
+	return file.read(4) == QByteArray::fromHex("7f454c46");
+}
+
+std::optional<QString> macBundleVersion(const QString& bundlePath) {
+	QFile plist(QDir(bundlePath).filePath(QStringLiteral("Contents/Info.plist")));
+	if (!plist.open(QIODevice::ReadOnly | QIODevice::Text))
+		return std::nullopt;
+	QXmlStreamReader xml(&plist);
+	QString key;
+	while (!xml.atEnd()) {
+		xml.readNext();
+		if (!xml.isStartElement())
+			continue;
+		if (xml.name() == QStringLiteral("key")) {
+			key = xml.readElementText();
+		} else if (xml.name() == QStringLiteral("string")
+			&& key == QStringLiteral("CFBundleShortVersionString")) {
+			return xml.readElementText();
+		}
+	}
+	return std::nullopt;
+}
+
+QString stageMacPackage(const UpdatePreparationInput& input, QString* error) {
+	const QString root = input.stagingRoot;
+	const QString extract = QDir(root).filePath(QStringLiteral("extract"));
+	if (!QDir().mkpath(extract))
+		return {};
+	if (!runProcess(QStringLiteral("/usr/bin/ditto"),
+		{QStringLiteral("-x"), QStringLiteral("-k"), input.packagePath, extract}, 60000, error))
+		return {};
+	const QString source = QDir(extract).filePath(QStringLiteral("QEGTRAIN-Lebanon/QEGTRAIN.app"));
+	const QFileInfo app(source);
+	if (!app.isDir() || app.fileName() != QStringLiteral("QEGTRAIN.app")
+		|| !QFileInfo(QDir(source).filePath("Contents/MacOS/QEGTRAIN")).isFile()
+		|| !QFileInfo(QDir(source).filePath("Contents/Info.plist")).isFile()) {
+		if (error)
+			*error = QStringLiteral("The macOS update package has an invalid app bundle.");
+		return {};
+	}
+	const QString stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN.app"));
+	if (!runProcess(QStringLiteral("/usr/bin/ditto"), {source, stagedPath}, 60000, error))
+		return {};
+	if (!runProcess(QStringLiteral("/usr/bin/codesign"),
+		{QStringLiteral("--verify"), QStringLiteral("--deep"), QStringLiteral("--strict"), stagedPath},
+		60000, error))
+		return {};
+	const std::optional<QString> version = macBundleVersion(stagedPath);
+	if (!version || *version != input.manifest.version) {
+		if (error)
+			*error = QStringLiteral("The macOS update app version does not match the release manifest.");
+		return {};
+	}
+	return stagedPath;
+}
+
+QString stageWindowsPackage(const UpdatePreparationInput& input, QString* error) {
+	const QString root = input.stagingRoot;
+	const QString extract = QDir(root).filePath(QStringLiteral("extract"));
+	if (!QDir().mkpath(extract))
+		return {};
+	QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+	environment.insert(QStringLiteral("EGTRAIN_UPDATE_ZIP"), input.packagePath);
+	environment.insert(QStringLiteral("EGTRAIN_UPDATE_DEST"), extract);
+	const QString script = QStringLiteral(
+		"$ErrorActionPreference='Stop'; Expand-Archive -LiteralPath $env:EGTRAIN_UPDATE_ZIP "
+		"-DestinationPath $env:EGTRAIN_UPDATE_DEST -Force");
+	if (!runProcess(QStringLiteral("powershell.exe"),
+		{QStringLiteral("-NoProfile"), QStringLiteral("-NonInteractive"), QStringLiteral("-Command"), script},
+		60000, error, &environment))
+		return {};
+	const QString stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN"));
+	if (!WindowsStaging::buildStage(extract, stagedPath, error))
+		return {};
+	return stagedPath;
+}
+
+QString stageLinuxPackage(const UpdatePreparationInput& input, QString* error) {
+	const QString root = input.stagingRoot;
+	const QString stagedPath = QDir(root).filePath(QStringLiteral("QEGTRAIN-linux-x86_64.AppImage"));
+	if (!QFile::copy(input.packagePath, stagedPath)) {
+		if (error)
+			*error = QStringLiteral("Could not stage the AppImage.");
+		return {};
+	}
+	QFile::Permissions permissions = QFileInfo(input.currentPath).permissions();
+	permissions |= QFile::ExeOwner;
+	if (!QFile::setPermissions(stagedPath, permissions) || !validElf(stagedPath)) {
+		if (error)
+			*error = QStringLiteral("The downloaded AppImage is structurally invalid.");
+		return {};
+	}
+	return stagedPath;
+}
+
+QString stagePlatformPackage(const UpdatePreparationInput& input, QString* error) {
+#if defined(Q_OS_MACOS)
+	return stageMacPackage(input, error);
+#elif defined(Q_OS_WIN)
+	return stageWindowsPackage(input, error);
+#elif defined(Q_OS_LINUX)
+	return stageLinuxPackage(input, error);
+#else
+	if (error)
+		*error = QStringLiteral("Self-update is not supported on this platform.");
+	return {};
+#endif
+}
+
+} // namespace
+
+bool verifyDownloadedPackageHash(const QString& packagePath,
+	const QString& expectedSha256, QString* error) {
+	QFile package(packagePath);
+	if (!package.open(QIODevice::ReadOnly)) {
+		if (error)
+			*error = QStringLiteral("Could not read the downloaded update.");
+		return false;
+	}
+	QCryptographicHash hash(QCryptographicHash::Sha256);
+	while (!package.atEnd())
+		hash.addData(package.read(kHashChunkBytes));
+	if (QString::fromLatin1(hash.result().toHex()) != expectedSha256) {
+		if (error)
+			*error = QStringLiteral("The downloaded update failed its SHA-256 check.");
+		return false;
+	}
+	return true;
+}
+
+void UpdatePreparationWorker::setPlatformStager(PlatformStager stager) {
+	m_platformStager = std::move(stager);
+}
+
+void UpdatePreparationWorker::prepare(UpdatePreparationInput input) {
+	UpdatePreparationResult result;
+	QString error;
+	QString stagedPath;
+	if (verifyDownloadedPackageHash(input.packagePath, input.manifest.sha256, &error)) {
+		if (m_platformStager)
+			stagedPath = m_platformStager(input, &error);
+		else
+			stagedPath = stagePlatformPackage(input, &error);
+	}
+	result.success = !stagedPath.isEmpty();
+	result.error = error;
+	result.stagedPath = stagedPath;
+	emit finished(result);
+}

--- a/EGTRAIN/QEGTRAIN/update/UpdatePreparation.h
+++ b/EGTRAIN/QEGTRAIN/update/UpdatePreparation.h
@@ -1,0 +1,57 @@
+#ifndef EGTRAIN_UPDATE_PREPARATION_H
+#define EGTRAIN_UPDATE_PREPARATION_H
+
+#include "update/ReleaseInfo.h"
+
+#include <QMetaType>
+#include <QObject>
+#include <QString>
+#include <functional>
+
+// Inputs for preparing a downloaded update package. Everything is copied so
+// the preparation worker never touches SelfUpdater or GUI-thread state.
+struct UpdatePreparationInput {
+	QString packagePath;
+	QString stagingRoot;
+	QString currentPath;
+	UpdateManifest manifest;
+};
+
+struct UpdatePreparationResult {
+	bool success = false;
+	QString error;
+	QString stagedPath;
+};
+
+Q_DECLARE_METATYPE(UpdatePreparationInput)
+Q_DECLARE_METATYPE(UpdatePreparationResult)
+
+// Verifies the downloaded package against the manifest SHA-256 using chunked
+// reads. A failed hash must never proceed to staging.
+bool verifyDownloadedPackageHash(const QString& packagePath,
+	const QString& expectedSha256, QString* error = nullptr);
+
+class UpdatePreparationWorker : public QObject {
+	Q_OBJECT
+
+public:
+	// Platform-specific structural preparation of the staged installation.
+	// Defaults to the real host implementation; injectable so the asynchronous
+	// handoff can be exercised on any platform in tests.
+	using PlatformStager = std::function<QString(
+		const UpdatePreparationInput&, QString*)>;
+	void setPlatformStager(PlatformStager stager);
+
+	// Runs in the worker thread. Emits exactly one finished() result and must
+	// not mutate any object owned by another thread.
+public slots:
+	void prepare(UpdatePreparationInput input);
+
+signals:
+	void finished(const UpdatePreparationResult& result);
+
+private:
+	PlatformStager m_platformStager;
+};
+
+#endif

--- a/EGTRAIN/QEGTRAIN/update/WindowsStaging.h
+++ b/EGTRAIN/QEGTRAIN/update/WindowsStaging.h
@@ -1,0 +1,82 @@
+#ifndef EGTRAIN_WINDOWS_STAGING_H
+#define EGTRAIN_WINDOWS_STAGING_H
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QString>
+
+// The staged Windows installation is assembled exclusively from the extracted
+// release package: the release owns its runtime files and shipped canonical
+// Scenes. Nothing is carried over from the installation being replaced, so a
+// released package always produces the same result as a fresh installation.
+namespace WindowsStaging {
+
+inline bool copyTree(const QString& sourcePath, const QString& destinationPath) {
+	const QFileInfo source(sourcePath);
+	if (!source.isDir() || source.isSymLink())
+		return false;
+	if (!QDir().mkpath(destinationPath))
+		return false;
+	const QDir sourceDir(sourcePath);
+	const QFileInfoList entries = sourceDir.entryInfoList(
+		QDir::NoDotAndDotDot | QDir::AllEntries | QDir::Hidden | QDir::System,
+		QDir::DirsFirst | QDir::Name);
+	for (const QFileInfo& entry : entries) {
+		if (entry.isSymLink())
+			return false;
+		const QString destination = QDir(destinationPath).filePath(entry.fileName());
+		if (entry.isDir()) {
+			if (!copyTree(entry.absoluteFilePath(), destination))
+				return false;
+			continue;
+		}
+		if (!entry.isFile())
+			return false;
+		QFile::remove(destination);
+		if (!QFile::copy(entry.absoluteFilePath(), destination))
+			return false;
+	}
+	return true;
+}
+
+inline bool completeWindowsRuntime(const QString& directory) {
+	const QDir root(directory);
+	return QFileInfo(root.filePath(QStringLiteral("QEGTRAIN.exe"))).isFile()
+		&& QFileInfo(root.filePath(QStringLiteral("egtrain_update_helper.exe"))).isFile()
+		&& QFileInfo(root.filePath(QStringLiteral("Qt5Network.dll"))).isFile()
+		&& QFileInfo(root.filePath(QStringLiteral("platforms/qwindows.dll"))).isFile()
+		&& QFileInfo(root.filePath(QStringLiteral("Scenes"))).isDir();
+}
+
+// Builds the staged installation at stagePath as an exact copy of the
+// extracted release package at extractPath. The stage path must not exist so
+// staging can never merge new content into old installation leftovers.
+inline bool buildStage(const QString& extractPath, const QString& stagePath,
+	QString* error = nullptr) {
+	if (!QFileInfo(QDir(extractPath).filePath(QStringLiteral("QEGTRAIN.exe"))).isFile()) {
+		if (error)
+			*error = QStringLiteral("The Windows update package does not contain QEGTRAIN.exe.");
+		return false;
+	}
+	if (QFileInfo(stagePath).exists()) {
+		if (error)
+			*error = QStringLiteral("The Windows update staging location is not empty.");
+		return false;
+	}
+	if (!copyTree(extractPath, stagePath)) {
+		if (error)
+			*error = QStringLiteral("Could not finish staging the Windows update.");
+		return false;
+	}
+	if (!completeWindowsRuntime(stagePath)) {
+		if (error)
+			*error = QStringLiteral("The Windows update package is missing required runtime files.");
+		return false;
+	}
+	return true;
+}
+
+} // namespace WindowsStaging
+
+#endif

--- a/tools/e2e/test_ci_workflow.py
+++ b/tools/e2e/test_ci_workflow.py
@@ -199,6 +199,28 @@ def main() -> None:
         missing.append("Windows Qt Network package verification")
     if "libqt5network5" not in release_workflow or "libQt5Network.so*" not in release_workflow:
         missing.append("Linux Qt Network package verification")
+    if release_workflow.count("-DEGTRAIN_PACKAGED_BUILD=ON") != 3:
+        missing.append("packaged-build updater gate on all platform packages")
+    if release_workflow.count("Verify update helper transaction") != 3 or any(
+        helper not in release_workflow
+        for helper in (
+            "QEGTRAIN.app/Contents/MacOS/egtrain_update_helper",
+            "egtrain_update_helper.exe",
+            "squashfs-root/usr/bin/egtrain_update_helper",
+        )
+    ):
+        missing.append("packaged update helper verification")
+    if any(
+        value not in release_workflow
+        for value in (
+            "update-manifest.json",
+            'QEGTRAIN-macos-arm64.zip",sha256:$mac_sha',
+            'QEGTRAIN-windows-x64.zip",sha256:$windows_sha',
+            'QEGTRAIN-linux-x86_64.AppImage",sha256:$linux_sha',
+            'if [[ "$count" != "10" ]]',
+        )
+    ):
+        missing.append("release update manifest and exact package checksums")
     if missing:
         raise SystemExit("CI workflows are missing: " + ", ".join(missing))
 


### PR DESCRIPTION
## Summary
- publish an exact platform update manifest with package sizes and SHA-256 checksums
- download, verify, stage, and replace packaged macOS, Windows, and Linux installations after exit
- preserve rollback and user case-study data, with manual release-page fallback for unsupported installations
- exercise the post-exit helper transaction in local and platform packaging gates

Closes #155

## Verification
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` (51/51)
- `tools/e2e/visual_polish_smoke.sh`
- focused helper working-directory regression
- release workflow YAML/configuration checks