### PR TITLE
Profile playback compute phases

### DIFF
--- a/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
+++ b/EGTRAIN/QEGTRAIN/app/DispatchController.cpp
@@ -430,26 +430,37 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 		clock_t startEGTRAIN = clock(); // EGTRAIN start time
 		std::cout << "\r Time of simulation is " << t;
 
-		// Simulate entrance process of passengers on the railway network according to route choice
-		checkJourneyStartForAllPassengers(t, initial_variables.startingSimulationTime, AllDailyPassengers);
+		{
+			QEGTRAIN_PROFILE_SCOPE("worker/playback_step/compute/passenger_entry_platform_refresh", "worker",
+				"worker/playback_step/compute");
+			// Simulate entrance process of passengers on the railway network according to route choice
+			checkJourneyStartForAllPassengers(t, initial_variables.startingSimulationTime, AllDailyPassengers);
 
-		// This function will update the list of all waiting passengers at all platforms in the network at every instant
-		// To reduce the computation time it is instead recommended that the function to update the list of waiting passengers at platform is only used in the functional "Simulate_Train_Passenger_Interaction"
-		// In that case  please comment the line below and uncomment the corresponding function Update_List_Passengers_Waiting_At_Platform in that function
-		if (initial_variables.PAX_GUI) {
-			Update_List_Passengers_Waiting_At_ALL_Platforms(AllStationPlatforms, AllDailyPassengers);
+			// This function will update the list of all waiting passengers at all platforms in the network at every instant
+			// To reduce the computation time it is instead recommended that the function to update the list of waiting passengers at platform is only used in the functional "Simulate_Train_Passenger_Interaction"
+			// In that case  please comment the line below and uncomment the corresponding function Update_List_Passengers_Waiting_At_Platform in that function
+			if (initial_variables.PAX_GUI) {
+				Update_List_Passengers_Waiting_At_ALL_Platforms(AllStationPlatforms, AllDailyPassengers);
+			}
 		}
 
-		// Simulate train movement at each simulation step
-		for (int j = 0; j < numRegions; j++) {
-			regional_train[j].trajectoryComputationIncludingMovingBlock(t, v1, v2, v3); // originally we shall call the function Trajectory_Block_Section_Free_Flow
-			regional_train[j].recordEarliestActiveTrajectoryIndex(t);
-			regional_train[j].recordStationPassagesAtTime(t);
+		{
+			QEGTRAIN_PROFILE_SCOPE("worker/playback_step/compute/train_movement", "worker",
+				"worker/playback_step/compute");
+			// Simulate train movement at each simulation step
+			for (int j = 0; j < numRegions; j++) {
+				regional_train[j].trajectoryComputationIncludingMovingBlock(t, v1, v2, v3); // originally we shall call the function Trajectory_Block_Section_Free_Flow
+				regional_train[j].recordEarliestActiveTrajectoryIndex(t);
+				regional_train[j].recordStationPassagesAtTime(t);
 
-			// check if train arrived at destination or departed from origin
-			regional_train[j].checkTrainArrDep(j, t);
+				// check if train arrived at destination or departed from origin
+				regional_train[j].checkTrainArrDep(j, t);
+			}
 		}
 
+		{
+		QEGTRAIN_PROFILE_SCOPE("worker/playback_step/compute/train_passenger_state_payload", "worker",
+			"worker/playback_step/compute");
 		// Here we prepare the Traffic State data
 		for (int n = 0; n < numRegions; n++) {
 
@@ -484,9 +495,14 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 				jsmsg["trains"][regional_train[n].trainDescription]["inArea"] = 0;
 
 		}
+		}
 
-		// Print Passenger Status after the simulation
-		printCurrentPassengerStatus(t, initial_variables.startingSimulationTime, AllDailyPassengers, (initial_variables.OutputMainFolder + "/PassengerStatus"));
+		{
+			QEGTRAIN_PROFILE_SCOPE("worker/playback_step/compute/passenger_status_output", "worker",
+				"worker/playback_step/compute");
+			// Print Passenger Status after the simulation
+			printCurrentPassengerStatus(t, initial_variables.startingSimulationTime, AllDailyPassengers, (initial_variables.OutputMainFolder + "/PassengerStatus"));
+		}
 
 		jsmsg["time"] = t;
 
@@ -506,37 +522,41 @@ void DispatchController::Train_Simulation_Mixed_Signalling_With_Passengers(doubl
 			send_external_state(route_choice_json, xml, "tcp://127.0.0.1:5556");
 		}
 
-		ETCS_MA.clear(); // Clear the list containing all the Movement Authorities given to the trains at the previous instant
+		{
+			QEGTRAIN_PROFILE_SCOPE("worker/playback_step/compute/infrastructure_signalling_cleanup", "worker",
+				"worker/playback_step/compute");
+			ETCS_MA.clear(); // Clear the list containing all the Movement Authorities given to the trains at the previous instant
 
-		Occupy_Block_Sections_Of_Route(t); // Fill in the lists Blocks_Occupied and BlocksConnected
+			Occupy_Block_Sections_Of_Route(t); // Fill in the lists Blocks_Occupied and BlocksConnected
 
-		// Occupy failed sections and give them an End of Authority so both
-		// aspect-driven and moving-block trains react to the incident
-		Apply_Signal_Failures_Mixed_Signalling(t);
+			// Occupy failed sections and give them an End of Authority so both
+			// aspect-driven and moving-block trains react to the incident
+			Apply_Signal_Failures_Mixed_Signalling(t);
 
-		// Only for level>=3
-		ReportAllTrainPositionsToRBC(t, 50);
+			// Only for level>=3
+			ReportAllTrainPositionsToRBC(t, 50);
 
-		// function to protect all station areas
-		protectStationAreas(t);
+			// function to protect all station areas
+			protectStationAreas(t);
 
-		releaseMixedSignallingSystem(); // Release Blocks connected with the one really occupied by a train
+			releaseMixedSignallingSystem(); // Release Blocks connected with the one really occupied by a train
 
-		activateMixedSignallingSystem(); // Apply the rules of the signalling system for all the Blocks contained
+			activateMixedSignallingSystem(); // Apply the rules of the signalling system for all the Blocks contained
 
-		unlockDoubleSwitches(); // unlock double switches (otherwise trains stop in the middle of double switches)
+			unlockDoubleSwitches(); // unlock double switches (otherwise trains stop in the middle of double switches)
 
-		for (int i = 0; i < numRegions; i++) {
-			regional_train[i].unlockSingleTrack(
-				train_route[regional_train[i].indexOfRoute].sequence_of_block_sections,
-				train_route[regional_train[i].indexOfRoute].N_Block_Sections,
-				t);
-		} // unlock occupied single tracks
+			for (int i = 0; i < numRegions; i++) {
+				regional_train[i].unlockSingleTrack(
+					train_route[regional_train[i].indexOfRoute].sequence_of_block_sections,
+					train_route[regional_train[i].indexOfRoute].N_Block_Sections,
+					t);
+			} // unlock occupied single tracks
 
-		BlocksOccupied.clear();	 // Clear the list BlocksOccupied
-		BlocksConnected.clear(); // Clear the list BlocksConnected
+			BlocksOccupied.clear();	 // Clear the list BlocksOccupied
+			BlocksConnected.clear(); // Clear the list BlocksConnected
 
-		Detect_Implemented_Order_For_All_OL(); // Detect The order Implemented for all the OLs in the network
+			Detect_Implemented_Order_For_All_OL(); // Detect The order Implemented for all the OLs in the network
+		}
 
 		clock_t endEGTRAIN = clock();																// variable that sets the time in which EGTRAIN ends
 		Comp_Time_EGTRAIN = Comp_Time_EGTRAIN + double(endEGTRAIN - startEGTRAIN) / CLOCKS_PER_SEC; // computing the cumulated computation time of EGTRAIN

--- a/docs/development/playback-profiling.md
+++ b/docs/development/playback-profiling.md
@@ -28,12 +28,14 @@ Scene loading, native preparation, `setupGUI()`, `startSimulation()`, and waitin
 
 The profiler records these paths; animation is conditional, so a trial with no movement reports `gui/train_animation/value_changed` as an unobserved optional path while every other listed path remains mandatory.
 
-- Worker: `worker/playback_step/compute`, `worker/playback_step/snapshot_build_publish`, and its `build_gui_snapshot` and `mailbox_publish` children.
+- Worker: `worker/playback_step/compute`; its five direct children `passenger_entry_platform_refresh`, `train_movement`, `train_passenger_state_payload`, `passenger_status_output`, and `infrastructure_signalling_cleanup`; `worker/playback_step/snapshot_build_publish`; and its `build_gui_snapshot` and `mailbox_publish` children.
 - GUI: `gui/snapshot_delivery`, `timeline`, throttled `render_frame`, and its `signalling`, `train_position`, `platforms`, `passenger_icons`, and `train_passenger_info` children.
 - Animation: `gui/train_animation/value_changed`.
 - Rendering: `render/viewport_paint` and `render/viewport_paint/background`.
 
-The worker compute scope starts after pause, stop, and step-delay handling and ends before snapshot publication. Snapshot deliveries, rendered updates, completed paints, and start/end timesteps are counted separately. Calls, inclusive totals, and extrema cover every observation. Median and p95 use a bounded deterministic streaming reservoir across the full window rather than retaining only early samples.
+The worker compute scope starts after pause, stop, and step-delay handling and ends before snapshot publication. Its five children are unconditional sequential scopes called once per compute step. `passenger_entry_platform_refresh` combines journey starts with the optional all-platform waiting-list refresh. `train_movement` covers trajectory calculation and per-train movement records. `train_passenger_state_payload` combines train-passenger interaction with construction of the per-train traffic-state payload. `passenger_status_output` covers writing the current passenger status. `infrastructure_signalling_cleanup` combines occupancy, failures, movement authorities, station protection, signalling activation and release, track unlocking, occupied-list cleanup, and operating-order detection.
+
+Compute self time is the residual after subtracting those five direct children. It intentionally retains progress output, traffic-state and route-choice external sharing, CPU-time bookkeeping, gaps between the compound phases, and profiler overhead. Snapshot deliveries, rendered updates, completed paints, and start/end timesteps are counted separately. Calls, inclusive totals, and extrema cover every observation. Median and p95 use a bounded deterministic streaming reservoir across the full window rather than retaining only early samples.
 
 ## Evidence and structural checks
 
@@ -42,8 +44,8 @@ The worker compute scope starts after pause, stop, and step-delay handling and e
 The harness persists only:
 
 - `records.jsonl`: validated run, aggregate, and completion records.
-- `summary.json`: the exact `structural` or `recorded` mode and evidence status, separate Fit and dense rankings, each trial's direct-child-subtracted self total, median trial self totals, median per-call median/p95, decision results, and valid dense-to-Fit comparisons.
-- `report.txt`: the same decision inputs in readable form, settings, and a path-safe reproducible command.
+- `summary.json`: schema 3, the exact `structural` or `recorded` mode and evidence status, separate Fit and dense rankings, each trial's direct-child-subtracted self total, each compute child's inclusive share of its compute parent, median trial self totals, median per-call median/p95, decision results, and valid dense-to-Fit comparisons.
+- `report.txt`: the same decision inputs and compute-parent shares in readable form, settings, and a path-safe reproducible command.
 
 It does not retain process output, environments, paths, binary details, identifiers, timestamps, or unrelated logs.
 

--- a/tools/performance/playback_profile.py
+++ b/tools/performance/playback_profile.py
@@ -13,8 +13,17 @@ from pathlib import Path
 
 PREFIX = "QEGTRAIN_PLAYBACK_PROFILE "
 REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPUTE_PATH = "worker/playback_step/compute"
+COMPUTE_CHILDREN = {
+    f"{COMPUTE_PATH}/passenger_entry_platform_refresh",
+    f"{COMPUTE_PATH}/train_movement",
+    f"{COMPUTE_PATH}/train_passenger_state_payload",
+    f"{COMPUTE_PATH}/passenger_status_output",
+    f"{COMPUTE_PATH}/infrastructure_signalling_cleanup",
+}
 PATHS = {
-    "worker/playback_step/compute",
+    COMPUTE_PATH,
+    *COMPUTE_CHILDREN,
     "worker/playback_step/snapshot_build_publish",
     "worker/playback_step/snapshot_build_publish/build_gui_snapshot",
     "worker/playback_step/snapshot_build_publish/mailbox_publish",
@@ -31,7 +40,8 @@ PATHS = {
     "render/viewport_paint/background",
 }
 PARENTS = {
-    "worker/playback_step/compute": ("worker", ""),
+    COMPUTE_PATH: ("worker", ""),
+    **{path: ("worker", COMPUTE_PATH) for path in COMPUTE_CHILDREN},
     "worker/playback_step/snapshot_build_publish": ("worker", ""),
     "worker/playback_step/snapshot_build_publish/build_gui_snapshot":
         ("worker", "worker/playback_step/snapshot_build_publish"),
@@ -201,6 +211,9 @@ def validate_trial(records: list[dict], *, trial: int, view: str, duration_ms: i
                 or not aggregate["calls"] * aggregate["min_ns"] <= aggregate["total_ns"]
                 <= aggregate["calls"] * aggregate["max_ns"]):
             raise ValueError("invalid aggregate totals")
+    compute_calls = aggregates_by_path[COMPUTE_PATH]["calls"]
+    if any(aggregates_by_path[path]["calls"] != compute_calls for path in COMPUTE_CHILDREN):
+        raise ValueError("compute child calls must match compute calls")
 
     minimum = 1 if structural else 100
     if completion["start_timestep"] >= completion["end_timestep"] or completion["timesteps"] < minimum:
@@ -250,6 +263,7 @@ def summarize(trials: list[dict], *, structural: bool) -> dict:
                 if path not in trial["self_ns"]:
                     values.append({"trial": trial["trial"], "self_total_ns": 0,
                                    "lane_share": 0.0, "window_share": 0.0,
+                                   "compute_parent_share": None,
                                    "lane_dominant": False, "meets_decision_rule": False,
                                    "observed": False})
                     medians.append(0)
@@ -264,11 +278,16 @@ def summarize(trials: list[dict], *, structural: bool) -> dict:
                 self_ns = trial["self_ns"][path]
                 lane_share = self_ns / lane_total if lane_total else 0.0
                 window_share = self_ns / trial["observed_ns"]
+                compute_parent_share = None
+                if path in COMPUTE_CHILDREN:
+                    compute_total = trial["aggregates"][COMPUTE_PATH]["total_ns"]
+                    compute_parent_share = aggregate["total_ns"] / compute_total if compute_total else 0.0
                 dominant = self_ns == lane_max
                 qualifies = dominant and lane_share >= 0.20 and window_share >= 0.05
                 dominant_trials += int(qualifies)
                 values.append({"trial": trial["trial"], "self_total_ns": self_ns,
                                "lane_share": lane_share, "window_share": window_share,
+                               "compute_parent_share": compute_parent_share,
                                "lane_dominant": dominant, "meets_decision_rule": qualifies,
                                "observed": True})
                 medians.append(aggregate["median_ns"])
@@ -307,7 +326,7 @@ def summarize(trials: list[dict], *, structural: bool) -> dict:
                     / fit[path]["median_per_call_p95_ns"] if fit[path]["median_per_call_p95_ns"] else None})
     mode = "structural" if structural else "recorded"
     evidence_status = "structural only; not recorded evidence" if structural else "recorded evidence"
-    return {"schema": 2, "mode": mode, "evidence_status": evidence_status,
+    return {"schema": 3, "mode": mode, "evidence_status": evidence_status,
             "views": views, "dense_to_fit": comparisons}
 
 
@@ -405,8 +424,10 @@ def main() -> None:
         for row in view_summary["rankings"]:
             trial_totals = ", ".join(
                 f"t{value['trial']}={value['self_total_ns']}ns/"
-                f"{value['lane_share']:.1%} lane/{value['window_share']:.1%} window/"
-                f"dominant={'yes' if value['lane_dominant'] else 'no'}"
+                f"{value['lane_share']:.1%} lane/{value['window_share']:.1%} window"
+                + (f"/{value['compute_parent_share']:.1%} compute parent"
+                   if value["compute_parent_share"] is not None else "")
+                + f"/dominant={'yes' if value['lane_dominant'] else 'no'}"
                 for value in row["trial_self_totals"])
             lines.append(f"{row['path']}: self [{trial_totals}], median self "
                          f"{row['median_trial_self_total_ns']}ns, median per-call "

--- a/tools/performance/test_playback_profile.py
+++ b/tools/performance/test_playback_profile.py
@@ -18,7 +18,12 @@ def records(*, paints=1, structural=True):
         "scope": "post_startup_playback", "mode": "structural" if structural else "recorded",
     }
     totals = {
-        "worker/playback_step/compute": 30,
+        "worker/playback_step/compute": 100,
+        "worker/playback_step/compute/passenger_entry_platform_refresh": 10,
+        "worker/playback_step/compute/train_movement": 10,
+        "worker/playback_step/compute/train_passenger_state_payload": 10,
+        "worker/playback_step/compute/passenger_status_output": 10,
+        "worker/playback_step/compute/infrastructure_signalling_cleanup": 10,
         "worker/playback_step/snapshot_build_publish": 30,
         "worker/playback_step/snapshot_build_publish/build_gui_snapshot": 10,
         "worker/playback_step/snapshot_build_publish/mailbox_publish": 10,
@@ -114,7 +119,32 @@ class PlaybackProfileTests(unittest.TestCase):
     def test_percentile_and_direct_child_self_time(self):
         self.assertEqual(profile.percentile([1, 2, 3, 100], 0.95), 100)
         trial = records()
-        self.assertEqual(profile.self_totals(trial)["gui/snapshot_delivery"], 10)
+        totals = profile.self_totals(trial)
+        self.assertEqual(totals["gui/snapshot_delivery"], 10)
+        self.assertEqual(totals[profile.COMPUTE_PATH], 50)
+
+    def test_compute_children_are_direct_mandatory_paths_with_matching_calls(self):
+        trial = records()
+        aggregates = {record["path"]: record for record in trial
+                      if record["type"] == "aggregate"}
+        self.assertTrue(profile.COMPUTE_CHILDREN <= profile.MANDATORY_PATHS)
+        for path in profile.COMPUTE_CHILDREN:
+            self.assertEqual(profile.PARENTS[path], ("worker", profile.COMPUTE_PATH))
+            self.assertEqual(aggregates[path]["calls"], aggregates[profile.COMPUTE_PATH]["calls"])
+
+        aggregates[next(iter(profile.COMPUTE_CHILDREN))]["calls"] -= 1
+        with self.assertRaisesRegex(ValueError, "compute child calls"):
+            profile.validate_trial(trial, trial=1, view="fit", duration_ms=50,
+                                   delay_ms=0, structural=True)
+
+    def test_compute_children_must_reconcile_with_parent(self):
+        bad = records()
+        parent = next(record for record in bad if record.get("path") == profile.COMPUTE_PATH)
+        set_total(parent, 49)
+        parent.update({"p95_ns": 5, "max_ns": 5})
+        with self.assertRaisesRegex(ValueError, "direct children exceed"):
+            profile.validate_trial(bad, trial=1, view="fit", duration_ms=50,
+                                   delay_ms=0, structural=True)
 
     def test_forbidden_metadata_and_absolute_paths_are_rejected(self):
         bad = records()
@@ -236,6 +266,7 @@ class PlaybackProfileTests(unittest.TestCase):
             trials.append({"view": view, "trial": 1, "self_ns": self_ns,
                            "aggregates": aggregates, "observed_ns": 50_000_000})
         summary = profile.summarize(trials, structural=True)
+        self.assertEqual(summary["schema"], 3)
         self.assertEqual(summary["mode"], "structural")
         self.assertEqual(summary["evidence_status"], "structural only; not recorded evidence")
         self.assertEqual(set(summary["views"]), {"fit", "dense"})
@@ -243,6 +274,12 @@ class PlaybackProfileTests(unittest.TestCase):
         fit_row = summary["views"]["fit"]["rankings"][0]
         self.assertIn("trial_self_totals", fit_row)
         self.assertIn("median_per_call_p95_ns", fit_row)
+        child_row = next(row for row in summary["views"]["fit"]["rankings"]
+                         if row["path"] in profile.COMPUTE_CHILDREN)
+        self.assertEqual(child_row["trial_self_totals"][0]["compute_parent_share"], 0.1)
+        nonchild_row = next(row for row in summary["views"]["fit"]["rankings"]
+                            if row["path"] == profile.COMPUTE_PATH)
+        self.assertIsNone(nonchild_row["trial_self_totals"][0]["compute_parent_share"])
         self.assertEqual(summary["views"]["fit"]["trials"][0]["unobserved_optional_paths"],
                          ["gui/train_animation/value_changed"])
 


### PR DESCRIPTION
## Summary

- split `worker/playback_step/compute` into five mandatory direct-child timing scopes
- validate parent reconciliation and matching call counts for every accepted trial
- report each child's compute-parent and measured-window shares
- document the compound phase boundaries and retained compute residual

The recorded Copenhagen protocol produced three Fit and three dense native Cocoa Release trials. `train_passenger_state_payload` qualified in all six trials, accounting for 90.42-91.07% of compute-parent time and 11.07-11.58% of the measured window. The result narrows the bottleneck to train-passenger interaction plus per-train state payload construction, but does not yet justify a specific optimization inside that combined region.

The build, 58-test CTest suite, 19 playback harness tests, structural profile, headless smoke, and six-case roundtrip smoke passed. Fresh implementation and recorded-evidence reviews found no issues.

Closes #345
