### PR TITLE
Add semantic zoom train overlays

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -34,6 +34,7 @@ GuiSimulationSnapshot buildGuiSimulationSnapshot(int timestep) {
 		state.id = train.ID;
 		state.type = train.type;
 		state.description = train.trainDescription;
+		state.operatingCode = train.operatingCode;
 		state.routeIndex = train.indexOfRoute;
 		const bool validRoute = train.indexOfRoute >= 0 && train.indexOfRoute < static_cast<int>(train_route.size());
 		state.reversedDirection = validRoute ? train_route[train.indexOfRoute].reversed_direction : false;

--- a/EGTRAIN/QEGTRAIN/app/GuiSimulationSnapshot.h
+++ b/EGTRAIN/QEGTRAIN/app/GuiSimulationSnapshot.h
@@ -16,6 +16,7 @@ struct GuiTrainState {
 	double id = 0.0;
 	std::string type;
 	std::string description;
+	std::string operatingCode;
 	int routeIndex = -1;
 	bool reversedDirection = false;
 	int wagonCount = 0;
@@ -30,6 +31,10 @@ struct GuiTrainState {
 	std::vector<double> wagonTailPositions;
 	std::vector<GuiOccupiedArc> occupiedArcs;
 };
+
+inline const std::string& guiTrainDisplayIdentifier(const GuiTrainState& train) {
+	return train.operatingCode.empty() ? train.description : train.operatingCode;
+}
 
 inline bool guiTrainPublishesOccupiedArcs(const GuiTrainState& train) {
 	return !train.outOfSimulation;

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.cpp
@@ -1698,7 +1698,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 	m_trainSpeedLabelsCheck->setObjectName("layerTrainSpeedLabels");
 	m_trainSpeedLabelsCheck->setProperty("secondaryLayerToggle", true);
 	m_trainSpeedLabelsCheck->setChecked(true);
-	m_trainSpeedLabelsCheck->setToolTip("Show train speeds without changing train symbols");
+	m_trainSpeedLabelsCheck->setToolTip("Show live speed in detailed train labels; overview markers stay compact.");
 	m_signalLayerCheck = new QCheckBox("Signals", caseLayersWidget);
 	m_signalLayerCheck->setObjectName("layerSignals");
 	m_signalLayerCheck->setChecked(true);
@@ -1761,27 +1761,12 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 				[it](const TrainItemGroup* train) { return train && train->index == it.key(); });
 			it.value()->setVisible(checked && trainIt != allTrains.cend() && !(*trainIt)->outOfSimulation);
 		}
-		for (auto it = m_trainSpeedLabels.cbegin(); it != m_trainSpeedLabels.cend(); ++it)
-			if (it.value()) {
-				auto trainIt = std::find_if(allTrains.cbegin(), allTrains.cend(),
-					[it](const TrainItemGroup* train) { return train && train->index == it.key(); });
-				it.value()->setVisible(checked && m_trainSpeedLabelsVisible && trainIt != allTrains.cend()
-					&& !(*trainIt)->outOfSimulation);
-			}
 	});
 	connect(m_trainSpeedLabelsCheck, &QCheckBox::toggled, this, [this](bool checked) {
 		m_trainSpeedLabelsVisible = checked;
 		for (auto* badge : m_trainBadges)
 			if (badge)
 				badge->setSpeedVisible(checked);
-		for (auto it = m_trainSpeedLabels.cbegin(); it != m_trainSpeedLabels.cend(); ++it) {
-			if (!it.value())
-				continue;
-			auto trainIt = std::find_if(allTrains.cbegin(), allTrains.cend(),
-				[it](const TrainItemGroup* train) { return train && train->index == it.key(); });
-			it.value()->setVisible(checked && m_trainLayerVisible && trainIt != allTrains.cend()
-				&& !(*trainIt)->outOfSimulation);
-		}
 	});
 	connect(m_signalLayerCheck, &QCheckBox::toggled, this, [this](bool checked) {
 		m_signalLayerVisible = checked;
@@ -11358,6 +11343,8 @@ void MainWindow::runVisualPolishE2E() {
 				return item && !qgraphicsitem_cast<SignalItem*>(item) && item->isVisible();
 				});
 	};
+	setFollowTrain(-1);
+	handleCloseInfoDockWidget();
 	if (networkView) {
 		networkView->fitToTopology();
 		updateViewportOverlays();
@@ -11597,7 +11584,32 @@ void MainWindow::runVisualPolishE2E() {
 		}
 	}
 	captureScreenshot("QEGTRAIN_E2E_SCREENSHOT", "default");
+	if (networkView) {
+		const bool fitMarkers = std::all_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
+			[](const TrainBadgeItem* badge) {
+				return !badge || badge->presentation() == TrainBadgeItem::Presentation::Overview
+					&& !badge->showsIdentifier() && !badge->showsSpeed();
+			});
+		if (!fitMarkers) {
+			ok = false;
+			failures << "Fit did not reduce ordinary train overlays to markers";
+		}
+		networkView->zoomBy(TrainBadgeItem::identityZoomThreshold());
+		updateViewportOverlays();
+		QApplication::processEvents();
+		const bool identityChips = std::all_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
+			[](const TrainBadgeItem* badge) {
+				return !badge || badge->presentation() == TrainBadgeItem::Presentation::Identity
+					&& badge->showsIdentifier() && !badge->showsSpeed();
+			});
+		if (!identityChips) {
+			ok = false;
+			failures << "1.8x did not show identity chips without speed";
+		}
+	}
+	captureScreenshot("QEGTRAIN_E2E_MEDIUM_SCREENSHOT", "medium");
 	if (networkView && !allTrains.isEmpty()) {
+		networkView->fitToTopology();
 		networkView->centerOn(allTrains.first()->sceneBoundingRect().center());
 		networkView->zoomBy(3.0);
 		if (qAbs(networkView->zoomRatio() - 3.0) > 1e-5) {
@@ -11605,11 +11617,56 @@ void MainWindow::runVisualPolishE2E() {
 			failures << "dense capture did not restore the 3x zoom state";
 		}
 		QApplication::processEvents();
+		const bool detailedLabels = std::all_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
+			[](const TrainBadgeItem* badge) {
+				return !badge || badge->presentation() == TrainBadgeItem::Presentation::Detailed
+					&& badge->showsIdentifier() && badge->showsSpeed();
+			});
+		if (!detailedLabels) {
+			ok = false;
+			failures << "3x did not show detailed train labels with speed";
+		}
+		m_trainSpeedLabelsCheck->setChecked(false);
+		QApplication::processEvents();
+		if (std::any_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
+				[](const TrainBadgeItem* badge) { return badge && badge->showsSpeed(); })) {
+			ok = false;
+			failures << "disabled train speed labels left detailed speed text visible";
+		}
+		m_trainSpeedLabelsCheck->setChecked(true);
+		QApplication::processEvents();
 	} else {
 		ok = false;
 		failures << "cannot create dense view without a train";
 	}
 	captureScreenshot("QEGTRAIN_E2E_DENSE_SCREENSHOT", "dense");
+	if (networkView && selectedTrain && selectedTrainBody) {
+		networkView->fitToTopology();
+		displayTrainDetails(selectedTrainBody, false);
+		QApplication::processEvents();
+		TrainBadgeItem* selectedBadge = m_trainBadges.value(selectedTrain->index, nullptr);
+		const bool ordinaryMarkers = std::all_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
+			[this](const TrainBadgeItem* badge) {
+				return !badge || badge->isPromoted()
+					|| badge->presentation() == TrainBadgeItem::Presentation::Overview;
+			});
+		if (!selectedBadge || !selectedBadge->isPromoted()
+				|| selectedBadge->presentation() != TrainBadgeItem::Presentation::Detailed
+				|| !ordinaryMarkers) {
+			ok = false;
+			failures << "selected train was not promoted over Fit markers";
+		}
+	} else {
+		ok = false;
+		failures << "cannot create selected-train Fit capture";
+	}
+	captureScreenshot("QEGTRAIN_E2E_SELECTED_SCREENSHOT", "selected Fit");
+	if (networkView) {
+		networkView->fitToTopology();
+		networkView->zoomBy(TrainBadgeItem::detailedZoomThreshold());
+		updateViewportOverlays();
+		QApplication::processEvents();
+	}
 
 	SignalItem* visibleSignal = nullptr;
 	QGraphicsItem* signalHit = nullptr;
@@ -12125,6 +12182,23 @@ void MainWindow::runVisualPolishE2E() {
 	} else {
 		ok = false;
 		failures << "follow mode controls disappeared";
+	}
+	if (networkView) {
+		networkView->fitToTopology();
+		updateViewportOverlays();
+		QApplication::processEvents();
+		TrainBadgeItem* followedBadge = m_trainBadges.value(m_followTrainIndex, nullptr);
+		const bool ordinaryMarkers = std::all_of(m_trainBadges.cbegin(), m_trainBadges.cend(),
+			[](const TrainBadgeItem* badge) {
+				return !badge || badge->isPromoted()
+					|| badge->presentation() == TrainBadgeItem::Presentation::Overview;
+			});
+		if (!followedBadge || !followedBadge->isPromoted()
+				|| followedBadge->presentation() != TrainBadgeItem::Presentation::Detailed
+				|| !ordinaryMarkers) {
+			ok = false;
+			failures << "followed train was not promoted over Fit markers";
+		}
 	}
 	captureScreenshot("QEGTRAIN_E2E_FOLLOW_SCREENSHOT", "follow");
 	if (scene && networkView && selectedTrainBody) {
@@ -18295,7 +18369,6 @@ void MainWindow::teardownGUI() {
 	scene->clear();
 
 	// Clear list pointers - the items were owned by the scene and are now deleted.
-	m_trainSpeedLabels.clear(); // items deleted by scene->clear() above
 	m_trainBadges.clear(); // items deleted by scene->clear() above
 	m_prevTrainPositions.clear();
 	allTrains.clear();
@@ -18322,6 +18395,7 @@ void MainWindow::teardownGUI() {
 
 	regionStations.clear();
 	m_followTrainIndex = -1;
+	m_selectedTrainIndex = -1;
 	m_e2eAttempts = 0;
 	m_e2eFinished = false;
 	if (m_followAction)
@@ -19067,16 +19141,20 @@ void MainWindow::paintTrain(const GuiTrainState& train, int size, int pen_width)
 	allTrains.push_back(trainPolygonGroup);
 
 	TrainBadgeItem* badge = new TrainBadgeItem();
-	badge->setIdentifier(QString::fromStdString(train.description));
+	badge->setIdentifier(QString::fromStdString(guiTrainDisplayIdentifier(train)));
+	badge->setTooltipDetails(QString::fromStdString(train.description),
+		QString::fromStdString(train.operatingCode), QString::fromStdString(train.type));
 	badge->setSpeedText(QString::fromStdString(formatSpeedLabel(train.speedKmh)));
 	badge->setSpeedVisible(m_trainSpeedLabelsVisible);
 	badge->setTrainVisual(visual);
 	badge->setReversed(train.reversedDirection);
-	badge->setCompact(!networkView || networkView->zoomRatio() < kDenseDetailZoom);
-	badge->setAcceptedMouseButtons(Qt::NoButton);
+	const bool promoted = isTrainOverlayPromoted(train.index);
+	badge->setPromoted(promoted);
+	badge->setPresentation(TrainBadgeItem::presentationForZoom(
+			networkView ? networkView->zoomRatio() : 1.0, promoted));
 	scene->addItem(badge);
 	badge->setVisible(m_trainLayerVisible && !train.outOfSimulation && hasVisibleGeometry);
-	badge->setPos(trainPolygonGroup->sceneBoundingRect().center() + QPointF(8.0, -24.0));
+	badge->setPos(trainPolygonGroup->sceneBoundingRect().center());
 	m_trainBadges[train.index] = badge;
 }
 
@@ -19424,6 +19502,7 @@ void MainWindow::handleHelpAbout() {
 // removes highlight from last clicked item
 void MainWindow::handleCloseInfoDockWidget() {
 	m_selectedStationName.clear();
+	m_selectedTrainIndex = -1;
 	for (auto* overlay : m_stationOverlays)
 		if (overlay)
 			overlay->setSelected(false);
@@ -19712,6 +19791,7 @@ void MainWindow::displayTrainDetails(TrainBodyItem* trainItem, bool changeFollow
 	if (!groupItem)
 		return;
 	handleCloseInfoDockWidget();
+	m_selectedTrainIndex = trainItem->index;
 	trainIDText->setText(QString::fromStdString(to_string_precision(groupItem->trainId, 0)));
 	trainTypeText->setText(QString::fromStdString(groupItem->trainType));
 	trainLengthText->setText(QString::fromStdString(to_string_precision(groupItem->trainLength, 0)));
@@ -19738,6 +19818,7 @@ void MainWindow::displayTrainDetails(TrainBodyItem* trainItem, bool changeFollow
 		setFollowTrain(trainItem->index);
 		centerSceneItem(groupItem);
 	}
+	updateViewportOverlays();
 
 	// effect on clicked item
 	if (!effect) {
@@ -20367,32 +20448,38 @@ void MainWindow::updateTrainPosition(int t) {
 
 				TrainBadgeItem* badge = m_trainBadges.value(train, nullptr);
 				if (badge) {
-					badge->setIdentifier(QString::fromStdString(state.description));
+					badge->setIdentifier(QString::fromStdString(guiTrainDisplayIdentifier(state)));
+					badge->setTooltipDetails(QString::fromStdString(state.description),
+						QString::fromStdString(state.operatingCode), QString::fromStdString(state.type));
 					badge->setSpeedText(QString::fromStdString(formatSpeedLabel(state.speedKmh)));
 					badge->setSpeedVisible(m_trainSpeedLabelsVisible);
 					badge->setTrainVisual(classifyTrainType(state.type, state.description));
 					badge->setReversed(state.reversedDirection);
+					const bool promoted = isTrainOverlayPromoted(train);
+					badge->setPromoted(promoted);
+					badge->setPresentation(TrainBadgeItem::presentationForZoom(
+						networkView ? networkView->zoomRatio() : 1.0, promoted));
 					badge->setVisible(m_trainLayerVisible && hasVisibleGeometry);
 				}
 				m_prevTrainPositions[train] = newCenter;
 				QPointF delta = oldCenter - newCenter;
-				const QPointF badgeBase = newCenter + QPointF(8.0, -24.0);
+				const QPointF badgeCenter = newCenter;
 				if (delta.manhattanLength() > 0.5) {
 					stopTrainAnimation(train);
 					trainItem->setPos(delta);
 					if (badge)
-						badge->setPos(badgeBase + delta);
+						badge->setPos(badgeCenter + delta);
 					QVariantAnimation* interp = new QVariantAnimation(this);
 					m_trainAnimations[train] = interp;
 					interp->setDuration(120);
 					interp->setStartValue(QVariant::fromValue(delta));
 					interp->setEndValue(QVariant::fromValue(QPointF(0, 0)));
 					interp->setEasingCurve(QEasingCurve::Linear);
-					connect(interp, &QVariantAnimation::valueChanged, this, [trainItem, badge, badgeBase](const QVariant& val) {
+					connect(interp, &QVariantAnimation::valueChanged, this, [trainItem, badge, badgeCenter](const QVariant& val) {
 						QPointF offset = val.toPointF();
 						trainItem->setPos(offset);
 						if (badge)
-							badge->setPos(badgeBase + offset);
+							badge->setPos(badgeCenter + offset);
 					});
 					connect(interp, &QVariantAnimation::finished, this, [this, train, interp]() {
 						if (m_trainAnimations.value(train, nullptr) == interp)
@@ -20404,7 +20491,7 @@ void MainWindow::updateTrainPosition(int t) {
 					stopTrainAnimation(train);
 					trainItem->setPos(QPointF(0, 0));
 					if (badge)
-						badge->setPos(badgeBase);
+						badge->setPos(badgeCenter);
 				}
 				if (hasVisibleGeometry && m_followAction && m_followAction->isChecked()
 						&& m_followTrainIndex == train)
@@ -20416,8 +20503,6 @@ void MainWindow::updateTrainPosition(int t) {
 				trainItem->hide();
 				if (m_trainBadges.contains(train))
 					m_trainBadges[train]->setVisible(false);
-				if (m_trainSpeedLabels.contains(train))
-					m_trainSpeedLabels[train]->setVisible(false);
 			}
 		}
 		// new train starting; >= not == because the frame throttle may drop
@@ -21715,6 +21800,11 @@ bool MainWindow::paxTextVisible() const {
 	return networkView->zoomRatio() >= kDenseDetailZoom;
 }
 
+bool MainWindow::isTrainOverlayPromoted(int trainIndex) const {
+	return trainIndex == m_selectedTrainIndex
+		|| (m_followAction && m_followAction->isChecked() && m_followTrainIndex == trainIndex);
+}
+
 void MainWindow::updateViewportOverlays() {
 	if (!networkView)
 		return;
@@ -21935,8 +22025,12 @@ void MainWindow::updateViewportOverlays() {
 	}
 
 	for (auto it = m_trainBadges.cbegin(); it != m_trainBadges.cend(); ++it) {
-		if (it.value())
-			it.value()->setCompact(!dense);
+		if (!it.value())
+			continue;
+		const bool promoted = isTrainOverlayPromoted(it.key());
+		it.value()->setPromoted(promoted);
+		it.value()->setPresentation(
+			TrainBadgeItem::presentationForZoom(networkView->zoomRatio(), promoted));
 	}
 }
 

--- a/EGTRAIN/QEGTRAIN/app/MainWindow.h
+++ b/EGTRAIN/QEGTRAIN/app/MainWindow.h
@@ -73,7 +73,6 @@
 #include <QSlider>
 #include <QHBoxLayout>
 #include <QFileDialog>
-#include <QGraphicsSimpleTextItem>
 #include <QComboBox>
 #include <QVariantAnimation>
 #include <QPointer>
@@ -365,6 +364,7 @@ private:
 	QComboBox* m_followTrainCombo = nullptr;
 	QPointer<QMenu> m_sceneContextMenu;
 	int m_followTrainIndex = -1;
+	int m_selectedTrainIndex = -1;
 	bool m_updatingFollowCombo = false;
 	int m_e2eAttempts = 0;
 	bool m_e2eFinished = false;
@@ -374,7 +374,6 @@ private:
 	int m_creatorAcceptancePolls = 0;
 	QPointer<DiagramWindow> m_creatorBaselineDiagram;
 	QMap<int, QPointF> m_prevTrainPositions;
-	QMap<int, QGraphicsSimpleTextItem*> m_trainSpeedLabels; // per-train speed overlay
 	QMap<int, TrainBadgeItem*> m_trainBadges;
 	QMap<int, QVariantAnimation*> m_trainAnimations;
 	qint64 m_lastRenderMs = 0;
@@ -875,6 +874,7 @@ private:
 	void buildSignalIndex();
 	void buildTrackIndexes();
 	void updateStationOverlayDegrees();
+	bool isTrainOverlayPromoted(int trainIndex) const;
 	void updateViewportOverlays();
 	void updateZoomStatus();
 	void updateTimeline(int timestep, int totalTimesteps);

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.cpp
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.cpp
@@ -1,130 +1,169 @@
 #include "graphics/items/TrainBadgeItem.h"
 
+#include <QFontMetricsF>
+#include <QPainterPath>
+#include <QStringList>
+
+namespace {
+constexpr qreal kAnchorOffsetX = 8.0;
+constexpr qreal kAnchorGapY = 8.0;
+constexpr qreal kNoseWidth = 3.0;
+constexpr qreal kTextGap = 4.0;
+constexpr qreal kSpeedGap = 6.0;
+constexpr qreal kSidePadding = 3.0;
+}
+
 TrainBadgeItem::TrainBadgeItem(QGraphicsItem* parent)
-	: QGraphicsItem(parent), m_visual(classifyTrainType("", "")), m_icon(m_visual.iconResource), m_reversed(false), m_compact(false) {
+	: QGraphicsItem(parent), m_visual(classifyTrainType("", "")), m_icon(m_visual.iconResource) {
 	setFlag(QGraphicsItem::ItemIgnoresTransformations);
 	setAcceptedMouseButtons(Qt::NoButton);
-	setZValue(5);
+	setZValue(5.0);
 	updateToolTip();
 }
 
-void TrainBadgeItem::setIdentifier(const QString& identifier) {
-	if (m_identifier == identifier)
+void TrainBadgeItem::setIdentifier(const QString& value) {
+	if (m_identifier == value) return;
+	prepareGeometryChange(); m_identifier = value; updateToolTip(); update();
+}
+void TrainBadgeItem::setTooltipDetails(const QString& description, const QString& operatingCode,
+		const QString& trainType) {
+	if (m_description == description && m_operatingCode == operatingCode && m_trainType == trainType)
 		return;
-	m_identifier = identifier;
+	m_description = description;
+	m_operatingCode = operatingCode;
+	m_trainType = trainType;
 	updateToolTip();
-	update();
 }
-
-void TrainBadgeItem::setSpeedText(const QString& speedText) {
-	if (m_speedText == speedText)
-		return;
-	m_speedText = speedText;
-	updateToolTip();
-	update();
+void TrainBadgeItem::setSpeedText(const QString& value) {
+	if (m_speedText == value) return;
+	prepareGeometryChange(); m_speedText = value; updateToolTip(); update();
 }
-
 void TrainBadgeItem::setSpeedVisible(bool visible) {
-	if (m_speedVisible == visible)
-		return;
-	m_speedVisible = visible;
-	updateToolTip();
-	update();
+	if (m_speedVisible == visible) return;
+	prepareGeometryChange(); m_speedVisible = visible; update();
 }
-
 void TrainBadgeItem::setTrainVisual(const TrainVisual& visual) {
-	m_visual = visual;
-	m_icon = QPixmap(m_visual.iconResource);
-	update();
+	m_visual = visual; m_icon = QPixmap(m_visual.iconResource); update();
 }
-
 void TrainBadgeItem::setReversed(bool reversed) {
-	if (m_reversed == reversed)
-		return;
-	m_reversed = reversed;
-	update();
+	if (m_reversed == reversed) return;
+	prepareGeometryChange();
+	m_reversed = reversed; update();
+}
+void TrainBadgeItem::setPresentation(Presentation presentation) {
+	if (m_presentation == presentation) return;
+	prepareGeometryChange(); m_presentation = presentation; update();
+}
+void TrainBadgeItem::setPromoted(bool promoted) {
+	if (m_promoted == promoted) return;
+	m_promoted = promoted; setZValue(promoted ? 6.0 : 5.0); update();
 }
 
-void TrainBadgeItem::setCompact(bool compact) {
-	if (m_compact == compact)
-		return;
-	prepareGeometryChange();
-	m_compact = compact;
-	update();
+TrainBadgeItem::Presentation TrainBadgeItem::presentationForZoom(qreal zoom, bool promoted) {
+	if (promoted || zoom >= detailedZoomThreshold())
+		return Presentation::Detailed;
+	return zoom >= identityZoomThreshold() ? Presentation::Identity : Presentation::Overview;
+}
+
+QFont TrainBadgeItem::identifierFont() const {
+	QFont font; font.setPointSize(m_presentation == Presentation::Identity ? 8 : 9); font.setBold(true); return font;
+}
+QFont TrainBadgeItem::speedFont() const {
+	QFont font = identifierFont(); font.setPointSize(8); font.setBold(false); return font;
+}
+
+qreal TrainBadgeItem::badgeWidth() const {
+	if (m_presentation == Presentation::Overview) return markerSize().width();
+	qreal width = kSidePadding + (m_reversed ? kNoseWidth : 0.0) + 14.0 + kTextGap
+		+ QFontMetricsF(identifierFont()).horizontalAdvance(m_identifier) + kSidePadding
+		+ (!m_reversed ? kNoseWidth : 0.0);
+	if (showsSpeed()) width += kSpeedGap + QFontMetricsF(speedFont()).horizontalAdvance(m_speedText);
+	return qMin(maximumWidth(m_presentation), qMax<qreal>(44.0, width));
 }
 
 QRectF TrainBadgeItem::badgeRect() const {
-	return QRectF(0.0, 0.0, m_compact ? 92.0 : 156.0, m_compact ? 24.0 : 32.0);
+	const qreal height = m_presentation == Presentation::Overview ? 16.0
+		: m_presentation == Presentation::Identity ? 22.0 : 26.0;
+	return QRectF(kAnchorOffsetX, -kAnchorGapY - height, badgeWidth(), height);
 }
-
-QRectF TrainBadgeItem::boundingRect() const {
-	return badgeRect();
+QRectF TrainBadgeItem::boundingRect() const { return badgeRect().adjusted(-1.0, -1.0, 1.0, 1.0); }
+QRectF TrainBadgeItem::iconRect() const {
+	const QRectF body = badgeRect();
+	const qreal size = m_presentation == Presentation::Overview ? 12.0 : 14.0;
+	return QRectF(body.left() + kSidePadding + (m_reversed ? kNoseWidth : 0.0),
+		body.center().y() - size / 2.0, size, size);
+}
+QRectF TrainBadgeItem::speedTextRect() const {
+	if (!showsSpeed()) return QRectF();
+	const QRectF body = badgeRect();
+	const qreal right = body.right() - kSidePadding - (!m_reversed ? kNoseWidth : 0.0);
+	const qreal width = qMin(QFontMetricsF(speedFont()).horizontalAdvance(m_speedText), body.width() / 2.0);
+	return QRectF(right - width, body.top(), width, body.height());
+}
+QRectF TrainBadgeItem::identifierTextRect() const {
+	if (!showsIdentifier()) return QRectF();
+	const QRectF body = badgeRect();
+	const qreal left = iconRect().right() + kTextGap;
+	const QRectF speed = speedTextRect();
+	const qreal right = speed.isEmpty() ? body.right() - kSidePadding - (!m_reversed ? kNoseWidth : 0.0)
+		: speed.left() - kSpeedGap;
+	return QRectF(left, body.top(), qMax<qreal>(0.0, right - left), body.height());
+}
+QString TrainBadgeItem::displayedIdentifier() const {
+	return QFontMetricsF(identifierFont()).elidedText(m_identifier, Qt::ElideMiddle,
+		qMax<qreal>(0.0, identifierTextRect().width()));
+}
+QPolygonF TrainBadgeItem::directionNose() const {
+	const QRectF body = badgeRect().adjusted(0.75, 0.75, -0.75, -0.75);
+	const qreal halfHeight = qMin<qreal>(4.0, body.height() / 3.0);
+	QPolygonF nose;
+	if (m_reversed)
+		nose << QPointF(body.left(), body.center().y())
+			<< QPointF(body.left() + kNoseWidth + 0.5, body.center().y() - halfHeight)
+			<< QPointF(body.left() + kNoseWidth + 0.5, body.center().y() + halfHeight);
+	else
+		nose << QPointF(body.right(), body.center().y())
+			<< QPointF(body.right() - kNoseWidth - 0.5, body.center().y() - halfHeight)
+			<< QPointF(body.right() - kNoseWidth - 0.5, body.center().y() + halfHeight);
+	return nose;
 }
 
 void TrainBadgeItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
-	Q_UNUSED(option);
-	Q_UNUSED(widget);
+	Q_UNUSED(option); Q_UNUSED(widget);
+	painter->setRenderHint(QPainter::Antialiasing, true);
+	const QRectF body = badgeRect().adjusted(0.75, 0.75, -0.75, -0.75);
+	const QRectF shell = m_reversed ? body.adjusted(kNoseWidth, 0.0, 0.0, 0.0)
+		: body.adjusted(0.0, 0.0, -kNoseWidth, 0.0);
+	QPainterPath shape; shape.addRoundedRect(shell,
+		m_presentation == Presentation::Overview ? 2.0 : 4.0,
+		m_presentation == Presentation::Overview ? 2.0 : 4.0);
+	QPainterPath nose; nose.addPolygon(directionNose()); shape = shape.united(nose);
+	QPen outline(m_promoted ? promotedBorderColor() : m_visual.outline);
+	outline.setWidthF(m_promoted ? 1.6 : 1.0);
+	painter->setPen(outline); painter->setBrush(badgeSurfaceColor()); painter->drawPath(shape);
 
-	const QRectF body = badgeRect().adjusted(1.0, 1.0, -1.0, -1.0);
-	QPen outline(m_visual.outline);
-	outline.setWidthF(1.2);
-	painter->setPen(outline);
-	painter->setBrush(badgeSurfaceColor());
-	const qreal radius = trainBadgeCornerRadius(m_visual.shape);
-	painter->drawRoundedRect(body, radius, radius);
-
-	QPolygonF direction;
-	const qreal centerY = body.center().y();
-	if (m_reversed) {
-		direction << QPointF(body.left() + 5.0, centerY)
-				  << QPointF(body.left() + 11.0, centerY - 4.0)
-				  << QPointF(body.left() + 11.0, centerY + 4.0);
-	} else {
-		direction << QPointF(body.right() - 5.0, centerY)
-				  << QPointF(body.right() - 11.0, centerY - 4.0)
-				  << QPointF(body.right() - 11.0, centerY + 4.0);
-	}
-	painter->setPen(Qt::NoPen);
-	painter->setBrush(badgePrimaryTextColor());
-	painter->drawPolygon(direction);
-
-	QPen plateOutline(m_visual.outline);
-	plateOutline.setWidthF(0.8);
-	painter->setPen(plateOutline);
-	painter->setBrush(m_visual.fill);
-	painter->drawRoundedRect(iconPlateRect(body, m_reversed), 2.0, 2.0);
-
-	painter->setPen(badgePrimaryTextColor());
+	const QRectF icon = iconRect();
+	QPen plateOutline(m_visual.outline); plateOutline.setWidthF(0.7);
+	painter->setPen(plateOutline); painter->setBrush(m_visual.fill);
+	const qreal radius = qMin<qreal>(2.5, trainBadgeCornerRadius(m_visual.shape));
+	painter->drawRoundedRect(icon.adjusted(-0.5, -0.5, 0.5, 0.5), radius, radius);
 	painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
-	painter->drawPixmap(iconRect(body, m_reversed), m_icon, m_icon.rect());
-	QFont font = painter->font();
-	font.setPointSize(m_compact ? 9 : 10);
-	font.setBold(true);
-	painter->setFont(font);
-	const QFontMetricsF metrics(font);
-	const QString visibleSpeedText = m_speedVisible ? m_speedText : QString();
-	const QRectF identifierRect = identifierTextRect(body, m_compact, m_reversed, metrics, visibleSpeedText);
-	const QRectF speedRect = speedTextRect(body, m_compact, m_reversed, metrics, visibleSpeedText);
-	painter->drawText(identifierRect, Qt::AlignVCenter | Qt::AlignLeft,
-		elidedIdentifier(m_identifier, metrics, identifierRect));
-	if (!m_compact) {
-		QFont speedFont = font;
-		speedFont.setPointSize(8);
-		speedFont.setBold(false);
-		painter->setFont(speedFont);
-		painter->setPen(badgeSecondaryTextColor());
-		painter->drawText(speedRect, Qt::AlignVCenter | Qt::AlignRight, visibleSpeedText);
+	painter->drawPixmap(icon, m_icon, m_icon.rect());
+	if (!showsIdentifier()) return;
+	painter->setFont(identifierFont()); painter->setPen(badgePrimaryTextColor());
+	painter->drawText(identifierTextRect(), Qt::AlignVCenter | Qt::AlignLeft, displayedIdentifier());
+	if (showsSpeed()) {
+		painter->setFont(speedFont()); painter->setPen(badgeSecondaryTextColor());
+		painter->drawText(speedTextRect(), Qt::AlignVCenter | Qt::AlignRight, m_speedText);
 	}
 }
 
 void TrainBadgeItem::updateToolTip() {
-	QString tooltip;
-	if (!m_identifier.isEmpty())
-		tooltip = QStringLiteral("Train: %1").arg(m_identifier);
-	if (!m_speedText.isEmpty()) {
-		if (!tooltip.isEmpty())
-			tooltip += QLatin1Char('\n');
-		tooltip += QStringLiteral("Speed: %1").arg(m_speedText);
-	}
-	setToolTip(tooltip);
+	QStringList lines;
+	if (!m_description.isEmpty()) lines << QStringLiteral("Train: %1").arg(m_description);
+	else if (!m_identifier.isEmpty()) lines << QStringLiteral("Train: %1").arg(m_identifier);
+	if (!m_operatingCode.isEmpty()) lines << QStringLiteral("Operating code: %1").arg(m_operatingCode);
+	if (!m_speedText.isEmpty()) lines << QStringLiteral("Speed: %1").arg(m_speedText);
+	if (!m_trainType.isEmpty()) lines << QStringLiteral("Type: %1").arg(m_trainType);
+	setToolTip(lines.join(QLatin1Char('\n')));
 }

--- a/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.h
+++ b/EGTRAIN/QEGTRAIN/graphics/items/TrainBadgeItem.h
@@ -1,81 +1,78 @@
 #ifndef TRAINBADGEITEM_H
 #define TRAINBADGEITEM_H
 
-#include <QFontMetricsF>
+#include <QFont>
+#include <QPainter>
 #include <QPixmap>
 #include <QtWidgets/QGraphicsItem>
-#include <QPainter>
-#include <QtWidgets/QStyleOptionGraphicsItem>
-#include <QtWidgets/QWidget>
 
 #include "graphics/VisualPolish.h"
 
 class TrainBadgeItem : public QGraphicsItem {
 public:
-	TrainBadgeItem(QGraphicsItem* parent = nullptr);
+	enum class Presentation { Overview, Identity, Detailed };
 
+	TrainBadgeItem(QGraphicsItem* parent = nullptr);
 	void setIdentifier(const QString& identifier);
+	void setTooltipDetails(const QString& description, const QString& operatingCode,
+		const QString& trainType);
 	void setSpeedText(const QString& speedText);
 	void setSpeedVisible(bool visible);
 	bool isSpeedVisible() const { return m_speedVisible; }
 	void setTrainVisual(const TrainVisual& visual);
 	void setReversed(bool reversed);
-	void setCompact(bool compact);
-
-	static QRectF iconRect(const QRectF& body, bool reversed) {
-		const qreal left = body.left() + (reversed ? 15.0 : 5.0);
-		return QRectF(left, body.center().y() - 7.0, 14.0, 14.0);
-	}
-
-	static QRectF iconPlateRect(const QRectF& body, bool reversed) {
-		return iconRect(body, reversed).adjusted(-1.0, -1.0, 1.0, 1.0);
+	void setPresentation(Presentation presentation);
+	Presentation presentation() const { return m_presentation; }
+	void setPromoted(bool promoted);
+	bool isPromoted() const { return m_promoted; }
+	bool showsIdentifier() const { return m_presentation != Presentation::Overview; }
+	bool showsSpeed() const {
+		return m_presentation == Presentation::Detailed && m_speedVisible && !m_speedText.isEmpty();
 	}
 
 	static QColor badgeSurfaceColor() { return QColor("#26313B"); }
 	static QColor badgePrimaryTextColor() { return QColor("#F2F5F7"); }
 	static QColor badgeSecondaryTextColor() { return QColor("#C5D0D6"); }
-
-	static QRectF speedTextRect(const QRectF& body, bool compact, bool reversed,
-		const QFontMetricsF& metrics, const QString& speedText) {
-		if (compact || speedText.isEmpty())
-			return QRectF();
-		const qreal right = body.right() - (reversed ? 8.0 : 16.0);
-		const qreal left = body.left() + 8.0;
-		const qreal width = qMin(metrics.horizontalAdvance(speedText), qMax(0.0, right - left));
-		return QRectF(right - width, body.top() + 1.0, width, body.height() - 2.0);
+	static QColor promotedBorderColor() { return QColor("#315A70"); }
+	static QSizeF markerSize() { return QSizeF(18.0, 16.0); }
+	static qreal identityZoomThreshold() { return 1.8; }
+	static qreal detailedZoomThreshold() { return 3.0; }
+	static Presentation presentationForZoom(qreal zoom, bool promoted);
+	static qreal maximumWidth(Presentation presentation) {
+		return presentation == Presentation::Identity ? 88.0
+			: presentation == Presentation::Detailed ? 132.0 : 18.0;
 	}
 
-	static QRectF identifierTextRect(const QRectF& body, bool compact, bool reversed,
-		const QFontMetricsF& metrics, const QString& speedText) {
-		const qreal left = iconRect(body, reversed).right() + 4.0;
-		const QRectF speed = speedTextRect(body, compact, reversed, metrics, speedText);
-		const qreal defaultRight = body.right() - (reversed ? 9.0 : 17.0);
-		const qreal right = speed.isEmpty() ? defaultRight : speed.left() - 4.0;
-		return QRectF(left, body.top() + 1.0, qMax(0.0, right - left), body.height() - 2.0);
-	}
-
-	static QString elidedIdentifier(const QString& identifier, const QFontMetricsF& metrics,
-		const QRectF& region) {
-		return metrics.elidedText(identifier, Qt::ElideMiddle, qMax(0.0, region.width()));
-	}
-
+	QRectF badgeRect() const;
+	QRectF iconRect() const;
+	QRectF identifierTextRect() const;
+	QRectF speedTextRect() const;
+	QString displayedIdentifier() const;
+	QPolygonF directionNose() const;
 	QRectF boundingRect() const override;
-	void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;
+	void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+		QWidget* widget = nullptr) override;
 
 	enum { Type = UserType + 11 };
 	int type() const override { return Type; }
 
 private:
-	QRectF badgeRect() const;
+	QFont identifierFont() const;
+	QFont speedFont() const;
+	qreal badgeWidth() const;
 	void updateToolTip();
 
 	QString m_identifier;
+	QString m_description;
+	QString m_operatingCode;
+	QString m_trainType;
 	QString m_speedText;
 	TrainVisual m_visual;
 	QPixmap m_icon;
-	bool m_reversed;
-	bool m_compact;
+	Presentation m_presentation = Presentation::Overview;
+	bool m_reversed = false;
+	bool m_promoted = false;
 	bool m_speedVisible = true;
 };
 
-#endif // TRAINBADGEITEM_H
+#endif

--- a/EGTRAIN/QEGTRAIN/tests/test_guisimulationsnapshot.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_guisimulationsnapshot.cpp
@@ -16,6 +16,12 @@ void require(bool condition, const char* message) {
 
 int main() {
 	GuiTrainState activeTrain;
+	activeTrain.description = "Intercity northbound";
+	require(guiTrainDisplayIdentifier(activeTrain) == activeTrain.description,
+		"train description fallback was not used");
+	activeTrain.operatingCode = "1725";
+	require(guiTrainDisplayIdentifier(activeTrain) == activeTrain.operatingCode,
+		"operating code was not preferred");
 	activeTrain.occupiedArcs.push_back({7, 2.5});
 	GuiTrainState exitedTrain = activeTrain;
 	exitedTrain.outOfSimulation = true;

--- a/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
+++ b/EGTRAIN/QEGTRAIN/tests/test_visualpolish.cpp
@@ -121,76 +121,86 @@ int main(int argc, char* argv[]) {
 	ok &= expect(badgeText.lightness() - badgeSurface.lightness() >= 100,
 		"train badge surface and primary text have strong luminance contrast");
 
-	TrainBadgeItem geometryBadge;
-	ok &= expect(geometryBadge.boundingRect() == QRectF(0.0, 0.0, 156.0, 32.0),
-		"detailed train badge uses the fixed 156 by 32 geometry");
-	geometryBadge.setCompact(true);
-	ok &= expect(geometryBadge.boundingRect() == QRectF(0.0, 0.0, 92.0, 24.0),
-		"compact train badge uses the fixed 92 by 24 geometry");
-	ok &= expect(geometryBadge.flags().testFlag(QGraphicsItem::ItemIgnoresTransformations),
-		"train badge ignores view transformations");
-	ok &= expect(geometryBadge.acceptedMouseButtons() == Qt::NoButton,
-		"train badge remains non-interactive");
+	TrainBadgeItem badge;
+	badge.setIdentifier("1725");
+	badge.setTooltipDetails("Intercity 1725 northbound", "1725", "Intercity");
+	badge.setSpeedText("102 km/h");
+	using Presentation = TrainBadgeItem::Presentation;
+	ok &= expect(TrainBadgeItem::presentationForZoom(1.0, false) == Presentation::Overview,
+		"zoom below the identity threshold uses the overview marker");
+	ok &= expect(TrainBadgeItem::presentationForZoom(
+		TrainBadgeItem::identityZoomThreshold() - 0.01, false) == Presentation::Overview,
+		"zoom just below the identity threshold stays overview");
+	ok &= expect(TrainBadgeItem::presentationForZoom(
+		TrainBadgeItem::identityZoomThreshold(), false) == Presentation::Identity,
+		"the identity threshold itself enters identity mode");
+	ok &= expect(TrainBadgeItem::presentationForZoom(2.4, false) == Presentation::Identity,
+		"mid-range zoom keeps the identity chip");
+	ok &= expect(TrainBadgeItem::presentationForZoom(
+		TrainBadgeItem::detailedZoomThreshold() - 0.01, false) == Presentation::Identity,
+		"zoom just below the detailed threshold keeps identity");
+	ok &= expect(TrainBadgeItem::presentationForZoom(
+		TrainBadgeItem::detailedZoomThreshold(), false) == Presentation::Detailed,
+		"the detailed threshold itself enters detailed mode");
+	ok &= expect(TrainBadgeItem::presentationForZoom(6.0, false) == Presentation::Detailed,
+		"high zoom keeps the detailed label");
+	ok &= expect(TrainBadgeItem::presentationForZoom(0.8, true) == Presentation::Detailed
+		&& TrainBadgeItem::presentationForZoom(0.8, true)
+			== TrainBadgeItem::presentationForZoom(6.0, true),
+		"selected or followed trains are promoted to detailed at any zoom");
+	const QRectF overview = badge.badgeRect();
+	ok &= expect(overview.size() == TrainBadgeItem::markerSize(),
+		"overview train overlay is an 18 by 16 marker");
+	ok &= expect(!badge.showsIdentifier() && !badge.showsSpeed(),
+		"overview marker hides identifier and speed");
+	ok &= expect(badge.flags().testFlag(QGraphicsItem::ItemIgnoresTransformations),
+		"train overlay ignores view transformations");
+	ok &= expect(badge.acceptedMouseButtons() == Qt::NoButton,
+		"train overlay remains non-interactive");
 
-	QFont badgeFont;
-	badgeFont.setPointSize(10);
-	badgeFont.setBold(true);
-	const QFontMetricsF badgeMetrics(badgeFont);
-	QFont compactBadgeFont;
-	compactBadgeFont.setPointSize(9);
-	compactBadgeFont.setBold(true);
-	const QFontMetricsF compactBadgeMetrics(compactBadgeFont);
-	const QRectF denseBody(1.0, 1.0, 154.0, 30.0);
-	const QRectF compactBody(1.0, 1.0, 90.0, 22.0);
-	const QString longIdentifier = "Intercity 2201 Northbound";
-	const QString speedText = "0 km/h";
-	const QRectF identifierRegion = TrainBadgeItem::identifierTextRect(
-		denseBody, false, false, badgeMetrics, speedText);
-	const QRectF speedRegion = TrainBadgeItem::speedTextRect(
-		denseBody, false, false, badgeMetrics, speedText);
-	const QRectF categoryIcon = TrainBadgeItem::iconRect(denseBody, false);
-	const QRectF categoryIconPlate = TrainBadgeItem::iconPlateRect(denseBody, false);
-	const QRectF compactIdentifierRegion = TrainBadgeItem::identifierTextRect(
-		compactBody, true, false, compactBadgeMetrics, speedText);
-	const QRectF compactSpeedRegion = TrainBadgeItem::speedTextRect(
-		compactBody, true, false, compactBadgeMetrics, speedText);
-	const QRectF reversedIdentifierRegion = TrainBadgeItem::identifierTextRect(
-		denseBody, false, true, badgeMetrics, speedText);
-	const QRectF reversedSpeedRegion = TrainBadgeItem::speedTextRect(
-		denseBody, false, true, badgeMetrics, speedText);
-	const QRectF reversedIconPlate = TrainBadgeItem::iconPlateRect(denseBody, true);
-	const QString displayedIdentifier = TrainBadgeItem::elidedIdentifier(
-		longIdentifier, badgeMetrics, identifierRegion);
-	const QString serviceOne = TrainBadgeItem::elidedIdentifier(
-		"H-Ballerup-Osterport-1", compactBadgeMetrics, compactIdentifierRegion);
-	const QString serviceTwo = TrainBadgeItem::elidedIdentifier(
-		"H-Ballerup-Osterport-2", compactBadgeMetrics, compactIdentifierRegion);
-	TrainBadgeItem speedBadge;
-	speedBadge.setIdentifier(longIdentifier);
-	speedBadge.setSpeedText(speedText);
-	ok &= expect(speedBadge.toolTip().contains(longIdentifier),
-		"train badge tooltip keeps the full unelided identifier");
-	ok &= expect(speedBadge.toolTip().contains(speedText),
-		"train badge tooltip includes speed when available");
-	speedBadge.setSpeedVisible(false);
-	ok &= expect(!speedBadge.isSpeedVisible(), "train speed label can hide independently");
-	speedBadge.setSpeedVisible(true);
-	ok &= expect(speedBadge.isSpeedVisible(), "train speed label can restore independently");
-	ok &= expect(badgeMetrics.horizontalAdvance(longIdentifier) > identifierRegion.width(),
-		"long identifier needs elision");
-	ok &= expect(badgeMetrics.horizontalAdvance(displayedIdentifier) <= identifierRegion.width(),
-		"elided identifier fits its region");
-	ok &= expect(serviceOne != serviceTwo && serviceOne.endsWith('1') && serviceTwo.endsWith('2'),
-		"middle elision preserves distinguishing service suffixes");
-	ok &= expect(identifierRegion.right() <= speedRegion.left(),
-		"identifier and speed regions do not overlap");
-	ok &= expect(reversedIdentifierRegion.right() <= reversedSpeedRegion.left(),
-		"reversed identifier and speed regions do not overlap");
-	ok &= expect(categoryIcon.right() <= identifierRegion.left()
-		&& categoryIconPlate.right() <= identifierRegion.left()
-		&& reversedIconPlate.right() <= reversedIdentifierRegion.left(),
-		"train icon plates and identifier do not overlap");
-	ok &= expect(compactSpeedRegion.isEmpty(), "compact train badge hides speed text");
+	badge.setPresentation(TrainBadgeItem::Presentation::Identity);
+	const QRectF identity = badge.badgeRect();
+	ok &= expect(identity.height() == 22.0 && identity.width() < TrainBadgeItem::maximumWidth(
+		TrainBadgeItem::Presentation::Identity), "short identity chip is content-sized");
+	ok &= expect(badge.showsIdentifier() && !badge.showsSpeed() && badge.speedTextRect().isEmpty(),
+		"identity chip shows identity without speed");
+
+	badge.setPresentation(TrainBadgeItem::Presentation::Detailed);
+	const QRectF detailed = badge.badgeRect();
+	ok &= expect(detailed.height() == 26.0 && detailed.width() <= TrainBadgeItem::maximumWidth(
+		TrainBadgeItem::Presentation::Detailed), "detailed train label stays within 132 pixels");
+	ok &= expect(badge.showsIdentifier() && badge.showsSpeed(),
+		"detailed train label shows enabled speed");
+	ok &= expect(badge.identifierTextRect().right() <= badge.speedTextRect().left(),
+		"detailed identity and speed do not overlap");
+	ok &= expect(overview.bottom() == identity.bottom() && identity.bottom() == detailed.bottom(),
+		"all train overlay modes expand from one anchor");
+	const qreal detailedWidthWithSpeed = detailed.width();
+	badge.setSpeedVisible(false);
+	ok &= expect(!badge.showsSpeed() && badge.badgeRect().width() < detailedWidthWithSpeed,
+		"speed toggle removes detailed speed text and unused width");
+	badge.setSpeedVisible(true);
+	badge.setPromoted(true);
+	ok &= expect(badge.isPromoted() && badge.zValue() > 5.0
+		&& TrainBadgeItem::promotedBorderColor() == QColor("#315A70"),
+		"promoted train label uses the application accent above ordinary overlays");
+
+	const QPolygonF forwardNose = badge.directionNose();
+	badge.setReversed(true);
+	const QPolygonF reversedNose = badge.directionNose();
+	ok &= expect(forwardNose.first().x() > forwardNose.at(1).x()
+		&& reversedNose.first().x() < reversedNose.at(1).x(),
+		"integrated train nose follows runtime direction");
+	ok &= expect(badge.toolTip().contains("Intercity 1725 northbound")
+		&& badge.toolTip().contains("Operating code: 1725")
+		&& badge.toolTip().contains("Speed: 102 km/h")
+		&& badge.toolTip().contains("Type: Intercity"),
+		"train tooltip retains full operational details");
+
+	badge.setIdentifier("H-Ballerup-Osterport-1");
+	const QString elided = badge.displayedIdentifier();
+	ok &= expect(elided != "H-Ballerup-Osterport-1" && elided.endsWith('1'),
+		"long train identifiers use middle elision and preserve the suffix");
 
 	if (!ok)
 		return 1;

--- a/docs/ui/renderer-style-map.md
+++ b/docs/ui/renderer-style-map.md
@@ -33,7 +33,9 @@ Measured against the `#12191F` canvas, the contrast ratios are 7.64:1 for free, 
 
 ## Train categories
 
-Train badges are fixed screen-space overlays: compact badges are 92 by 24 px and detailed badges are 156 by 32 px. Both use the dark neutral surface `#26313B`, bright `#F2F5F7` identifier text, and the existing category outline, shape, and icon cues. The category fill is retained as the small 16 by 16 px icon plate behind each dark train SVG:
+Train overlays ignore view transformations and expand from one geometry-based anchor. Below 1.8x, ordinary trains use an 18 by 16 px category marker with no text. From 1.8x to below 3x, a content-sized identity chip shows the category icon and operating code, falling back to the description. At 3x and above, the detailed label also shows speed when Train speed labels is enabled. Selected and followed trains use the detailed label at every zoom, with a `#315A70` border and a higher stacking order.
+
+Identity chips are 22 px high and at most 88 px wide. Detailed labels are 26 px high and at most 132 px wide. Both use `#26313B`, `#F2F5F7` identifier text, `#C5D0D6` speed text, and the existing category icon and accent:
 
 | Category | Icon plate | Outline | Shape |
 | --- | --- | --- | --- |
@@ -43,15 +45,15 @@ Train badges are fixed screen-space overlays: compact badges are 92 by 24 px and
 | High speed | `#86A6B9` | `#3E627A` | rounded |
 | Freight | `#A99787` | `#5D4C3F` | square |
 
-The identifier is semibold/bold at 9 pt in compact mode and 10 pt in detailed mode. Detailed speed text is subordinate at 8 pt in `#C5D0D6`; speed is hidden in compact mode. A bright direction triangle stays on the left for reversed trains and right otherwise, so direction is not conveyed by color. The badge keeps its identifier and optional speed text in one non-interactive `QGraphicsItem` with `ItemIgnoresTransformations`. Long identifiers use middle elision so a distinguishing service suffix remains visible, while the Follow selector retains the full identifier.
+The small triangular nose is part of the leading edge of every marker or label; reversed trains point left. Long identifiers use middle elision. The overlay remains non-interactive, and the underlying train body owns clicks.
 
-The badge tooltip exposes the full unelided identifier and speed where available as a pointer-access fallback. The badge has no focusable or screen-reader presentation; use the full Follow selector for keyboard-oriented train identification.
+The tooltip exposes the full description, operating code, speed, and train type. The Follow selector and train details retain their full identifiers.
 
 ## Entity icons
 
 Entity icons use 24 by 24 SVGs on a transparent canvas. Geometry stays inside the 2 to 22 coordinate range. Primary strokes use 1.5 px with round joins and caps, and rounded housings use a 3 px corner radius. The palette is `#101A22` for the surface, `#26313B` for housings, `#0D131A` for outlines, `#F2F5F7` for ink, `#D2D7DC` with `#464646` outlines for stations, `#2AAA7A` for passengers, `#2ECC71` for Proceed, `#F2A516` for Caution, `#EF5350` for Stop, and `#7F8C95` for Neutral.
 
-Stations use one circular marker on the network and in the map key. The `station.svg` asset is used for station details and context icons. Passenger icons render at 14 by 14 pixels and keep their passenger IDs in `PassengerItem` objects. Train category icons render at 14 by 14 pixels inside the badge: Passenger, Sprinter, Intercity, High speed, and Freight each have a distinct cab or locomotive shape. Signal icons occupy the 12 by 12 square at the top of the fixed 12 by 16 signal item. Neutral uses a gray lamp and center dot, Stop uses a red lamp and bar, Caution uses a yellow lamp and triangle, and Proceed uses a green lamp and chevron. The direction triangle remains in the lower signal area.
+Stations use one circular marker on the network and in the map key. The `station.svg` asset is used for station details and context icons. Passenger icons render at 14 by 14 pixels and keep their passenger IDs in `PassengerItem` objects. Train category icons render at 12 px in overview markers and 14 px in labels. Signal icons occupy the 12 by 12 square at the top of the fixed 12 by 16 signal item. Neutral uses a gray lamp and center dot, Stop uses a red lamp and bar, Caution uses a yellow lamp and triangle, and Proceed uses a green lamp and chevron. The direction triangle remains in the lower signal area.
 
 The application loads these assets through the Qt resource aliases under `:/icons/`. `MainWindow`, `TrainBadgeItem`, and `SignalItem` cache the pixmaps and draw them with smooth transformation. Station, passenger, train badge, and signal overlays ignore view transformations so their screen sizes remain stable while the network zooms.
 

--- a/tools/e2e/visual_polish_smoke.sh
+++ b/tools/e2e/visual_polish_smoke.sh
@@ -8,6 +8,8 @@ SCENE="$SCENE_ROOT/Copenhagen"
 OUT="${TMPDIR:-/tmp}/qegtrain-visual-polish-e2e.log"
 SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-e2e.png"
 DENSE_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-dense-e2e.png"
+MEDIUM_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-medium-e2e.png"
+SELECTED_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-selected-e2e.png"
 FOLLOW_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-follow-e2e.png"
 CONTEXT_SHOT="${TMPDIR:-/tmp}/qegtrain-visual-polish-context-e2e.png"
 COMMAND_BAR_1024_SHOT="${TMPDIR:-/tmp}/qegtrain-command-bar-1024-e2e.png"
@@ -28,13 +30,17 @@ if [[ ! -x "$APP" ]]; then
 fi
 
 cd "$ROOT/EGTRAIN/QEGTRAIN"
-rm -f "$CONTEXT_SHOT"
+rm -f "$SHOT" "$MEDIUM_SHOT" "$DENSE_SHOT" "$SELECTED_SHOT" "$FOLLOW_SHOT" "$CONTEXT_SHOT" \
+	"$DPR2_SHOT" "${DPR2_SHOT%.png}-medium.png" "${DPR2_SHOT%.png}-dense.png" \
+	"${DPR2_SHOT%.png}-selected.png" "${DPR2_SHOT%.png}-follow.png"
 QT_QPA_PLATFORM=offscreen \
 QT_SCALE_FACTOR=1 \
 QEGTRAIN_AUTOSTART=1 \
 QEGTRAIN_E2E_VISUAL_POLISH=1 \
 QEGTRAIN_E2E_SCREENSHOT="$SHOT" \
 QEGTRAIN_E2E_DENSE_SCREENSHOT="$DENSE_SHOT" \
+QEGTRAIN_E2E_MEDIUM_SCREENSHOT="$MEDIUM_SHOT" \
+QEGTRAIN_E2E_SELECTED_SCREENSHOT="$SELECTED_SHOT" \
 QEGTRAIN_E2E_FOLLOW_SCREENSHOT="$FOLLOW_SHOT" \
 QEGTRAIN_E2E_CONTEXT_SCREENSHOT="$CONTEXT_SHOT" \
 QEGTRAIN_E2E_COMMAND_BAR_1024_SCREENSHOT="$COMMAND_BAR_1024_SHOT" \
@@ -46,6 +52,8 @@ grep -q "E2E_VISUAL_POLISH_OK" "$OUT"
 grep -q "E2E_VISUAL_POLISH_DPR_1.0" "$OUT"
 test -s "$SHOT"
 test -s "$DENSE_SHOT"
+test -s "$MEDIUM_SHOT"
+test -s "$SELECTED_SHOT"
 test -s "$FOLLOW_SHOT"
 test -s "$CONTEXT_SHOT"
 test -s "$COMMAND_BAR_1024_SHOT"
@@ -61,7 +69,7 @@ if grep -Fq 'name="actionShow_Graph"' "$ROOT/EGTRAIN/QEGTRAIN/app/MainWindow.ui"
 	echo "dead Show Graph action still present in MainWindow.ui" >&2
 	exit 1
 fi
-echo "visual polish e2e passed: $SHOT $DENSE_SHOT $FOLLOW_SHOT $CONTEXT_SHOT $COMMAND_BAR_1024_SHOT $COMMAND_BAR_1200_SHOT $COMMAND_BAR_1440_SHOT"
+echo "visual polish e2e passed: $SHOT $MEDIUM_SHOT $DENSE_SHOT $SELECTED_SHOT $FOLLOW_SHOT $CONTEXT_SHOT $COMMAND_BAR_1024_SHOT $COMMAND_BAR_1200_SHOT $COMMAND_BAR_1440_SHOT"
 
 if ! QT_QPA_PLATFORM=offscreen \
 	QT_SCALE_FACTOR=2 \
@@ -69,6 +77,8 @@ if ! QT_QPA_PLATFORM=offscreen \
 	QEGTRAIN_E2E_VISUAL_POLISH=1 \
 	QEGTRAIN_E2E_SCREENSHOT="$DPR2_SHOT" \
 	QEGTRAIN_E2E_DENSE_SCREENSHOT="${DPR2_SHOT%.png}-dense.png" \
+	QEGTRAIN_E2E_MEDIUM_SCREENSHOT="${DPR2_SHOT%.png}-medium.png" \
+	QEGTRAIN_E2E_SELECTED_SCREENSHOT="${DPR2_SHOT%.png}-selected.png" \
 	QEGTRAIN_E2E_FOLLOW_SCREENSHOT="${DPR2_SHOT%.png}-follow.png" \
 	QEGTRAIN_E2E_CONTEXT_SCREENSHOT="${DPR2_SHOT%.png}-context.png" \
 	QEGTRAIN_E2E_COMMAND_BAR_1024_SCREENSHOT="$DPR2_COMMAND_BAR_1024_SHOT" \
@@ -81,6 +91,10 @@ fi
 grep -q "E2E_VISUAL_POLISH_DPR_2.0" "$DPR2_OUT"
 grep -q "E2E_VISUAL_POLISH_OK" "$DPR2_OUT"
 test -s "$DPR2_SHOT"
+test -s "${DPR2_SHOT%.png}-medium.png"
+test -s "${DPR2_SHOT%.png}-dense.png"
+test -s "${DPR2_SHOT%.png}-selected.png"
+test -s "${DPR2_SHOT%.png}-follow.png"
 test -s "$DPR2_COMMAND_BAR_1024_SHOT"
 test -s "$DPR2_COMMAND_BAR_1200_SHOT"
 test -s "$DPR2_COMMAND_BAR_1440_SHOT"


### PR DESCRIPTION
## Summary
- consolidate train overlays into one `TrainBadgeItem` with three semantic-zoom presentations: compact direction marker below 1.8x zoom, operating-code identity chip (description fallback) from 1.8x, and detailed label with live speed from 3.0x
- promote selected or followed trains to the detailed presentation at any zoom; promotion follows selection/follow changes through `updateViewportOverlays()` and reverts automatically
- integrate direction into the badge nose (no separate arrow overlays), remove the old separate speed-label mechanism so no duplicate speed text remains, and keep full details in tooltips

## Verification
- `cmake --build build --target QEGTRAIN test_guisimulationsnapshot test_visualpolish` — clean
- `ctest --test-dir build -R 'test_guisimulationsnapshot|test_visualpolish' --output-on-failure` — 2/2 passed
- `QT_QPA_PLATFORM=offscreen tools/e2e/visual_polish_smoke.sh` — passed (incl. new overview/identity/detail/selected/follow assertions)
- `ctest --test-dir build --output-on-failure` — **54/54 passed**
- Landed updater/scene-versioning behavior verified intact (null-safe update dispatch, background preparation, scene compatibility wiring)
